### PR TITLE
fix(frontend): same-origin API base — fixes sign-in under HTTPS

### DIFF
--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,9 +1,13 @@
 import axios from 'axios'
 import { App } from '../lib/shared'
 
-// Use relative URLs since nginx proxies /api/ to backend
-// This works both in development (via nginx proxy) and production
-const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://fuzefront.dev.local'
+// Default to the same origin the app is served from (the in-pod / ingress nginx
+// proxies /api/ to the backend). Same-origin keeps the protocol correct — http
+// on http, https on https — so there's no mixed-content breakage under TLS.
+// VITE_API_URL still overrides for cross-origin setups.
+const API_BASE_URL =
+  import.meta.env.VITE_API_URL ||
+  (typeof window !== 'undefined' ? window.location.origin : 'http://localhost:3001')
 const API_URL = `${API_BASE_URL}/api`
 
 console.log('🔧 API Configuration:', {


### PR DESCRIPTION
## Problem
Sign-in was broken in the local k8s deployment — users couldn't get past the login screen.

**Root cause:** `frontend/src/services/api.ts` defaulted the API base to a hardcoded `http://fuzefront.dev.local` when `VITE_API_URL` was unset. After the ingress started serving the app over **HTTPS**, the page loaded on `https://` but the SPA called the `http://` API → the browser blocked it as **mixed content** → all auth requests (and everything else) failed silently.

## Fix
Default the API base to **`window.location.origin`** so it always matches the page protocol. The in-pod/ingress nginx already proxies `/api` to the backend on the same origin, so no cross-origin config is needed. `VITE_API_URL` still overrides for cross-origin setups.

## Verification (end-to-end, against the live kind deployment)
- Rebuilt the frontend image same-origin, `kind load`, rolled the deployment.
- Backend/DB/auth confirmed healthy: `POST /api/auth/login` (admin) → 200 + JWT over HTTPS.
- **Playwright auth suite: 3/3 pass** against `https://fuzefront.dev.local` with **TLS validation ON** (local cert-manager CA trusted — no `ignoreHTTPSErrors`): login form, valid login, invalid-creds error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)