### PR TITLE
fix: host-shell console errors (organizations 500, permissions 404)

### DIFF
--- a/backend/src/routes/organizations.ts
+++ b/backend/src/routes/organizations.ts
@@ -289,8 +289,9 @@ router.get('/', authenticateToken, async (req: any, res) => {
       })
     }
 
-    // Get total count
-    const countQuery = query.clone().count('* as total').first()
+    // Get total count. clearSelect() drops the `organizations.*` projection so the
+    // count query is a plain count(*) (otherwise Postgres requires a GROUP BY).
+    const countQuery = query.clone().clearSelect().count('* as total').first()
     const totalResult = await countQuery
     const total = parseInt((totalResult?.total as string) || '0')
 

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -278,7 +278,8 @@ export const appsAPI = {
 export const organizationsAPI = {
   async getOrganizations() {
     const response = await api.get('/organizations')
-    return response.data
+    // Backend returns { organizations, pagination }; callers expect the array.
+    return response.data?.organizations ?? response.data
   },
 }
 
@@ -378,23 +379,23 @@ export const removeMember = async (orgId: string, memberId: string) => {
   return res.data
 }
 
-// Permissions (best-effort; permissive fallback for local dev so the UI renders
-// when the authorization endpoints aren't wired yet).
+// Permission checks: no PDP endpoint is wired yet (Permit deferred), so resolve
+// permissively client-side instead of POSTing to a non-existent endpoint (which
+// 404s on every check). Role-based gating below uses the real user roles.
+// Signature matches PermissionGate: (permissions, organizationId?, requireAll?).
 export const checkPermissions = async (
-  resource?: string,
-  action?: string
+  _permissions?: string | string[],
+  _organizationId?: string,
+  _requireAll?: boolean
 ): Promise<boolean> => {
-  try {
-    const res = await api.post('/auth/permissions/check', { resource, action })
-    return Boolean(res.data?.allowed ?? true)
-  } catch {
-    return true
-  }
+  return true
 }
-export const getUserRoles = async (): Promise<string[]> => {
+export const getUserRoles = async (
+  _organizationId?: string
+): Promise<string[]> => {
   try {
-    const user = JSON.parse(localStorage.getItem('user') || '{}')
-    return Array.isArray(user?.roles) ? user.roles : []
+    const user = await authAPI.getCurrentUser()
+    return Array.isArray(user.roles) ? user.roles : []
   } catch {
     return []
   }


### PR DESCRIPTION
Fixes the dev-tools errors that showed alongside FuzeClock loading (they were host-shell bugs, not FuzeClock):

- **`GET /organizations` 500** — count query mixed `organizations.*` with `count(*)` and no GROUP BY; `clearSelect()` before `count()`.
- **`POST /auth/permissions/check` 404** — frontend permission shim hit a non-existent endpoint with the wrong signature; `checkPermissions` now resolves locally (no PDP wired), `getUserRoles` uses the real `/auth/user`.
- **`apiOrganizations.map is not a function`** — `getOrganizations` now unwraps the `{ organizations, pagination }` envelope.

Verified locally: FuzeClock loads via the launcher with a clean console.