### PR TITLE
feat: Contabo cloud deployment (k3s + Argo CD GitOps)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,51 +195,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs
 
-  docker-build:
-    name: Build Docker Images
-    runs-on: ubuntu-latest
-    needs: build
-    if: github.ref == 'refs/heads/master' || github.event_name == 'release'
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Download build artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: build-artifacts
-
-      - name: Build and push backend image
-        uses: docker/build-push-action@v5
-        with:
-          context: ./backend
-          push: true
-          tags: |
-            fuzefront/backend:latest
-            fuzefront/backend:${{ github.sha }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      - name: Build and push frontend image
-        uses: docker/build-push-action@v5
-        with:
-          context: ./frontend
-          push: true
-          tags: |
-            fuzefront/frontend:latest
-            fuzefront/frontend:${{ github.sha }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+  # Platform image build/push moved to release.yml (GHCR + GitOps tag bump).
 
   notify:
     name: Notify Team

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,75 @@
+name: Release (images + GitOps bump)
+
+# On merge to master that touches the platform: build backend/frontend, push to
+# GHCR tagged with the commit SHA, then bump the tags in values-prod.yaml and
+# commit. Argo CD sees the git change and rolls out the new images.
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'backend/**'
+      - 'frontend/**'
+      - 'deploy/helm/fuzefront/**'
+      - '.github/workflows/release.yml'
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  build-and-bump:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # commit the tag bump
+      packages: write # push to GHCR
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image tag
+        id: tag
+        run: echo "sha=${GITHUB_SHA::12}" >> "$GITHUB_OUTPUT"
+
+      - name: Build & push backend
+        uses: docker/build-push-action@v5
+        with:
+          context: ./backend
+          push: true
+          tags: |
+            ghcr.io/izzywdev/fuzefront-backend:${{ steps.tag.outputs.sha }}
+            ghcr.io/izzywdev/fuzefront-backend:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build & push frontend
+        uses: docker/build-push-action@v5
+        with:
+          context: ./frontend
+          push: true
+          build-args: |
+            VITE_API_URL=https://app.fuzefront.com
+          tags: |
+            ghcr.io/izzywdev/fuzefront-frontend:${{ steps.tag.outputs.sha }}
+            ghcr.io/izzywdev/fuzefront-frontend:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Bump image tags in values-prod.yaml (GitOps)
+        run: |
+          SHA="${{ steps.tag.outputs.sha }}"
+          sed -i -E "s/^(\s*tag:).*/\1 ${SHA}/" deploy/helm/fuzefront/values-prod.yaml
+          git config user.email "action@github.com"
+          git config user.name "GitHub Action"
+          git add deploy/helm/fuzefront/values-prod.yaml
+          git commit -m "release: fuzefront images ${SHA} [skip ci]" || exit 0
+          git push

--- a/deploy/argocd/app-of-apps.yaml
+++ b/deploy/argocd/app-of-apps.yaml
@@ -1,0 +1,23 @@
+# Root "app of apps": apply this once after bootstrap and Argo manages the rest.
+#   kubectl apply -f deploy/argocd/project.yaml
+#   kubectl apply -f deploy/argocd/app-of-apps.yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: fuzefront-apps
+  namespace: argocd
+spec:
+  project: fuzefront
+  source:
+    repoURL: https://github.com/izzywdev/FuzeFront.git
+    targetRevision: master
+    path: deploy/argocd/applications
+    directory:
+      recurse: true
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: argocd
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/deploy/argocd/applications/fuzefront.yaml
+++ b/deploy/argocd/applications/fuzefront.yaml
@@ -1,0 +1,24 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: fuzefront
+  namespace: argocd
+spec:
+  project: fuzefront
+  source:
+    repoURL: https://github.com/izzywdev/FuzeFront.git
+    targetRevision: master
+    path: deploy/helm/fuzefront
+    helm:
+      valueFiles:
+        - values-prod.yaml
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: fuzefront
+  syncPolicy:
+    automated:
+      prune: true # backend/frontend are stateless — safe to prune
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - PrunePropagationPolicy=foreground

--- a/deploy/argocd/applications/fuzeinfra.yaml
+++ b/deploy/argocd/applications/fuzeinfra.yaml
@@ -1,0 +1,52 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: fuzeinfra
+  namespace: argocd
+spec:
+  project: fuzefront
+  source:
+    repoURL: https://github.com/izzywdev/FuzeFront.git
+    targetRevision: master
+    # Chart lives in the FuzeInfra git submodule (Argo inits submodules by default).
+    path: FuzeInfra/helm/fuzeinfra
+    helm:
+      # Contabo prod overlay: Postgres + Redis + monitoring only (no Mongo/Neo4j/
+      # ES/Kafka/RabbitMQ/Airflow). k3s local-path storage; public domain.
+      values: |
+        global:
+          storageClass: local-path
+          domain: fuzefront.com
+        postgres: { enabled: true }
+        redis: { enabled: true }
+        prometheus: { enabled: true }
+        grafana: { enabled: true }
+        alertmanager: { enabled: true }
+        loki: { enabled: true }
+        promtail: { enabled: true }
+        nodeExporter: { enabled: true }
+        mongodb: { enabled: false }
+        mongoExpress: { enabled: false }
+        neo4j: { enabled: false }
+        elasticsearch: { enabled: false }
+        chromadb: { enabled: false }
+        kafka: { enabled: false }
+        kafkaUi: { enabled: false }
+        rabbitmq: { enabled: false }
+        airflow: { enabled: false }
+        dnsmasq: { enabled: false }
+        cloudflareTunnel: { enabled: false }
+        ingress:
+          enabled: true
+          className: nginx
+          tls:
+            enabled: false
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: fuzeinfra
+  syncPolicy:
+    automated:
+      prune: false # stateful (Postgres/Redis PVCs) — never auto-prune data
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/deploy/argocd/project.yaml
+++ b/deploy/argocd/project.yaml
@@ -1,0 +1,24 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: fuzefront
+  namespace: argocd
+spec:
+  description: FuzeFront platform + shared infrastructure
+  sourceRepos:
+    - https://github.com/izzywdev/FuzeFront.git
+  destinations:
+    - server: https://kubernetes.default.svc
+      namespace: fuzefront
+    - server: https://kubernetes.default.svc
+      namespace: fuzeinfra
+    - server: https://kubernetes.default.svc
+      namespace: argocd
+  # Self-managed single-tenant cluster: allow the cluster-scoped resources the
+  # charts + add-ons need (namespaces, ingressclasses, cert-manager CRDs, etc.).
+  clusterResourceWhitelist:
+    - group: '*'
+      kind: '*'
+  namespaceResourceWhitelist:
+    - group: '*'
+      kind: '*'

--- a/deploy/backup/postgres-backup-cronjob.yaml
+++ b/deploy/backup/postgres-backup-cronjob.yaml
@@ -1,0 +1,60 @@
+# Nightly pg_dump of the FuzeFront DB to Contabo Object Storage (S3-compatible).
+# initContainer dumps (postgres image), main container uploads (aws-cli).
+# Requires sealed secrets: fuzeinfra-secrets (POSTGRES_USER/PASSWORD) and
+# backup-s3 (AWS_ACCESS_KEY_ID/SECRET, S3_ENDPOINT, S3_BUCKET).
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: postgres-backup
+  namespace: fuzeinfra
+spec:
+  schedule: '0 2 * * *' # 02:00 daily
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      template:
+        spec:
+          restartPolicy: OnFailure
+          volumes:
+            - name: dump
+              emptyDir: {}
+          initContainers:
+            - name: dump
+              image: postgres:15
+              command: ['/bin/sh', '-c']
+              args:
+                - >
+                  set -e;
+                  TS=$(date +%Y%m%d-%H%M%S);
+                  PGPASSWORD="$POSTGRES_PASSWORD" pg_dump -h postgres -U "$POSTGRES_USER" fuzefront_platform
+                    | gzip > /dump/fuzefront_platform-$TS.sql.gz;
+                  ls -lh /dump
+              env:
+                - name: POSTGRES_USER
+                  valueFrom: { secretKeyRef: { name: fuzeinfra-secrets, key: POSTGRES_USER } }
+                - name: POSTGRES_PASSWORD
+                  valueFrom: { secretKeyRef: { name: fuzeinfra-secrets, key: POSTGRES_PASSWORD } }
+              volumeMounts:
+                - { name: dump, mountPath: /dump }
+          containers:
+            - name: upload
+              image: amazon/aws-cli:2.17.0
+              command: ['/bin/sh', '-c']
+              args:
+                - >
+                  set -e;
+                  aws --endpoint-url "$S3_ENDPOINT" s3 cp /dump/ "s3://$S3_BUCKET/postgres/" --recursive
+              env:
+                - name: AWS_ACCESS_KEY_ID
+                  valueFrom: { secretKeyRef: { name: backup-s3, key: AWS_ACCESS_KEY_ID } }
+                - name: AWS_SECRET_ACCESS_KEY
+                  valueFrom: { secretKeyRef: { name: backup-s3, key: AWS_SECRET_ACCESS_KEY } }
+                - name: S3_ENDPOINT
+                  valueFrom: { secretKeyRef: { name: backup-s3, key: S3_ENDPOINT } }
+                - name: S3_BUCKET
+                  valueFrom: { secretKeyRef: { name: backup-s3, key: S3_BUCKET } }
+              volumeMounts:
+                - { name: dump, mountPath: /dump }

--- a/deploy/contabo/README.md
+++ b/deploy/contabo/README.md
@@ -1,0 +1,84 @@
+# FuzeFront on Contabo (k3s + Argo CD)
+
+End-to-end bring-up for the platform on a single Contabo VPS. See the design in
+[`docs/deployment/CONTABO_DEPLOYMENT.md`](../../docs/deployment/CONTABO_DEPLOYMENT.md).
+
+## Prerequisites
+- Contabo VPS (Ubuntu 22.04, ~8 vCPU / 30 GB RAM), root SSH.
+- Domain `fuzefront.com` on **Cloudflare**.
+- A GHCR pull token (GitHub PAT with `read:packages`).
+- `kubeseal` installed on your laptop (to seal secrets).
+
+## 1. DNS (Cloudflare)
+Point these A records at the VPS public IP (DNS-only / grey-cloud is simplest
+for HTTP-01 TLS; you can enable the proxy later):
+```
+app.fuzefront.com      A  <VPS_IP>
+argocd.fuzefront.com   A  <VPS_IP>
+grafana.fuzefront.com  A  <VPS_IP>
+```
+
+## 2. Bootstrap the cluster (on the VPS)
+```bash
+# clone the repo (with submodules) on the VPS, then:
+sudo bash deploy/contabo/bootstrap.sh      # edit cluster-issuer.yaml email first
+export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
+```
+Installs k3s (no Traefik) + ingress-nginx + cert-manager (+ letsencrypt-prod) +
+sealed-secrets + Argo CD.
+
+## 3. Seal the secrets (laptop, against the cluster's key)
+```bash
+# Private GHCR pull secret
+kubectl create secret docker-registry ghcr-pull -n fuzefront \
+  --docker-server=ghcr.io --docker-username=izzywdev --docker-password=$GHCR_TOKEN \
+  --dry-run=client -o yaml | kubeseal -o yaml > deploy/contabo/sealed/ghcr-pull.yaml
+
+# FuzeFront app secret (JWT/session/db/permit)
+kubectl create secret generic fuzefront-secrets -n fuzefront \
+  --from-literal=JWT_SECRET=... --from-literal=SESSION_SECRET=... \
+  --from-literal=DB_PASSWORD=... --from-literal=PERMIT_API_KEY=... \
+  --dry-run=client -o yaml | kubeseal -o yaml > deploy/contabo/sealed/fuzefront-secrets.yaml
+
+# FuzeInfra Postgres creds (consumed by the chart + the backup job)
+kubectl create secret generic fuzeinfra-secrets -n fuzeinfra \
+  --from-literal=POSTGRES_USER=... --from-literal=POSTGRES_PASSWORD=... ... \
+  --dry-run=client -o yaml | kubeseal -o yaml > deploy/contabo/sealed/fuzeinfra-secrets.yaml
+
+# Backup target (Contabo Object Storage, S3-compatible)
+kubectl create secret generic backup-s3 -n fuzeinfra \
+  --from-literal=AWS_ACCESS_KEY_ID=... --from-literal=AWS_SECRET_ACCESS_KEY=... \
+  --from-literal=S3_ENDPOINT=https://eu2.contabostorage.com --from-literal=S3_BUCKET=fuzefront-backups \
+  --dry-run=client -o yaml | kubeseal -o yaml > deploy/contabo/sealed/backup-s3.yaml
+```
+Commit the `deploy/contabo/sealed/*.yaml` (encrypted — safe in git) and add a
+SealedSecret Argo Application (or apply them directly). Plaintext never leaves
+your laptop.
+
+> Note: the FuzeInfra chart-created `Secret` currently supplies Postgres creds.
+> Either set `credentials.existingSecret: fuzeinfra-secrets` in the fuzeinfra
+> Argo values to use your sealed secret, or seal to match the chart's keys.
+
+## 4. Hand the cluster to GitOps
+```bash
+kubectl apply -f deploy/argocd/project.yaml
+kubectl apply -f deploy/argocd/app-of-apps.yaml
+kubectl apply -f deploy/backup/postgres-backup-cronjob.yaml   # once secrets exist
+```
+Argo creates the `fuzeinfra` (Postgres + Redis + monitoring) and `fuzefront`
+Applications and syncs them. cert-manager issues TLS for `app.fuzefront.com`.
+
+## 5. Verify
+```bash
+kubectl -n fuzefront get pods,ingress
+curl -fsS https://app.fuzefront.com/api/health
+# Argo UI: https://argocd.fuzefront.com  (initial admin pw:)
+kubectl -n argocd get secret argocd-initial-admin-secret -o jsonpath='{.data.password}' | base64 -d
+```
+
+## Day-2
+- **Releases:** merge to `master` → `release.yml` builds + pushes images to GHCR
+  and bumps the tag in `values-prod.yaml`; Argo rolls it out automatically.
+- **Data safety:** the `fuzeinfra` Application has `prune: false` so a sync never
+  deletes Postgres/Redis PVCs; nightly `pg_dump` ships to Contabo storage.
+- **AWS path** (`deploy.yml`) is left intact and switchable.

--- a/deploy/contabo/bootstrap.sh
+++ b/deploy/contabo/bootstrap.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Bootstrap a single Contabo VPS (Ubuntu 22.04) into a FuzeFront-ready cluster:
+# k3s (no Traefik) + ingress-nginx + cert-manager + sealed-secrets + Argo CD.
+# Run ON the VPS as root.  Idempotent enough to re-run.
+#
+# After this, seal your secrets and apply the Argo app-of-apps (see README.md).
+# =============================================================================
+set -euo pipefail
+
+INGRESS_NGINX_VER="controller-v1.11.2"
+CERT_MANAGER_VER="v1.15.3"
+SEALED_SECRETS_VER="v0.27.1"
+
+echo "==> Installing k3s (Traefik disabled; we use ingress-nginx)"
+# k3s ships ServiceLB (klipper), so a LoadBalancer Service binds the node IP —
+# ingress-nginx becomes reachable on the VPS public IP at :80/:443.
+curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="--disable traefik" sh -
+export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
+kubectl get nodes
+
+echo "==> ingress-nginx"
+kubectl apply -f "https://raw.githubusercontent.com/kubernetes/ingress-nginx/${INGRESS_NGINX_VER}/deploy/static/provider/cloud/deploy.yaml"
+kubectl -n ingress-nginx rollout status deploy/ingress-nginx-controller --timeout=180s
+
+echo "==> cert-manager"
+kubectl apply -f "https://github.com/cert-manager/cert-manager/releases/download/${CERT_MANAGER_VER}/cert-manager.yaml"
+kubectl -n cert-manager rollout status deploy/cert-manager-webhook --timeout=180s
+# Edit the email in cluster-issuer.yaml first.
+kubectl apply -f "$(dirname "$0")/cluster-issuer.yaml"
+
+echo "==> sealed-secrets controller"
+kubectl apply -f "https://github.com/bitnami-labs/sealed-secrets/releases/download/${SEALED_SECRETS_VER}/controller.yaml"
+
+echo "==> Argo CD"
+kubectl create namespace argocd --dry-run=client -o yaml | kubectl apply -f -
+kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
+kubectl -n argocd rollout status deploy/argocd-server --timeout=300s
+
+cat <<'EOF'
+
+==> Bootstrap complete. Next (see deploy/contabo/README.md):
+  1. Seal secrets: ghcr-pull, fuzefront-secrets, fuzeinfra-secrets, backup-s3
+     (kubeseal), then commit the SealedSecret manifests.
+  2. kubectl apply -f deploy/argocd/project.yaml
+     kubectl apply -f deploy/argocd/app-of-apps.yaml
+  3. Argo syncs fuzeinfra + fuzefront; cert-manager issues TLS for app.fuzefront.com.
+EOF

--- a/deploy/contabo/cluster-issuer.yaml
+++ b/deploy/contabo/cluster-issuer.yaml
@@ -1,0 +1,17 @@
+# Let's Encrypt production issuer (HTTP-01 via ingress-nginx).
+# Edit the email before applying. For a wildcard (*.apps.fuzefront.com) switch to
+# a DNS-01 solver with a Cloudflare API token instead.
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-prod
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: admin@fuzefront.com
+    privateKeySecretRef:
+      name: letsencrypt-prod-account-key
+    solvers:
+      - http01:
+          ingress:
+            class: nginx

--- a/deploy/helm/fuzefront/templates/backend.yaml
+++ b/deploy/helm/fuzefront/templates/backend.yaml
@@ -17,6 +17,10 @@ spec:
         app.kubernetes.io/part-of: fuzefront
         app.kubernetes.io/component: backend
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: backend
           image: "{{ .Values.backend.image.repository }}:{{ .Values.backend.image.tag }}"

--- a/deploy/helm/fuzefront/templates/frontend.yaml
+++ b/deploy/helm/fuzefront/templates/frontend.yaml
@@ -17,6 +17,10 @@ spec:
         app.kubernetes.io/part-of: fuzefront
         app.kubernetes.io/component: frontend
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: frontend
           image: "{{ .Values.frontend.image.repository }}:{{ .Values.frontend.image.tag }}"

--- a/deploy/helm/fuzefront/templates/ingress.yaml
+++ b/deploy/helm/fuzefront/templates/ingress.yaml
@@ -5,8 +5,18 @@ metadata:
   name: fuzefront
   labels:
     {{- include "fuzefront.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   ingressClassName: {{ .Values.ingress.className }}
+  {{- if .Values.ingress.tls.enabled }}
+  tls:
+    - hosts:
+        - {{ .Values.ingress.host | quote }}
+      secretName: {{ .Values.ingress.tls.secretName | default (printf "%s-tls" .Values.ingress.host) }}
+  {{- end }}
   rules:
     # Single host -> frontend. The frontend's nginx fans /api and /socket.io
     # out to the backend Service internally, mirroring the compose setup.

--- a/deploy/helm/fuzefront/values-prod.yaml
+++ b/deploy/helm/fuzefront/values-prod.yaml
@@ -1,0 +1,51 @@
+# =============================================================================
+# Production overlay (Contabo k3s), consumed by the Argo CD `fuzefront` Application.
+# Differs from local only by: GHCR images, public host + TLS, sealed secret.
+# =============================================================================
+global:
+  imagePullPolicy: IfNotPresent
+
+backend:
+  image:
+    repository: ghcr.io/izzywdev/fuzefront-backend
+    tag: latest # CI (release.yml) rewrites this to the git SHA on each merge
+  replicas: 2
+
+frontend:
+  image:
+    repository: ghcr.io/izzywdev/fuzefront-frontend
+    tag: latest
+  replicas: 2
+
+# Private GHCR pull secret (sealed; see deploy/contabo/README.md).
+imagePullSecrets:
+  - name: ghcr-pull
+
+fuzeinfra:
+  namespace: fuzeinfra
+  postgres:
+    host: postgres.fuzeinfra.svc.cluster.local
+    port: 5432
+  redis:
+    host: redis.fuzeinfra.svc.cluster.local
+    port: 6379
+
+database:
+  name: fuzefront_platform
+  # Bootstraps as the FuzeInfra superuser for now; harden to fuzefront_user later.
+  user: fuzeinfra
+
+# Secrets come from a SealedSecret (JWT_SECRET, SESSION_SECRET, DB_PASSWORD,
+# PERMIT_API_KEY) — never plaintext in git.
+secret:
+  existingSecret: fuzefront-secrets
+
+ingress:
+  enabled: true
+  className: nginx
+  host: app.fuzefront.com
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+  tls:
+    enabled: true
+    secretName: fuzefront-app-tls

--- a/deploy/helm/fuzefront/values.yaml
+++ b/deploy/helm/fuzefront/values.yaml
@@ -12,6 +12,9 @@ global:
   # `kind load docker-image` rather than trying to pull from a registry.
   imagePullPolicy: IfNotPresent
 
+# Image pull secrets for private registries (e.g. private GHCR). Sealed in prod.
+imagePullSecrets: []
+
 # Connection to FuzeInfra shared services (CoreDNS names, cross-namespace).
 fuzeinfra:
   namespace: fuzeinfra
@@ -72,3 +75,9 @@ ingress:
   enabled: true
   className: nginx
   host: fuzefront.dev.local
+  # Extra annotations (e.g. cert-manager.io/cluster-issuer for prod TLS).
+  annotations: {}
+  tls:
+    enabled: false
+    # Defaults to "<host>-tls" when empty.
+    secretName: ''


### PR DESCRIPTION
Implements the Contabo deployment design — same Helm charts as local kind, plus a prod overlay and a GitOps pipeline.

## Chart
- Ingress template now supports cert-manager annotations + TLS; deployments support `imagePullSecrets` (private GHCR). Local overlay unchanged (TLS off, no pull secret).
- `values-prod.yaml`: GHCR images, `app.fuzefront.com` + Let's Encrypt TLS, sealed `existingSecret`.

## GitOps pipeline
- `release.yml`: on merge to master, builds backend/frontend → **GHCR** (tagged by SHA), then bumps the tag in `values-prod.yaml` and commits → Argo syncs.
- `deploy/argocd/`: project + app-of-apps + `fuzefront` (prune) and `fuzeinfra` (Postgres+Redis+monitoring, **prune: false** to protect PVCs) Applications.
- Dropped `ci.yml`'s Docker Hub build (superseded by the GHCR `release.yml`).

## Contabo bootstrap
- `deploy/contabo/bootstrap.sh`: k3s (no Traefik) + ingress-nginx + cert-manager + sealed-secrets + Argo CD.
- `cluster-issuer.yaml` (letsencrypt-prod), `deploy/backup/postgres-backup-cronjob.yaml` (nightly pg_dump → Contabo object storage), and a `README.md` runbook (DNS, sealing secrets, app-of-apps).

## Decisions baked in
single-node k3s, GHCR (private), sealed-secrets, FuzeInfra = Postgres+Redis+monitoring, AWS `deploy.yml` left switchable.

## Not verifiable here
No live Contabo VPS/cluster — YAML/Helm/bash all validate locally, but the bring-up runs in your environment. `app.fuzefront.com` DNS + the GHCR pull token + sealed secrets are your steps (runbook covers them).