### PR TITLE
fix(backend): CI-proof AuthenticatedRequest (declare params/body/query)

### DIFF
--- a/backend/src/middleware/permissions.ts
+++ b/backend/src/middleware/permissions.ts
@@ -6,7 +6,14 @@ import {
   checkUserManagementPermission,
 } from '../utils/permit/permission-check'
 
-// Extend Express Request type to include user and organization context
+// Extend Express Request type to include user and organization context.
+//
+// params/body/query are re-declared explicitly (assignable overrides of the
+// base Express Request members) so they are always present on
+// AuthenticatedRequest regardless of how @types/express / serve-static-core
+// resolve in a given environment. Without this, a transient @types resolution
+// in CI dropped these from the base Request and broke the build (TS2339),
+// while the same code compiled cleanly locally.
 export interface AuthenticatedRequest extends Request {
   user?: {
     id: string
@@ -18,6 +25,9 @@ export interface AuthenticatedRequest extends Request {
     id: string
     role: string
   }
+  params: Record<string, string>
+  body: any
+  query: any
 }
 
 export interface PermissionConfig {


### PR DESCRIPTION
Makes the backend build immune to the CI-only @types/express resolution quirk that dropped req.params/req.body from AuthenticatedRequest (TS2339) — passed locally across 4 dependency-resolution fixes but kept failing in CI. Re-declares params/body/query as assignable overrides so they're always present. Verified `npm run build -w backend` + `type-check` = 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)