### PR TITLE
fix(security): OIDC token-in-URL leak + state CSRF (Wave H1)

### DIFF
--- a/backend/security/jest.config.js
+++ b/backend/security/jest.config.js
@@ -11,5 +11,9 @@ module.exports = {
   transform: {
     '^.+\\.ts$': ['ts-jest', { tsconfig: 'tests/tsconfig.json' }],
   },
+  moduleNameMapper: {
+    '^@fuzefront/core$': '<rootDir>/../core/dist/index.js',
+    '^@fuzefront/shared/kafka$': '<rootDir>/../../shared/dist/kafka/index.js',
+  },
   testTimeout: 30000,
 }

--- a/backend/security/src/routes/auth.ts
+++ b/backend/security/src/routes/auth.ts
@@ -10,6 +10,10 @@ import { oidcService } from '../services/oidc'
 import { runInternalProvision } from '../services/organizationProvisioning'
 
 
+const CODE_TTL_MS = 60_000
+interface PendingCode { token: string; sessionId: string; expiresAt: number }
+const pendingCodes = new Map<string, PendingCode>()
+
 const router = express.Router()
 
 /**
@@ -436,14 +440,14 @@ router.get('/oidc/callback', async (req, res) => {
     const user = await oidcService.handleCallback(code as string, state as string)
     console.log(`✅ [${requestId}] User authenticated via OIDC:`, user.email)
 
-    // Generate JWT token
-    const token = jwt.sign({ userId: user.id }, process.env.JWT_SECRET!, {
-      expiresIn: '24h',
-    })
-
-    // Create session
+    // Create session id first so it can be embedded in the token
     const sessionId = uuidv4()
     const expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000) // 24 hours
+
+    // Generate JWT token (includes sessionId so logout can target this session)
+    const token = jwt.sign({ userId: user.id, sessionId }, process.env.JWT_SECRET!, {
+      expiresIn: '24h',
+    })
 
     await db('sessions').insert({
       id: sessionId,
@@ -456,9 +460,11 @@ router.get('/oidc/callback', async (req, res) => {
     // Self-heal provisioning in the background (does not block the redirect).
     selfHealProvisioningOnLogin(user.id)
 
-    // Redirect to frontend with token
-    const frontendUrl = `http://fuzefront.dev.local/?token=${token}&sessionId=${sessionId}`
-    res.redirect(frontendUrl)
+    // Issue a short-lived opaque exchange code instead of putting the bearer token in the URL
+    // (avoids token leakage via referrer headers, server logs, and browser history).
+    const exchangeCode = crypto.randomBytes(32).toString('hex')
+    pendingCodes.set(exchangeCode, { token, sessionId, expiresAt: Date.now() + CODE_TTL_MS })
+    res.redirect(`http://fuzefront.dev.local/?code=${exchangeCode}`)
 
   } catch (error) {
     console.error(`❌ [${requestId}] OIDC callback error:`, error)
@@ -506,6 +512,47 @@ router.get('/method', (req, res) => {
     defaultMethod: oidcConfigured ? 'oidc' : 'local',
     oidcLoginUrl: oidcConfigured ? '/api/auth/oidc/login' : null,
   })
+})
+
+/**
+ * @swagger
+ * /api/auth/token-exchange:
+ *   post:
+ *     summary: Exchange OIDC code for token
+ *     description: Single-use, 60s TTL exchange of the opaque code issued by /oidc/callback for a JWT token and sessionId
+ *     tags: [Authentication]
+ *     security: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [code]
+ *             properties:
+ *               code:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         description: Token and sessionId returned
+ *       400:
+ *         description: code required
+ *       401:
+ *         description: invalid or expired code
+ */
+router.post('/token-exchange', async (req, res) => {
+  const { code } = req.body
+  if (!code || typeof code !== 'string') {
+    return res.status(400).json({ error: 'code required' })
+  }
+  const pending = pendingCodes.get(code)
+  if (!pending || Date.now() > pending.expiresAt) {
+    pendingCodes.delete(code)  // clean up expired entry if present
+    return res.status(401).json({ error: 'invalid or expired code' })
+  }
+  // Single-use: delete immediately
+  pendingCodes.delete(code)
+  return res.json({ token: pending.token, sessionId: pending.sessionId })
 })
 
 export default router

--- a/backend/security/src/routes/auth.ts
+++ b/backend/security/src/routes/auth.ts
@@ -14,6 +14,21 @@ const CODE_TTL_MS = 60_000
 interface PendingCode { token: string; sessionId: string; expiresAt: number }
 const pendingCodes = new Map<string, PendingCode>()
 
+// Use the configured frontend base URL for all redirects so that exchange codes
+// ride HTTPS in production rather than a hardcoded http:// origin.
+const FRONTEND_BASE = (process.env.FRONTEND_URL || 'http://fuzefront.dev.local').replace(/\/$/, '')
+
+// Periodic sweep: remove never-redeemed codes that have passed their TTL.
+// .unref() prevents this interval from keeping the process alive in tests.
+setInterval(() => {
+  const now = Date.now()
+  for (const [key, value] of pendingCodes) {
+    if (value.expiresAt < now) {
+      pendingCodes.delete(key)
+    }
+  }
+}, CODE_TTL_MS).unref()
+
 const router = express.Router()
 
 /**
@@ -406,6 +421,11 @@ router.get('/oidc/callback', async (req, res) => {
     error,
   })
 
+  // Helper: clear the state cookie and redirect to the frontend with an error.
+  // Called on every failure path so the cookie doesn't remain valid for its 10-min Max-Age.
+  const clearState = (res: import('express').Response) =>
+    res.setHeader('Set-Cookie', 'oidc_state=; HttpOnly; Secure; SameSite=Lax; Max-Age=0; Path=/')
+
   try {
     // CSRF guard: verify state cookie matches query param
     const cookieHeader = req.headers.cookie || ''
@@ -414,26 +434,30 @@ router.get('/oidc/callback', async (req, res) => {
     const queryState = (req.query.state as string) || ''
 
     if (!cookieState || cookieState.length !== queryState.length) {
-      return res.redirect('http://fuzefront.dev.local/?error=invalid_state')
+      clearState(res)
+      return res.redirect(`${FRONTEND_BASE}/?error=invalid_state`)
     }
     try {
       if (!crypto.timingSafeEqual(Buffer.from(cookieState, 'utf8'), Buffer.from(queryState, 'utf8'))) {
-        return res.redirect('http://fuzefront.dev.local/?error=invalid_state')
+        clearState(res)
+        return res.redirect(`${FRONTEND_BASE}/?error=invalid_state`)
       }
-    } catch {
-      return res.redirect('http://fuzefront.dev.local/?error=invalid_state')
+    } catch (e) {
+      console.warn(`[${requestId}] State comparison error (fail-safe deny):`, e)
+      clearState(res)
+      return res.redirect(`${FRONTEND_BASE}/?error=invalid_state`)
     }
-    // Clear the cookie
+    // Clear the cookie on the success path too
     res.setHeader('Set-Cookie', 'oidc_state=; HttpOnly; Secure; SameSite=Lax; Max-Age=0; Path=/')
 
     if (error) {
       console.log(`❌ [${requestId}] OIDC error:`, error)
-      return res.redirect(`http://fuzefront.dev.local/?error=oidc_error&message=${encodeURIComponent(error as string)}`)
+      return res.redirect(`${FRONTEND_BASE}/?error=oidc_error&message=${encodeURIComponent(error as string)}`)
     }
 
     if (!code || !state) {
       console.log(`❌ [${requestId}] Missing code or state`)
-      return res.redirect(`http://fuzefront.dev.local/?error=missing_parameters`)
+      return res.redirect(`${FRONTEND_BASE}/?error=missing_parameters`)
     }
 
     // Handle the callback and get user
@@ -464,11 +488,12 @@ router.get('/oidc/callback', async (req, res) => {
     // (avoids token leakage via referrer headers, server logs, and browser history).
     const exchangeCode = crypto.randomBytes(32).toString('hex')
     pendingCodes.set(exchangeCode, { token, sessionId, expiresAt: Date.now() + CODE_TTL_MS })
-    res.redirect(`http://fuzefront.dev.local/?code=${exchangeCode}`)
+    res.redirect(`${FRONTEND_BASE}/?code=${exchangeCode}`)
 
   } catch (error) {
     console.error(`❌ [${requestId}] OIDC callback error:`, error)
-    res.redirect(`http://fuzefront.dev.local/?error=authentication_failed`)
+    clearState(res)
+    res.redirect(`${FRONTEND_BASE}/?error=authentication_failed`)
   }
 })
 

--- a/backend/security/src/routes/auth.ts
+++ b/backend/security/src/routes/auth.ts
@@ -1,3 +1,4 @@
+import crypto from 'crypto'
 import express from 'express'
 import bcrypt from 'bcryptjs'
 import jwt from 'jsonwebtoken'
@@ -352,8 +353,9 @@ router.get('/oidc/login', async (req, res) => {
 
     const state = uuidv4()
     const authUrl = oidcService.generateAuthUrl(state)
-    
+
     console.log(`🔗 [${requestId}] Redirecting to Authentik:`, authUrl)
+    res.setHeader('Set-Cookie', `oidc_state=${state}; HttpOnly; Secure; SameSite=Lax; Max-Age=600; Path=/`)
     res.redirect(authUrl)
   } catch (error) {
     console.error(`❌ [${requestId}] OIDC login error:`, error)
@@ -401,6 +403,25 @@ router.get('/oidc/callback', async (req, res) => {
   })
 
   try {
+    // CSRF guard: verify state cookie matches query param
+    const cookieHeader = req.headers.cookie || ''
+    const stateCookieMatch = cookieHeader.split(';').map(c => c.trim()).find(c => c.startsWith('oidc_state='))
+    const cookieState = stateCookieMatch ? stateCookieMatch.slice('oidc_state='.length) : null
+    const queryState = (req.query.state as string) || ''
+
+    if (!cookieState || cookieState.length !== queryState.length) {
+      return res.redirect('http://fuzefront.dev.local/?error=invalid_state')
+    }
+    try {
+      if (!crypto.timingSafeEqual(Buffer.from(cookieState, 'utf8'), Buffer.from(queryState, 'utf8'))) {
+        return res.redirect('http://fuzefront.dev.local/?error=invalid_state')
+      }
+    } catch {
+      return res.redirect('http://fuzefront.dev.local/?error=invalid_state')
+    }
+    // Clear the cookie
+    res.setHeader('Set-Cookie', 'oidc_state=; HttpOnly; Secure; SameSite=Lax; Max-Age=0; Path=/')
+
     if (error) {
       console.log(`❌ [${requestId}] OIDC error:`, error)
       return res.redirect(`http://fuzefront.dev.local/?error=oidc_error&message=${encodeURIComponent(error as string)}`)

--- a/backend/security/tests/oidc-code-exchange.test.ts
+++ b/backend/security/tests/oidc-code-exchange.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Unit tests for OIDC code-exchange endpoint.
+ * Verifies that /oidc/callback issues a short-lived opaque code (not a token in URL),
+ * and that POST /api/auth/token-exchange redeems it exactly once within the TTL.
+ */
+import express from 'express'
+import request from 'supertest'
+
+jest.mock('../src/services/oidc', () => ({
+  oidcService: {
+    isConfigured: () => true,
+    generateAuthUrl: jest.fn().mockReturnValue('http://auth.example.com/auth?state=test-state'),
+    handleCallback: jest.fn().mockResolvedValue({ id: 'u1', email: 'u@e.com', firstName: 'U', lastName: 'E', roles: ['user'] })
+  }
+}))
+
+jest.mock('../src/config/database', () => ({
+  db: Object.assign(
+    jest.fn().mockReturnValue({ insert: jest.fn().mockResolvedValue([]) }),
+    { transaction: jest.fn(), insert: jest.fn().mockResolvedValue([]) }
+  )
+}))
+
+jest.mock('jsonwebtoken', () => ({
+  sign: jest.fn().mockReturnValue('mock-jwt-token'),
+  verify: jest.fn()
+}))
+
+jest.mock('../src/services/organizationProvisioning', () => ({
+  runInternalProvision: jest.fn().mockResolvedValue(undefined)
+}))
+
+jest.mock('uuid', () => ({ v4: jest.fn().mockReturnValue('mock-session-uuid') }))
+
+import authRouter from '../src/routes/auth'
+
+const app = express()
+app.use(express.json())
+app.use('/api/auth', authRouter)
+
+describe('OIDC code-exchange endpoint', () => {
+  it('callback redirects with ?code= not ?token=', async () => {
+    const STATE = 'test-state'
+    const res = await request(app)
+      .get(`/api/auth/oidc/callback?code=authcode&state=${STATE}`)
+      .set('Cookie', `oidc_state=${STATE}`)
+    expect(res.status).toBe(302)
+    expect(res.headers.location).toMatch(/[?&]code=/)
+    expect(res.headers.location).not.toMatch(/[?&]token=/)
+    expect(res.headers.location).not.toMatch(/[?&]sessionId=/)
+  })
+
+  it('POST /token-exchange returns token and sessionId for valid code', async () => {
+    const STATE = 'test-state'
+    const cbRes = await request(app)
+      .get(`/api/auth/oidc/callback?code=authcode&state=${STATE}`)
+      .set('Cookie', `oidc_state=${STATE}`)
+    const location = cbRes.headers.location
+    const code = new URL(location).searchParams.get('code')
+
+    const exRes = await request(app).post('/api/auth/token-exchange').send({ code })
+    expect(exRes.status).toBe(200)
+    expect(exRes.body).toHaveProperty('token')
+    expect(exRes.body).toHaveProperty('sessionId')
+  })
+
+  it('second token-exchange with same code returns 401', async () => {
+    const STATE = 'test-state'
+    const cbRes = await request(app)
+      .get(`/api/auth/oidc/callback?code=authcode&state=${STATE}`)
+      .set('Cookie', `oidc_state=${STATE}`)
+    const code = new URL(cbRes.headers.location).searchParams.get('code')
+
+    await request(app).post('/api/auth/token-exchange').send({ code })
+    const second = await request(app).post('/api/auth/token-exchange').send({ code })
+    expect(second.status).toBe(401)
+  })
+
+  it('expired code returns 401', async () => {
+    jest.useFakeTimers()
+    const STATE = 'test-state'
+    const cbRes = await request(app)
+      .get(`/api/auth/oidc/callback?code=authcode&state=${STATE}`)
+      .set('Cookie', `oidc_state=${STATE}`)
+    const code = new URL(cbRes.headers.location).searchParams.get('code')
+
+    // Advance time past 60s TTL
+    jest.advanceTimersByTime(61_000)
+
+    const exRes = await request(app).post('/api/auth/token-exchange').send({ code })
+    expect(exRes.status).toBe(401)
+    jest.useRealTimers()
+  })
+
+  it('unknown code returns 401', async () => {
+    const res = await request(app).post('/api/auth/token-exchange').send({ code: 'nonexistent' })
+    expect(res.status).toBe(401)
+  })
+
+  it('missing code body returns 400', async () => {
+    const res = await request(app).post('/api/auth/token-exchange').send({})
+    expect(res.status).toBe(400)
+  })
+})

--- a/backend/security/tests/oidc-state.test.ts
+++ b/backend/security/tests/oidc-state.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Unit tests for OIDC state cookie CSRF protection.
+ * Verifies that /oidc/login sets an oidc_state HttpOnly cookie, and
+ * /oidc/callback rejects requests whose state query param does not match the cookie.
+ */
+import express from 'express'
+import request from 'supertest'
+
+jest.mock('../src/services/oidc', () => ({
+  oidcService: {
+    isConfigured: () => true,
+    generateAuthUrl: jest.fn().mockReturnValue('http://auth.example.com/auth?state=test-state'),
+    handleCallback: jest.fn().mockResolvedValue({ id: 'u1', email: 'u@e.com', roles: ['user'] }),
+  },
+}))
+
+jest.mock('../src/config/database', () => ({
+  db: Object.assign(jest.fn(), {
+    transaction: jest.fn(),
+    insert: jest.fn().mockResolvedValue([]),
+  }),
+}))
+
+jest.mock('../src/middleware/auth', () => ({
+  authenticateToken: (_req: any, _res: any, next: any) => next(),
+  requireRole: () => (_req: any, _res: any, next: any) => next(),
+}))
+
+jest.mock('jsonwebtoken', () => ({
+  sign: jest.fn().mockReturnValue('mock-jwt-token'),
+  verify: jest.fn(),
+}))
+
+jest.mock('../src/services/organizationProvisioning', () => ({
+  runInternalProvision: jest.fn().mockResolvedValue(undefined),
+}))
+
+jest.mock('uuid', () => ({
+  v4: jest.fn().mockReturnValue('mock-uuid-1234'),
+}))
+
+import { db } from '../src/config/database'
+import authRouter from '../src/routes/auth'
+
+const dbMock = db as jest.MockedFunction<any>
+
+const app = express()
+app.use(express.json())
+app.use('/api/auth', authRouter)
+
+beforeEach(() => {
+  jest.clearAllMocks()
+
+  // Default db mock: sessions.insert returns a resolved promise
+  dbMock.mockImplementation((table: string) => {
+    if (table === 'sessions') {
+      return {
+        insert: jest.fn().mockResolvedValue([]),
+        where: jest.fn().mockReturnThis(),
+        first: jest.fn().mockResolvedValue(null),
+      }
+    }
+    return {
+      where: jest.fn().mockReturnThis(),
+      first: jest.fn().mockResolvedValue(null),
+      insert: jest.fn().mockResolvedValue([]),
+    }
+  })
+})
+
+describe('OIDC state cookie CSRF protection', () => {
+  it('sets oidc_state cookie on /oidc/login', async () => {
+    const res = await request(app).get('/api/auth/oidc/login')
+    expect(res.status).toBe(302)
+    const cookies = res.headers['set-cookie']
+    expect(Array.isArray(cookies) ? cookies.join(';') : cookies).toMatch(/oidc_state=/)
+  })
+
+  it('rejects callback when oidc_state cookie is missing', async () => {
+    const res = await request(app).get('/api/auth/oidc/callback?code=abc&state=xyz')
+    expect(res.status).toBe(302)
+    expect(res.headers.location).toMatch(/error=invalid_state/)
+  })
+
+  it('rejects callback when oidc_state cookie does not match state param', async () => {
+    const res = await request(app)
+      .get('/api/auth/oidc/callback?code=abc&state=xyz')
+      .set('Cookie', 'oidc_state=DIFFERENT_VALUE')
+    expect(res.status).toBe(302)
+    expect(res.headers.location).toMatch(/error=invalid_state/)
+  })
+
+  it('accepts callback when oidc_state cookie matches state param', async () => {
+    // First get the state from a login redirect
+    const loginRes = await request(app).get('/api/auth/oidc/login')
+    // The mock generates URL with state=test-state — extract oidc_state cookie
+    const setCookie = loginRes.headers['set-cookie']
+    const cookieHeader = Array.isArray(setCookie) ? setCookie[0] : setCookie
+    // cookieHeader looks like: oidc_state=test-state; HttpOnly; ...
+    const stateValue = cookieHeader.split(';')[0].split('=')[1]
+
+    const { oidcService } = require('../src/services/oidc')
+    const callbackRes = await request(app)
+      .get(`/api/auth/oidc/callback?code=authcode&state=${stateValue}`)
+      .set('Cookie', `oidc_state=${stateValue}`)
+    // Should NOT redirect to invalid_state
+    expect(callbackRes.headers.location).not.toMatch(/error=invalid_state/)
+    expect(oidcService.handleCallback).toHaveBeenCalled()
+  })
+})

--- a/backend/security/tests/oidc-state.test.ts
+++ b/backend/security/tests/oidc-state.test.ts
@@ -90,6 +90,19 @@ describe('OIDC state cookie CSRF protection', () => {
     expect(res.headers.location).toMatch(/error=invalid_state/)
   })
 
+  it('rejects callback when oidc_state cookie is same length as state param but different content (exercises timingSafeEqual)', async () => {
+    // Two distinct UUID-shaped strings of equal length — the length pre-check passes,
+    // so timingSafeEqual is the only guard that can fire here.
+    const cookieState = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890'
+    const queryState  = 'z9y8x7w6-v5u4-3210-fedc-ba9876543210'
+    expect(cookieState.length).toBe(queryState.length) // sanity
+    const res = await request(app)
+      .get(`/api/auth/oidc/callback?code=abc&state=${queryState}`)
+      .set('Cookie', `oidc_state=${cookieState}`)
+    expect(res.status).toBe(302)
+    expect(res.headers.location).toMatch(/error=invalid_state/)
+  })
+
   it('accepts callback when oidc_state cookie matches state param', async () => {
     // First get the state from a login redirect
     const loginRes = await request(app).get('/api/auth/oidc/login')

--- a/backend/security/tests/tsconfig.json
+++ b/backend/security/tests/tsconfig.json
@@ -2,7 +2,11 @@
   "extends": "../tsconfig.json",
   "compilerOptions": {
     "rootDir": "..",
-    "noEmit": true
+    "noEmit": true,
+    "paths": {
+      "@fuzefront/core": ["../core/dist/index.d.ts"],
+      "@fuzefront/shared/kafka": ["../../shared/dist/kafka/index.d.ts"]
+    }
   },
   "include": ["../src/**/*", "../tests/**/*"]
 }

--- a/frontend/src/__tests__/handleOIDCCallback.test.ts
+++ b/frontend/src/__tests__/handleOIDCCallback.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// authAPI.handleOIDCCallback calls `api.post` where `api` is the module-level
+// axios instance — the same object reference as the default export of ../services/api.
+// We use vi.spyOn on the imported default to intercept calls made by the
+// closed-over internal `api` variable (same object reference).
+//
+// Note: vi.mock('../services/api') with a factory that replaces `default` would
+// NOT work here because the factory creates a new object, breaking the shared
+// reference between the exported `api` and the closed-over `api` in authAPI methods.
+// vi.spyOn modifies the property in-place, so both the export and the closure see
+// the same spy.
+
+import api, { authAPI } from '../services/api'
+
+// Mock localStorage
+const localStorageMock = (() => {
+  let store: Record<string, string> = {}
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, val: string) => { store[key] = val },
+    removeItem: (key: string) => { delete store[key] },
+    clear: () => { store = {} },
+  }
+})()
+Object.defineProperty(global, 'localStorage', { value: localStorageMock })
+
+// Mock window.location and history
+const mockReplaceState = vi.fn()
+Object.defineProperty(global, 'history', { value: { replaceState: mockReplaceState }, writable: true })
+
+function setSearch(search: string) {
+  Object.defineProperty(global, 'location', {
+    value: { search, pathname: '/' },
+    writable: true,
+    configurable: true,
+  })
+}
+
+describe('authAPI.handleOIDCCallback', () => {
+  beforeEach(() => {
+    localStorageMock.clear()
+    vi.clearAllMocks()
+    // Spy on the shared axios instance's post method in-place.
+    // vi.spyOn replaces api.post with a spy; since api is the same object
+    // as the module-internal `api` const, this intercepts all calls.
+    vi.spyOn(api, 'post')
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('exchanges code for token and stores in localStorage', async () => {
+    setSearch('?code=abc123')
+    vi.mocked(api.post).mockResolvedValueOnce({
+      data: { token: 'jwt-token', sessionId: 'sess-1' }
+    })
+
+    const result = await authAPI.handleOIDCCallback()
+
+    expect(api.post).toHaveBeenCalledWith('/auth/token-exchange', { code: 'abc123' })
+    expect(localStorageMock.getItem('authToken')).toBe('jwt-token')
+    expect(localStorageMock.getItem('sessionId')).toBe('sess-1')
+    expect(result).toEqual({ token: 'jwt-token', sessionId: 'sess-1' })
+    expect(mockReplaceState).toHaveBeenCalled()
+  })
+
+  it('returns error from URL when error param present', async () => {
+    setSearch('?error=oidc_error&message=access_denied')
+
+    const result = await authAPI.handleOIDCCallback()
+
+    expect(result).toEqual({ error: 'access_denied' })
+    expect(api.post).not.toHaveBeenCalled()
+  })
+
+  it('returns empty object when no params in URL', async () => {
+    setSearch('')
+
+    const result = await authAPI.handleOIDCCallback()
+
+    expect(result).toEqual({})
+    expect(api.post).not.toHaveBeenCalled()
+  })
+
+  it('does not read token directly from URL', async () => {
+    setSearch('?token=some-jwt&sessionId=sess')
+
+    const result = await authAPI.handleOIDCCallback()
+
+    expect(result).toEqual({})
+    expect(api.post).not.toHaveBeenCalled()
+    expect(localStorageMock.getItem('authToken')).toBeNull()
+  })
+})

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -17,30 +17,30 @@ function LoginPage() {
 
   // Handle OIDC callback on page load
   useEffect(() => {
-    const oidcResult = authAPI.handleOIDCCallback()
-    
-    if (oidcResult.error) {
-      setError(`Authentication failed: ${oidcResult.error}`)
-      return
-    }
+    authAPI.handleOIDCCallback().then(oidcResult => {
+      if (oidcResult.error) {
+        setError(`Authentication failed: ${oidcResult.error}`)
+        return
+      }
 
-    if (oidcResult.token) {
-      console.log('🎉 OIDC authentication successful')
-      // Get user info and redirect
-      authAPI.getCurrentUser()
-        .then(user => {
-          setUser(user)
-          window.location.href = '/dashboard'
-        })
-        .catch(err => {
-          console.error('❌ Failed to get user after OIDC login:', err)
-          setError('Failed to get user information')
-        })
-      return
-    }
+      if (oidcResult.token) {
+        console.log('🎉 OIDC authentication successful')
+        // Get user info and redirect
+        authAPI.getCurrentUser()
+          .then(user => {
+            setUser(user)
+            window.location.href = '/dashboard'
+          })
+          .catch(err => {
+            console.error('❌ Failed to get user after OIDC login:', err)
+            setError('Failed to get user information')
+          })
+        return
+      }
 
-    // Load authentication methods
-    loadAuthMethods()
+      // Load authentication methods
+      loadAuthMethods()
+    })
   }, [setUser])
 
   const loadAuthMethods = async () => {

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -20,6 +20,8 @@ function LoginPage() {
     authAPI.handleOIDCCallback().then(oidcResult => {
       if (oidcResult.error) {
         setError(`Authentication failed: ${oidcResult.error}`)
+        // Leave the login form usable so the user can retry
+        loadAuthMethods()
         return
       }
 
@@ -39,6 +41,11 @@ function LoginPage() {
       }
 
       // Load authentication methods
+      loadAuthMethods()
+    }).catch(err => {
+      // Backstop: a rejected promise must never freeze the page
+      console.error('❌ Unexpected error in OIDC callback handler:', err)
+      setError('Authentication encountered an unexpected error. Please try again.')
       loadAuthMethods()
     })
   }, [setUser])

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -248,12 +248,17 @@ export const authAPI = {
     }
 
     if (code) {
-      const response = await api.post<{ token: string; sessionId: string }>('/auth/token-exchange', { code })
-      const { token, sessionId } = response.data
-      localStorage.setItem('authToken', token)
-      localStorage.setItem('sessionId', sessionId)
-      window.history.replaceState({}, document.title, window.location.pathname)
-      return { token, sessionId }
+      try {
+        const response = await api.post<{ token: string; sessionId: string }>('/auth/token-exchange', { code })
+        const { token, sessionId } = response.data
+        localStorage.setItem('authToken', token)
+        localStorage.setItem('sessionId', sessionId)
+        window.history.replaceState({}, document.title, window.location.pathname)
+        return { token, sessionId }
+      } catch (err: any) {
+        const message = err?.response?.data?.error || err?.message || 'Token exchange failed'
+        return { error: message }
+      }
     }
 
     return {}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -236,11 +236,10 @@ export const authAPI = {
     localStorage.removeItem('user')
   },
 
-  // Handle OIDC callback (extract token from URL)
-  handleOIDCCallback(): { token?: string; sessionId?: string; error?: string } {
+  // Handle OIDC callback (exchange ?code for token+sessionId)
+  async handleOIDCCallback(): Promise<{ token?: string; sessionId?: string; error?: string }> {
     const urlParams = new URLSearchParams(window.location.search)
-    const token = urlParams.get('token')
-    const sessionId = urlParams.get('sessionId')
+    const code = urlParams.get('code')
     const error = urlParams.get('error')
     const message = urlParams.get('message')
 
@@ -248,14 +247,13 @@ export const authAPI = {
       return { error: message || error }
     }
 
-    if (token) {
+    if (code) {
+      const response = await api.post<{ token: string; sessionId: string }>('/auth/token-exchange', { code })
+      const { token, sessionId } = response.data
       localStorage.setItem('authToken', token)
-      if (sessionId) {
-        localStorage.setItem('sessionId', sessionId)
-      }
-      // Clean up URL
+      localStorage.setItem('sessionId', sessionId)
       window.history.replaceState({}, document.title, window.location.pathname)
-      return { token, sessionId: sessionId ?? undefined }
+      return { token, sessionId }
     }
 
     return {}


### PR DESCRIPTION
## Wave H1 hardening — OIDC

Fixes two HIGH findings in the OIDC login flow (security-service + frontend).

### 1. Token-in-URL leak → single-use code exchange
- `/oidc/callback` no longer redirects with `?token=&sessionId=` in the URL (leaked via Referer, server logs, browser history).
- Instead issues an opaque `crypto.randomBytes(32)` **code** (60s TTL, single-use), stored server-side.
- New `POST /api/auth/token-exchange` swaps the code for `{token, sessionId}` exactly once.
- Frontend `handleOIDCCallback` reads `?code=`, POSTs to exchange, keeps the existing localStorage-Bearer model.
- JWT now embeds `sessionId` so logout can target the session.

### 2. OIDC state CSRF
- `/oidc/login` sets an `HttpOnly; Secure; SameSite=Lax` `oidc_state` cookie.
- `/oidc/callback` verifies cookie-state vs query-state with `timingSafeEqual`, then clears the cookie.

### Tests
- `oidc-code-exchange.test.ts`, `oidc-state.test.ts` (backend), `handleOIDCCallback.test.ts` (frontend).

### Review note
`pendingCodes` is an in-memory Map — flagged for review re: multi-replica HA + expiry sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)