### PR TITLE
feat: Authentik IdP in k8s (bootstrap fix) + FuzeFront expert agent

### DIFF
--- a/agents/fuzefront-expert.md
+++ b/agents/fuzefront-expert.md
@@ -1,0 +1,57 @@
+---
+name: fuzefront-expert
+description: Deep expert on the FuzeFront platform — its architecture, Module-Federation host shell, Kubernetes/Helm deployment (kind-fuzeinfra / Contabo k3s), backend (Express/Postgres/Authentik/Permit), the "fuse seam" design system, auth, CI/CD, and local dev workflow. Use when building, deploying, debugging, or extending FuzeFront or any product that runs on top of it, so you don't have to relearn FuzeFront from scratch. Knows the gotchas (workspace @types/express pinning, os=linux npmrc, same-origin API base, k8s image refresh, mixed-content under TLS).
+tools: ['*']
+---
+
+You are the **FuzeFront platform expert**. You know this product end to end. Be concrete and grounded in the actual repo — verify against files before asserting; this prompt is a map, not a substitute for reading the code.
+
+## What FuzeFront is
+A **Module-Federation host shell** ("runtime fabric"): a dark-default dashboard that discovers, mounts, and fuses remote micro-frontends ("apps") into one runtime experience. The brand motif is the **"fuse seam"** — an indigo→cyan gradient marking where the shell joins hosted content.
+
+## Repo layout (monorepo)
+- `frontend/` — React 18 + Vite + `@originjs/vite-plugin-federation` host shell. Built to static assets served by an **in-pod nginx on :8080** (`frontend/nginx.conf` proxies `/api` and `/socket.io` → `fuzefront-backend:3001`). Tailwind v4. Design tokens in `frontend/src/index.css`.
+- `backend/` — Express + TypeScript + Postgres (knex) + Socket.io on **:3001**. Auth: local JWT **and** Authentik OIDC (`src/services/oidc.ts`); permissions via **Permit.io** (`src/utils/permit/*`, degrades gracefully without a PDP). It is an **npm workspace member** (root `package.json` `workspaces: [backend, shared]`).
+- `shared/` — shared types (workspace member).
+- `sdk/` — `@izzywdev/fuzefront-sdk-react`, published to npm by `.github/workflows/sdk-publish.yml`.
+- `clock-app/`, `task-manager-app/` — example remote micro-frontends.
+- `design-system/` — standalone "fuse seam" design system package (tokens, components, guideline cards, `build.mjs`). See `design-system/readme.md` / its `SKILL.md`.
+- `deploy/helm/fuzefront/` — the Helm chart. `deploy/local-tls/` — local cert-manager CA. `FuzeInfra/` — git submodule providing shared k8s infra.
+
+## Deployment (Kubernetes — this is the current model; docker-compose is legacy)
+FuzeFront deploys via **Helm** into the **kind `fuzeinfra`** cluster (context `kind-fuzeinfra`, namespace `fuzefront`), fronted by **ingress-nginx**, using FuzeInfra's Postgres (`postgres.fuzeinfra.svc.cluster.local`) and Redis (`redis.fuzeinfra.svc.cluster.local`).
+```bash
+# Deploy / upgrade locally
+helm upgrade --install fuzefront deploy/helm/fuzefront \
+  -n fuzefront --create-namespace -f deploy/helm/fuzefront/values-local.yaml
+# Refresh an image after a code change (tag stays :local, IfNotPresent → must restart)
+docker build -t fuzefront/frontend:local ./frontend            # backend: ./backend
+kind load docker-image fuzefront/frontend:local --name fuzeinfra
+kubectl -n fuzefront rollout restart deployment/fuzefront-frontend
+```
+- Images are **built from Dockerfiles** (k8s runs images; Helm/Terraform don't build them). CI builds + pushes to **GHCR** in `release.yml`; **Argo CD** deploys to **Contabo k3s** in prod (`values-prod.yaml`, host `app.fuzefront.com`, cert-manager `letsencrypt-prod`).
+- Hosts: add `127.0.0.1 fuzefront.dev.local` (and `auth.fuzefront.dev.local`) to your hosts file.
+
+## HTTPS (local)
+TLS terminates at ingress-nginx. There is **no cert-manager in FuzeInfra yet** (tracked in FuzeInfra#10), so FuzeFront ships its own local CA: `deploy/local-tls/cert-manager-local-ca.yaml` (cert-manager `ClusterIssuer fuzefront-local-ca`). `values-local.yaml` enables `ingress.tls` + the cert-manager annotation. Trust the CA once:
+`certutil -addstore -f ROOT deploy/local-tls/fuzefront-local-ca.crt` (Windows). Browsers don't hard-fail on the missing CRL for a locally-trusted CA.
+
+## Auth
+- **Local JWT:** seeded `admin@fuzefront.dev` / `admin123` (`backend/src/seeds/001_initial_users.ts`). `POST /api/auth/login`.
+- **Authentik OIDC:** runs in-cluster (`authentik-server`/`authentik-worker` Deployments, `auth.fuzefront.dev.local`), backed by FuzeInfra Postgres (`authentik` DB) + Redis. Bootstrap creds (`AUTHENTIK_BOOTSTRAP_*`) must be on **both** server **and** worker (the worker runs the bootstrap blueprint) or you get stuck on the initial-setup page. Backend OIDC env: `AUTHENTIK_CLIENT_ID/SECRET/ISSUER_URL/REDIRECT_URI`.
+- Frontend API base defaults to **`window.location.origin`** (same-origin) — never hardcode `http://…` or you get mixed-content under HTTPS.
+
+## CI/CD (`.github/workflows/`)
+- `ci.yml` — Lint & Test (node 18+20), Build, Security Scan (Trivy), Integration Tests (Postgres service), Deploy Docs. Backend is installed **from the workspace root** (`npm ci` at root) so root `overrides` apply.
+- `e2e.yml` — Playwright sign-in + FuzeClock federated-load (Postgres + backend + frontend + clock-app brought up live).
+- `release.yml` — build + push GHCR images + GitOps tag bump. `backend-tests.yml` — auth tests with Postgres. `auto-merge.yml` — squash-merges owner PRs when checks pass.
+
+## Gotchas (learned the hard way)
+- **`@types/express` must be v4** across the backend; it's a workspace member so put `overrides` in the **root** `package.json` (npm ignores overrides in a child) and install from root.
+- `AuthenticatedRequest` explicitly declares `params/body/query` to be resolution-independent.
+- The user's global `~/.npmrc` pins `os=linux` → local Windows `vite build` fails on native binaries; CI (Linux) is fine. Build images via Docker instead.
+- `knex.migrate`/seeds default `loadExtensions` matches `.ts`, so in `dist/` it tries to `require()` `.d.ts` files → "Unexpected token export". Pin `loadExtensions: ['.js']` in prod.
+- vitest scoped to `src` (Playwright specs live in `frontend/tests/`); use `vitest run --passWithNoTests` (no `.ts` config → Node 18 ESM issue).
+
+## How to work
+When asked to add/deploy/debug: read the relevant chart/template/source first, prefer the Helm + kind flow over docker-compose, keep the dark-default + fuse-seam design language, source secrets from env/k8s Secrets (never hardcode), and verify changes by actually exercising the cluster (`kubectl`, curl through the ingress) or the Playwright e2e. Offload base-infra setup (DBs, DNS, certs, ingress) to FuzeInfra conventions.

--- a/deploy/helm/fuzefront/templates/authentik.yaml
+++ b/deploy/helm/fuzefront/templates/authentik.yaml
@@ -1,0 +1,191 @@
+{{- /*
+  Authentik IdP (server + worker) running in-cluster, backed by the shared
+  FuzeInfra Postgres ("authentik" DB) and Redis. The bootstrap credentials are
+  set on BOTH the worker (which runs migrations + the bootstrap blueprint that
+  creates akadmin) and the server — without them on the worker, akadmin is
+  created with no usable password and you get stuck on the initial-setup flow.
+*/}}
+{{- define "authentik.commonEnv" -}}
+- name: AUTHENTIK_SECRET_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "fuzefront.secretName" . }}
+      key: AUTHENTIK_SECRET_KEY
+- name: AUTHENTIK_POSTGRESQL__HOST
+  value: {{ .Values.fuzeinfra.postgres.host | quote }}
+- name: AUTHENTIK_POSTGRESQL__PORT
+  value: {{ .Values.fuzeinfra.postgres.port | quote }}
+- name: AUTHENTIK_POSTGRESQL__USER
+  value: {{ .Values.database.user | quote }}
+- name: AUTHENTIK_POSTGRESQL__NAME
+  value: {{ .Values.authentik.dbName | quote }}
+- name: AUTHENTIK_POSTGRESQL__PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "fuzefront.secretName" . }}
+      key: DB_PASSWORD
+- name: AUTHENTIK_REDIS__HOST
+  value: {{ .Values.fuzeinfra.redis.host | quote }}
+- name: AUTHENTIK_REDIS__PORT
+  value: {{ .Values.fuzeinfra.redis.port | quote }}
+- name: AUTHENTIK_LOG_LEVEL
+  value: "info"
+- name: AUTHENTIK_DISABLE_UPDATE_CHECK
+  value: "true"
+- name: AUTHENTIK_ERROR_REPORTING__ENABLED
+  value: "false"
+- name: AUTHENTIK_COOKIE_DOMAIN
+  value: {{ .Values.authentik.cookieDomain | quote }}
+# Bootstrap the akadmin user with a known password/token so the initial-setup
+# flow is skipped. MUST be present on the worker (runs the bootstrap).
+- name: AUTHENTIK_BOOTSTRAP_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "fuzefront.secretName" . }}
+      key: AUTHENTIK_BOOTSTRAP_PASSWORD
+- name: AUTHENTIK_BOOTSTRAP_TOKEN
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "fuzefront.secretName" . }}
+      key: AUTHENTIK_BOOTSTRAP_TOKEN
+- name: AUTHENTIK_BOOTSTRAP_EMAIL
+  value: {{ .Values.authentik.bootstrapEmail | quote }}
+{{- end -}}
+{{- if .Values.authentik.enabled }}
+{{- $ak := .Values.authentik }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: authentik-server
+  labels:
+    {{- include "fuzefront.labels" . | nindent 4 }}
+    app: authentik-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: authentik-server
+  template:
+    metadata:
+      labels:
+        {{- include "fuzefront.labels" . | nindent 8 }}
+        app: authentik-server
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: server
+          image: "{{ $ak.image.repository }}:{{ $ak.image.tag }}"
+          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          args: ["server"]
+          env:
+            {{- include "authentik.commonEnv" . | nindent 12 }}
+          ports:
+            - containerPort: 9000
+          startupProbe:
+            httpGet: { path: /-/health/live/, port: 9000 }
+            periodSeconds: 5
+            failureThreshold: 60 # up to ~5min for first-boot migrations
+          livenessProbe:
+            httpGet: { path: /-/health/live/, port: 9000 }
+            periodSeconds: 30
+          readinessProbe:
+            httpGet: { path: /-/health/ready/, port: 9000 }
+            periodSeconds: 15
+          volumeMounts:
+            - { name: media, mountPath: /media }
+          resources:
+            requests: { cpu: 100m, memory: 384Mi }
+            limits:   { cpu: "1",  memory: 768Mi }
+      volumes:
+        - name: media
+          emptyDir: {}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: authentik-worker
+  labels:
+    {{- include "fuzefront.labels" . | nindent 4 }}
+    app: authentik-worker
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: authentik-worker
+  template:
+    metadata:
+      labels:
+        {{- include "fuzefront.labels" . | nindent 8 }}
+        app: authentik-worker
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: worker
+          image: "{{ $ak.image.repository }}:{{ $ak.image.tag }}"
+          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          args: ["worker"]
+          env:
+            {{- include "authentik.commonEnv" . | nindent 12 }}
+          volumeMounts:
+            - { name: media, mountPath: /media }
+          resources:
+            requests: { cpu: 100m, memory: 384Mi }
+            limits:   { cpu: "1",  memory: 768Mi }
+      volumes:
+        - name: media
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: authentik-server
+  labels:
+    {{- include "fuzefront.labels" . | nindent 4 }}
+    app: authentik-server
+spec:
+  selector:
+    app: authentik-server
+  ports:
+    - port: 9000
+      targetPort: 9000
+---
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: authentik
+  labels:
+    {{- include "fuzefront.labels" . | nindent 4 }}
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-buffer-size: "16k"
+    {{- with .Values.ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- if .Values.ingress.tls.enabled }}
+  tls:
+    - hosts:
+        - {{ $ak.host | quote }}
+      secretName: {{ printf "%s-tls" $ak.host }}
+  {{- end }}
+  rules:
+    - host: {{ $ak.host | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: authentik-server
+                port:
+                  number: 9000
+{{- end }}
+{{- end }}

--- a/deploy/helm/fuzefront/templates/secret.yaml
+++ b/deploy/helm/fuzefront/templates/secret.yaml
@@ -11,4 +11,7 @@ stringData:
   SESSION_SECRET: {{ .Values.secret.sessionSecret | quote }}
   DB_PASSWORD: {{ .Values.secret.dbPassword | quote }}
   PERMIT_API_KEY: {{ .Values.secret.permitApiKey | quote }}
+  AUTHENTIK_SECRET_KEY: {{ .Values.secret.authentikSecretKey | quote }}
+  AUTHENTIK_BOOTSTRAP_PASSWORD: {{ .Values.secret.authentikBootstrapPassword | quote }}
+  AUTHENTIK_BOOTSTRAP_TOKEN: {{ .Values.secret.authentikBootstrapToken | quote }}
 {{- end }}

--- a/deploy/helm/fuzefront/values.yaml
+++ b/deploy/helm/fuzefront/values.yaml
@@ -48,6 +48,10 @@ secret:
   # to be set at import time. The SDK is built with throwOnError:false, so with a
   # placeholder it boots and degrades gracefully (Permit-gated routes will deny).
   permitApiKey: "dev-no-permit"
+  # Authentik (DEV ONLY — override). Secret key must be long/random in real use.
+  authentikSecretKey: "dev-authentik-secret-key-change-me-0123456789abcdef0123"
+  authentikBootstrapPassword: "admin123"
+  authentikBootstrapToken: "dev-bootstrap-token-change-me-0123456789"
 
 backend:
   image:
@@ -70,6 +74,16 @@ frontend:
   resources:
     requests: { cpu: 50m,  memory: 64Mi }
     limits:   { cpu: 500m, memory: 256Mi }
+
+authentik:
+  enabled: true
+  image:
+    repository: ghcr.io/goauthentik/server
+    tag: "2024.12.3"
+  host: auth.fuzefront.dev.local
+  dbName: authentik # must pre-exist in the FuzeInfra Postgres
+  cookieDomain: fuzefront.dev.local
+  bootstrapEmail: admin@fuzefront.dev
 
 ingress:
   enabled: true


### PR DESCRIPTION
Adds Authentik (server+worker+ingress) to the Helm chart, backed by FuzeInfra Postgres/Redis. Fixes the 'stuck on initial admin setup' issue — bootstrap creds were missing from the worker (which runs the bootstrap blueprint). Verified akadmin is active with a password and the bootstrap token authenticates as superuser. Also adds `agents/fuzefront-expert.md` (installed globally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)