### PR TITLE
fix(ci): scope vitest to src + non-fatal Trivy SARIF upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,9 @@ jobs:
   security-scan:
     name: Security Scan
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write # required to upload SARIF to the Security tab
 
     steps:
       - name: Checkout code
@@ -167,6 +170,9 @@ jobs:
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v3
         if: always()
+        # Don't fail CI if code scanning isn't enabled for the repo (e.g. no
+        # GitHub Advanced Security); the scan itself still ran above.
+        continue-on-error: true
         with:
           sarif_file: 'trivy-results.sarif'
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,7 @@
     "type-check": "tsc --noEmit",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "lint:fix": "eslint . --ext ts,tsx --fix",
-    "test": "vitest run --passWithNoTests",
+    "test": "vitest run --passWithNoTests src",
     "test:ui": "vitest --ui",
     "test:coverage": "vitest --coverage",
     "test:e2e": "playwright test",

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -38,7 +38,7 @@
     "type-check": "tsc --noEmit",
     "lint": "eslint src/**/*.{ts,tsx}",
     "lint:fix": "eslint src/**/*.{ts,tsx} --fix",
-    "test": "vitest run --passWithNoTests",
+    "test": "vitest run --passWithNoTests src",
     "test:watch": "vitest --watch",
     "test:coverage": "vitest --coverage",
     "clean": "rimraf dist",


### PR DESCRIPTION
Two remaining ci.yml failures:
- `Run frontend tests`: vitest picked up the Playwright specs in `frontend/tests/` (`test.describe() not expected`). Scoped `vitest run --passWithNoTests src` so it only scans unit-test dirs; Playwright runs in the e2e workflow.
- `Security Scan`: Trivy scan passes but SARIF upload failed (permissions). Added `security-events: write` + `continue-on-error` on the upload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)