### PR TITLE
fix(ci): integration tests DB-setup race (concurrent CREATE DATABASE)

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -17,7 +17,7 @@
     "test:coverage": "jest --coverage",
     "test:auth": "jest --testPathPattern=auth",
     "test:auth:production": "jest --testPathPattern=auth-production",
-    "test:integration": "jest --testPathPattern=\"(auth|apps|permissions)\" --testPathIgnorePatterns=permit-integration",
+    "test:integration": "jest --runInBand --testPathPattern=\"(auth|apps|permissions)\" --testPathIgnorePatterns=permit-integration",
     "test:auth:live": "node scripts/test-auth.js",
     "test:auth:live:prod": "node scripts/test-auth.js http://localhost:3004",
     "version": "echo $npm_package_version"

--- a/backend/src/config/database.ts
+++ b/backend/src/config/database.ts
@@ -187,10 +187,21 @@ export async function ensureDatabase(): Promise<void> {
       console.log(
         `📦 Creating database "${process.env.DB_NAME || 'fuzefront_platform'}"...`
       )
-      await client.query(
-        `CREATE DATABASE "${process.env.DB_NAME || 'fuzefront_platform'}"`
-      )
-      console.log('✅ Database created successfully!')
+      try {
+        await client.query(
+          `CREATE DATABASE "${process.env.DB_NAME || 'fuzefront_platform'}"`
+        )
+        console.log('✅ Database created successfully!')
+      } catch (createError: any) {
+        // Concurrent creators (e.g. parallel test workers) race between the
+        // existence check above and CREATE. Treat "already exists" as success.
+        // 42P04 = duplicate_database; 23505 = unique_violation on pg_database.
+        if (createError?.code === '42P04' || createError?.code === '23505') {
+          console.log('✅ Database already exists (created concurrently)')
+        } else {
+          throw createError
+        }
+      }
     } else {
       console.log('✅ Database already exists')
     }


### PR DESCRIPTION
Integration Tests now run but failed with `duplicate key ... pg_database_datname_index` — parallel jest workers raced on `CREATE DATABASE`. Made `ensureDatabase()` tolerate concurrent-create (42P04/23505) and run the suite `--runInBand`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)