### PR TITLE
ci/dev: Skaffold local loop, Playwright sign-in PR check, gated SDK publish

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,117 @@
+name: E2E (sign-in)
+
+# PR check: brings up Postgres + backend + frontend, creates an admin user,
+# and runs the Playwright sign-in flow (frontend/tests/auth-simple.spec.ts).
+on:
+  pull_request:
+    branches: [master]
+  push:
+    branches: [master]
+
+jobs:
+  signin:
+    name: Playwright sign-in flow
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: fuzeinfra
+          POSTGRES_PASSWORD: fuzeinfra_secure_password
+        options: >-
+          --health-cmd "pg_isready -U fuzeinfra"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
+    env:
+      # Backend -> Postgres (connects as the superuser, creates its own DB)
+      NODE_ENV: production
+      USE_POSTGRES: 'true'
+      DB_HOST: localhost
+      DB_PORT: '5432'
+      DB_NAME: fuzefront_platform
+      DB_USER: fuzeinfra
+      DB_PASSWORD: fuzeinfra_secure_password
+      JWT_SECRET: ci-e2e-secret
+      SESSION_SECRET: ci-e2e-session
+      PERMIT_API_KEY: ci-noop
+      PERMIT_PDP_URL: http://localhost:7766
+      PORT: '3001'
+      FRONTEND_URL: http://localhost:4173
+      # Browser-facing API base (cross-origin to the previewed frontend; CORS
+      # is allowed via FRONTEND_URL above).
+      VITE_API_URL: http://localhost:3001
+      BASE_URL: http://localhost:4173
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+
+      # ---- Backend: build, start, migrate, wait ----
+      - name: Build & start backend
+        working-directory: backend
+        run: |
+          npm ci
+          npm run build
+          node dist/index.js > /tmp/backend.log 2>&1 &
+          echo "Waiting for backend /health..."
+          for i in $(seq 1 60); do
+            if curl -fsS http://localhost:3001/health >/dev/null 2>&1; then echo "backend up"; exit 0; fi
+            sleep 2
+          done
+          echo "backend failed to start"; cat /tmp/backend.log; exit 1
+
+      - name: Create admin user
+        working-directory: backend
+        run: |
+          node -e '
+            const bcrypt = require("bcrypt");
+            const knex = require("knex")({
+              client: "pg",
+              connection: { host: process.env.DB_HOST, port: +process.env.DB_PORT,
+                database: process.env.DB_NAME, user: process.env.DB_USER, password: process.env.DB_PASSWORD },
+            });
+            (async () => {
+              const password_hash = await bcrypt.hash("admin123", 10);
+              await knex("users").insert({ email: "admin@fuzefront.dev", password_hash,
+                first_name: "Admin", last_name: "User", roles: JSON.stringify(["admin","user"]) })
+                .onConflict("email").merge({ password_hash });
+              console.log("admin user ready");
+              await knex.destroy();
+            })().catch(e => { console.error(e); process.exit(1); });
+          '
+
+      # ---- Frontend: build & preview ----
+      - name: Build & preview frontend
+        working-directory: frontend
+        run: |
+          npm ci
+          npm run build
+          npx vite preview --port 4173 --host 127.0.0.1 > /tmp/frontend.log 2>&1 &
+          for i in $(seq 1 30); do
+            if curl -fsS http://localhost:4173 >/dev/null 2>&1; then echo "frontend up"; exit 0; fi
+            sleep 2
+          done
+          echo "frontend failed to start"; cat /tmp/frontend.log; exit 1
+
+      # ---- Playwright sign-in flow ----
+      - name: Run Playwright sign-in test
+        working-directory: frontend
+        run: |
+          npx playwright install --with-deps chromium
+          npx playwright test tests/auth-simple.spec.ts
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: frontend/playwright-report/
+          retention-days: 7

--- a/.github/workflows/sdk-publish.yml
+++ b/.github/workflows/sdk-publish.yml
@@ -1,0 +1,58 @@
+name: Publish SDK
+
+# Publishes @izzywdev/fuzefront-sdk-react to npm when a PR that touched the SDK
+# is merged to master. The `paths` filter is GitHub's native "only if the SDK
+# was modified" gate.
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'sdk/**'
+
+# Avoid overlapping publishes if several SDK PRs merge in quick succession.
+concurrency:
+  group: sdk-publish
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Build & publish SDK
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # to push the version bump commit
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install & build
+        working-directory: sdk
+        run: |
+          npm ci || npm install
+          npm run build
+
+      - name: Bump patch version
+        id: version
+        working-directory: sdk
+        run: |
+          NEW_VERSION=$(npm version patch --no-git-tag-version)
+          echo "version=${NEW_VERSION#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Publish to npm
+        working-directory: sdk
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Commit version bump
+        run: |
+          git config user.email "action@github.com"
+          git config user.name "GitHub Action"
+          git add sdk/package.json sdk/package-lock.json 2>/dev/null || git add sdk/package.json
+          git commit -m "chore(sdk): publish v${{ steps.version.outputs.version }} [skip ci]" || exit 0
+          git push

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: process.env.BASE_URL || 'http://fuzefront.dev.local:8008',
+    baseURL: process.env.BASE_URL || 'http://fuzefront.dev.local',
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1,0 +1,57 @@
+# Skaffold — local in-cluster dev loop for FuzeFront on kind.
+#
+#   skaffold run     # one-shot: build images -> load into kind -> deploy
+#   skaffold dev     # watch sources, rebuild + reload + redeploy on change
+#   skaffold verify  # run the Playwright sign-in check against the deployment
+#
+# Prereqs: the kind cluster "fuzeinfra" exists with FuzeInfra (Postgres/Redis)
+# deployed and ingress-nginx installed (see FuzeInfra: make kind-up). Skaffold
+# auto-loads images into kind (build.local.push=false + a kind kube-context), so
+# no registry is needed.
+apiVersion: skaffold/v4beta11
+kind: Config
+metadata:
+  name: fuzefront
+
+build:
+  local:
+    push: false # kind: load images into nodes instead of pushing to a registry
+    useBuildkit: true
+  artifacts:
+    - image: fuzefront/backend
+      context: backend
+    - image: fuzefront/frontend
+      context: frontend
+      docker:
+        buildArgs:
+          VITE_API_URL: http://fuzefront.dev.local
+    - image: fuzefront/clock-app
+      context: clock-app
+
+manifests:
+  helm:
+    releases:
+      - name: fuzefront
+        chartPath: deploy/helm/fuzefront
+        namespace: fuzefront
+        createNamespace: true
+        valuesFiles:
+          - deploy/helm/fuzefront/values-local.yaml
+        # Inject the freshly-built image refs into the chart's image values.
+        setValueTemplates:
+          backend.image.repository: '{{.IMAGE_REPO_fuzefront_backend}}'
+          backend.image.tag: '{{.IMAGE_TAG_fuzefront_backend}}'
+          frontend.image.repository: '{{.IMAGE_REPO_fuzefront_frontend}}'
+          frontend.image.tag: '{{.IMAGE_TAG_fuzefront_frontend}}'
+  # clock-app example: image ref is substituted automatically from the artifact.
+  rawYaml:
+    - deploy/examples/clock-app.yaml
+
+deploy:
+  kubeContext: kind-fuzeinfra
+  helm: {}
+
+# After `skaffold run`/`dev`, run the Playwright sign-in check against the
+# deployment with:  cd frontend && npm run test:e2e
+# (BASE_URL defaults to http://fuzefront.dev.local). The same spec runs in CI
+# on every PR — see .github/workflows/e2e.yml.


### PR DESCRIPTION
Automates the local in-cluster dev loop and adds the requested CI gates.

## Skaffold (local builds → kind)
`skaffold.yaml`: `skaffold run`/`skaffold dev` builds backend + frontend + clock-app locally, auto-loads them into the `fuzeinfra` kind cluster (no registry), and deploys the Helm chart + clock-app manifest. This is the local "redeploy on change" loop with local builds.

## Playwright sign-in — PR check + local
`.github/workflows/e2e.yml` runs on PRs to master: spins up Postgres + backend + frontend, creates the admin user, and runs the existing `auth-simple.spec.ts` sign-in flow (asserts token persisted + app shell renders — i.e. it guards the login bug we just fixed). Locally: `cd frontend && npm run test:e2e` after `skaffold run` (baseURL fixed to the kind ingress).

## SDK publish on merge, if modified
`.github/workflows/sdk-publish.yml`: publishes `@izzywdev/fuzefront-sdk-react` on merge to master, gated by `paths: ['sdk/**']` (GitHub-native "only if the SDK changed"). Requires the `NPM_TOKEN` secret (rotated earlier — needs re-adding).

## FuzeInfra
Submodule bumped to pick up the **Argo CD GitOps layer** (`argocd/`). No cluster change — just the git pointer; PVCs untouched.

## Follow-ups (not in this PR)
- **Cloud CD** for the platform (the existing `deploy.yml` targets the AWS *website*, not the platform). When you pick AWS vs Contabo, wire image build/push + an Argo Application to sync the FuzeFront chart to the cloud cluster.
- `ci.yml` triggers on `main`/`develop` but the default branch is `master`, so its lint/test/build + its own `publish-sdk` are dormant — reconcile branch names (the new workflows already target `master`).