### PR TITLE
fix(frontend): repair CSS comment that broke the production build

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -67,7 +67,7 @@
 /* ============================================================
    FuzeFront design tokens — "runtime fabric"
    Dark is the default. One source of truth feeds BOTH the host's
-   legacy --bg-*/--text-* vars and the shadcn token layer, so
+   legacy --bg-* and --text-* vars and the shadcn token layer, so
    shadcn components no longer fall back to light on a dark shell.
    ============================================================ */
 :root,


### PR DESCRIPTION
## Summary
Hotfix for the frontend Docker build failure introduced by #18.

The design-tokens header comment in `frontend/src/index.css` contained `--bg-*/--text-*`. The `*/` substring **closed the `/* */` comment early**, so the text after it parsed as CSS and PostCSS failed:

```
[postcss] /app/src/index.css:70:27: Unknown word vars
```

This broke the production frontend image build in the **Release (images + GitOps bump)** workflow. Local builds couldn't catch it — the repo's `.npmrc` `os=linux` pin blocks the Windows native binding, so `vite build` aborted before reaching CSS parsing.

## Fix
Rephrased `--bg-*/--text-*` → `--bg-* and --text-*` to remove the `*/` sequence.

## Verification
- ✅ `postcss.parse(index.css)` → valid (the exact parser layer that failed in CI)
- ✅ `/*` / `*/` balanced (35/35); scanned for other glued `*/` hazards — none

🤖 Generated with [Claude Code](https://claude.com/claude-code)