### PR TITLE
fix(ci): backend test:integration script + deploy-docs gh-pages permission

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,6 +146,9 @@ jobs:
         env:
           DATABASE_URL: postgres://postgres:postgres@localhost:5432/frontfuse_test
           NODE_ENV: test
+          # No-op Permit config so permission checks don't crash without a PDP.
+          PERMIT_API_KEY: ci-noop
+          PERMIT_PDP_URL: http://localhost:7766
         run: cd backend && npm run test:integration
 
   security-scan:
@@ -181,6 +184,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     if: github.ref == 'refs/heads/master'
+    permissions:
+      contents: write # peaceiris/actions-gh-pages creates/pushes the gh-pages branch
 
     steps:
       - name: Checkout code

--- a/backend/package.json
+++ b/backend/package.json
@@ -17,6 +17,7 @@
     "test:coverage": "jest --coverage",
     "test:auth": "jest --testPathPattern=auth",
     "test:auth:production": "jest --testPathPattern=auth-production",
+    "test:integration": "jest --testPathPattern=\"(auth|apps|permissions)\" --testPathIgnorePatterns=permit-integration",
     "test:auth:live": "node scripts/test-auth.js",
     "test:auth:live:prod": "node scripts/test-auth.js http://localhost:3004",
     "version": "echo $npm_package_version"


### PR DESCRIPTION
Last two ci.yml jobs: Integration Tests failed on a missing `test:integration` script (added — DB-backed auth/apps/permissions suites, Permit suite excluded, no-op Permit env); Deploy Documentation couldn't create gh-pages without `contents: write` (granted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)