### PR TITLE
feat: run FuzeFront in-cluster on FuzeInfra (kind), first light

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,8 @@
+node_modules
+dist
+build
+coverage
+package-lock.json
+# Helm chart templates contain Go-template syntax that is not valid YAML.
+deploy/helm/**/templates/
+*.tpl

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,9 @@
+node_modules
+dist
+.env
+*.sqlite
+database.sqlite
+npm-debug.log*
+.git
+coverage
+tests

--- a/backend/src/migrations/004_create_organizations_table.ts
+++ b/backend/src/migrations/004_create_organizations_table.ts
@@ -26,6 +26,7 @@ export async function up(knex: Knex): Promise<void> {
     table
       .enum('type', null, {
         useNative: true,
+        existingType: true,
         enumName: 'organization_type_enum',
       })
       .notNullable()

--- a/backend/src/migrations/005_create_organization_memberships_table.ts
+++ b/backend/src/migrations/005_create_organization_memberships_table.ts
@@ -27,11 +27,16 @@ export async function up(knex: Knex): Promise<void> {
       .inTable('organizations')
       .onDelete('CASCADE')
     table
-      .enum('role', null, { useNative: true, enumName: 'membership_role_enum' })
+      .enum('role', null, {
+        useNative: true,
+        existingType: true,
+        enumName: 'membership_role_enum',
+      })
       .notNullable()
     table
       .enum('status', null, {
         useNative: true,
+        existingType: true,
         enumName: 'membership_status_enum',
       })
       .defaultTo('active')

--- a/backend/src/migrations/006_update_apps_for_organizations.ts
+++ b/backend/src/migrations/006_update_apps_for_organizations.ts
@@ -17,6 +17,7 @@ export async function up(knex: Knex): Promise<void> {
     table
       .enum('visibility', null, {
         useNative: true,
+        existingType: true,
         enumName: 'app_visibility_enum',
       })
       .defaultTo('private')

--- a/backend/src/migrations/007_update_sessions_for_organizations.ts
+++ b/backend/src/migrations/007_update_sessions_for_organizations.ts
@@ -11,9 +11,8 @@ export async function up(knex: Knex): Promise<void> {
     table.jsonb('organization_context').defaultTo('{}')
     table.string('tenant_id', 255).nullable().alter() // Make consistent with apps table
 
-    // Indexes for performance
+    // Indexes for performance (tenant_id is already indexed by migration 003)
     table.index(['active_organization_id'])
-    table.index(['tenant_id'])
   })
 }
 

--- a/backend/src/migrations/008_create_fuzefront_user.ts
+++ b/backend/src/migrations/008_create_fuzefront_user.ts
@@ -20,19 +20,20 @@ export async function up(knex: Knex): Promise<void> {
     if (userExists.rows.length === 0) {
       console.log(`📝 Creating user: ${username}`)
       
-      // Create the user with password
+      // Create the user with password. Postgres DDL does not accept a bound
+      // parameter ($1) for the password literal, so inline it (constant value).
       await knex.raw(`
-        CREATE USER ?? WITH PASSWORD ?
-      `, [username, password])
+        CREATE USER ?? WITH PASSWORD '${password}'
+      `, [username])
       
       console.log(`✅ User ${username} created successfully`)
     } else {
       console.log(`✅ User ${username} already exists`)
       
-      // Update password in case it changed
+      // Update password in case it changed (inline literal — see note above).
       await knex.raw(`
-        ALTER USER ?? WITH PASSWORD ?
-      `, [username, password])
+        ALTER USER ?? WITH PASSWORD '${password}'
+      `, [username])
       
       console.log(`✅ User ${username} password updated`)
     }

--- a/deploy/fuzeinfra-lean-values.yaml
+++ b/deploy/fuzeinfra-lean-values.yaml
@@ -1,0 +1,36 @@
+# Lean FuzeInfra overlay for FuzeFront "first light".
+# Starts ONLY the backbone services FuzeFront's minimal cut consumes (Postgres + Redis)
+# and turns the rest of the FuzeInfra menu off to keep the local cluster light.
+#
+# Layer on top of the chart's local overlay:
+#   helm upgrade --install fuzeinfra FuzeInfra/helm/fuzeinfra -n fuzeinfra --create-namespace \
+#     -f FuzeInfra/helm/fuzeinfra/values-local.yaml \
+#     -f deploy/fuzeinfra-lean-values.yaml
+#
+# To bring up more later, drop the relevant `enabled: false` (or use the full make kind-up).
+
+# FuzeInfra's own ingress only fronts its web UIs (Grafana, etc.) — all disabled
+# here, which would render an Ingress with no rules (invalid). FuzeFront brings its
+# own ingress, and Postgres/Redis are internal ClusterIP services, so turn it off.
+ingress:    { enabled: false }
+
+postgres:   { enabled: true }
+redis:      { enabled: true }
+
+mongodb:       { enabled: false }
+mongoExpress:  { enabled: false }
+neo4j:         { enabled: false }
+elasticsearch: { enabled: false }
+chromadb:      { enabled: false }
+kafka:         { enabled: false }
+kafkaUi:       { enabled: false }
+rabbitmq:      { enabled: false }
+prometheus:    { enabled: false }
+grafana:       { enabled: false }
+alertmanager:  { enabled: false }
+loki:          { enabled: false }
+promtail:      { enabled: false }
+nodeExporter:  { enabled: false }
+airflow:       { enabled: false }
+dnsmasq:       { enabled: false }
+cloudflareTunnel: { enabled: false }

--- a/deploy/helm/fuzefront/Chart.yaml
+++ b/deploy/helm/fuzefront/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+name: fuzefront
+description: >-
+  FuzeFront microfrontend hosting platform (backend + frontend), deployed
+  in-cluster and wired to the shared FuzeInfra services. Minimal first cut:
+  backend + frontend with local JWT auth; Authentik (OIDC) and Permit (PDP)
+  are layered on later.
+type: application
+version: 0.1.0
+appVersion: "1.0.0"

--- a/deploy/helm/fuzefront/README.md
+++ b/deploy/helm/fuzefront/README.md
@@ -1,0 +1,108 @@
+# FuzeFront — in-cluster deployment (minimal first cut)
+
+Deploys the FuzeFront **backend + frontend** into the same local `kind` cluster as
+FuzeInfra, wired to FuzeInfra's shared Postgres/Redis. Local JWT auth only;
+Authentik (OIDC) and Permit (PDP) are added in a later overlay.
+
+```
+browser ──http──▶ ingress-nginx (host :80)
+                    └─▶ fuzefront-frontend (nginx :8080)
+                          ├─ serves the React host shell (Module Federation container)
+                          └─ proxies /api and /socket.io ─▶ fuzefront-backend (:3001)
+                                                              └─▶ postgres.fuzeinfra.svc / redis.fuzeinfra.svc
+```
+
+## Prerequisites (install once — modifies your machine, run these yourself)
+
+```
+winget install Kubernetes.kind RedHat.Helm    # kind + helm (kubectl/docker already present)
+```
+
+## 1. Bring up FuzeInfra in kind
+
+```
+cd FuzeInfra
+make kind-up            # creates kind cluster "fuzeinfra" + ingress-nginx + deploys the infra chart
+kubectl -n fuzeinfra get pods        # wait until postgres/redis are Running
+```
+
+This creates kind cluster **`fuzeinfra`** (kube-context `kind-fuzeinfra`) with host
+ports 80/443 mapped to the ingress controller.
+
+## 2. Build the FuzeFront images and load them into kind
+
+`kind` can't pull `fuzefront/*:local` from a registry, so build locally and load:
+
+```
+# from the repo root (D:\source\FuzeFront)
+docker build -t fuzefront/backend:local ./backend
+docker build -t fuzefront/frontend:local \
+  --build-arg VITE_API_URL=http://fuzefront.dev.local ./frontend
+
+kind load docker-image fuzefront/backend:local fuzefront/frontend:local --name fuzeinfra
+```
+
+> The `VITE_API_URL` build-arg is baked into the frontend bundle, so the browser
+> calls `http://fuzefront.dev.local/api/...`, which the ingress routes to the
+> frontend nginx, which proxies to the backend.
+
+## 3. Deploy FuzeFront
+
+```
+helm upgrade --install fuzefront deploy/helm/fuzefront \
+  -n fuzefront --create-namespace \
+  -f deploy/helm/fuzefront/values-local.yaml
+```
+
+For real secrets (instead of the dev placeholders), either:
+
+```
+helm upgrade --install fuzefront deploy/helm/fuzefront -n fuzefront --create-namespace \
+  -f deploy/helm/fuzefront/values-local.yaml \
+  --set secret.jwtSecret="$JWT" --set secret.sessionSecret="$SESSION" \
+  --set secret.dbPassword="$DBPASS"
+```
+
+…or create a Secret yourself and set `secret.existingSecret=fuzefront-secrets`.
+
+## 4. Resolve the hostname
+
+Add to your hosts file (`C:\Windows\System32\drivers\etc\hosts`):
+
+```
+127.0.0.1 fuzefront.dev.local
+```
+
+## 5. Verify
+
+```
+kubectl -n fuzefront get pods,svc,ingress
+curl http://fuzefront.dev.local/api/health      # {"status":"ok",...}
+# open http://fuzefront.dev.local
+```
+
+## 6. Plug an app in at runtime
+
+```
+curl -X POST http://fuzefront.dev.local/api/apps/register \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"My App","url":"http://my-app:8080",
+       "integrationType":"module-federation",
+       "remoteUrl":"http://my-app:8080/remoteEntry.js",
+       "scope":"myApp","module":"./App"}'
+```
+
+The app appears in the 9-dots launcher and is loaded via Module Federation at
+runtime — no rebuild of the host.
+
+## Notes / known follow-ups
+
+- **DB credentials:** the backend authenticates as the FuzeInfra Postgres superuser
+  (`fuzeinfra`) to bootstrap its own `fuzefront_platform` DB. Harden later to a
+  dedicated `fuzefront_user` with limited grants.
+- **No seed data:** `NODE_ENV=production` (required so the image's compiled `.js`
+  migrations are found) skips seeds. The platform starts empty; apps self-register
+  at runtime. Run seeds as a one-off Job if you want the demo apps.
+- **Auth/AuthZ:** Authentik + Permit PDP are intentionally out of this first cut.
+- Validate the chart before deploying: `helm lint deploy/helm/fuzefront` and
+  `helm template fuzefront deploy/helm/fuzefront -f deploy/helm/fuzefront/values-local.yaml`.

--- a/deploy/helm/fuzefront/templates/NOTES.txt
+++ b/deploy/helm/fuzefront/templates/NOTES.txt
@@ -1,0 +1,28 @@
+FuzeFront ({{ .Chart.AppVersion }}) deployed to namespace "{{ .Release.Namespace }}".
+
+1. Watch the pods come up:
+     kubectl -n {{ .Release.Namespace }} get pods -w
+
+2. Make sure the host resolves to the kind ingress (127.0.0.1):
+     {{ .Values.ingress.host }}  ->  add to /etc/hosts (or C:\Windows\System32\drivers\etc\hosts)
+
+3. Open the platform:
+     http://{{ .Values.ingress.host }}
+
+4. Backend health (through the frontend nginx proxy):
+     curl http://{{ .Values.ingress.host }}/api/health
+
+5. Plug in an app at runtime (no rebuild of the host):
+     curl -X POST http://{{ .Values.ingress.host }}/api/apps/register \
+       -H 'Content-Type: application/json' \
+       -d '{"name":"My App","url":"http://my-app:8080",
+            "integrationType":"module-federation",
+            "remoteUrl":"http://my-app:8080/remoteEntry.js",
+            "scope":"myApp","module":"./App"}'
+
+{{- if not .Values.secret.existingSecret }}
+
+WARNING: this release created its Secret from chart values (dev placeholders).
+Override secret.jwtSecret / secret.sessionSecret / secret.dbPassword for anything
+real, or set secret.existingSecret to a Secret you manage out-of-band.
+{{- end }}

--- a/deploy/helm/fuzefront/templates/_helpers.tpl
+++ b/deploy/helm/fuzefront/templates/_helpers.tpl
@@ -1,0 +1,15 @@
+{{/* Name of the Secret the workloads read from. */}}
+{{- define "fuzefront.secretName" -}}
+{{- if .Values.secret.existingSecret -}}
+{{- .Values.secret.existingSecret -}}
+{{- else -}}
+fuzefront-secrets
+{{- end -}}
+{{- end -}}
+
+{{/* Common labels. */}}
+{{- define "fuzefront.labels" -}}
+app.kubernetes.io/part-of: fuzefront
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version }}
+{{- end -}}

--- a/deploy/helm/fuzefront/templates/backend.yaml
+++ b/deploy/helm/fuzefront/templates/backend.yaml
@@ -1,0 +1,102 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fuzefront-backend
+  labels:
+    {{- include "fuzefront.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backend
+spec:
+  replicas: {{ .Values.backend.replicas }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/part-of: fuzefront
+      app.kubernetes.io/component: backend
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/part-of: fuzefront
+        app.kubernetes.io/component: backend
+    spec:
+      containers:
+        - name: backend
+          image: "{{ .Values.backend.image.repository }}:{{ .Values.backend.image.tag }}"
+          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.backend.port }}
+          env:
+            - name: NODE_ENV
+              value: "production"            # required: built image ships compiled .js migrations
+            - name: USE_POSTGRES
+              value: "true"
+            - name: PORT
+              value: {{ .Values.backend.port | quote }}
+            - name: DB_HOST
+              value: {{ .Values.fuzeinfra.postgres.host | quote }}
+            - name: DB_PORT
+              value: {{ .Values.fuzeinfra.postgres.port | quote }}
+            - name: DB_NAME
+              value: {{ .Values.database.name | quote }}
+            - name: DB_USER
+              value: {{ .Values.database.user | quote }}
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "fuzefront.secretName" . }}
+                  key: DB_PASSWORD
+            - name: JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "fuzefront.secretName" . }}
+                  key: JWT_SECRET
+            - name: SESSION_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "fuzefront.secretName" . }}
+                  key: SESSION_SECRET
+            - name: FRONTEND_URL
+              value: "http://{{ .Values.ingress.host }}"
+            # Permit.io deferred in the minimal cut; placeholder lets the backend
+            # boot (SDK uses throwOnError:false). PDP is intentionally absent.
+            - name: PERMIT_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "fuzefront.secretName" . }}
+                  key: PERMIT_API_KEY
+            - name: PERMIT_PDP_URL
+              value: "http://localhost:7766"
+            - name: PERMIT_DEBUG
+              value: "false"
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 45
+            periodSeconds: 15
+          resources:
+            {{- toYaml .Values.backend.resources | nindent 12 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  # Name is significant: the frontend nginx proxies to http://fuzefront-backend:3001.
+  name: fuzefront-backend
+  labels:
+    {{- include "fuzefront.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backend
+spec:
+  selector:
+    app.kubernetes.io/part-of: fuzefront
+    app.kubernetes.io/component: backend
+  ports:
+    - name: http
+      port: {{ .Values.backend.port }}
+      targetPort: http

--- a/deploy/helm/fuzefront/templates/frontend.yaml
+++ b/deploy/helm/fuzefront/templates/frontend.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fuzefront-frontend
+  labels:
+    {{- include "fuzefront.labels" . | nindent 4 }}
+    app.kubernetes.io/component: frontend
+spec:
+  replicas: {{ .Values.frontend.replicas }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/part-of: fuzefront
+      app.kubernetes.io/component: frontend
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/part-of: fuzefront
+        app.kubernetes.io/component: frontend
+    spec:
+      containers:
+        - name: frontend
+          image: "{{ .Values.frontend.image.repository }}:{{ .Values.frontend.image.tag }}"
+          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.frontend.port }}
+          # Static nginx; it proxies /api and /socket.io to the fuzefront-backend
+          # Service in this namespace. The browser-facing API base (VITE_API_URL)
+          # is baked at image-build time — build with
+          #   --build-arg VITE_API_URL=http://{{ .Values.ingress.host }}
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 20
+            periodSeconds: 15
+          resources:
+            {{- toYaml .Values.frontend.resources | nindent 12 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: fuzefront-frontend
+  labels:
+    {{- include "fuzefront.labels" . | nindent 4 }}
+    app.kubernetes.io/component: frontend
+spec:
+  selector:
+    app.kubernetes.io/part-of: fuzefront
+    app.kubernetes.io/component: frontend
+  ports:
+    - name: http
+      port: {{ .Values.frontend.port }}
+      targetPort: http

--- a/deploy/helm/fuzefront/templates/ingress.yaml
+++ b/deploy/helm/fuzefront/templates/ingress.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: fuzefront
+  labels:
+    {{- include "fuzefront.labels" . | nindent 4 }}
+spec:
+  ingressClassName: {{ .Values.ingress.className }}
+  rules:
+    # Single host -> frontend. The frontend's nginx fans /api and /socket.io
+    # out to the backend Service internally, mirroring the compose setup.
+    - host: {{ .Values.ingress.host | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: fuzefront-frontend
+                port:
+                  number: {{ .Values.frontend.port }}
+{{- end }}

--- a/deploy/helm/fuzefront/templates/secret.yaml
+++ b/deploy/helm/fuzefront/templates/secret.yaml
@@ -1,0 +1,14 @@
+{{- if not .Values.secret.existingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "fuzefront.secretName" . }}
+  labels:
+    {{- include "fuzefront.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  JWT_SECRET: {{ .Values.secret.jwtSecret | quote }}
+  SESSION_SECRET: {{ .Values.secret.sessionSecret | quote }}
+  DB_PASSWORD: {{ .Values.secret.dbPassword | quote }}
+  PERMIT_API_KEY: {{ .Values.secret.permitApiKey | quote }}
+{{- end }}

--- a/deploy/helm/fuzefront/values-local.yaml
+++ b/deploy/helm/fuzefront/values-local.yaml
@@ -1,0 +1,15 @@
+# =============================================================================
+# Local (kind) overlay for FuzeFront.
+#   helm upgrade --install fuzefront deploy/helm/fuzefront \
+#     -n fuzefront --create-namespace -f deploy/helm/fuzefront/values-local.yaml
+#
+# The defaults in values.yaml already target the local kind setup. Override
+# secrets here (in a gitignored copy) or via --set for anything real.
+# =============================================================================
+global:
+  imagePullPolicy: IfNotPresent
+
+ingress:
+  enabled: true
+  className: nginx
+  host: fuzefront.dev.local

--- a/deploy/helm/fuzefront/values.yaml
+++ b/deploy/helm/fuzefront/values.yaml
@@ -1,0 +1,74 @@
+# =============================================================================
+# FuzeFront Helm chart — default values (minimal first cut: backend + frontend).
+#
+# Deploy into its own namespace, wired to FuzeInfra services in the `fuzeinfra`
+# namespace via cross-namespace CoreDNS names:
+#   helm upgrade --install fuzefront deploy/helm/fuzefront \
+#     -n fuzefront --create-namespace -f deploy/helm/fuzefront/values-local.yaml
+# =============================================================================
+
+global:
+  # Applied to every workload. IfNotPresent so kind uses images loaded via
+  # `kind load docker-image` rather than trying to pull from a registry.
+  imagePullPolicy: IfNotPresent
+
+# Connection to FuzeInfra shared services (CoreDNS names, cross-namespace).
+fuzeinfra:
+  namespace: fuzeinfra
+  postgres:
+    host: postgres.fuzeinfra.svc.cluster.local
+    port: 5432
+  redis:
+    host: redis.fuzeinfra.svc.cluster.local
+    port: 6379
+
+# FuzeFront application database. The backend creates this DB on first startup,
+# so it only needs Postgres credentials that can CREATE DATABASE.
+database:
+  name: fuzefront_platform
+  # For first light the backend authenticates as the FuzeInfra Postgres superuser
+  # (so it can bootstrap its own database). Harden later to a dedicated
+  # fuzefront_user with limited grants. Password comes from the Secret below.
+  user: fuzeinfra
+
+# Secret handling. Either let the chart create a Secret from the values here
+# (DEV ONLY — override!), or point at an existing Secret via `existingSecret`.
+secret:
+  existingSecret: ""        # e.g. "fuzefront-secrets" created out-of-band
+  # Dev-only placeholders. OVERRIDE for anything real, e.g.:
+  #   --set secret.jwtSecret=... --set secret.dbPassword=...
+  # or a gitignored values file. NEVER commit real secrets here.
+  jwtSecret: "dev-only-change-me"
+  sessionSecret: "dev-only-change-me"
+  dbPassword: "fuzeinfra_secure_password"   # matches FuzeInfra postgres default
+  # Permit.io is deferred in the minimal cut, but the backend requires this var
+  # to be set at import time. The SDK is built with throwOnError:false, so with a
+  # placeholder it boots and degrades gracefully (Permit-gated routes will deny).
+  permitApiKey: "dev-no-permit"
+
+backend:
+  image:
+    repository: fuzefront/backend
+    tag: local
+  # Must stay 3001: the frontend nginx proxies /api and /socket.io to
+  # http://fuzefront-backend:3001, and the backend Service is named accordingly.
+  port: 3001
+  replicas: 1
+  resources:
+    requests: { cpu: 100m, memory: 256Mi }
+    limits:   { cpu: "1",  memory: 512Mi }
+
+frontend:
+  image:
+    repository: fuzefront/frontend
+    tag: local
+  port: 8080
+  replicas: 1
+  resources:
+    requests: { cpu: 50m,  memory: 64Mi }
+    limits:   { cpu: 500m, memory: 256Mi }
+
+ingress:
+  enabled: true
+  className: nginx
+  host: fuzefront.dev.local

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,9 @@
+node_modules
+dist
+.env
+.git
+npm-debug.log*
+playwright-report
+test-results
+tests
+*.png

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,16 +1,16 @@
-# Build stage
-FROM node:18-alpine AS build
+# Build stage — glibc + Node 20 so Tailwind v4's @tailwindcss/oxide native
+# binding resolves reliably (it is flaky on alpine/musl).
+FROM node:20-bookworm-slim AS build
 
 WORKDIR /app
-
-# Install dependencies for native modules
-RUN apk add --no-cache python3 make g++
 
 # Copy package files
 COPY package*.json ./
 
-# Install dependencies
-RUN npm install
+# Install dependencies. Drop the host (Windows) lockfile first so npm re-resolves
+# platform-native optional deps (e.g. @tailwindcss/oxide linux binding) inside the
+# linux build — works around npm's optional-deps bug (npm/cli#4828).
+RUN rm -f package-lock.json && npm install
 
 # Copy source code
 COPY . .

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -36,6 +36,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.53.1",
+    "@tailwindcss/postcss": "^4.1.11",
     "@types/node": "^24.0.3",
     "@types/react": "^18.3.17",
     "@types/react-dom": "^18.3.5",

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,6 +1,5 @@
 export default {
   plugins: {
-    tailwindcss: {},
-    autoprefixer: {},
+    '@tailwindcss/postcss': {},
   },
-} 
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,11 +1,46 @@
 
-@import "tw-animate-css";
+@import 'tailwindcss';
+@import 'tw-animate-css';
 
 @custom-variant dark (&:is(.dark *));
 
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+@theme inline {
+  --radius-sm: calc(var(--radius) - 4px);
+  --radius-md: calc(var(--radius) - 2px);
+  --radius-lg: var(--radius);
+  --radius-xl: calc(var(--radius) + 4px);
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-destructive: var(--destructive);
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
+  --color-chart-1: var(--chart-1);
+  --color-chart-2: var(--chart-2);
+  --color-chart-3: var(--chart-3);
+  --color-chart-4: var(--chart-4);
+  --color-chart-5: var(--chart-5);
+  --color-sidebar: var(--sidebar);
+  --color-sidebar-foreground: var(--sidebar-foreground);
+  --color-sidebar-primary: var(--sidebar-primary);
+  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
+  --color-sidebar-accent: var(--sidebar-accent);
+  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
+  --color-sidebar-border: var(--sidebar-border);
+  --color-sidebar-ring: var(--sidebar-ring);
+}
 
 :root {
   font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -274,4 +274,122 @@ export const organizationsAPI = {
   },
 }
 
+// ---------------------------------------------------------------------------
+// Backward-compatible standalone exports.
+// Components import these named functions/types directly. They wrap the *API
+// objects above and add the org/member/app-CRUD + permission calls the
+// components expect, following the backend's /api routes.
+// ---------------------------------------------------------------------------
+
+export interface Organization {
+  id: string
+  name: string
+  slug?: string
+  description?: string
+  ownerId?: string
+  parentId?: string | null
+  type?: string
+  metadata?: Record<string, any>
+  createdAt?: string
+  updatedAt?: string
+}
+
+export interface OrganizationMember {
+  id: string
+  organizationId: string
+  userId: string
+  email?: string
+  firstName?: string
+  lastName?: string
+  role: string
+  status?: string
+  createdAt?: string
+}
+
+// Auth
+export const getCurrentUser = () => authAPI.getCurrentUser()
+export const logout = () => authAPI.logout()
+
+// Apps
+export const fetchApps = () => appsAPI.getApps()
+export const createApp = async (app: Partial<App>) => {
+  const res = await api.post('/apps', app)
+  return res.data
+}
+export const updateAppStatus = async (id: string, isActive: boolean) => {
+  const res = await api.put(`/apps/${id}/activate`, { isActive })
+  return res.data
+}
+export const deleteApp = async (id: string) => {
+  const res = await api.delete(`/apps/${id}`)
+  return res.data
+}
+
+// Organizations
+export const getOrganizations = () => organizationsAPI.getOrganizations()
+export const createOrganization = async (data: Partial<Organization>) => {
+  const res = await api.post('/organizations', data)
+  return res.data
+}
+export const updateOrganization = async (
+  id: string,
+  data: Partial<Organization>
+) => {
+  const res = await api.put(`/organizations/${id}`, data)
+  return res.data
+}
+export const deleteOrganization = async (id: string) => {
+  const res = await api.delete(`/organizations/${id}`)
+  return res.data
+}
+
+// Organization members
+export const getOrganizationMembers = async (orgId: string) => {
+  const res = await api.get(`/organizations/${orgId}/members`)
+  return res.data
+}
+export const inviteOrganizationMember = async (
+  orgId: string,
+  data: { email: string; role: string }
+) => {
+  const res = await api.post(`/organizations/${orgId}/members`, data)
+  return res.data
+}
+export const updateMemberRole = async (
+  orgId: string,
+  memberId: string,
+  role: string
+) => {
+  const res = await api.put(`/organizations/${orgId}/members/${memberId}`, {
+    role,
+  })
+  return res.data
+}
+export const removeMember = async (orgId: string, memberId: string) => {
+  const res = await api.delete(`/organizations/${orgId}/members/${memberId}`)
+  return res.data
+}
+
+// Permissions (best-effort; permissive fallback for local dev so the UI renders
+// when the authorization endpoints aren't wired yet).
+export const checkPermissions = async (
+  resource?: string,
+  action?: string
+): Promise<boolean> => {
+  try {
+    const res = await api.post('/auth/permissions/check', { resource, action })
+    return Boolean(res.data?.allowed ?? true)
+  } catch {
+    return true
+  }
+}
+export const getUserRoles = async (): Promise<string[]> => {
+  try {
+    const user = JSON.parse(localStorage.getItem('user') || '{}')
+    return Array.isArray(user?.roles) ? user.roles : []
+  } catch {
+    return []
+  }
+}
+
 export default api


### PR DESCRIPTION
Brings FuzeFront up **in-cluster** against the k8s-migrated FuzeInfra, and gets the microfrontend platform to first light: the host shell serves, the backend connects to FuzeInfra's Postgres, and an app can **self-register and load at runtime** (no compile-time knowledge of the host beyond the SDK).

## What's here
- **Deploy** (`deploy/helm/fuzefront`): backend + frontend Deployments/Services/Ingress/Secret, wired to FuzeInfra via cross-namespace CoreDNS (`postgres.fuzeinfra.svc`). Lean FuzeInfra overlay (`deploy/fuzeinfra-lean-values.yaml`) brings up just Postgres+Redis. Runbook in the chart README.
- **Backend migration fixes** (fresh-DB blockers): native-enum `existingType`, duplicate `sessions(tenant_id)` index, parameterized-DDL in the user migration.
- **Frontend build fixes**: completed the half-done Tailwind v4 wiring, glibc build stage (oxide native binding), and restored the standalone `api.ts` exports ~9 components import.
- FuzeInfra submodule bumped to the Helm/kind migration.

## Verified
- `/api/health` through ingress → frontend nginx → backend → Postgres: `ok, connected`
- `POST /api/apps/register` → 201, persisted (canonical `module-federation` type)

## Deferred (follow-ups)
Authentik (OIDC), Permit (PDP), dedicated `fuzefront_user` DB role, demo seeds. kind needs node image `v1.34` + ingress-nginx `controller-v1.11.2` on this host (noted for FuzeInfra's setup-kind.sh).