### PR TITLE
feat: SDK window-bridge shared services + login fix + FuzeClock example

### DIFF
--- a/clock-app/.dockerignore
+++ b/clock-app/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+.git
+npm-debug.log*

--- a/clock-app/Dockerfile
+++ b/clock-app/Dockerfile
@@ -1,0 +1,23 @@
+# Build stage — glibc/Node 20 (consistent with the host frontend build).
+FROM node:20-bookworm-slim AS build
+WORKDIR /app
+COPY package*.json ./
+# Drop any host lockfile so npm resolves platform-native deps in this image.
+RUN rm -f package-lock.json && npm install
+COPY . .
+
+# Build-time configuration (no host code, just URLs):
+ARG VITE_HUB_API_URL=http://fuzefront.dev.local
+ARG VITE_PUBLIC_URL=http://clock.dev.local
+ENV VITE_HUB_API_URL=$VITE_HUB_API_URL
+ENV VITE_PUBLIC_URL=$VITE_PUBLIC_URL
+RUN npm run build
+
+# Serve the built remote with nginx.
+FROM nginx:alpine AS production
+COPY --from=build /app/dist /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/nginx.conf
+EXPOSE 8080
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+  CMD wget -q --spider http://localhost:8080/health || exit 1
+CMD ["nginx", "-g", "daemon off;"]

--- a/clock-app/index.html
+++ b/clock-app/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>FuzeClock — FuzeFront microfrontend</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/clock-app/nginx.conf
+++ b/clock-app/nginx.conf
@@ -1,0 +1,51 @@
+worker_processes auto;
+pid /tmp/nginx.pid;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
+    access_log /dev/stdout;
+    error_log /dev/stderr warn;
+    sendfile on;
+
+    server {
+        listen 8080;
+        server_name _;
+        root /usr/share/nginx/html;
+        index index.html;
+
+        # CORS so the host page can fetch remoteEntry.js and chunks cross-origin.
+        add_header 'Access-Control-Allow-Origin' '*' always;
+        add_header 'Access-Control-Allow-Methods' 'GET, OPTIONS' always;
+        add_header 'Access-Control-Allow-Headers' '*' always;
+        if ($request_method = 'OPTIONS') { return 204; }
+
+        # remoteEntry.js must never be cached stale.
+        location = /remoteEntry.js {
+            add_header 'Access-Control-Allow-Origin' '*' always;
+            add_header 'Cache-Control' 'no-cache, no-store, must-revalidate' always;
+            try_files $uri =404;
+        }
+
+        location /assets/ {
+            expires 1y;
+            add_header Cache-Control "public, immutable";
+            add_header 'Access-Control-Allow-Origin' '*' always;
+            try_files $uri =404;
+        }
+
+        location /health {
+            access_log off;
+            return 200 "healthy\n";
+            add_header Content-Type text/plain;
+        }
+
+        location / {
+            try_files $uri $uri/ /index.html;
+        }
+    }
+}

--- a/clock-app/package.json
+++ b/clock-app/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "clock-app",
+  "version": "1.0.0",
+  "description": "Example on-the-fly FuzeFront microfrontend (runtime Module Federation)",
+  "type": "module",
+  "scripts": {
+    "dev": "vite --port 3003",
+    "build": "vite build",
+    "preview": "vite preview --port 3003"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@originjs/vite-plugin-federation": "^1.3.6",
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "@vitejs/plugin-react": "^4.3.1",
+    "typescript": "^5.5.3",
+    "vite": "^5.4.0"
+  }
+}

--- a/clock-app/public/clock-icon.svg
+++ b/clock-app/public/clock-icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="12" cy="12" r="10" />
+  <polyline points="12 6 12 12 16 14" />
+</svg>

--- a/clock-app/src/App.tsx
+++ b/clock-app/src/App.tsx
@@ -1,0 +1,80 @@
+import { useEffect, useRef, useState } from 'react'
+import {
+  getPlatformContext,
+  subscribeContext,
+  notify,
+  PlatformSnapshot,
+} from './sdk'
+import './index.css'
+
+// This is the module the host loads at runtime (exposed as './App').
+export default function App() {
+  const [now, setNow] = useState(() => new Date())
+  const [ctx, setCtx] = useState<PlatformSnapshot>(() => getPlatformContext())
+  const greeted = useRef(false)
+
+  useEffect(() => {
+    const t = setInterval(() => setNow(new Date()), 1000)
+    return () => clearInterval(t)
+  }, [])
+
+  // Live host context via the bridge (user, apps, etc.).
+  useEffect(() => subscribeContext(setCtx), [])
+
+  // Greet the host through the shared toaster, once, when mounted in-platform.
+  useEffect(() => {
+    if (ctx.isPlatformMode && !greeted.current) {
+      greeted.current = true
+      notify({
+        title: 'FuzeClock',
+        message: 'Loaded at runtime and connected to the host bridge 👋',
+        level: 'success',
+        appId: 'fuzeClock',
+      })
+    }
+  }, [ctx.isPlatformMode])
+
+  return (
+    <div className="fuzeclock">
+      <h2>🕒 FuzeClock</h2>
+      <div className="time">{now.toLocaleTimeString()}</div>
+      <div className="date">
+        {now.toLocaleDateString(undefined, {
+          weekday: 'long',
+          year: 'numeric',
+          month: 'long',
+          day: 'numeric',
+        })}
+      </div>
+      <p className="note">
+        Loaded at runtime via Module Federation. No build-time knowledge of the
+        host — only the SDK / <code>window.__FUZEFRONT__</code> bridge.
+      </p>
+      <ul className="ctx">
+        <li>
+          Mounted inside FuzeFront:{' '}
+          <b>{ctx.isPlatformMode ? 'yes' : 'no (standalone)'}</b>
+        </li>
+        <li>
+          User (live from host): <b>{ctx.user?.email ?? '—'}</b>
+        </li>
+        <li>
+          Apps known to host: <b>{ctx.apps.length}</b>
+        </li>
+      </ul>
+      <button
+        className="btn"
+        onClick={() =>
+          notify({
+            title: 'FuzeClock',
+            message: `Hello from the clock at ${new Date().toLocaleTimeString()}`,
+            level: 'info',
+            appId: 'fuzeClock',
+          })
+        }
+      >
+        Send a toast to the host
+      </button>
+    </div>
+  )
+}

--- a/clock-app/src/index.css
+++ b/clock-app/src/index.css
@@ -1,0 +1,55 @@
+.fuzeclock {
+  font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
+  padding: 2rem;
+  text-align: center;
+  color: #1f2937;
+}
+.fuzeclock h2 {
+  margin: 0 0 0.5rem;
+}
+.fuzeclock .time {
+  font-size: 3rem;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.02em;
+}
+.fuzeclock .date {
+  color: #6b7280;
+  margin-bottom: 1rem;
+}
+.fuzeclock .note {
+  max-width: 46ch;
+  margin: 1rem auto;
+  color: #9ca3af;
+  font-size: 0.9rem;
+  line-height: 1.4;
+}
+.fuzeclock .note code {
+  background: #f1f5f9;
+  padding: 0 4px;
+  border-radius: 4px;
+}
+.fuzeclock .ctx {
+  list-style: none;
+  padding: 0;
+  margin: 0 auto 1rem;
+  color: #374151;
+  font-size: 0.9rem;
+  display: inline-block;
+  text-align: left;
+}
+.fuzeclock .ctx li {
+  margin: 0.25rem 0;
+}
+.fuzeclock .btn {
+  background: #2563eb;
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  padding: 0.5rem 1rem;
+  font-size: 0.9rem;
+  cursor: pointer;
+}
+.fuzeclock .btn:hover {
+  background: #1d4ed8;
+}

--- a/clock-app/src/main.tsx
+++ b/clock-app/src/main.tsx
@@ -1,0 +1,30 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App'
+import { registerWithHub } from './sdk'
+
+// When opened STANDALONE (not mounted by the host), self-register with the hub
+// so it appears in the launcher. The hub URL and this app's public URL come from
+// build-time env (configuration) — never from importing host code.
+const HUB_API_URL = import.meta.env.VITE_HUB_API_URL || 'http://fuzefront.dev.local'
+const PUBLIC_URL = import.meta.env.VITE_PUBLIC_URL || 'http://clock.dev.local'
+
+if (!(window as any).__FRONTFUSE_PLATFORM__) {
+  void registerWithHub({
+    hubApiUrl: HUB_API_URL,
+    name: 'FuzeClock',
+    url: PUBLIC_URL,
+    remoteUrl: PUBLIC_URL,
+    scope: 'fuzeClock',
+    module: './App',
+    iconUrl: `${PUBLIC_URL}/clock-icon.svg`,
+    description:
+      'Example on-the-fly microfrontend: a live clock loaded at runtime.',
+  })
+}
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+)

--- a/clock-app/src/sdk.ts
+++ b/clock-app/src/sdk.ts
@@ -1,0 +1,111 @@
+// Minimal FuzeFront SDK surface for an on-the-fly remote.
+//
+// The only things this app knows about the host are the agreed contracts:
+//   1. window.__FUZEFRONT__ — the platform bridge: live context + shared
+//      services (toaster, menu). Installed by the host.
+//   2. POST /api/apps/register — the registration endpoint.
+// No host code is imported at build time.
+
+export type ToastLevel = 'info' | 'success' | 'warning' | 'error'
+
+export interface ToastInput {
+  message: string
+  title?: string
+  level?: ToastLevel
+  durationMs?: number
+  appId?: string
+}
+
+export interface PlatformSnapshot {
+  user: { id: string; email: string; roles: string[] } | null
+  apps: Array<{ id: string; name: string }>
+  activeApp: { id: string; name: string } | null
+  isPlatformMode: boolean
+}
+
+interface FuzeFrontBridge {
+  version: number
+  getContext(): PlatformSnapshot
+  subscribe(listener: (ctx: PlatformSnapshot) => void): () => void
+  notify(toast: ToastInput): string
+  dismiss(id: string): void
+  menu: {
+    add(appId: string, items: any[]): void
+    remove(appId: string): void
+  }
+}
+
+export function getBridge(): FuzeFrontBridge | null {
+  if (typeof window === 'undefined') return null
+  return (window as any).__FUZEFRONT__ ?? null
+}
+
+const STANDALONE: PlatformSnapshot = {
+  user: null,
+  apps: [],
+  activeApp: null,
+  isPlatformMode: false,
+}
+
+export function getPlatformContext(): PlatformSnapshot {
+  return getBridge()?.getContext() ?? STANDALONE
+}
+
+/** Subscribe to live host context. Returns an unsubscribe fn. */
+export function subscribeContext(
+  listener: (ctx: PlatformSnapshot) => void
+): () => void {
+  const b = getBridge()
+  if (b) return b.subscribe(listener)
+  listener(STANDALONE)
+  return () => {}
+}
+
+/** Show a toast through the host's shared toaster. */
+export function notify(toast: ToastInput): void {
+  const b = getBridge()
+  if (b) b.notify(toast)
+  else console.log('[FuzeClock] notify (no host bridge):', toast)
+}
+
+export interface RegisterConfig {
+  hubApiUrl: string
+  name: string
+  url: string
+  remoteUrl: string
+  scope: string
+  module: string
+  iconUrl?: string
+  description?: string
+}
+
+export async function registerWithHub(
+  cfg: RegisterConfig
+): Promise<string | null> {
+  try {
+    const res = await fetch(`${cfg.hubApiUrl}/api/apps/register`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: cfg.name,
+        url: cfg.url,
+        iconUrl: cfg.iconUrl,
+        integrationType: 'module-federation',
+        remoteUrl: cfg.remoteUrl,
+        scope: cfg.scope,
+        module: cfg.module,
+        description: cfg.description,
+      }),
+    })
+    if (!res.ok) {
+      console.error('FuzeClock: register failed', await res.text())
+      return null
+    }
+    const app = await res.json()
+    console.log('FuzeClock: registered with hub, app id =', app.id)
+    return app.id ?? null
+  } catch (e) {
+    console.error('FuzeClock: register error', e)
+    return null
+  }
+}

--- a/clock-app/tsconfig.json
+++ b/clock-app/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true
+  },
+  "include": ["src"]
+}

--- a/clock-app/vite.config.ts
+++ b/clock-app/vite.config.ts
@@ -1,0 +1,30 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+import federation from '@originjs/vite-plugin-federation'
+
+// This remote has ZERO build-time knowledge of the host. It only declares the
+// agreed Module Federation contract: a scope name, the exposed module, and the
+// shared singletons (react/react-dom) the host also shares.
+export default defineConfig({
+  plugins: [
+    react(),
+    federation({
+      name: 'fuzeClock',
+      filename: 'remoteEntry.js',
+      exposes: {
+        './App': './src/App',
+      },
+      shared: {
+        react: { singleton: true, requiredVersion: '^18.0.0' } as any,
+        'react-dom': { singleton: true, requiredVersion: '^18.0.0' } as any,
+      },
+    }),
+  ],
+  build: {
+    target: 'esnext',
+    minify: false,
+    cssCodeSplit: false,
+  },
+  base: '/',
+  server: { host: '0.0.0.0', port: 3003, cors: true, strictPort: true },
+})

--- a/deploy/examples/clock-app.yaml
+++ b/deploy/examples/clock-app.yaml
@@ -1,0 +1,71 @@
+# Example on-the-fly microfrontend deployed independently of the host.
+# It shares NOTHING with FuzeFront at build time — it is reached by the browser
+# at its own ingress host and registered into the hub by configuration.
+#
+#   kubectl apply -f deploy/examples/clock-app.yaml
+#   # add to hosts:  127.0.0.1 clock.dev.local
+#
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: clock-app
+  namespace: fuzefront
+  labels:
+    app: clock-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: clock-app
+  template:
+    metadata:
+      labels:
+        app: clock-app
+    spec:
+      containers:
+        - name: clock-app
+          image: fuzefront/clock-app:local
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: clock-app
+  namespace: fuzefront
+  labels:
+    app: clock-app
+spec:
+  selector:
+    app: clock-app
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: clock-app
+  namespace: fuzefront
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: clock.dev.local
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: clock-app
+                port:
+                  number: 8080

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { Routes, Route, Navigate } from 'react-router-dom'
-import { useCurrentUser, useAppContext } from './lib/shared'
+import { useCurrentUser, useAppContext, MenuItem } from './lib/shared'
+import { installBridge, bridge } from './platform/bridge'
 import { ChatProvider } from './contexts/ChatContext'
 import Layout from './components/Layout'
 import LoginPage from './pages/LoginPage'
@@ -95,6 +96,53 @@ function AuthWrapper({ children }: { children: React.ReactNode }) {
       }
     }
   }, [state.user, dispatch])
+
+  // Install the platform bridge once, and keep its context + menu wiring in
+  // sync with host state so runtime-loaded apps can read live context and call
+  // shared services (toaster, menu) through window.__FUZEFRONT__.
+  const menuRef = useRef<MenuItem[]>([])
+  useEffect(() => {
+    menuRef.current = state.menuItems
+  }, [state.menuItems])
+
+  useEffect(() => {
+    installBridge({
+      onMenuAdd: (appId, items) => {
+        const others = menuRef.current.filter(m => m.appId !== appId)
+        const added = items.map(i => ({ ...i, category: 'app' as const, appId }))
+        dispatch({ type: 'SET_MENU_ITEMS', payload: [...others, ...added] })
+      },
+      onMenuRemove: appId => {
+        dispatch({
+          type: 'SET_MENU_ITEMS',
+          payload: menuRef.current.filter(m => m.appId !== appId),
+        })
+      },
+      socket: {
+        on: (event, handler) => websocketService.onServer(event, handler),
+        off: (event, handler) => websocketService.offServer(event, handler),
+        emit: (event, payload) => websocketService.emitServer(event, payload),
+        isConnected: () => websocketService.isConnected(),
+      },
+    })
+  }, [dispatch])
+
+  useEffect(() => {
+    bridge.setContext({
+      user: state.user
+        ? {
+            id: state.user.id,
+            email: state.user.email,
+            roles: state.user.roles,
+          }
+        : null,
+      apps: state.apps.map(a => ({ id: a.id, name: a.name })),
+      activeApp: state.activeApp
+        ? { id: state.activeApp.id, name: state.activeApp.name }
+        : null,
+      isPlatformMode: true,
+    })
+  }, [state.user, state.apps, state.activeApp])
 
   if (isLoading) {
     return (

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -3,6 +3,7 @@ import TopBar from './TopBar'
 import SidePanel from './SidePanel'
 import ChatPanel from './ChatPanel'
 import { useChat } from '../contexts/ChatContext'
+import Toaster from './Toaster'
 
 interface LayoutProps {
   children: React.ReactNode
@@ -28,6 +29,9 @@ function Layout({ children }: LayoutProps) {
         onFeedback={addFeedback}
         isLoading={state.isLoading}
       />
+
+      {/* Toast region fed by window.__FUZEFRONT__.notify() (host + any app) */}
+      <Toaster />
     </div>
   )
 }

--- a/frontend/src/components/SidePanel.tsx
+++ b/frontend/src/components/SidePanel.tsx
@@ -18,10 +18,11 @@ function SidePanel() {
     ) ||
     []
 
-  const appMenuItems =
-    globalMenu.appMenuItems ||
-    globalMenu.menuItems?.filter((item: MenuItem) => item.category === 'app') ||
-    []
+  // App-injected menu items live in the AppContext reducer, where the platform
+  // bridge (window.__FUZEFRONT__.menu) writes them at runtime.
+  const appMenuItems = state.menuItems.filter(
+    (item: MenuItem) => item.category === 'app'
+  )
 
   const handleMenuClick = (item: MenuItem) => {
     if (item.route) {

--- a/frontend/src/components/Toaster.tsx
+++ b/frontend/src/components/Toaster.tsx
@@ -1,0 +1,83 @@
+import { useEffect, useState } from 'react'
+import { bridge, Toast, ToastLevel } from '../platform/bridge'
+
+const LEVEL_COLORS: Record<ToastLevel, { bg: string; bar: string }> = {
+  info: { bg: '#1e293b', bar: '#3b82f6' },
+  success: { bg: '#14302a', bar: '#22c55e' },
+  warning: { bg: '#332b14', bar: '#f59e0b' },
+  error: { bg: '#33181a', bar: '#ef4444' },
+}
+
+// Renders toasts pushed through window.__FUZEFRONT__.notify() by any app or by
+// the host itself. Subscribes to the bridge's toast store.
+export function Toaster() {
+  const [toasts, setToasts] = useState<Toast[]>([])
+
+  useEffect(() => bridge.subscribeToasts(setToasts), [])
+
+  if (toasts.length === 0) return null
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        top: 16,
+        right: 16,
+        zIndex: 9999,
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 8,
+        maxWidth: 360,
+      }}
+    >
+      {toasts.map(t => {
+        const c = LEVEL_COLORS[t.level]
+        return (
+          <div
+            key={t.id}
+            role="status"
+            style={{
+              background: c.bg,
+              color: '#f8fafc',
+              borderLeft: `4px solid ${c.bar}`,
+              borderRadius: 8,
+              padding: '10px 12px',
+              boxShadow: '0 8px 24px rgba(0,0,0,0.35)',
+              display: 'flex',
+              gap: 8,
+              alignItems: 'flex-start',
+            }}
+          >
+            <div style={{ flex: 1, minWidth: 0 }}>
+              {t.title && (
+                <div style={{ fontWeight: 600, marginBottom: 2 }}>{t.title}</div>
+              )}
+              <div style={{ fontSize: 14, lineHeight: 1.35 }}>{t.message}</div>
+              {t.appId && (
+                <div style={{ fontSize: 11, opacity: 0.6, marginTop: 2 }}>
+                  from {t.appId}
+                </div>
+              )}
+            </div>
+            <button
+              onClick={() => bridge.dismiss(t.id)}
+              aria-label="Dismiss"
+              style={{
+                background: 'transparent',
+                border: 'none',
+                color: '#94a3b8',
+                cursor: 'pointer',
+                fontSize: 16,
+                lineHeight: 1,
+              }}
+            >
+              ×
+            </button>
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+export default Toaster

--- a/frontend/src/platform/bridge.ts
+++ b/frontend/src/platform/bridge.ts
@@ -1,0 +1,202 @@
+// The FuzeFront platform bridge.
+//
+// The host installs a single, versioned API object on `window.__FUZEFRONT__`.
+// Runtime-loaded microfrontends (which share nothing with the host at build
+// time) call this object through the SDK to use shared services: live platform
+// context, the toaster, and the global menu. Because it's a plain object on
+// `window`, it works across the Module Federation boundary regardless of how
+// React instances are bundled.
+
+export type ToastLevel = 'info' | 'success' | 'warning' | 'error'
+
+export interface ToastInput {
+  message: string
+  title?: string
+  level?: ToastLevel
+  durationMs?: number
+  appId?: string
+}
+
+export interface Toast {
+  id: string
+  message: string
+  title?: string
+  level: ToastLevel
+  durationMs: number
+  appId?: string
+  createdAt: number
+}
+
+export interface PlatformSnapshot {
+  user: { id: string; email: string; roles: string[] } | null
+  apps: Array<{ id: string; name: string }>
+  activeApp: { id: string; name: string } | null
+  isPlatformMode: boolean
+}
+
+export interface BridgeMenuItem {
+  id: string
+  label: string
+  icon?: string
+  route?: string
+  order?: number
+}
+
+export interface FuzeFrontBridge {
+  /** Contract version — apps can feature-detect. */
+  version: number
+  getContext(): PlatformSnapshot
+  /** Subscribe to live context changes. Returns an unsubscribe fn. */
+  subscribe(listener: (ctx: PlatformSnapshot) => void): () => void
+  /** Show a toast. Returns the toast id. */
+  notify(toast: ToastInput): string
+  dismiss(id: string): void
+  /** Subscribe to the toast list (used by the host's Toaster). */
+  subscribeToasts(listener: (toasts: Toast[]) => void): () => void
+  menu: {
+    add(appId: string, items: BridgeMenuItem[]): void
+    remove(appId: string): void
+  }
+  socket: BridgeSocket
+}
+
+export interface BridgeSocket {
+  on(event: string, handler: (payload: any) => void): void
+  off(event: string, handler: (payload: any) => void): void
+  emit(event: string, payload: any): void
+  isConnected(): boolean
+}
+
+const CONTRACT_VERSION = 1
+
+function newId(prefix: string): string {
+  try {
+    return `${prefix}_${crypto.randomUUID()}`
+  } catch {
+    return `${prefix}_${Date.now()}_${Math.floor(Math.random() * 1e6)}`
+  }
+}
+
+export interface BridgeHandlers {
+  onMenuAdd: (appId: string, items: BridgeMenuItem[]) => void
+  onMenuRemove: (appId: string) => void
+  socket: BridgeSocket
+}
+
+class PlatformBridge implements FuzeFrontBridge {
+  version = CONTRACT_VERSION
+  private ctx: PlatformSnapshot = {
+    user: null,
+    apps: [],
+    activeApp: null,
+    isPlatformMode: true,
+  }
+  private ctxListeners = new Set<(ctx: PlatformSnapshot) => void>()
+  private toasts: Toast[] = []
+  private toastListeners = new Set<(toasts: Toast[]) => void>()
+  private timers = new Map<string, ReturnType<typeof setTimeout>>()
+  private handlers: BridgeHandlers = {
+    onMenuAdd: () => {},
+    onMenuRemove: () => {},
+    socket: {
+      on: () => {},
+      off: () => {},
+      emit: () => {},
+      isConnected: () => false,
+    },
+  }
+
+  setHandlers(handlers: BridgeHandlers) {
+    this.handlers = handlers
+  }
+
+  /** Host pushes context updates here when its state changes. */
+  setContext(ctx: PlatformSnapshot) {
+    this.ctx = ctx
+    this.ctxListeners.forEach(l => l(ctx))
+  }
+
+  getContext() {
+    return this.ctx
+  }
+
+  subscribe(listener: (ctx: PlatformSnapshot) => void) {
+    this.ctxListeners.add(listener)
+    listener(this.ctx)
+    return () => this.ctxListeners.delete(listener)
+  }
+
+  notify(input: ToastInput): string {
+    const toast: Toast = {
+      id: newId('toast'),
+      message: input.message,
+      title: input.title,
+      level: input.level || 'info',
+      durationMs: input.durationMs ?? 5000,
+      appId: input.appId,
+      createdAt: Date.now(),
+    }
+    this.toasts = [...this.toasts, toast]
+    this.emitToasts()
+    if (toast.durationMs > 0) {
+      this.timers.set(
+        toast.id,
+        setTimeout(() => this.dismiss(toast.id), toast.durationMs)
+      )
+    }
+    return toast.id
+  }
+
+  dismiss(id: string) {
+    const timer = this.timers.get(id)
+    if (timer) {
+      clearTimeout(timer)
+      this.timers.delete(id)
+    }
+    this.toasts = this.toasts.filter(t => t.id !== id)
+    this.emitToasts()
+  }
+
+  subscribeToasts(listener: (toasts: Toast[]) => void) {
+    this.toastListeners.add(listener)
+    listener(this.toasts)
+    return () => this.toastListeners.delete(listener)
+  }
+
+  private emitToasts() {
+    this.toastListeners.forEach(l => l(this.toasts))
+  }
+
+  menu = {
+    add: (appId: string, items: BridgeMenuItem[]) =>
+      this.handlers.onMenuAdd(appId, items),
+    remove: (appId: string) => this.handlers.onMenuRemove(appId),
+  }
+
+  socket: BridgeSocket = {
+    on: (event, handler) => this.handlers.socket.on(event, handler),
+    off: (event, handler) => this.handlers.socket.off(event, handler),
+    emit: (event, payload) => this.handlers.socket.emit(event, payload),
+    isConnected: () => this.handlers.socket.isConnected(),
+  }
+}
+
+// Module singleton — created once per host page load.
+export const bridge = new PlatformBridge()
+
+declare global {
+  interface Window {
+    __FUZEFRONT__?: FuzeFrontBridge
+    __FRONTFUSE_PLATFORM__?: boolean
+  }
+}
+
+/** Install the bridge on window so federated remotes can find it. */
+export function installBridge(handlers: BridgeHandlers): PlatformBridge {
+  bridge.setHandlers(handlers)
+  if (typeof window !== 'undefined') {
+    window.__FUZEFRONT__ = bridge
+    window.__FRONTFUSE_PLATFORM__ = true
+  }
+  return bridge
+}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -210,6 +210,14 @@ export const authAPI = {
   // Local authentication
   async login(credentials: LoginCredentials): Promise<LoginResponse> {
     const response = await api.post<LoginResponse>('/auth/login', credentials)
+    // Persist the token so it survives the post-login page reload and is sent
+    // on subsequent requests by the axios interceptor.
+    if (response.data?.token) {
+      localStorage.setItem('authToken', response.data.token)
+    }
+    if (response.data?.sessionId) {
+      localStorage.setItem('sessionId', response.data.sessionId)
+    }
     return response.data
   },
 
@@ -219,10 +227,10 @@ export const authAPI = {
     window.location.href = `${API_URL}/auth/oidc/login`
   },
 
-  // Get current user
+  // Get current user (the backend wraps the payload as { user })
   async getCurrentUser(): Promise<User> {
-    const response = await api.get<User>('/auth/user')
-    return response.data
+    const response = await api.get<{ user: User }>('/auth/user')
+    return response.data.user
   },
 
   // Logout

--- a/frontend/src/services/websocket.ts
+++ b/frontend/src/services/websocket.ts
@@ -72,6 +72,23 @@ class WebSocketService {
   isConnected(): boolean {
     return this.socket?.connected || false
   }
+
+  // Raw server pub/sub used by the platform bridge's socket bus so that
+  // runtime-loaded apps can subscribe to / emit platform events over the
+  // host's single socket connection.
+  onServer(event: string, callback: (payload: any) => void) {
+    const socket = this.connect()
+    socket.on(event, callback as any)
+  }
+
+  offServer(event: string, callback: (payload: any) => void) {
+    this.socket?.off(event, callback as any)
+  }
+
+  emitServer(event: string, payload: any) {
+    const socket = this.connect()
+    socket.emit(event, payload)
+  }
 }
 
 export const websocketService = new WebSocketService()

--- a/sdk/src/bridge.ts
+++ b/sdk/src/bridge.ts
@@ -1,0 +1,75 @@
+// The FuzeFront platform bridge contract.
+//
+// The host installs a single, versioned API object on `window.__FUZEFRONT__`.
+// This is the one thing a runtime-loaded microfrontend needs to know about the
+// host — it shares nothing else at build time. The hooks in this SDK are thin,
+// typed wrappers over this object.
+
+export type ToastLevel = 'info' | 'success' | 'warning' | 'error'
+
+export interface ToastInput {
+  message: string
+  title?: string
+  level?: ToastLevel
+  durationMs?: number
+  appId?: string
+}
+
+export interface Toast extends Required<Omit<ToastInput, 'title' | 'appId'>> {
+  id: string
+  title?: string
+  appId?: string
+  createdAt: number
+}
+
+export interface PlatformSnapshot {
+  user: { id: string; email: string; roles: string[] } | null
+  apps: Array<{ id: string; name: string }>
+  activeApp: { id: string; name: string } | null
+  isPlatformMode: boolean
+}
+
+export interface BridgeMenuItem {
+  id: string
+  label: string
+  icon?: string
+  route?: string
+  order?: number
+}
+
+export interface BridgeSocket {
+  on(event: string, handler: (payload: any) => void): void
+  off(event: string, handler: (payload: any) => void): void
+  emit(event: string, payload: any): void
+  isConnected(): boolean
+}
+
+export interface FuzeFrontBridge {
+  version: number
+  getContext(): PlatformSnapshot
+  subscribe(listener: (ctx: PlatformSnapshot) => void): () => void
+  notify(toast: ToastInput): string
+  dismiss(id: string): void
+  menu: {
+    add(appId: string, items: BridgeMenuItem[]): void
+    remove(appId: string): void
+  }
+  socket: BridgeSocket
+}
+
+declare global {
+  interface Window {
+    __FUZEFRONT__?: FuzeFrontBridge
+    __FRONTFUSE_PLATFORM__?: boolean
+  }
+}
+
+/** Returns the host-provided bridge, or null when running standalone. */
+export function getBridge(): FuzeFrontBridge | null {
+  if (typeof window === 'undefined') return null
+  return window.__FUZEFRONT__ ?? null
+}
+
+export function isInPlatform(): boolean {
+  return getBridge() != null
+}

--- a/sdk/src/hooks/usePlatform.ts
+++ b/sdk/src/hooks/usePlatform.ts
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react'
+import { getBridge } from '../bridge'
+import type { PlatformSnapshot } from '../bridge'
+
+const STANDALONE: PlatformSnapshot = {
+  user: null,
+  apps: [],
+  activeApp: null,
+  isPlatformMode: false,
+}
+
+/**
+ * Live platform context from the host (user, apps, active app), delivered over
+ * the bridge. Re-renders when the host pushes updates. Returns a standalone
+ * snapshot when not running inside the platform.
+ */
+export function usePlatform(): PlatformSnapshot {
+  const [snapshot, setSnapshot] = useState<PlatformSnapshot>(
+    () => getBridge()?.getContext() ?? STANDALONE
+  )
+
+  useEffect(() => {
+    const bridge = getBridge()
+    if (!bridge) return
+    return bridge.subscribe(setSnapshot)
+  }, [])
+
+  return snapshot
+}

--- a/sdk/src/hooks/useToast.ts
+++ b/sdk/src/hooks/useToast.ts
@@ -1,0 +1,16 @@
+import { useCallback } from 'react'
+import { getBridge } from '../bridge'
+import type { ToastInput } from '../bridge'
+
+/** Show toasts through the host's shared toaster (window.__FUZEFRONT__). */
+export function useToast() {
+  const notify = useCallback(
+    (toast: ToastInput): string | undefined => getBridge()?.notify(toast),
+    []
+  )
+  const dismiss = useCallback(
+    (id: string): void => getBridge()?.dismiss(id),
+    []
+  )
+  return { notify, dismiss }
+}

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -20,6 +20,20 @@ export { useSession } from './hooks/useSession'
 export { useGlobalMenu } from './hooks/useGlobalMenu'
 export { useSocketBus } from './hooks/useSocketBus'
 
+// Platform bridge — the window.__FUZEFRONT__ contract + bridge-native hooks.
+export { getBridge, isInPlatform } from './bridge'
+export type {
+  FuzeFrontBridge,
+  BridgeSocket,
+  BridgeMenuItem,
+  Toast,
+  ToastInput,
+  ToastLevel,
+  PlatformSnapshot,
+} from './bridge'
+export { useToast } from './hooks/useToast'
+export { usePlatform } from './hooks/usePlatform'
+
 // Module Federation Loader
 export {
   loadApp,
@@ -35,6 +49,9 @@ import { useSession } from './hooks/useSession'
 import { useGlobalMenu } from './hooks/useGlobalMenu'
 import { useSocketBus } from './hooks/useSocketBus'
 import { loadApp, clearModuleCache } from './loader/moduleFederation'
+import { getBridge } from './bridge'
+import { useToast } from './hooks/useToast'
+import { usePlatform } from './hooks/usePlatform'
 
 // Default export for convenience
 export default {
@@ -43,6 +60,9 @@ export default {
   useSession,
   useGlobalMenu,
   useSocketBus,
+  useToast,
+  usePlatform,
+  getBridge,
   loadApp,
   clearModuleCache,
 }


### PR DESCRIPTION
Completes the SDK shared-services layer using a **window-bridge** so runtime-loaded microfrontends can use host services with zero build-time coupling — and fixes browser sign-in.

## Login fix
Local login never persisted the JWT to `localStorage`, so the post-login reload bounced back to the login screen. Now the token is stored on login and `getCurrentUser` unwraps the `{ user }` envelope.

## SDK shared services (window.__FUZEFRONT__)
The host installs a versioned bridge object; the SDK + apps consume it. Replaces the old one-way `__FRONTFUSE_CONTEXT__` data snapshot with a real API across the MF boundary.

| Service | Host | SDK |
|---|---|---|
| **Live context** (user/apps/activeApp) | fed from app state, subscribable | `usePlatform()` |
| **Toaster** | `<Toaster/>` region | `useToast()` |
| **Menu** | `menu.add/remove` → reducer → SidePanel renders app items | `getBridge().menu` |
| **Sockets** | bus over the host's single connection | `getBridge().socket` |

`getBridge()` / `isInPlatform()` expose the contract; types are exported for app authors.

## Example
**FuzeClock** (`clock-app/`, `deploy/examples/clock-app.yaml`): an independently containerized federated remote that self-registers, reads live host context, and pushes toasts through the bridge — proving the model end to end.

## Verified
Login endpoints + token persistence shipped; bridge + toaster present in host bundle; clock-app consumes `__FUZEFRONT__`; remote serves and is registered.

## Follow-ups (not in this PR)
Publish `@izzywdev/fuzefront-sdk-react` so apps `npm install` it instead of vendoring; migrate the remaining provider-based SDK hooks fully onto the bridge; notifications backend behind `notify()` for persistence/fan-out.