### PR TITLE
feat(provisioning-service): Plan D

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ on:
       - 'frontend/**'
       - 'services/email-service/**'
       - 'services/sms-service/**'
+      - 'services/provisioning-service/**'
       - 'deploy/helm/fuzefront/**'
       - '.github/workflows/release.yml'
 
@@ -88,6 +89,18 @@ jobs:
           tags: |
             ghcr.io/izzywdev/fuzefront-sms-service:${{ steps.tag.outputs.sha }}
             ghcr.io/izzywdev/fuzefront-sms-service:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build and push provisioning-service
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: services/provisioning-service/Dockerfile
+          push: true
+          tags: |
+            ghcr.io/izzywdev/fuzefront-provisioning-service:${{ steps.tag.outputs.sha }}
+            ghcr.io/izzywdev/fuzefront-provisioning-service:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/deploy/helm/fuzefront/templates/NOTES.txt
+++ b/deploy/helm/fuzefront/templates/NOTES.txt
@@ -35,3 +35,9 @@ contain the following keys:
   - TWILIO_AUTH_TOKEN     — Twilio auth token
   - TWILIO_VERIFY_SERVICE_SID — Twilio Verify service SID
 {{- end }}
+{{- if .Values.provisioningService.enabled }}
+
+WARNING: provisioningService is enabled. Your SealedSecret (fuzefront-secrets) MUST
+contain the key INTERNAL_PROVISION_SECRET before the pod can start. Deploying
+without it will cause the provisioning-service pod to crash on startup.
+{{- end }}

--- a/deploy/helm/fuzefront/templates/provisioning-service.yaml
+++ b/deploy/helm/fuzefront/templates/provisioning-service.yaml
@@ -1,0 +1,81 @@
+{{- if .Values.provisioningService.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fuzefront-provisioning-service
+  labels:
+    {{- include "fuzefront.labels" . | nindent 4 }}
+    app.kubernetes.io/component: provisioning-service
+spec:
+  replicas: {{ .Values.provisioningService.replicas }}
+  selector:
+    matchLabels:
+      app: fuzefront-provisioning-service
+  template:
+    metadata:
+      labels:
+        app: fuzefront-provisioning-service
+        {{- include "fuzefront.labels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: provisioning-service
+          image: "{{ .Values.provisioningService.image.repository }}:{{ .Values.provisioningService.image.tag }}"
+          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.provisioningService.port }}
+          env:
+            - name: NODE_ENV
+              value: "production"
+            - name: PORT
+              value: {{ .Values.provisioningService.port | quote }}
+            - name: KAFKA_BROKERS
+              value: {{ .Values.provisioningService.kafka.brokers | quote }}
+            - name: KAFKA_CLIENT_ID
+              value: {{ .Values.provisioningService.kafka.clientId | quote }}
+            - name: KAFKA_GROUP_ID
+              value: {{ .Values.provisioningService.kafka.groupId | quote }}
+            - name: SECURITY_SERVICE_URL
+              # fuzefront-security is the in-cluster Service name for security-service (port 3002).
+              # See deploy/helm/fuzefront/templates/security.yaml.
+              value: "http://fuzefront-security:{{ .Values.securityService.port }}"
+            - name: INTERNAL_PROVISION_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "fuzefront.secretName" . }}
+                  key: INTERNAL_PROVISION_SECRET
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 15
+          resources:
+            {{- toYaml .Values.provisioningService.resources | nindent 12 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  # Health probes only — no ingress; this is a consumer-only service.
+  name: fuzefront-provisioning-service
+  labels:
+    {{- include "fuzefront.labels" . | nindent 4 }}
+spec:
+  selector:
+    app: fuzefront-provisioning-service
+  ports:
+    - name: http
+      port: {{ .Values.provisioningService.port }}
+      targetPort: http
+{{- end }}

--- a/deploy/helm/fuzefront/values-prod.yaml
+++ b/deploy/helm/fuzefront/values-prod.yaml
@@ -41,6 +41,11 @@ smsService:
     repository: ghcr.io/izzywdev/fuzefront-sms-service
     tag: ""  # CI's release sed writes the real image SHA here
 
+provisioningService:
+  image:
+    repository: ghcr.io/izzywdev/fuzefront-provisioning-service
+    tag: ""  # CI's release sed writes the real image SHA here
+
 permit:
   enabled: true
 

--- a/deploy/helm/fuzefront/values-prod.yaml
+++ b/deploy/helm/fuzefront/values-prod.yaml
@@ -41,6 +41,9 @@ smsService:
     repository: ghcr.io/izzywdev/fuzefront-sms-service
     tag: ""  # CI's release sed writes the real image SHA here
 
+# IMPORTANT: Before setting provisioningService.enabled: true in production, ensure
+# the SealedSecret `fuzefront-secrets` contains the key INTERNAL_PROVISION_SECRET.
+# Without it the provisioning-service pod will fail to start (missing env var).
 provisioningService:
   image:
     repository: ghcr.io/izzywdev/fuzefront-provisioning-service

--- a/deploy/helm/fuzefront/values.yaml
+++ b/deploy/helm/fuzefront/values.yaml
@@ -192,6 +192,25 @@ smsService:
     tag: local
   resources: {}
 
+# Plan D — thin Kafka→HTTP bridge: consumes identity.user.created, calls
+# security-service POST /internal/provision. No DB, no domain logic.
+# SECURITY_SERVICE_URL is derived in the Helm template from securityService.port
+# (http://fuzefront-security:<port>) — do not override separately.
+provisioningService:
+  enabled: false
+  replicas: 1
+  port: 3005
+  image:
+    repository: fuzefront/provisioning-service
+    tag: local
+  kafka:
+    brokers: "kafka.fuzeinfra.svc.cluster.local:9092"
+    clientId: "provisioning-service"
+    groupId: "provisioning-service-group"
+  resources:
+    requests: { cpu: 50m, memory: 128Mi }
+    limits:   { cpu: 500m, memory: 256Mi }
+
 authentik:
   enabled: true
   image:

--- a/docs/superpowers/plans/2026-06-19-provisioning-service-D.md
+++ b/docs/superpowers/plans/2026-06-19-provisioning-service-D.md
@@ -1,0 +1,82 @@
+# Plan D — provisioning-service
+
+**Date:** 2026-06-19
+**Status:** Implementing
+
+---
+
+## Capability + hard requirements
+
+A thin Kafka → HTTP bridge: consume `identity.user.created`, call security-service
+`POST /internal/provision` (idempotent, header-auth'd), emit poison messages to a DLQ,
+retry 5xx with bounded exponential backoff.
+
+Hard requirements:
+- No DB, no domain logic. All provisioning logic stays in security-service.
+- DLQ on schema-invalid / JSON-parse failure (Zod catch).
+- Bounded retry-with-backoff (3 retries, 200ms base, 2× factor, max 2 s) on transient
+  HTTP 5xx.
+- `/health` for Kubernetes probes.
+- Config via env vars / Helm chart Secret — zero hardcoded secrets.
+- Mirror email-service TS/Dockerfile/jest/Helm/lerna/skaffold/release structure.
+
+---
+
+## Library & Architecture Review
+
+### Kafka consumer
+
+| Option | Fit | Notes |
+|---|---|---|
+| `TypedConsumer` from `@fuzefront/shared` | Full | Project-native; DLQ wired in; already used by email-service / sms-service. **Adopted.** |
+| Raw `kafkajs` | Full | More boilerplate; no DLQ helper. Runner-up if shared consumer ever becomes a bottleneck. |
+| `kafkajs` with `kafkajs-retry` lib | Overkill | Retry belongs at the HTTP layer here, not the Kafka layer — topic offset only moves after a commit, and the endpoint is idempotent. |
+
+**Recommendation: adopt `TypedConsumer`** — it handles DLQ, JSON parse failures, and Zod validation in one place.
+
+### HTTP client with retry
+
+| Option | Fit | Notes |
+|---|---|---|
+| `axios` + `axios-retry` | Good | Familiar, explicit retry config. |
+| `node-fetch` + custom retry | Minimal | Less config surface; bespoke but tiny for 3 retries. |
+| `got` with built-in retry | Good | More config knobs than needed. |
+| Native `fetch` (Node 18+) + custom | Good | Zero deps. Chosen — Node 18 built-in `fetch` + a 30-line retry wrapper is the lightest option and matches Node version in all service Dockerfiles. |
+
+**Recommendation: native `fetch` + bespoke `retryWithBackoff`** — no extra dependency, easily mockable in tests.
+
+---
+
+## Componentization decision
+
+**Standalone microservice** (`services/provisioning-service`). Rationale:
+- Independent lifecycle from security-service; can scale/restart independently.
+- Consumer-only: no DB, no routes except `/health`.
+- Already established pattern in the repo (email-service, sms-service).
+
+Public interface: none (no ingress, no API). Internal interface: reads from
+`identity.user.created`, writes failures to `identity.user.created.dlq`.
+
+---
+
+## Implementation plan (bite-sized)
+
+1. **`services/provisioning-service/`** — mirror email-service structure.
+2. **`src/config.ts`** — `loadConfig()` reads `KAFKA_BROKERS`, `KAFKA_CLIENT_ID`, `KAFKA_GROUP_ID`, `SECURITY_SERVICE_URL`, `INTERNAL_PROVISION_SECRET`, `PORT`.
+3. **`src/provision.ts`** — `callProvision(userId, config)`: `fetch` with `x-internal-secret` header, `retryWithBackoff` on 5xx, throws on 4xx.
+4. **`src/handler.ts`** — `handleUserCreated(event, deps)`: validates event, calls `callProvision`, logs result. Deps interface for test injection.
+5. **`src/app.ts`** — Express `/health` endpoint.
+6. **`src/index.ts`** — wires Kafka consumer + Express server + graceful shutdown.
+7. **`tests/`** — unit tests: success, 5xx-retry, DLQ-on-invalid, no-double-call.
+8. **Helm**: `deploy/helm/fuzefront/templates/provisioning-service.yaml`, values block, prod overlay entry.
+9. **GitOps**: `lerna.json`, `skaffold.yaml`, `release.yml`, `values-prod.yaml`.
+
+---
+
+## Security-service in-cluster URL
+
+From `deploy/helm/fuzefront/templates/security.yaml`:
+- Service name: `fuzefront-security`
+- Port: `3002` (`.Values.securityService.port`)
+
+Therefore: `SECURITY_SERVICE_URL=http://fuzefront-security:3002`

--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "version": "1.0.0",
   "npmClient": "npm",
-  "packages": ["backend", "frontend", "shared", "sdk", "task-manager-app", "services/email-service", "services/sms-service"],
+  "packages": ["backend", "frontend", "shared", "sdk", "task-manager-app", "services/email-service", "services/sms-service", "services/provisioning-service"],
   "command": {
     "version": {
       "allowBranch": ["main", "master", "develop"],

--- a/services/provisioning-service/Dockerfile
+++ b/services/provisioning-service/Dockerfile
@@ -1,0 +1,58 @@
+# syntax=docker/dockerfile:1
+
+# ---------- base: install production deps only ----------
+FROM node:18-alpine AS base
+WORKDIR /app
+RUN apk add --no-cache dumb-init
+
+# Copy workspace root manifests (needed so npm ci can resolve workspace links)
+COPY package.json package-lock.json ./
+COPY shared/package.json ./shared/
+COPY services/provisioning-service/package.json ./services/provisioning-service/
+
+# Install only production deps for provisioning-service
+RUN npm ci --workspace=services/provisioning-service --omit=dev --ignore-scripts
+
+# ---------- build: full compile ----------
+FROM node:18-alpine AS build
+WORKDIR /app
+COPY package.json package-lock.json ./
+COPY shared/package.json ./shared/
+COPY services/provisioning-service/package.json ./services/provisioning-service/
+
+RUN npm ci --workspace=services/provisioning-service --ignore-scripts
+
+# Copy source
+COPY shared/ ./shared/
+COPY services/provisioning-service/ ./services/provisioning-service/
+
+# Build shared first, then provisioning-service
+RUN cd shared && npm run build
+RUN cd services/provisioning-service && npm run build
+
+# ---------- production ----------
+FROM node:18-alpine AS production
+WORKDIR /app
+
+RUN apk add --no-cache dumb-init && \
+    addgroup -S provisioningservice && adduser -S provisioningservice -G provisioningservice -u 1001
+
+COPY --from=base /app/node_modules ./node_modules
+COPY --from=base /app/services/provisioning-service/node_modules ./services/provisioning-service/node_modules
+COPY --from=build /app/shared/dist ./shared/dist
+COPY --from=build /app/services/provisioning-service/dist ./services/provisioning-service/dist
+
+# Remove declaration files from production image
+RUN find ./services/provisioning-service/dist -name "*.d.ts" -type f -delete
+
+WORKDIR /app/services/provisioning-service
+
+ENV PORT=3005
+ENV NODE_ENV=production
+
+EXPOSE 3005
+
+USER provisioningservice
+
+ENTRYPOINT ["dumb-init", "--"]
+CMD ["node", "dist/index.js"]

--- a/services/provisioning-service/jest.config.js
+++ b/services/provisioning-service/jest.config.js
@@ -1,0 +1,20 @@
+// services/provisioning-service/jest.config.js
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/tests'],
+  testMatch: ['**/*.test.ts'],
+  transform: {
+    '^.+\\.ts$': ['ts-jest', { tsconfig: 'tests/tsconfig.json' }],
+  },
+  // Map @fuzefront/shared to the kafka sub-barrel (TypeScript source) so ts-jest can compile it.
+  // Narrower mapping intentional: provisioning-service only uses kafka exports.
+  moduleNameMapper: {
+    '^@fuzefront/shared$': '<rootDir>/../../shared/src/kafka/index.ts',
+    '^@fuzefront/shared/kafka$': '<rootDir>/../../shared/src/kafka/index.ts',
+  },
+  // Ensure node_modules from this service are resolved even when ts-jest traverses
+  // shared/src/* files that are outside rootDir.
+  moduleDirectories: ['node_modules', '<rootDir>/node_modules'],
+  testTimeout: 60000,
+};

--- a/services/provisioning-service/package.json
+++ b/services/provisioning-service/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@fuzefront/provisioning-service",
+  "version": "1.0.0",
+  "description": "Kafka consumer that bridges identity.user.created events to security-service /internal/provision",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "dev": "nodemon --exec ts-node src/index.ts",
+    "test": "jest"
+  },
+  "dependencies": {
+    "@fuzefront/shared": "file:../../shared",
+    "express": "^4.19.2",
+    "kafkajs": "^2.2.4",
+    "zod": "^3.22.4"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21",
+    "@types/node": "^18.19.0",
+    "jest": "^29.7.0",
+    "nodemon": "^3.0.1",
+    "ts-jest": "^29.1.1",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.1.6"
+  }
+}

--- a/services/provisioning-service/src/app.ts
+++ b/services/provisioning-service/src/app.ts
@@ -1,0 +1,12 @@
+import express, { Application, Request, Response } from 'express';
+
+export function createApp(): Application {
+  const app = express();
+  app.use(express.json());
+
+  app.get('/health', (_req: Request, res: Response) => {
+    res.json({ status: 'ok', service: 'provisioning-service' });
+  });
+
+  return app;
+}

--- a/services/provisioning-service/src/config.ts
+++ b/services/provisioning-service/src/config.ts
@@ -1,0 +1,32 @@
+export interface Config {
+  port: number;
+  kafka: {
+    brokers: string[];
+    clientId: string;
+    groupId: string;
+  };
+  securityServiceUrl: string;
+  internalProvisionSecret: string;
+}
+
+export function loadConfig(): Config {
+  const brokers = process.env.KAFKA_BROKERS;
+  if (!brokers) throw new Error('KAFKA_BROKERS is required');
+
+  const securityServiceUrl = process.env.SECURITY_SERVICE_URL;
+  if (!securityServiceUrl) throw new Error('SECURITY_SERVICE_URL is required');
+
+  const internalProvisionSecret = process.env.INTERNAL_PROVISION_SECRET;
+  if (!internalProvisionSecret) throw new Error('INTERNAL_PROVISION_SECRET is required');
+
+  return {
+    port: parseInt(process.env.PORT || '3005', 10),
+    kafka: {
+      brokers: brokers.split(',').map((b) => b.trim()),
+      clientId: process.env.KAFKA_CLIENT_ID || 'provisioning-service',
+      groupId: process.env.KAFKA_GROUP_ID || 'provisioning-service-group',
+    },
+    securityServiceUrl,
+    internalProvisionSecret,
+  };
+}

--- a/services/provisioning-service/src/handler.ts
+++ b/services/provisioning-service/src/handler.ts
@@ -1,0 +1,36 @@
+import { FuzeEvent, IdentityUserCreatedPayloadV1 } from '@fuzefront/shared/kafka';
+import { callProvision, HttpClient, nodeFetchClient } from './provision';
+
+export interface HandlerDeps {
+  securityServiceUrl: string;
+  internalProvisionSecret: string;
+  http?: HttpClient;
+}
+
+/**
+ * Handles an identity.user.created event by calling security-service
+ * POST /internal/provision. The TypedConsumer already validated the payload
+ * against identityUserCreatedSchemaV1 before this handler is called.
+ */
+export async function handleUserCreated(
+  event: FuzeEvent<IdentityUserCreatedPayloadV1>,
+  deps: HandlerDeps
+): Promise<void> {
+  const { userId } = event.payload;
+  const http = deps.http ?? nodeFetchClient;
+
+  console.log(
+    `[provisioning-service] Provisioning user ${userId} (correlationId=${event.correlationId})`
+  );
+
+  const result = await callProvision(
+    userId,
+    deps.securityServiceUrl,
+    deps.internalProvisionSecret,
+    http
+  );
+
+  console.log(
+    `[provisioning-service] Provisioned user ${userId}: personalOrgId=${result.personalOrgId} reconciled=${result.reconciled}`
+  );
+}

--- a/services/provisioning-service/src/index.ts
+++ b/services/provisioning-service/src/index.ts
@@ -3,6 +3,8 @@ import {
   TypedProducer,
   TypedConsumer,
   TOPICS,
+  FuzeEvent,
+  IdentityUserCreatedPayloadV1,
   identityUserCreatedSchemaV1,
 } from '@fuzefront/shared/kafka';
 import { loadConfig } from './config';
@@ -26,11 +28,33 @@ async function main() {
   await consumer.connect();
   await consumer.subscribe(TOPICS.IDENTITY_USER_CREATED);
   await consumer.run(
-    (event) =>
-      handleUserCreated(event as any, {
-        securityServiceUrl: config.securityServiceUrl,
-        internalProvisionSecret: config.internalProvisionSecret,
-      }),
+    async (event: FuzeEvent<IdentityUserCreatedPayloadV1>) => {
+      try {
+        await handleUserCreated(event, {
+          securityServiceUrl: config.securityServiceUrl,
+          internalProvisionSecret: config.internalProvisionSecret,
+        });
+      } catch (err) {
+        // HTTP-layer failures (4xx or 5xx-exhaustion) must not crash the consumer.
+        // Route the message to the DLQ so the offset is committed and processing continues.
+        console.error(
+          `[provisioning-service] Handler failed for correlationId=${event.correlationId}, routing to DLQ: ${String(err)}`
+        );
+        const dlqTopicName = `${TOPICS.IDENTITY_USER_CREATED}.dlq`;
+        await dlqProducer.raw.send({
+          topic: dlqTopicName,
+          messages: [
+            {
+              value: JSON.stringify({
+                raw: JSON.stringify(event),
+                reason: String(err),
+                sourceTopic: TOPICS.IDENTITY_USER_CREATED,
+              }),
+            },
+          ],
+        });
+      }
+    },
     identityUserCreatedSchemaV1,
     dlqProducer
   );

--- a/services/provisioning-service/src/index.ts
+++ b/services/provisioning-service/src/index.ts
@@ -1,0 +1,58 @@
+import {
+  createKafkaClient,
+  TypedProducer,
+  TypedConsumer,
+  TOPICS,
+  identityUserCreatedSchemaV1,
+} from '@fuzefront/shared/kafka';
+import { loadConfig } from './config';
+import { handleUserCreated } from './handler';
+import { createApp } from './app';
+
+async function main() {
+  const config = loadConfig();
+
+  // --- Kafka ---
+  const kafka = createKafkaClient({
+    clientId: config.kafka.clientId,
+    brokers: config.kafka.brokers,
+  });
+
+  // DLQ producer: forwards poison/schema-invalid messages to identity.user.created.dlq
+  const dlqProducer = new TypedProducer(kafka);
+  await dlqProducer.connect();
+
+  const consumer = new TypedConsumer(kafka, config.kafka.groupId);
+  await consumer.connect();
+  await consumer.subscribe(TOPICS.IDENTITY_USER_CREATED);
+  await consumer.run(
+    (event) =>
+      handleUserCreated(event as any, {
+        securityServiceUrl: config.securityServiceUrl,
+        internalProvisionSecret: config.internalProvisionSecret,
+      }),
+    identityUserCreatedSchemaV1,
+    dlqProducer
+  );
+
+  // --- HTTP health probe ---
+  const app = createApp();
+  app.listen(config.port, () => {
+    console.log(`[provisioning-service] Listening on port ${config.port}`);
+  });
+
+  // --- Graceful shutdown ---
+  const shutdown = async () => {
+    console.log('[provisioning-service] Shutting down...');
+    await consumer.disconnect();
+    await dlqProducer.disconnect();
+    process.exit(0);
+  };
+  process.on('SIGTERM', shutdown);
+  process.on('SIGINT', shutdown);
+}
+
+main().catch((err) => {
+  console.error('[provisioning-service] Fatal error:', err);
+  process.exit(1);
+});

--- a/services/provisioning-service/src/provision.ts
+++ b/services/provisioning-service/src/provision.ts
@@ -1,0 +1,74 @@
+/**
+ * Calls security-service POST /internal/provision with the given userId.
+ * Retries on transient HTTP 5xx with bounded exponential backoff.
+ * The endpoint is idempotent so retries are safe.
+ */
+
+export interface ProvisionResult {
+  ok: boolean;
+  personalOrgId: string;
+  reconciled: boolean;
+}
+
+export interface HttpClient {
+  fetch(url: string, init: RequestInit): Promise<{ status: number; json(): Promise<any> }>;
+}
+
+/** Real HTTP client backed by Node 18 native fetch */
+export const nodeFetchClient: HttpClient = {
+  fetch: (url, init) => fetch(url, init),
+};
+
+const RETRY_COUNT = 3;
+const RETRY_BASE_MS = 200;
+const RETRY_FACTOR = 2;
+const RETRY_MAX_MS = 2000;
+
+async function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function callProvision(
+  userId: string,
+  securityServiceUrl: string,
+  internalProvisionSecret: string,
+  http: HttpClient = nodeFetchClient
+): Promise<ProvisionResult> {
+  let lastError: Error | null = null;
+
+  for (let attempt = 0; attempt <= RETRY_COUNT; attempt++) {
+    if (attempt > 0) {
+      const delay = Math.min(RETRY_BASE_MS * Math.pow(RETRY_FACTOR, attempt - 1), RETRY_MAX_MS);
+      await sleep(delay);
+    }
+
+    const response = await http.fetch(`${securityServiceUrl}/internal/provision`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-internal-secret': internalProvisionSecret,
+      },
+      body: JSON.stringify({ userId }),
+    });
+
+    if (response.status === 200) {
+      const body = await response.json();
+      return body as ProvisionResult;
+    }
+
+    if (response.status >= 500) {
+      // Transient — retry
+      lastError = new Error(`security-service returned ${response.status} (attempt ${attempt + 1})`);
+      console.warn(`[provisioning-service] Transient error: ${lastError.message}`);
+      continue;
+    }
+
+    // 4xx — non-retryable
+    const body = await response.json().catch(() => ({}));
+    throw new Error(
+      `security-service returned ${response.status}: ${JSON.stringify(body)}`
+    );
+  }
+
+  throw lastError ?? new Error('callProvision: exhausted retries');
+}

--- a/services/provisioning-service/tests/consumer-dlq.test.ts
+++ b/services/provisioning-service/tests/consumer-dlq.test.ts
@@ -1,0 +1,143 @@
+/**
+ * C2: DLQ routing tests for the consumer wrapper in src/index.ts.
+ *
+ * Strategy: replicate the same try/catch wrapper logic used in index.ts's consumer.run()
+ * handler, wiring it to a mocked dlqProducer and a mocked handleUserCreated.
+ * This verifies:
+ *   (a) on 4xx failure  → DLQ send is called with the right topic + payload, no throw
+ *   (b) on 5xx-exhaustion → DLQ send is called with the right topic + payload, no throw
+ */
+
+import { FuzeEvent, TOPICS, IdentityUserCreatedPayloadV1 } from '@fuzefront/shared/kafka';
+import { handleUserCreated } from '../src/handler';
+import { HttpClient } from '../src/provision';
+
+jest.mock('../src/handler');
+
+const mockedHandleUserCreated = handleUserCreated as jest.MockedFunction<typeof handleUserCreated>;
+
+const SECRET = 'test-secret';
+const SECURITY_URL = 'http://security:3002';
+
+function makeEvent(
+  overrides: Partial<IdentityUserCreatedPayloadV1> = {}
+): FuzeEvent<IdentityUserCreatedPayloadV1> {
+  return {
+    version: '1.0',
+    topic: TOPICS.IDENTITY_USER_CREATED,
+    correlationId: 'corr-dlq-1',
+    occurredAt: new Date().toISOString(),
+    payload: {
+      userId: '22222222-2222-2222-2222-222222222222',
+      email: 'bob@example.com',
+      intent: 'signup',
+      ...overrides,
+    },
+  };
+}
+
+/** Builds a minimal mock for dlqProducer (only raw.send is needed). */
+function makeDlqProducer() {
+  const sendMock = jest.fn().mockResolvedValue(undefined);
+  return {
+    raw: { send: sendMock },
+    _sendMock: sendMock,
+  };
+}
+
+/**
+ * The inline handler wrapper from index.ts, extracted here for unit testing.
+ * Mirrors the logic in consumer.run(async (event) => { try { ... } catch { DLQ } }).
+ */
+async function consumerHandlerWrapper(
+  event: FuzeEvent<IdentityUserCreatedPayloadV1>,
+  deps: { securityServiceUrl: string; internalProvisionSecret: string },
+  dlqProducer: { raw: { send: jest.Mock } }
+): Promise<void> {
+  try {
+    await handleUserCreated(event, deps);
+  } catch (err) {
+    const dlqTopicName = `${TOPICS.IDENTITY_USER_CREATED}.dlq`;
+    await dlqProducer.raw.send({
+      topic: dlqTopicName,
+      messages: [
+        {
+          value: JSON.stringify({
+            raw: JSON.stringify(event),
+            reason: String(err),
+            sourceTopic: TOPICS.IDENTITY_USER_CREATED,
+          }),
+        },
+      ],
+    });
+  }
+}
+
+describe('consumer DLQ routing (C2)', () => {
+  const deps = {
+    securityServiceUrl: SECURITY_URL,
+    internalProvisionSecret: SECRET,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('(a) routes 4xx failure to DLQ and does not throw', async () => {
+    const dlqProducer = makeDlqProducer();
+    const error4xx = new Error('security-service returned 401: {"error":"Unauthorized"}');
+    mockedHandleUserCreated.mockRejectedValueOnce(error4xx);
+
+    const event = makeEvent();
+
+    // Must NOT throw — consumer keeps running
+    await expect(
+      consumerHandlerWrapper(event, deps, dlqProducer)
+    ).resolves.toBeUndefined();
+
+    // DLQ producer must have been called once
+    expect(dlqProducer._sendMock).toHaveBeenCalledTimes(1);
+
+    const callArg = dlqProducer._sendMock.mock.calls[0][0];
+    expect(callArg.topic).toBe(`${TOPICS.IDENTITY_USER_CREATED}.dlq`);
+
+    const payload = JSON.parse(callArg.messages[0].value);
+    expect(payload.reason).toContain('401');
+    expect(payload.sourceTopic).toBe(TOPICS.IDENTITY_USER_CREATED);
+    expect(JSON.parse(payload.raw).correlationId).toBe(event.correlationId);
+  });
+
+  it('(b) routes 5xx-exhaustion failure to DLQ and does not throw', async () => {
+    const dlqProducer = makeDlqProducer();
+    const error5xx = new Error('security-service returned 503 (attempt 4)');
+    mockedHandleUserCreated.mockRejectedValueOnce(error5xx);
+
+    const event = makeEvent();
+
+    // Must NOT throw — consumer keeps running
+    await expect(
+      consumerHandlerWrapper(event, deps, dlqProducer)
+    ).resolves.toBeUndefined();
+
+    // DLQ producer must have been called once
+    expect(dlqProducer._sendMock).toHaveBeenCalledTimes(1);
+
+    const callArg = dlqProducer._sendMock.mock.calls[0][0];
+    expect(callArg.topic).toBe(`${TOPICS.IDENTITY_USER_CREATED}.dlq`);
+
+    const payload = JSON.parse(callArg.messages[0].value);
+    expect(payload.reason).toContain('503');
+    expect(payload.sourceTopic).toBe(TOPICS.IDENTITY_USER_CREATED);
+    expect(JSON.parse(payload.raw).correlationId).toBe(event.correlationId);
+  });
+
+  it('does NOT call DLQ when handler succeeds', async () => {
+    const dlqProducer = makeDlqProducer();
+    mockedHandleUserCreated.mockResolvedValueOnce(undefined);
+
+    const event = makeEvent();
+    await consumerHandlerWrapper(event, deps, dlqProducer);
+
+    expect(dlqProducer._sendMock).not.toHaveBeenCalled();
+  });
+});

--- a/services/provisioning-service/tests/handler.test.ts
+++ b/services/provisioning-service/tests/handler.test.ts
@@ -1,0 +1,135 @@
+import { handleUserCreated } from '../src/handler';
+import { FuzeEvent, TOPICS, IdentityUserCreatedPayloadV1 } from '@fuzefront/shared/kafka';
+import { HttpClient } from '../src/provision';
+
+const SECRET = 'test-secret';
+const SECURITY_URL = 'http://security:3002';
+
+function makeEvent(
+  overrides: Partial<IdentityUserCreatedPayloadV1> = {}
+): FuzeEvent<IdentityUserCreatedPayloadV1> {
+  return {
+    version: '1.0',
+    topic: TOPICS.IDENTITY_USER_CREATED,
+    correlationId: 'corr-test-1',
+    occurredAt: new Date().toISOString(),
+    payload: {
+      userId: '11111111-1111-1111-1111-111111111111',
+      email: 'alice@example.com',
+      intent: 'signup',
+      ...overrides,
+    },
+  };
+}
+
+function makeHttpClient(responses: Array<{ status: number; body?: object }>): HttpClient & { calls: any[] } {
+  const calls: any[] = [];
+  let idx = 0;
+  return {
+    calls,
+    fetch: jest.fn(async (url: string, init: RequestInit) => {
+      const resp = responses[idx] ?? responses[responses.length - 1];
+      idx++;
+      calls.push({ url, init, respondedWith: resp });
+      return {
+        status: resp.status,
+        json: async () => resp.body ?? {},
+      };
+    }),
+  };
+}
+
+describe('handleUserCreated', () => {
+  it('calls POST /internal/provision with correct headers and body on success', async () => {
+    const http = makeHttpClient([
+      { status: 200, body: { ok: true, personalOrgId: 'org-1', reconciled: false } },
+    ]);
+
+    await handleUserCreated(makeEvent(), {
+      securityServiceUrl: SECURITY_URL,
+      internalProvisionSecret: SECRET,
+      http,
+    });
+
+    expect(http.calls).toHaveLength(1);
+    const call = http.calls[0];
+    expect(call.url).toBe(`${SECURITY_URL}/internal/provision`);
+    expect(call.init.method).toBe('POST');
+
+    const headers = call.init.headers as Record<string, string>;
+    expect(headers['x-internal-secret']).toBe(SECRET);
+    expect(headers['Content-Type']).toBe('application/json');
+
+    const body = JSON.parse(call.init.body as string);
+    expect(body.userId).toBe('11111111-1111-1111-1111-111111111111');
+  });
+
+  it('does NOT call provision twice on success', async () => {
+    const http = makeHttpClient([
+      { status: 200, body: { ok: true, personalOrgId: 'org-1', reconciled: false } },
+    ]);
+
+    await handleUserCreated(makeEvent(), {
+      securityServiceUrl: SECURITY_URL,
+      internalProvisionSecret: SECRET,
+      http,
+    });
+
+    expect(http.calls).toHaveLength(1);
+  });
+
+  it('retries on 5xx up to RETRY_COUNT times then throws', async () => {
+    // All responses are 500 — exhausts retries (1 initial + 3 retries = 4 calls)
+    const http = makeHttpClient([
+      { status: 500 },
+      { status: 500 },
+      { status: 500 },
+      { status: 500 },
+    ]);
+
+    await expect(
+      handleUserCreated(makeEvent(), {
+        securityServiceUrl: SECURITY_URL,
+        internalProvisionSecret: SECRET,
+        http,
+      })
+    ).rejects.toThrow();
+
+    // 1 initial attempt + 3 retries = 4 total
+    expect(http.calls).toHaveLength(4);
+  });
+
+  it('succeeds on the final retry after initial 5xx failures', async () => {
+    // Two 500s then success
+    const http = makeHttpClient([
+      { status: 500 },
+      { status: 500 },
+      { status: 200, body: { ok: true, personalOrgId: 'org-2', reconciled: true } },
+    ]);
+
+    await handleUserCreated(makeEvent(), {
+      securityServiceUrl: SECURITY_URL,
+      internalProvisionSecret: SECRET,
+      http,
+    });
+
+    expect(http.calls).toHaveLength(3);
+  });
+
+  it('does NOT retry on 4xx — throws immediately', async () => {
+    const http = makeHttpClient([
+      { status: 401, body: { error: 'Unauthorized' } },
+    ]);
+
+    await expect(
+      handleUserCreated(makeEvent(), {
+        securityServiceUrl: SECURITY_URL,
+        internalProvisionSecret: SECRET,
+        http,
+      })
+    ).rejects.toThrow(/401/);
+
+    // Only one attempt — no retries for 4xx
+    expect(http.calls).toHaveLength(1);
+  });
+});

--- a/services/provisioning-service/tests/tsconfig.json
+++ b/services/provisioning-service/tests/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "strict": false,
+    "noImplicitAny": false,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "baseUrl": "..",
+    "paths": {
+      "@fuzefront/shared/kafka": ["../../shared/src/kafka/index.ts"],
+      "@fuzefront/shared": ["../../shared/src/kafka/index.ts"]
+    }
+  },
+  "include": ["**/*.test.ts", "../src/**/*.ts"]
+}

--- a/services/provisioning-service/tsconfig.json
+++ b/services/provisioning-service/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": false,
+    "noImplicitAny": false,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "moduleResolution": "node16",
+    "module": "node16"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "tests"]
+}

--- a/services/provisioning-service/tsconfig.json
+++ b/services/provisioning-service/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "module": "commonjs",
+    "module": "node16",
     "outDir": "./dist",
     "rootDir": "./src",
     "strict": false,
@@ -12,8 +12,7 @@
     "esModuleInterop": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,
-    "moduleResolution": "node16",
-    "module": "node16"
+    "moduleResolution": "node16"
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "tests"]

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -45,6 +45,10 @@ build:
       context: .
       docker:
         dockerfile: services/sms-service/Dockerfile
+    - image: fuzefront/provisioning-service
+      context: .
+      docker:
+        dockerfile: services/provisioning-service/Dockerfile
     - image: fuzefront/security-service
       # Root context so the image can build @fuzefront/core + @fuzefront/shared.
       context: .
@@ -74,6 +78,8 @@ manifests:
           emailService.image.tag: "{{.IMAGE_TAG_fuzefront_email_service}}"
           smsService.image.repository: "{{.IMAGE_REPO_fuzefront_sms_service}}"
           smsService.image.tag: "{{.IMAGE_TAG_fuzefront_sms_service}}"
+          provisioningService.image.repository: "{{.IMAGE_REPO_fuzefront_provisioning_service}}"
+          provisioningService.image.tag: "{{.IMAGE_TAG_fuzefront_provisioning_service}}"
           securityService.image.repository: "{{.IMAGE_REPO_fuzefront_security_service}}"
           securityService.image.tag: "{{.IMAGE_TAG_fuzefront_security_service}}"
           applicationsService.image.repository: "{{.IMAGE_REPO_fuzefront_applications_service}}"


### PR DESCRIPTION
## Summary

- Adds `services/provisioning-service`: thin Kafka consumer of `identity.user.created` that calls `security-service POST /internal/provision` — no DB, no domain logic
- DLQ via `TypedConsumer` on schema-invalid / JSON-parse failure; bounded retry-with-backoff (3 retries, 200ms base, 2× factor, 2s max) on HTTP 5xx
- `/health` endpoint for Kubernetes liveness/readiness probes
- `SECURITY_SERVICE_URL` wired in Helm as `http://fuzefront-security:3002` (read from `securityService.port`); `INTERNAL_PROVISION_SECRET` read from existing chart Secret key

## Test plan

- [x] 5 unit tests green: success path, no-double-call, 5xx-retry exhaustion (4 attempts), retry-then-success, no-retry-on-4xx
- [x] `npm run build` clean (TypeScript)
- [ ] Enable `provisioningService.enabled: true` in `values-local.yaml` and `skaffold run` to validate end-to-end in kind cluster
- [ ] Confirm DLQ messages land in `identity.user.created.dlq` topic on malformed event

## Files changed

| Area | Files |
|---|---|
| Service | `services/provisioning-service/src/` (5 files), `Dockerfile`, `package.json`, `tsconfig.json`, `jest.config.js` |
| Tests | `services/provisioning-service/tests/handler.test.ts` |
| Helm | `deploy/helm/fuzefront/templates/provisioning-service.yaml`, `values.yaml`, `values-prod.yaml` |
| GitOps | `lerna.json`, `skaffold.yaml`, `.github/workflows/release.yml` |
| Plan | `docs/superpowers/plans/2026-06-19-provisioning-service-D.md` |