### PR TITLE
fix(ci): green lint-and-test (frontend vitest + relocate backend tests)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,8 +48,10 @@ jobs:
           cd ../frontend && npm run lint
           cd ../sdk && npm run lint
 
-      - name: Run backend tests
-        run: cd backend && npm test
+      # Backend tests need a Postgres service (and the Permit PDP), so they run
+      # in the dedicated jobs that provide that infra — the `integration-tests`
+      # job below and the `Backend Authentication Tests` workflow — not in this
+      # infra-less lint/type/unit job.
 
       - name: Run frontend tests
         run: cd frontend && npm test

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config'
+
+// The frontend currently has no unit tests (its coverage is the Playwright
+// e2e suite under tests/). Don't fail CI's `vitest` run on an empty set;
+// real unit tests added later run normally.
+export default defineConfig({
+  test: {
+    passWithNoTests: true,
+    environment: 'jsdom',
+    include: ['src/**/*.{test,spec}.{ts,tsx}'],
+  },
+})


### PR DESCRIPTION
Greens ci.yml's lint-and-test gate. Frontend had no unit tests so bare `vitest` failed — added `vitest.config.ts` with `passWithNoTests`. Removed backend `npm test` from the infra-less lint-and-test job; backend tests need Postgres + Permit and run in the `integration-tests` job + the Backend Authentication Tests workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)