### PR TITLE
chore(npm): private @fuzefront publishing via GitHub Packages

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,4 @@
+# Private registry for @fuzefront/* packages (GitHub Packages, restricted access).
+# Public deps still resolve from the default npm registry.
+@fuzefront:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}

--- a/lerna.json
+++ b/lerna.json
@@ -8,12 +8,12 @@
       "allowBranch": ["main", "master", "develop"],
       "conventionalCommits": true,
       "message": "chore(release): publish %s",
-      "registry": "https://registry.npmjs.org/"
+      "registry": "https://npm.pkg.github.com"
     },
     "publish": {
       "conventionalCommits": true,
       "message": "chore(release): publish %s",
-      "registry": "https://registry.npmjs.org/"
+      "registry": "https://npm.pkg.github.com"
     }
   }
 }


### PR DESCRIPTION
Foundational config so all reusable `@fuzefront/*` packages publish **privately** to GitHub Packages (restricted), not public npm.

- `lerna.json` publish/version registry → `https://npm.pkg.github.com`
- root `.npmrc`: scopes `@fuzefront` to GitHub Packages, auth via `GITHUB_TOKEN` (public deps still resolve from default registry)

Per-package `publishConfig` (access: restricted) + `repository` fields are added by each feature wave as packages are created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)