### PR TITLE
test(e2e): FuzeClock runtime-load test (real launcher flow) + CI wiring

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -101,12 +101,28 @@ jobs:
           done
           echo "frontend failed to start"; cat /tmp/frontend.log; exit 1
 
-      # ---- Playwright sign-in flow ----
-      - name: Run Playwright sign-in test
+      # ---- Example remote: build, serve (vite preview w/ CORS), register ----
+      - name: Build, serve & register clock-app
+        working-directory: clock-app
+        run: |
+          npm install
+          VITE_HUB_API_URL=http://localhost:3001 VITE_PUBLIC_URL=http://localhost:4174 npm run build
+          npx vite preview --port 4174 --host 127.0.0.1 > /tmp/clock.log 2>&1 &
+          for i in $(seq 1 30); do
+            if curl -fsS http://localhost:4174/assets/remoteEntry.js >/dev/null 2>&1; then echo "clock-app up"; break; fi
+            sleep 2
+          done
+          # url = backend-reachable (drives the health check); remoteUrl = browser-reachable.
+          curl -fsS -X POST http://localhost:3001/api/apps/register \
+            -H 'Content-Type: application/json' \
+            -d '{"name":"FuzeClock","url":"http://localhost:4174","integrationType":"module-federation","remoteUrl":"http://localhost:4174/assets","scope":"fuzeClock","module":"./App","description":"on-the-fly clock"}'
+
+      # ---- Playwright: sign-in + runtime federated load ----
+      - name: Run Playwright e2e (sign-in + FuzeClock load)
         working-directory: frontend
         run: |
           npx playwright install --with-deps chromium
-          npx playwright test tests/auth-simple.spec.ts
+          npx playwright test tests/auth-simple.spec.ts tests/clock-load.spec.ts
 
       - name: Upload Playwright report
         if: failure()

--- a/clock-app/vite.config.ts
+++ b/clock-app/vite.config.ts
@@ -27,4 +27,7 @@ export default defineConfig({
   },
   base: '/',
   server: { host: '0.0.0.0', port: 3003, cors: true, strictPort: true },
+  // CORS on preview too, so the host page can cross-origin import remoteEntry.js
+  // when served via `vite preview` (used in the CI e2e job).
+  preview: { host: '127.0.0.1', port: 4174, cors: true, strictPort: true },
 })

--- a/frontend/tests/clock-load.spec.ts
+++ b/frontend/tests/clock-load.spec.ts
@@ -1,9 +1,19 @@
 import { test, expect } from '@playwright/test'
 
-// Verifies a registered microfrontend (FuzeClock) loads at runtime via Module
-// Federation and renders inside the host shell.
-test('FuzeClock loads at runtime via Module Federation', async ({ page }) => {
-  // sign in
+// Real user path: sign in, open the 9-dots launcher, click FuzeClock, and verify
+// the federated remote renders inside the host (no "app unavailable" alert).
+test('FuzeClock loads from the launcher at runtime', async ({ page }) => {
+  let dialogMessage = ''
+  page.on('dialog', d => {
+    dialogMessage = d.message()
+    d.dismiss().catch(() => {})
+  })
+  const consoleErrors: string[] = []
+  page.on('console', m => {
+    if (m.type() === 'error') consoleErrors.push(m.text())
+  })
+
+  // --- sign in ---
   await page.goto('/')
   await page.waitForLoadState('domcontentloaded')
   await page.fill('input[type="email"]', 'admin@fuzefront.dev')
@@ -18,23 +28,23 @@ test('FuzeClock loads at runtime via Module Federation', async ({ page }) => {
     timeout: 10000,
   })
 
-  // find FuzeClock in the registry
-  const appId = await page.evaluate(async () => {
-    const token = localStorage.getItem('authToken')
-    const res = await fetch('/api/apps', {
-      headers: { Authorization: `Bearer ${token}` },
-    })
-    return (await res.json()).find((x: any) => x.name === 'FuzeClock')?.id
-  })
-  expect(appId, 'FuzeClock must be registered').toBeTruthy()
+  // --- open the 9-dots launcher and click FuzeClock (the real path) ---
+  await page.locator('button.app-grid-button').click()
+  await page.getByText('FuzeClock', { exact: true }).first().click()
 
-  // load the federated remote
-  await page.goto(`/app/${appId}`)
+  // The launcher must NOT have blocked it with an "unavailable" alert.
+  await page.waitForTimeout(500)
+  expect(dialogMessage, `unexpected dialog popup: "${dialogMessage}"`).toBe('')
 
   // The remote's own content (unique to clock-app) must render — proving the
-  // runtime Module Federation load succeeded, not the error boundary.
+  // runtime Module Federation load succeeded inside the host, not the error UI.
   await expect(
     page.getByText('No build-time knowledge of the host')
   ).toBeVisible({ timeout: 20000 })
   await expect(page.getByText('Failed to Load App')).toHaveCount(0)
+
+  // Surface any console errors for visibility (not a hard failure here).
+  if (consoleErrors.length) {
+    console.log('Console errors during load:\n - ' + consoleErrors.join('\n - '))
+  }
 })


### PR DESCRIPTION
Closes the gap where the FuzeClock test passed but the real UX showed 'app unavailable'. The test now uses the **actual user path** (sign in → 9-dots → click FuzeClock) and asserts no unavailable alert + the remote renders. clock-app preview serves with CORS; `e2e.yml` builds/serves/registers clock-app and runs both specs on PRs.

Root cause of 'unavailable': the launcher gates clicks on `app.isHealthy`, which the backend computes via `fetch(app.url)` — FuzeClock's `url` was the browser-only `clock.dev.local`, unreachable from the backend pod. Register with a backend-reachable `url` (the in-cluster service); `remoteUrl` stays browser-reachable.