### PR TITLE
fix(ci): backend ESLint config + knex migration .d.ts loader fix

### DIFF
--- a/backend/.eslintrc.cjs
+++ b/backend/.eslintrc.cjs
@@ -1,0 +1,25 @@
+/* ESLint config for the FuzeFront backend (Node + TypeScript, CommonJS).
+   ESLint 8 classic config to match the pinned toolchain. */
+module.exports = {
+  root: true,
+  env: { node: true, es2021: true },
+  parser: '@typescript-eslint/parser',
+  parserOptions: { ecmaVersion: 2021, sourceType: 'module' },
+  plugins: ['@typescript-eslint'],
+  extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended'],
+  ignorePatterns: ['dist', 'node_modules', 'coverage', '.eslintrc.cjs', 'scripts'],
+  rules: {
+    // Pragmatic for a service codebase with dynamic payloads / 3rd-party SDKs.
+    '@typescript-eslint/no-explicit-any': 'off',
+    '@typescript-eslint/no-unused-vars': [
+      'warn',
+      { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
+    ],
+    'no-console': 'off',
+    'no-undef': 'off', // TS handles this; avoids false positives on Node globals
+    // Service code intentionally uses dynamic require() (lazy/optional deps)
+    // and namespace augmentation (e.g. Express.Request) — allow both.
+    '@typescript-eslint/no-var-requires': 'off',
+    '@typescript-eslint/no-namespace': 'off',
+  },
+}

--- a/backend/src/config/database.ts
+++ b/backend/src/config/database.ts
@@ -57,9 +57,15 @@ const getDatabaseConfig = (): Knex.Config => {
           isProduction ? '../migrations' : '../migrations'
         ),
         extension: isProduction ? 'js' : 'ts',
+        // Only load the compiled .js (or .ts in dev). Without this, knex's
+        // default loadExtensions also matches the emitted .d.ts declaration
+        // files in dist/migrations and require()s them -> "Unexpected token
+        // 'export'", which broke migrations on server startup in CI.
+        loadExtensions: [isProduction ? '.js' : '.ts'],
       },
       seeds: {
         directory: path.join(__dirname, isProduction ? '../seeds' : '../seeds'),
+        loadExtensions: [isProduction ? '.js' : '.ts'],
       },
     }
   } else {
@@ -77,9 +83,15 @@ const getDatabaseConfig = (): Knex.Config => {
           isProduction ? '../migrations' : '../migrations'
         ),
         extension: isProduction ? 'js' : 'ts',
+        // Only load the compiled .js (or .ts in dev). Without this, knex's
+        // default loadExtensions also matches the emitted .d.ts declaration
+        // files in dist/migrations and require()s them -> "Unexpected token
+        // 'export'", which broke migrations on server startup in CI.
+        loadExtensions: [isProduction ? '.js' : '.ts'],
       },
       seeds: {
         directory: path.join(__dirname, isProduction ? '../seeds' : '../seeds'),
+        loadExtensions: [isProduction ? '.js' : '.ts'],
       },
     }
   }

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -408,7 +408,7 @@ async function findAvailablePort(
   maxAttempts: number = 10
 ): Promise<number> {
   return new Promise((resolve, reject) => {
-    let currentPort = startPort
+    const currentPort = startPort
     let attempts = 0
 
     function tryPort(port: number) {

--- a/backend/src/services/oidc.ts
+++ b/backend/src/services/oidc.ts
@@ -11,6 +11,8 @@ interface OIDCConfig {
 
 // Declare global types for code verifier storage
 declare global {
+  // `var` is required here — global augmentation can't use let/const.
+  // eslint-disable-next-line no-var
   var codeVerifiers: Map<string, string> | undefined;
 }
 


### PR DESCRIPTION
Finishes CI greenify.

**ci.yml `Lint code`**: backend had no ESLint config. Added `backend/.eslintrc.cjs` (ESLint 8 + @typescript-eslint, pragmatic for service code) and fixed the surfaced errors.

**e2e.yml migrations**: `runMigrations()` crashed with `Unexpected token 'export'` because knex's default `loadExtensions` matched the emitted `.d.ts` files in `dist/migrations` and `require()`'d them. Pinned `loadExtensions: ['.js']` (prod) / `['.ts']` (dev) for migrations + seeds.

Verified locally: backend `type-check` and `eslint src/**/*.ts` both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)