### PR TITLE
fix(fuzeclock): HTTPS load + spinner-first loader UX

### DIFF
--- a/clock-app/Dockerfile
+++ b/clock-app/Dockerfile
@@ -6,9 +6,10 @@ COPY package*.json ./
 RUN rm -f package-lock.json && npm install
 COPY . .
 
-# Build-time configuration (no host code, just URLs):
-ARG VITE_HUB_API_URL=http://fuzefront.dev.local
-ARG VITE_PUBLIC_URL=http://clock.dev.local
+# Build-time configuration (no host code, just URLs). HTTPS by default so the
+# federated remote loads from the https host without a mixed-content block.
+ARG VITE_HUB_API_URL=https://fuzefront.dev.local
+ARG VITE_PUBLIC_URL=https://clock.dev.local
 ENV VITE_HUB_API_URL=$VITE_HUB_API_URL
 ENV VITE_PUBLIC_URL=$VITE_PUBLIC_URL
 RUN npm run build

--- a/deploy/examples/clock-app.yaml
+++ b/deploy/examples/clock-app.yaml
@@ -56,8 +56,16 @@ kind: Ingress
 metadata:
   name: clock-app
   namespace: fuzefront
+  annotations:
+    # Trusted local TLS so the federated remote loads over https without a
+    # mixed-content block (FuzeFront is served over https).
+    cert-manager.io/cluster-issuer: fuzefront-local-ca
 spec:
   ingressClassName: nginx
+  tls:
+    - hosts:
+        - clock.dev.local
+      secretName: clock-dev-local-tls
   rules:
     - host: clock.dev.local
       http:

--- a/frontend/src/components/FederatedAppLoader.tsx
+++ b/frontend/src/components/FederatedAppLoader.tsx
@@ -99,6 +99,14 @@ export function FederatedAppLoader({ appId }: FederatedAppLoaderProps) {
 
     const loadFederatedApp = async () => {
       if (!app) {
+        // The app list may not be fetched yet (deep-link / page refresh). Don't
+        // flash a "not found" failure before it loads — stay on the spinner and
+        // let this effect re-run once apps arrive. Only error once the list is
+        // loaded and the app genuinely isn't there.
+        if (state.isLoading || state.apps.length === 0) {
+          setLoading(true)
+          return
+        }
         setError(`App with ID "${appId}" not found`)
         setLoading(false)
         return
@@ -289,7 +297,9 @@ export function FederatedAppLoader({ appId }: FederatedAppLoaderProps) {
     return () => {
       mounted = false
     }
-  }, [appId, app, retryKey])
+    // Re-run when the app resolves or the app-list finishes loading, so a
+    // deep-link doesn't get stuck on the spinner or flash a premature error.
+  }, [appId, app, retryKey, state.isLoading, state.apps.length])
 
   const handleRetry = () => {
     // Clear module cache and retry


### PR DESCRIPTION
FuzeClock failed→spinner→failed. Fixed the loader to show the spinner first (no premature 'not found' before the app list loads), and fixed the actual load failure (mixed content): clock served over trusted TLS, clock-app built with an https base, remote_url registered as https. Verified remoteEntry returns 200 over https with the local-CA cert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)