### PR TITLE
fix(e2e): sign-in spec uses domcontentloaded (networkidle never settles with Socket.IO)

### DIFF
--- a/frontend/tests/auth-simple.spec.ts
+++ b/frontend/tests/auth-simple.spec.ts
@@ -4,7 +4,7 @@ test.describe('Authentication - Simple', () => {
   test('should successfully authenticate', async ({ page }) => {
     // Navigate to the app
     await page.goto('/')
-    await page.waitForLoadState('networkidle')
+    await page.waitForLoadState('domcontentloaded')
 
     // Verify login form is present
     await expect(page.locator('input[type="email"]')).toBeVisible({ timeout: 10000 })
@@ -27,7 +27,7 @@ test.describe('Authentication - Simple', () => {
     expect(response.status()).toBe(200)
 
     // Wait for authentication to complete
-    await page.waitForLoadState('networkidle')
+    await page.waitForLoadState('domcontentloaded')
     await page.waitForTimeout(3000)
 
     // Verify authentication token is set


### PR DESCRIPTION
Verified locally against the live kind deployment: the sign-in flow passes (login -> token persisted -> app shell renders). `networkidle` never settles because the app keeps a Socket.IO connection open after login, which would also hang the CI e2e job.