### PR TITLE
fix(ci): install backend from workspace root (applies @types/express overrides)

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -44,10 +44,12 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
-          cache-dependency-path: backend/package-lock.json
+          cache-dependency-path: package-lock.json
 
       - name: Install backend dependencies
-        working-directory: ./backend
+        # Install from the workspace ROOT so root package.json `overrides`
+        # (pinning @types/express* to v4) apply; a child `cd backend && npm ci`
+        # ignores them and pulls @types/express@5, breaking the build.
         run: npm ci
 
       - name: Set up test environment

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          cd backend && npm ci
-          cd ../frontend && npm ci
+          npm ci   # root workspace (backend + shared) — applies root overrides
+          cd frontend && npm ci
           cd ../sdk && npm ci
           cd ../api-client && npm ci
           cd ../task-manager-app && npm ci
@@ -74,8 +74,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          cd backend && npm ci
-          cd ../frontend && npm ci
+          npm ci   # root workspace (backend + shared) — applies root overrides
+          cd frontend && npm ci
           cd ../sdk && npm ci
           cd ../task-manager-app && npm ci
 
@@ -137,8 +137,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          cd backend && npm ci
-          cd ../frontend && npm ci
+          npm ci   # root workspace (backend + shared) — applies root overrides
+          cd frontend && npm ci
 
       - name: Run integration tests
         env:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -55,11 +55,14 @@ jobs:
           node-version: '20.x'
 
       # ---- Backend: build, start, migrate, wait ----
+      # Install from the workspace ROOT so the root package.json `overrides`
+      # (pinning @types/express* to v4) apply — a child `cd backend && npm ci`
+      # ignores them and resolves @types/express@5, breaking the tsc build.
       - name: Build & start backend
-        working-directory: backend
         run: |
           npm ci
-          npm run build
+          npm run build -w backend
+          cd backend
           node dist/index.js > /tmp/backend.log 2>&1 &
           echo "Waiting for backend /health..."
           for i in $(seq 1 60); do


### PR DESCRIPTION
## Problem
The backend `tsc` build kept failing in CI (`req.params`/`req.body` missing on `AuthenticatedRequest`) even after pinning `@types/express*` to v4 via root `overrides` (#23). Reason: the workflows install backend with `cd backend && npm ci`. As an npm **workspace member**, a child `npm ci` **ignores the root `overrides`** (npm only honors overrides from the workspace root) and resolves `@types/express@5` → `@types/express-serve-static-core@5`, which shadows the v4 `Request`.

## Fix
Install backend from the **workspace root** so the root overrides apply:
- `e2e.yml`: backend step runs `npm ci` at root, `npm run build -w backend`, then `cd backend && node dist/index.js`.
- `ci.yml`: the three install blocks (lint-and-test, build, integration) use root `npm ci` for the backend workspace (other non-workspace packages keep their own `cd X && npm ci`).
- `backend-tests.yml`: install at root; npm cache key → root `package-lock.json`.

## Verified locally
`npm run build -w backend` from the repo root resolves `@types/express-serve-static-core@4.19.6` and builds with **0 errors**. This unblocks the backend build in ci.yml + e2e.yml, so the Playwright sign-in suite can actually run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)