### PR TITLE
ci: publish @fuzefront/* packages to GitHub Packages on merge (versioned, changed-only)

### DIFF
--- a/.github/workflows/packages-publish.yml
+++ b/.github/workflows/packages-publish.yml
@@ -1,0 +1,60 @@
+name: Publish packages (GitHub Packages, private)
+
+# On merge to master, version-bump and publish the reusable @fuzefront/* packages
+# to GitHub Packages (private/restricted). Lerna with conventional commits detects
+# which packages changed since their last release tag, computes the semver bump
+# from commit messages (feat->minor, fix->patch, BREAKING CHANGE->major), and
+# publishes only those. Private packages (apps + deployed services) are skipped.
+#
+# NOTE: GitHub Packages requires the npm scope to match the owning org/user.
+# @fuzefront/* can only publish once this repo is owned by the `fuzefront` GitHub
+# org. The job guard below makes this workflow a no-op under any other owner, so
+# it is safe to merge now and auto-activates after the org transfer.
+on:
+  push:
+    branches: [master]
+
+concurrency:
+  group: packages-publish
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    if: github.repository_owner == 'fuzefront'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # push lerna version commits + tags
+      packages: write # publish to GitHub Packages
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # lerna needs full history for change detection
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@fuzefront'
+
+      - name: Install
+        run: npm ci || npm install
+
+      - name: Build packages (topological, if a build script exists)
+        run: npx lerna run build --if-present
+
+      - name: Configure git identity
+        run: |
+          git config user.email "action@github.com"
+          git config user.name "GitHub Action"
+
+      - name: Version + publish changed packages
+        # --conventional-commits: bump + changelog + tag from commit messages
+        # --no-private: skip "private": true packages (apps, deployed services)
+        # --yes: non-interactive; [skip ci] avoids retriggering CI on the bump commit
+        run: >-
+          npx lerna publish --conventional-commits --no-private --yes
+          --message "chore(release): publish %s [skip ci]"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "version": "1.0.0",
   "npmClient": "npm",
-  "packages": ["backend", "frontend", "shared", "sdk", "task-manager-app", "services/email-service", "services/sms-service", "services/provisioning-service"],
+  "packages": ["backend", "frontend", "shared", "task-manager-app", "services/email-service", "services/sms-service", "services/provisioning-service"],
   "command": {
     "version": {
       "allowBranch": ["main", "master", "develop"],


### PR DESCRIPTION
Wires the requested behavior: **merge to `master` → CI version-bumps and publishes changed `@fuzefront/*` packages privately to GitHub Packages.**

### How
- New workflow `.github/workflows/packages-publish.yml` runs `lerna publish --conventional-commits --no-private` on push to `master`.
- **Semver from commit messages** (we already use conventional commits): `feat`→minor, `fix`→patch, `BREAKING CHANGE`→major. No separate semver tool needed.
- **Changed-only:** lerna publishes only packages with changes since their last release tag — untouched packages are skipped automatically (no fragile `paths` filters).
- **Private:** publishes to `npm.pkg.github.com` with each package's `publishConfig.access: restricted`. `--no-private` skips `"private": true` packages.
- Drops the legacy `@izzywdev` `sdk` from the lerna `packages` list — it keeps its existing dedicated public-npm workflow (`sdk-publish.yml`), avoiding a scope clash.

### Gating / activation checklist (post org-transfer)
GitHub Packages requires the npm scope to match the owning org. The job is guarded by `if: github.repository_owner == 'fuzefront'`, so it **no-ops under the personal account and is safe to merge now**. Before it goes live:
- [ ] Create the `fuzefront` GitHub org and transfer this repo to it.
- [ ] Update each package's `repository` field to the org URL (GitHub Packages links a package to its repo).
- [ ] Mark deployed services/apps (`backend`, `frontend`, `*-service`, `task-manager-app`) `"private": true` so only true libraries (`shared`, `identity-ui`, `billing-*`, `chat-*`) publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)