### PR TITLE
fix(security): remove hardcoded DB password from test helper

### DIFF
--- a/tests/test-db-connection.js
+++ b/tests/test-db-connection.js
@@ -3,12 +3,17 @@ const { Client } = require('pg');
 async function testConnection() {
   console.log('🔍 Testing database connection...');
   
+  if (!process.env.DB_PASSWORD) {
+    console.error('❌ DB_PASSWORD must be set in the environment');
+    process.exit(1);
+  }
+
   const client = new Client({
-    host: 'fuzeinfra-postgres',
-    port: 5432,
-    database: 'fuzefront_platform',
-    user: 'fuzefront_user',
-    password: 'FuzeFront_2024_SecureDB_Pass!',
+    host: process.env.DB_HOST || 'fuzeinfra-postgres',
+    port: Number(process.env.DB_PORT) || 5432,
+    database: process.env.DB_NAME || 'fuzefront_platform',
+    user: process.env.DB_USER || 'fuzefront_user',
+    password: process.env.DB_PASSWORD,
   });
 
   try {


### PR DESCRIPTION
Automated security review flagged a committed plaintext DB password. Only the real committed instance is fixed here.

- `tests/test-db-connection.js`: now reads `DB_HOST/DB_PORT/DB_NAME/DB_USER/DB_PASSWORD` from env, fail-fast if `DB_PASSWORD` unset. No hardcoded secret.

The other two flagged files (`backend/src/config/database-fixed.ts`, `database-old.ts`) were **local untracked cruft, not on master** — removed locally. The flagged logout-scope regression in `auth.ts` is **already correct on master** (`where('id', decoded.sessionId)`), no conflict markers.

Note: `FuzeFront_2024_SecureDB_Pass!` is a local/dev DB credential; rotate it in any environment where it was actually used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)