### PR TITLE
feat(prod-cd): app.fuzefront.com on Contabo k3s — overlay, app config, kafka topics, observability, CI gate

### DIFF
--- a/.github/workflows/claude-auto-pr.yml
+++ b/.github/workflows/claude-auto-pr.yml
@@ -1,0 +1,42 @@
+name: Auto-PR from claude branches
+
+# Closes the issue->PR autonomy gap: `anthropics/claude-code-action` (in claude.yml)
+# pushes a `claude/**` branch and only posts a "Create PR" link — it does not open
+# the PR itself. This workflow opens a DRAFT PR from any pushed `claude/**` branch
+# when one doesn't already exist (draft = a human still reviews before merge).
+on:
+  push:
+    branches:
+      - 'claude/**'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  open-draft-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Open draft PR if none exists
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: ${{ github.ref_name }}
+          BASE: ${{ github.event.repository.default_branch }}
+        run: |
+          existing=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number' 2>/dev/null || true)
+          if [ -n "$existing" ]; then
+            echo "PR #$existing already open for $BRANCH — nothing to do."
+            exit 0
+          fi
+          # Only open a PR if the branch actually diverges from base.
+          if git rev-list --count "origin/${BASE}..origin/${BRANCH}" | grep -qvE '^0$'; then
+            gh pr create --draft --base "$BASE" --head "$BRANCH" --fill \
+              || echo "gh pr create failed (no diff or transient) — skipping."
+          else
+            echo "No commits on $BRANCH ahead of $BASE — no PR opened."
+          fi

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,42 @@
+name: Claude
+
+# Lets maintainers delegate work to Claude by mentioning @claude in an issue,
+# issue comment, PR, or review comment. Claude reads the thread + repo and
+# responds / pushes a claude/** branch. The companion `claude-auto-pr.yml`
+# workflow then opens a draft PR from that branch (issue -> PR autonomy).
+#
+# Requires repo secret: ANTHROPIC_API_KEY.
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned, labeled]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/helm-validate.yml
+++ b/.github/workflows/helm-validate.yml
@@ -1,0 +1,79 @@
+name: Helm validate
+
+# Lint + schema-validate the FuzeFront Helm chart against both overlays on every
+# PR that touches the chart. Mirrors FuzeInfra's helm-validate.yml: helm lint
+# then `helm template | kubeconform --strict` (Kubernetes 1.29 schemas). Catches
+# malformed templates and invalid resource specs before they reach Argo.
+on:
+  pull_request:
+    paths:
+      - 'deploy/helm/**'
+      - '.github/workflows/helm-validate.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  helm-validate:
+    name: Lint & kubeconform
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        values: [values-local.yaml, values-prod.yaml]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.16.2
+
+      - name: Install kubeconform
+        run: |
+          curl -fsSL https://github.com/yannh/kubeconform/releases/download/v0.6.7/kubeconform-linux-amd64.tar.gz \
+            | tar xz kubeconform
+          sudo install kubeconform /usr/local/bin/kubeconform
+          kubeconform -v
+
+      - name: helm lint (${{ matrix.values }})
+        run: |
+          helm lint deploy/helm/fuzefront \
+            -f deploy/helm/fuzefront/${{ matrix.values }} \
+            --set secret.authentikClientSecret=ci-placeholder
+
+      - name: helm template + kubeconform (${{ matrix.values }})
+        run: |
+          # Render with every optional workload enabled so kubeconform sees the
+          # full surface. Placeholder secrets satisfy the OIDC render guard;
+          # existingSecret="" forces the chart Secret to render too. permit is
+          # also enabled so the PDP + schema-sync Job are validated. --output-dir
+          # writes one file per template so we can exclude a single one below.
+          rm -rf rendered
+          helm template fuzefront deploy/helm/fuzefront \
+            -f deploy/helm/fuzefront/${{ matrix.values }} \
+            --set secret.existingSecret="" \
+            --set secret.authentikClientSecret=ci-placeholder \
+            --set securityService.enabled=true \
+            --set applicationsService.enabled=true \
+            --set emailService.enabled=true \
+            --set smsService.enabled=true \
+            --set provisioningService.enabled=true \
+            --set permit.enabled=true \
+            --output-dir rendered
+
+          # Strict: reject unknown fields. Skip CRDs cert-manager/sealed-secrets
+          # owns (not in upstream k8s schemas). Helm hooks render as plain Jobs.
+          #
+          # Exclude authentik-blueprints.yaml: that ConfigMap's `data` keys embed
+          # multi-document Authentik blueprint YAML with custom tags (!Env/!Find)
+          # and repeated top-level keys, which kubeconform's strict unmarshaller
+          # mis-reads. It is opaque string data to Kubernetes — no schema applies.
+          kubeconform \
+            -strict \
+            -kubernetes-version 1.29.0 \
+            -schema-location default \
+            -skip CustomResourceDefinition \
+            -ignore-filename-pattern 'authentik-blueprints' \
+            -summary \
+            rendered/fuzefront/templates/

--- a/.github/workflows/prod-smoke.yml
+++ b/.github/workflows/prod-smoke.yml
@@ -1,0 +1,53 @@
+name: Prod smoke
+
+# After release.yml bumps image tags in values-prod.yaml (commit message starts
+# with "release:"), Argo CD syncs the new images onto Contabo. This job waits for
+# the rollout, then polls https://app.fuzefront.com/api/health until it returns
+# 200 (or fails after the timeout). Pure black-box check over the public ingress —
+# no cluster credentials needed.
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'deploy/helm/fuzefront/values-prod.yaml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: prod-smoke
+  cancel-in-progress: true
+
+jobs:
+  smoke:
+    name: Poll /api/health
+    runs-on: ubuntu-latest
+    # Only run for release tag-bump commits (skip unrelated values-prod edits).
+    if: startsWith(github.event.head_commit.message, 'release:')
+    steps:
+      - name: Wait for Argo to roll out, then poll health
+        env:
+          URL: https://app.fuzefront.com/api/health
+        run: |
+          echo "Smoke target: $URL"
+          # Give Argo CD time to detect the git change and roll the Deployments.
+          echo "Waiting 90s for Argo CD sync + rollout..."
+          sleep 90
+
+          # Poll for up to ~5 min (30 attempts × 10s).
+          attempts=30
+          for i in $(seq 1 "$attempts"); do
+            code="$(curl -sS -o /tmp/health.json -w '%{http_code}' --max-time 10 "$URL" || echo 000)"
+            if [ "$code" = "200" ]; then
+              echo "✅ $URL returned 200 on attempt $i"
+              cat /tmp/health.json
+              exit 0
+            fi
+            echo "attempt $i/$attempts: HTTP $code (retrying in 10s)"
+            sleep 10
+          done
+
+          echo "::error::$URL did not return 200 within the timeout"
+          echo "Last response body:"
+          cat /tmp/health.json 2>/dev/null || true
+          exit 1

--- a/backend/package.json
+++ b/backend/package.json
@@ -48,6 +48,7 @@
     "passport-openidconnect": "^0.1.1",
     "permitio": "^2.4.0",
     "pg": "^8.11.5",
+    "prom-client": "^15.1.3",
     "socket.io": "^4.7.5",
     "sqlite3": "^5.1.7",
     "swagger-jsdoc": "^6.2.8",

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -17,9 +17,14 @@ import {
   checkDatabaseHealth,
 } from './config/database'
 import { oidcService } from './services/oidc'
+import { setupMetrics } from './metrics'
 
 // Load environment variables
 dotenv.config()
+
+// Prometheus metrics (Phase E). Scraped at /metrics; gracefully degrades to a
+// 503 if prom-client is not installed.
+const metrics = setupMetrics()
 
 // Extend Express Request interface to include requestId
 declare global {
@@ -107,6 +112,11 @@ app.use((req, res, next) => {
 
   next()
 })
+
+// Prometheus request metrics (records method/route/status + duration).
+app.use(metrics.middleware)
+// Expose /metrics for the Prometheus scrape.
+metrics.registerEndpoint(app)
 
 // Setup Swagger documentation
 try {

--- a/backend/src/metrics.ts
+++ b/backend/src/metrics.ts
@@ -1,0 +1,93 @@
+// Prometheus metrics (Phase E). Exposes a /metrics endpoint scraped by the
+// FuzeInfra Prometheus via the prometheus.io/* pod annotations set in the Helm
+// chart. Uses prom-client default process/Node metrics plus a per-request HTTP
+// histogram (drives the 5xx-rate + latency alert rules).
+//
+// Defensive: if prom-client is not installed the module degrades to a no-op so
+// the backend still boots (mirrors the optional-require pattern used for Swagger).
+import type { Express, Request, Response, NextFunction } from 'express'
+
+interface MetricsHandle {
+  /** Express middleware that records request count + duration. */
+  middleware: (req: Request, res: Response, next: NextFunction) => void
+  /** Registers GET /metrics on the app. */
+  registerEndpoint: (app: Express) => void
+}
+
+function noopMetrics(): MetricsHandle {
+  return {
+    middleware: (_req, _res, next) => next(),
+    registerEndpoint: app => {
+      app.get('/metrics', (_req, res) => {
+        res
+          .status(503)
+          .type('text/plain')
+          .send('# prom-client not installed; metrics unavailable\n')
+      })
+    },
+  }
+}
+
+export function setupMetrics(): MetricsHandle {
+  let client: any
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    client = require('prom-client')
+  } catch {
+    console.warn('⚠️ prom-client not installed — /metrics will return 503')
+    return noopMetrics()
+  }
+
+  const register = new client.Registry()
+  register.setDefaultLabels({ service: 'fuzefront-backend' })
+  client.collectDefaultMetrics({ register })
+
+  const httpRequestDuration = new client.Histogram({
+    name: 'http_request_duration_seconds',
+    help: 'Duration of HTTP requests in seconds',
+    labelNames: ['method', 'route', 'status_code'],
+    // Buckets tuned for a web API (1ms → 5s).
+    buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5],
+    registers: [register],
+  })
+
+  const httpRequestsTotal = new client.Counter({
+    name: 'http_requests_total',
+    help: 'Total number of HTTP requests',
+    labelNames: ['method', 'route', 'status_code'],
+    registers: [register],
+  })
+
+  return {
+    middleware: (req, res, next) => {
+      // Skip the scrape endpoint itself to avoid self-referential noise.
+      if (req.path === '/metrics') return next()
+      const end = httpRequestDuration.startTimer()
+      res.on('finish', () => {
+        // Prefer the matched route pattern (low cardinality); fall back to path.
+        const route =
+          (req.route && req.route.path) ||
+          (req.baseUrl ? `${req.baseUrl}` : req.path) ||
+          'unknown'
+        const labels = {
+          method: req.method,
+          route,
+          status_code: String(res.statusCode),
+        }
+        end(labels)
+        httpRequestsTotal.inc(labels)
+      })
+      next()
+    },
+    registerEndpoint: app => {
+      app.get('/metrics', async (_req, res) => {
+        try {
+          res.set('Content-Type', register.contentType)
+          res.end(await register.metrics())
+        } catch (err) {
+          res.status(500).end(String(err))
+        }
+      })
+    },
+  }
+}

--- a/deploy/argocd/applications/fuzeinfra.yaml
+++ b/deploy/argocd/applications/fuzeinfra.yaml
@@ -11,8 +11,9 @@ spec:
     # Chart lives in the FuzeInfra git submodule (Argo inits submodules by default).
     path: FuzeInfra/helm/fuzeinfra
     helm:
-      # Contabo prod overlay: Postgres + Redis + monitoring only (no Mongo/Neo4j/
-      # ES/Kafka/RabbitMQ/Airflow). k3s local-path storage; public domain.
+      # Contabo prod overlay: Postgres + Redis + monitoring + Kafka + ChromaDB
+      # (no Mongo/Neo4j/ES/RabbitMQ/Airflow). Kafka backs the FuzeFront event bus
+      # and ChromaDB backs chat-RAG. k3s local-path storage; public domain.
       values: |
         global:
           storageClass: local-path
@@ -29,9 +30,11 @@ spec:
         mongoExpress: { enabled: false }
         neo4j: { enabled: false }
         elasticsearch: { enabled: false }
-        chromadb: { enabled: false }
-        kafka: { enabled: false }
-        kafkaUi: { enabled: false }
+        # ChromaDB + Kafka enabled: chat-RAG (vector store) and the event bus
+        # (email/sms/provisioning/billing/chat consumers) depend on them.
+        chromadb: { enabled: true }
+        kafka: { enabled: true }
+        kafkaUi: { enabled: false } # admin UI only — keep off in prod
         rabbitmq: { enabled: false }
         airflow: { enabled: false }
         dnsmasq: { enabled: false }

--- a/deploy/helm/fuzefront/alerts/fuzefront-alerts.yaml
+++ b/deploy/helm/fuzefront/alerts/fuzefront-alerts.yaml
@@ -1,0 +1,66 @@
+# Prometheus alert rules for FuzeFront. Shipped as a ConfigMap labeled
+# prometheus_rule: "1" so the FuzeInfra Prometheus rule_files mount / sidecar
+# discovers and loads it (discovery hook added in FuzeInfra separately). This is
+# a plain Prometheus rule-group file (NOT a PrometheusRule CRD), since FuzeInfra
+# runs vanilla Prometheus, not the prometheus-operator.
+groups:
+  - name: fuzefront.rules
+    rules:
+      - alert: FuzeFrontPodCrashLooping
+        expr: |
+          increase(kube_pod_container_status_restarts_total{namespace="fuzefront"}[15m]) > 3
+        for: 5m
+        labels:
+          severity: critical
+          team: fuzefront
+        annotations:
+          summary: "Pod {{ $labels.pod }} is crash-looping"
+          description: "{{ $labels.namespace }}/{{ $labels.pod }} restarted >3 times in 15m."
+
+      - alert: FuzeFrontPodNotReady
+        expr: |
+          sum by (pod) (kube_pod_status_ready{namespace="fuzefront",condition="true"}) == 0
+          and on (pod) (kube_pod_status_phase{namespace="fuzefront",phase="Running"} == 1)
+        for: 10m
+        labels:
+          severity: warning
+          team: fuzefront
+        annotations:
+          summary: "Pod {{ $labels.pod }} not ready"
+          description: "{{ $labels.pod }} has been Running but not Ready for 10m."
+
+      - alert: FuzeFrontHigh5xxRate
+        expr: |
+          100 * sum by (service) (rate(http_requests_total{service=~"fuzefront.*",status_code=~"5.."}[5m]))
+          / clamp_min(sum by (service) (rate(http_requests_total{service=~"fuzefront.*"}[5m])), 1) > 5
+        for: 5m
+        labels:
+          severity: critical
+          team: fuzefront
+        annotations:
+          summary: "High 5xx rate on {{ $labels.service }}"
+          description: "{{ $labels.service }} is serving >5% 5xx responses over 5m."
+
+      - alert: FuzeFrontHighLatencyP95
+        expr: |
+          histogram_quantile(0.95,
+            sum by (le, service) (rate(http_request_duration_seconds_bucket{service=~"fuzefront.*"}[5m]))
+          ) > 1
+        for: 10m
+        labels:
+          severity: warning
+          team: fuzefront
+        annotations:
+          summary: "High p95 latency on {{ $labels.service }}"
+          description: "{{ $labels.service }} p95 request latency >1s over 10m."
+
+      - alert: FuzeFrontTargetDown
+        expr: |
+          up{service=~"fuzefront.*"} == 0
+        for: 5m
+        labels:
+          severity: critical
+          team: fuzefront
+        annotations:
+          summary: "Scrape target down for {{ $labels.service }}"
+          description: "Prometheus cannot scrape {{ $labels.service }} ({{ $labels.instance }}) for 5m."

--- a/deploy/helm/fuzefront/dashboards/fuzefront-overview.json
+++ b/deploy/helm/fuzefront/dashboards/fuzefront-overview.json
@@ -1,0 +1,106 @@
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "schemaVersion": 39,
+  "title": "FuzeFront — Overview",
+  "tags": ["fuzefront"],
+  "timezone": "",
+  "time": { "from": "now-6h", "to": "now" },
+  "templating": {
+    "list": [
+      {
+        "name": "service",
+        "type": "query",
+        "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+        "query": "label_values(http_requests_total, service)",
+        "includeAll": true,
+        "multi": true,
+        "current": { "text": "All", "value": "$__all" }
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Request rate (req/s)",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "targets": [
+        {
+          "expr": "sum by (service) (rate(http_requests_total{service=~\"$service\"}[5m]))",
+          "legendFormat": "{{service}}"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "5xx error rate (%)",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "fieldConfig": { "defaults": { "unit": "percent" } },
+      "targets": [
+        {
+          "expr": "100 * sum by (service) (rate(http_requests_total{service=~\"$service\",status_code=~\"5..\"}[5m])) / clamp_min(sum by (service) (rate(http_requests_total{service=~\"$service\"}[5m])), 1)",
+          "legendFormat": "{{service}}"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "Request latency p95 (s)",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "fieldConfig": { "defaults": { "unit": "s" } },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (le, service) (rate(http_request_duration_seconds_bucket{service=~\"$service\"}[5m])))",
+          "legendFormat": "{{service}} p95"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "Pod restarts (1h increase)",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "targets": [
+        {
+          "expr": "sum by (pod) (increase(kube_pod_container_status_restarts_total{namespace=\"fuzefront\"}[1h]))",
+          "legendFormat": "{{pod}}"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "title": "Resident memory (bytes)",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
+      "fieldConfig": { "defaults": { "unit": "bytes" } },
+      "targets": [
+        {
+          "expr": "process_resident_memory_bytes{service=~\"$service\"}",
+          "legendFormat": "{{service}}"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "title": "Event-loop lag p99 (s)",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
+      "fieldConfig": { "defaults": { "unit": "s" } },
+      "targets": [
+        {
+          "expr": "nodejs_eventloop_lag_p99_seconds{service=~\"$service\"}",
+          "legendFormat": "{{service}}"
+        }
+      ]
+    }
+  ]
+}

--- a/deploy/helm/fuzefront/templates/_helpers.tpl
+++ b/deploy/helm/fuzefront/templates/_helpers.tpl
@@ -13,3 +13,46 @@ app.kubernetes.io/part-of: fuzefront
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version }}
 {{- end -}}
+
+{{/*
+Pod scheduling block (nodeSelector + affinity + tolerations).
+Usage:  {{- include "fuzefront.scheduling" (dict "svc" .Values.someService "root" .) | nindent 6 }}
+Falls back to the global placement defaults when a service sets nothing. Renders
+nothing when neither the service nor the global defaults specify placement, so it
+is a no-op by default (heavy stateless services can opt into node-2 via values).
+*/}}
+{{- define "fuzefront.scheduling" -}}
+{{- $svc := .svc | default dict -}}
+{{- $g := .root.Values.global.scheduling | default dict -}}
+{{- $nodeSelector := $svc.nodeSelector | default $g.nodeSelector -}}
+{{- $affinity := $svc.affinity | default $g.affinity -}}
+{{- $tolerations := $svc.tolerations | default $g.tolerations -}}
+{{- with $nodeSelector }}
+nodeSelector:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- with $affinity }}
+affinity:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- with $tolerations }}
+tolerations:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Prometheus scrape annotations for a pod template.
+Usage:  {{- include "fuzefront.metricsAnnotations" (dict "port" .Values.backend.port "root" .) | nindent 8 }}
+Renders nothing when observability.metrics.enabled is false, so it is a no-op by
+default. `path` defaults to /metrics.
+*/}}
+{{- define "fuzefront.metricsAnnotations" -}}
+{{- $obs := .root.Values.observability | default dict -}}
+{{- $m := $obs.metrics | default dict -}}
+{{- if $m.enabled -}}
+prometheus.io/scrape: "true"
+prometheus.io/port: {{ .port | quote }}
+prometheus.io/path: {{ .path | default $m.path | default "/metrics" | quote }}
+{{- end -}}
+{{- end -}}

--- a/deploy/helm/fuzefront/templates/applications.yaml
+++ b/deploy/helm/fuzefront/templates/applications.yaml
@@ -17,7 +17,10 @@ spec:
       labels:
         app.kubernetes.io/part-of: fuzefront
         app.kubernetes.io/component: applications-service
+      annotations:
+        {{- include "fuzefront.metricsAnnotations" (dict "port" .Values.applicationsService.port "root" .) | nindent 8 }}
     spec:
+      {{- include "fuzefront.scheduling" (dict "svc" .Values.applicationsService "root" .) | nindent 6 }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/deploy/helm/fuzefront/templates/authentik.yaml
+++ b/deploy/helm/fuzefront/templates/authentik.yaml
@@ -146,6 +146,7 @@ spec:
         {{- include "fuzefront.labels" . | nindent 8 }}
         app: authentik-server
     spec:
+      {{- include "fuzefront.scheduling" (dict "svc" .Values.authentik "root" .) | nindent 6 }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -200,6 +201,7 @@ spec:
         {{- include "fuzefront.labels" . | nindent 8 }}
         app: authentik-worker
     spec:
+      {{- include "fuzefront.scheduling" (dict "svc" .Values.authentik "root" .) | nindent 6 }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/deploy/helm/fuzefront/templates/backend.yaml
+++ b/deploy/helm/fuzefront/templates/backend.yaml
@@ -16,7 +16,10 @@ spec:
       labels:
         app.kubernetes.io/part-of: fuzefront
         app.kubernetes.io/component: backend
+      annotations:
+        {{- include "fuzefront.metricsAnnotations" (dict "port" .Values.backend.port "root" .) | nindent 8 }}
     spec:
+      {{- include "fuzefront.scheduling" (dict "svc" .Values.backend "root" .) | nindent 6 }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/deploy/helm/fuzefront/templates/email-service.yaml
+++ b/deploy/helm/fuzefront/templates/email-service.yaml
@@ -17,6 +17,11 @@ spec:
         app: fuzefront-email-service
         {{- include "fuzefront.labels" . | nindent 8 }}
     spec:
+      {{- include "fuzefront.scheduling" (dict "svc" .Values.emailService "root" .) | nindent 6 }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: email-service
           image: "{{ .Values.emailService.image.repository }}:{{ .Values.emailService.image.tag }}"

--- a/deploy/helm/fuzefront/templates/frontend.yaml
+++ b/deploy/helm/fuzefront/templates/frontend.yaml
@@ -17,6 +17,7 @@ spec:
         app.kubernetes.io/part-of: fuzefront
         app.kubernetes.io/component: frontend
     spec:
+      {{- include "fuzefront.scheduling" (dict "svc" .Values.frontend "root" .) | nindent 6 }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/deploy/helm/fuzefront/templates/kafka-topics-job.yaml
+++ b/deploy/helm/fuzefront/templates/kafka-topics-job.yaml
@@ -1,0 +1,75 @@
+{{- /*
+  Kafka topic pre-creation (Phase D).
+
+  A Helm post-install/post-upgrade hook Job that idempotently creates the
+  fuzefront.* / identity.* / notify.* / billing.* topics on the FuzeInfra Kafka
+  broker, with explicit partitions + retention, so prod does not rely on broker
+  auto-create. `kafka-topics.sh --create --if-not-exists` is a no-op for topics
+  that already exist, so re-running on every upgrade is safe. Partition counts
+  and retention can only grow safely with --alter; this Job does NOT shrink them.
+
+  Gated behind .Values.kafkaTopics.enabled (off locally; on in values-prod.yaml).
+  The topic set is reconciled from the shared @fuzefront/shared TOPICS constant
+  plus the planned billing/chat events — keep .Values.kafkaTopics.topics in sync
+  when that constant changes.
+*/}}
+{{- if .Values.kafkaTopics.enabled }}
+{{- $kt := .Values.kafkaTopics }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: fuzefront-kafka-topics
+  labels:
+    {{- include "fuzefront.labels" . | nindent 4 }}
+    app.kubernetes.io/component: kafka-topics
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    # After db-bootstrap (-5) / before permit-schema-sync (5); topics only need
+    # the broker, which is external (FuzeInfra), so ordering is loose.
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 4
+  ttlSecondsAfterFinished: 600
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/part-of: fuzefront
+        app.kubernetes.io/component: kafka-topics
+    spec:
+      restartPolicy: Never
+      {{- include "fuzefront.scheduling" (dict "svc" $kt "root" .) | nindent 6 }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: kafka-topics
+          image: "{{ $kt.image.repository }}:{{ $kt.image.tag }}"
+          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          command: ["/bin/bash", "-ec"]
+          args:
+            - |
+              BOOTSTRAP="{{ $kt.bootstrapServer }}"
+              echo "Reconciling FuzeFront Kafka topics against ${BOOTSTRAP}"
+              # Wait for the broker to accept connections (FuzeInfra Kafka may
+              # still be coming up on first install).
+              for i in $(seq 1 30); do
+                if kafka-topics.sh --bootstrap-server "${BOOTSTRAP}" --list >/dev/null 2>&1; then
+                  echo "broker reachable"; break
+                fi
+                echo "waiting for broker ($i/30)..."; sleep 5
+              done
+              {{- range $kt.topics }}
+              echo "ensure topic {{ .name }} (partitions={{ .partitions }}, rf={{ .replicationFactor }})"
+              kafka-topics.sh --bootstrap-server "${BOOTSTRAP}" \
+                --create --if-not-exists \
+                --topic {{ .name | quote }} \
+                --partitions {{ .partitions }} \
+                --replication-factor {{ .replicationFactor }} \
+                --config retention.ms={{ .retentionMs | default $kt.defaultRetentionMs | int64 }}
+              {{- end }}
+              echo "Topic reconciliation complete."
+          resources:
+            {{- toYaml $kt.resources | nindent 12 }}
+{{- end }}

--- a/deploy/helm/fuzefront/templates/observability.yaml
+++ b/deploy/helm/fuzefront/templates/observability.yaml
@@ -1,0 +1,56 @@
+{{- /*
+  Observability ConfigMaps (Phase E).
+
+  Wraps the FuzeFront Grafana dashboards (dashboards/*.json) and Prometheus alert
+  rules (alerts/*.yaml) into ConfigMaps carrying the discovery labels the
+  FuzeInfra monitoring stack watches for:
+    - grafana_dashboard: "1"  → Grafana dashboard sidecar imports the JSON
+    - prometheus_rule:  "1"   → Prometheus rule_files mount / sidecar loads the rules
+  These discovery hooks live in FuzeInfra (added separately); we ship the
+  ConfigMaps regardless so they are present the moment the hooks land.
+
+  Gated behind observability.dashboards.enabled / observability.alerts.enabled
+  (both default true under observability so prod gets them; harmless locally —
+  they are inert ConfigMaps if nothing watches the labels).
+*/}}
+{{- $obs := .Values.observability | default dict }}
+{{- if $obs.metrics }}
+{{- if $obs.metrics.enabled }}
+{{- $dash := $obs.dashboards | default (dict "enabled" true) }}
+{{- if $dash.enabled }}
+{{- range $path, $_ := .Files.Glob "dashboards/*.json" }}
+{{- $name := base $path | trimSuffix ".json" }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ printf "fuzefront-dashboard-%s" $name }}
+  labels:
+    {{- include "fuzefront.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: grafana-dashboard
+    grafana_dashboard: "1"
+data:
+  {{ base $path }}: |-
+    {{- $.Files.Get $path | nindent 4 }}
+{{- end }}
+{{- end }}
+{{- $alerts := $obs.alerts | default (dict "enabled" true) }}
+{{- if $alerts.enabled }}
+{{- range $path, $_ := .Files.Glob "alerts/*.yaml" }}
+{{- $name := base $path | trimSuffix ".yaml" }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ printf "fuzefront-alert-%s" $name }}
+  labels:
+    {{- include "fuzefront.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: prometheus-rule
+    prometheus_rule: "1"
+data:
+  {{ base $path }}: |-
+    {{- $.Files.Get $path | nindent 4 }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/fuzefront/templates/permit-pdp.yaml
+++ b/deploy/helm/fuzefront/templates/permit-pdp.yaml
@@ -18,6 +18,7 @@ spec:
         app.kubernetes.io/part-of: fuzefront
         app.kubernetes.io/component: permit-pdp
     spec:
+      {{- include "fuzefront.scheduling" (dict "svc" .Values.permit.pdp "root" .) | nindent 6 }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/deploy/helm/fuzefront/templates/provisioning-service.yaml
+++ b/deploy/helm/fuzefront/templates/provisioning-service.yaml
@@ -17,6 +17,7 @@ spec:
         app: fuzefront-provisioning-service
         {{- include "fuzefront.labels" . | nindent 8 }}
     spec:
+      {{- include "fuzefront.scheduling" (dict "svc" .Values.provisioningService "root" .) | nindent 6 }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/deploy/helm/fuzefront/templates/security.yaml
+++ b/deploy/helm/fuzefront/templates/security.yaml
@@ -17,7 +17,10 @@ spec:
       labels:
         app.kubernetes.io/part-of: fuzefront
         app.kubernetes.io/component: security-service
+      annotations:
+        {{- include "fuzefront.metricsAnnotations" (dict "port" .Values.securityService.port "root" .) | nindent 8 }}
     spec:
+      {{- include "fuzefront.scheduling" (dict "svc" .Values.securityService "root" .) | nindent 6 }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/deploy/helm/fuzefront/templates/sms-service.yaml
+++ b/deploy/helm/fuzefront/templates/sms-service.yaml
@@ -20,6 +20,11 @@ spec:
         app: fuzefront-sms-service
         {{- include "fuzefront.labels" . | nindent 8 }}
     spec:
+      {{- include "fuzefront.scheduling" (dict "svc" .Values.smsService "root" .) | nindent 6 }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: sms-service
           image: "{{ .Values.smsService.image.repository }}:{{ .Values.smsService.image.tag }}"

--- a/deploy/helm/fuzefront/values-prod.yaml
+++ b/deploy/helm/fuzefront/values-prod.yaml
@@ -1,9 +1,33 @@
 # =============================================================================
 # Production overlay (Contabo k3s), consumed by the Argo CD `fuzefront` Application.
-# Differs from local only by: GHCR images, public host + TLS, sealed secret.
+# Differs from local by: GHCR images, public host + TLS, sealed secret, prod
+# Authentik OIDC, Prometheus metrics, pre-created Kafka topics, and node-2
+# placement for heavy stateless services.
+#
+# Node topology (see docs/deployment/CONTABO_DEPLOYMENT.md):
+#   node-1 (kubernetes.io/hostname=fuzefront-node-1): control-plane + stateful
+#           (FuzeInfra Postgres/Redis/Kafka/Chroma live here on local-path).
+#   node-2 (kubernetes.io/hostname=fuzefront-node-2): heavy stateless compute
+#           (litellm/chat/billing). Relabel/rename to match the real join.
+# All secrets come from the SealedSecret `fuzefront-secrets` — never inline here.
 # =============================================================================
 global:
   imagePullPolicy: IfNotPresent
+  # Default placement: none (let the scheduler spread app pods across both nodes).
+  # Heavy stateless services pin to node-2 via their own affinity blocks below.
+  scheduling:
+    nodeSelector: {}
+    affinity: {}
+    tolerations: []
+
+# Prometheus scrape annotations on FuzeFront pods. The FuzeInfra Prometheus
+# auto-discovers pods carrying prometheus.io/scrape=true (see Phase E). The
+# backend exposes /metrics via prom-client; other pods are annotated for when
+# their /metrics lands.
+observability:
+  metrics:
+    enabled: true
+    path: /metrics
 
 backend:
   image:
@@ -95,3 +119,66 @@ ingress:
   tls:
     enabled: true
     secretName: fuzefront-app-tls
+
+# Authentik IdP — production. Public host with Let's Encrypt TLS via the same
+# ingress annotation as the app. OIDC SSO enabled with the prod issuer/redirect.
+# Cookie domain is the apex so the session is shared across *.fuzefront.com.
+# Secrets (AUTHENTIK_SECRET_KEY/BOOTSTRAP_*/CLIENT_SECRET) come from the
+# SealedSecret `fuzefront-secrets` — none are set here.
+authentik:
+  enabled: true
+  host: auth.fuzefront.com
+  cookieDomain: fuzefront.com
+  bootstrapEmail: admin@fuzefront.com
+  oidc:
+    enabled: true
+    issuerUrl: "https://auth.fuzefront.com/application/o/fuzefront/"
+    redirectUri: "https://app.fuzefront.com/api/auth/oidc/callback"
+    # No split-DNS in prod: real public DNS + a real Let's Encrypt cert mean the
+    # backend reaches Authentik over the internet without a hostAlias or a custom
+    # CA. Leave these empty so backend.yaml/security.yaml skip the dev-only bits.
+    backendHostAliasIP: ""
+    caConfigMap: ""
+
+# Pre-create the prod Kafka topics (FuzeInfra Kafka is enabled in the Argo
+# overlay). Avoids relying on broker auto-create for the prefixed topics.
+kafkaTopics:
+  enabled: true
+
+# --- Heavy stateless services → node-2 -------------------------------------
+# These are forward-looking placeholders (enabled flipped by Phase F). The
+# affinity steers them onto node-2 so the LLM/chat/billing load stays off the
+# DB-heavy node-1. nodeSelector uses the standard hostname label; adjust the
+# value to the real node name after the 2nd-node join.
+litellm:
+  affinity:
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          preference:
+            matchExpressions:
+              - key: kubernetes.io/hostname
+                operator: In
+                values: ["fuzefront-node-2"]
+
+chatService:
+  affinity:
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          preference:
+            matchExpressions:
+              - key: kubernetes.io/hostname
+                operator: In
+                values: ["fuzefront-node-2"]
+
+billingService:
+  affinity:
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          preference:
+            matchExpressions:
+              - key: kubernetes.io/hostname
+                operator: In
+                values: ["fuzefront-node-2"]

--- a/deploy/helm/fuzefront/values.yaml
+++ b/deploy/helm/fuzefront/values.yaml
@@ -27,6 +27,13 @@ observability:
   metrics:
     enabled: false
     path: /metrics
+  # Ship FuzeFront Grafana dashboards / Prometheus alert rules as labeled
+  # ConfigMaps (consumed by FuzeInfra discovery hooks). Only rendered when
+  # metrics.enabled is also true (no point shipping dashboards with no metrics).
+  dashboards:
+    enabled: true
+  alerts:
+    enabled: true
 
 # Image pull secrets for private registries (e.g. private GHCR). Sealed in prod.
 imagePullSecrets: []

--- a/deploy/helm/fuzefront/values.yaml
+++ b/deploy/helm/fuzefront/values.yaml
@@ -11,6 +11,22 @@ global:
   # Applied to every workload. IfNotPresent so kind uses images loaded via
   # `kind load docker-image` rather than trying to pull from a registry.
   imagePullPolicy: IfNotPresent
+  # Default pod placement for ALL workloads (per-service blocks override these).
+  # Empty = no-op (the scheduler decides). In prod, set per-service nodeSelector/
+  # affinity to steer heavy stateless services (litellm/chat/billing) onto node-2
+  # and keep app pods spread; see values-prod.yaml.
+  scheduling:
+    nodeSelector: {}
+    affinity: {}
+    tolerations: []
+
+# Observability (Phase E). Disabled by default → metrics annotations and the
+# backend /metrics scrape are a no-op locally. Enabled in values-prod.yaml so the
+# FuzeInfra Prometheus auto-discovers FuzeFront pods via prometheus.io/* annots.
+observability:
+  metrics:
+    enabled: false
+    path: /metrics
 
 # Image pull secrets for private registries (e.g. private GHCR). Sealed in prod.
 imagePullSecrets: []
@@ -114,6 +130,10 @@ backend:
   resources:
     requests: { cpu: 100m, memory: 256Mi }
     limits:   { cpu: "1",  memory: 512Mi }
+  # Per-service placement overrides (empty → falls back to global.scheduling).
+  nodeSelector: {}
+  affinity: {}
+  tolerations: []
 
 # Backend 3-way split (dual-serving). Both default to disabled; the old backend
 # still serves every route until the Phase 3 cutover flips routing. Enable in
@@ -130,6 +150,11 @@ securityService:
   resources:
     requests: { cpu: 100m, memory: 256Mi }
     limits:   { cpu: "1",  memory: 512Mi }
+  nodeSelector: {}
+  affinity: {}
+  tolerations: []
+  # security-service owns auth; keep it co-located with the DB-heavy node-1 by
+  # default (no-op here, set in values-prod if desired).
 
 applicationsService:
   enabled: false
@@ -141,6 +166,9 @@ applicationsService:
   resources:
     requests: { cpu: 100m, memory: 256Mi }
     limits:   { cpu: "1",  memory: 512Mi }
+  nodeSelector: {}
+  affinity: {}
+  tolerations: []
 
 # Permit.io authorization. Disabled by default (minimal cut). When enabled, the
 # chart runs a standalone PDP and (Task 3) a schema-sync Job. PERMIT_API_KEY is
@@ -156,6 +184,9 @@ permit:
     resources:
       requests: { cpu: 100m, memory: 256Mi }
       limits:   { cpu: 500m, memory: 512Mi }
+    nodeSelector: {}
+    affinity: {}
+    tolerations: []
 
 frontend:
   image:
@@ -166,6 +197,9 @@ frontend:
   resources:
     requests: { cpu: 50m,  memory: 64Mi }
     limits:   { cpu: 500m, memory: 256Mi }
+  nodeSelector: {}
+  affinity: {}
+  tolerations: []
 
 emailService:
   enabled: false
@@ -181,7 +215,13 @@ emailService:
   email:
     provider: "smtp"  # "sendgrid" or "smtp"
     from: "noreply@fuzefront.com"
-  resources: {}
+  resources:
+    requests: { cpu: 50m, memory: 128Mi }
+    limits:   { cpu: 500m, memory: 256Mi }
+  # Per-service placement overrides (default empty → falls back to global.scheduling).
+  nodeSelector: {}
+  affinity: {}
+  tolerations: []
 
 smsService:
   enabled: false
@@ -190,7 +230,12 @@ smsService:
   image:
     repository: fuzefront/sms-service
     tag: local
-  resources: {}
+  resources:
+    requests: { cpu: 50m, memory: 128Mi }
+    limits:   { cpu: 500m, memory: 256Mi }
+  nodeSelector: {}
+  affinity: {}
+  tolerations: []
 
 # Plan D — thin Kafka→HTTP bridge: consumes identity.user.created, calls
 # security-service POST /internal/provision. No DB, no domain logic.
@@ -210,6 +255,69 @@ provisioningService:
   resources:
     requests: { cpu: 50m, memory: 128Mi }
     limits:   { cpu: 500m, memory: 256Mi }
+  nodeSelector: {}
+  affinity: {}
+  tolerations: []
+
+# ---------------------------------------------------------------------------
+# Forward-looking service placeholders (disabled by default). These are wired
+# into deploy/CD ahead of the feature merges (billing #65, chat #66, litellm).
+# The chart does NOT yet ship Deployment templates for them; these blocks exist
+# so values-prod can size/place them and so the release pipeline (Phase F, owned
+# by the orchestrator) can flip `enabled` + bump tags without a schema change.
+# When enabled with no matching template, Helm simply ignores the extra values.
+# ---------------------------------------------------------------------------
+billingService:
+  enabled: false
+  image:
+    repository: fuzefront/billing-service
+    tag: local
+  port: 3006
+  replicas: 1
+  kafka:
+    brokers: "kafka.fuzeinfra.svc.cluster.local:9092"
+    clientId: "billing-service"
+    groupId: "billing-service-group"
+  resources:
+    requests: { cpu: 100m, memory: 256Mi }
+    limits:   { cpu: 500m, memory: 512Mi }
+  nodeSelector: {}
+  affinity: {}
+  tolerations: []
+
+chatService:
+  enabled: false
+  image:
+    repository: fuzefront/chat-service
+    tag: local
+  port: 3007
+  replicas: 1
+  kafka:
+    brokers: "kafka.fuzeinfra.svc.cluster.local:9092"
+    clientId: "chat-service"
+    groupId: "chat-service-group"
+  chromadb:
+    url: "http://chromadb.fuzeinfra.svc.cluster.local:8000"
+  resources:
+    requests: { cpu: 250m, memory: 512Mi }
+    limits:   { cpu: "1",  memory: "1Gi" }
+  nodeSelector: {}
+  affinity: {}
+  tolerations: []
+
+litellm:
+  enabled: false
+  image:
+    repository: ghcr.io/berriai/litellm
+    tag: "main-stable"
+  port: 4000
+  replicas: 1
+  resources:
+    requests: { cpu: 250m, memory: 512Mi }
+    limits:   { cpu: "1",  memory: "1Gi" }
+  nodeSelector: {}
+  affinity: {}
+  tolerations: []
 
 authentik:
   enabled: true
@@ -245,6 +353,10 @@ authentik:
     useTls: false
     useSSL: false
     timeout: 10
+  # Placement for the Authentik server + worker (empty → global.scheduling).
+  nodeSelector: {}
+  affinity: {}
+  tolerations: []
 
 ingress:
   enabled: true
@@ -256,3 +368,66 @@ ingress:
     enabled: false
     # Defaults to "<host>-tls" when empty.
     secretName: ''
+
+# ---------------------------------------------------------------------------
+# Kafka topic pre-creation (Phase D). A Helm post-install/post-upgrade Job runs
+# `kafka-topics.sh --create --if-not-exists` for each topic below so prod does
+# not rely on broker auto-create. Disabled by default (local kind has no Kafka);
+# enabled in values-prod.yaml. `topics[]` is the reconciled set from the shared
+# Kafka constants (@fuzefront/shared TOPICS: identity.user.created,
+# notify.email.requested, notify.email.status) plus the planned billing/chat
+# events. Edit this list when the shared TOPICS constant changes.
+kafkaTopics:
+  enabled: false
+  # Bitnami Kafka image ships kafka-topics.sh; pin a concrete tag (no :latest).
+  image:
+    repository: bitnami/kafka
+    tag: "3.7.0"
+  # Bootstrap server the Job talks to (FuzeInfra Kafka, cross-namespace DNS).
+  bootstrapServer: "kafka.fuzeinfra.svc.cluster.local:9092"
+  resources:
+    requests: { cpu: 50m, memory: 128Mi }
+    limits:   { cpu: 250m, memory: 256Mi }
+  nodeSelector: {}
+  affinity: {}
+  tolerations: []
+  # retentionMs default applied when a topic omits its own. 7 days.
+  defaultRetentionMs: 604800000
+  # Each topic: name (required), partitions, replicationFactor, retentionMs.
+  # DLQ companions are created for the consumer topics (dlqTopic() = "<t>.dlq").
+  topics:
+    # --- identity (security-service → provisioning-service) ---
+    - name: identity.user.created
+      partitions: 3
+      replicationFactor: 1
+      retentionMs: 604800000
+    # --- notifications (backend/security → email-service) ---
+    - name: notify.email.requested
+      partitions: 3
+      replicationFactor: 1
+      retentionMs: 604800000
+    - name: notify.email.requested.dlq
+      partitions: 1
+      replicationFactor: 1
+      retentionMs: 1209600000 # 14d — keep failures longer for triage
+    - name: notify.email.status
+      partitions: 3
+      replicationFactor: 1
+      retentionMs: 604800000
+    # --- billing (planned: billing-service / chat-service emitters) ---
+    - name: billing.subscription.changed
+      partitions: 3
+      replicationFactor: 1
+      retentionMs: 2592000000 # 30d — billing audit trail
+    - name: billing.usage.recorded
+      partitions: 6
+      replicationFactor: 1
+      retentionMs: 2592000000
+    - name: billing.usage.recorded.dlq
+      partitions: 1
+      replicationFactor: 1
+      retentionMs: 2592000000
+    - name: billing.llm.usage
+      partitions: 6
+      replicationFactor: 1
+      retentionMs: 2592000000

--- a/docs/deployment/CONTABO_DEPLOYMENT.md
+++ b/docs/deployment/CONTABO_DEPLOYMENT.md
@@ -1,185 +1,266 @@
-# FuzeFront — Cloud Deployment Design (Contabo)
+# FuzeFront — Contabo Production Runbook
 
-Status: **design** (for review). Implementation artifacts are listed at the end;
-nothing here changes the running system yet.
+Status: **operational**. This is the day-to-day runbook for the FuzeFront
+platform running on **Contabo k3s + Argo CD** at **`app.fuzefront.com`**. The
+`fuzefront.com` apex (static landing) stays on AWS CloudFront and is out of scope
+here.
 
-Goal: run the **FuzeFront platform** (not the corporate website) on Contabo with a
-GitOps pipeline — push to `master` → images built/pushed → Argo CD syncs the
-cluster — using the **same Helm charts** we run locally on kind, so local and
-cloud differ only by a values overlay.
-
----
-
-## 1. Why this shape
-
-- **Contabo gives VPS/dedicated servers, not managed Kubernetes.** So we run a
-  lightweight self-managed cluster (**k3s**) on a Contabo VPS. k3s is a single
-  binary, production-capable, and speaks standard Kubernetes — our existing
-  `deploy/helm/fuzefront` + the FuzeInfra Helm chart apply unchanged.
-- **GitOps with Argo CD** (already added to FuzeInfra) makes git the source of
-  truth: the cluster continuously reconciles to what's committed. This is what
-  gives us "automated cloud redeploys" — the cloud analogue of Skaffold locally.
-- **Local builds → Skaffold/kind. Cloud builds → GitHub Actions → GHCR → Argo.**
-  Same charts, different image source + values.
+> Architecture/design rationale lives in the second half of this doc
+> ([Design background](#design-background)). Read the runbook first.
 
 ---
 
-## 2. Topology
+## 0. TL;DR — how a change ships
 
 ```
-GitHub (master)
-  │  merge
+merge PR → master
+  │
   ▼
-GitHub Actions ──build──▶ GHCR (ghcr.io/izzywdev/fuzefront-*)   [images, by SHA]
-  │  bump image tag in values-prod.yaml + commit
+release.yml (GitHub Actions)
+  ├─ build + push images to GHCR  (ghcr.io/izzywdev/fuzefront-*:<sha>)
+  └─ bump image tags in deploy/helm/fuzefront/values-prod.yaml + commit "release: … [skip ci]"
+  │
   ▼
-git repo (deploy manifests = source of truth)
-  │  watches
+git (source of truth)
+  │  Argo CD watches the repo
   ▼
-Argo CD (in-cluster on Contabo k3s)  ──sync──▶ namespaces: fuzeinfra, fuzefront
-                                                   │
-Cloudflare DNS ──▶ Contabo VPS public IP ──▶ ingress-nginx ──▶ frontend/backend
-                                                   ▲
-                                          cert-manager (Let's Encrypt TLS)
+Argo CD on Contabo  ──sync──▶ rolling update of fuzefront Deployments
+  │
+  ▼
+prod-smoke.yml polls https://app.fuzefront.com/api/health → expects 200
 ```
 
-### Cluster components (installed once, then GitOps-managed)
-| Component | Purpose | Notes |
-|---|---|---|
-| **k3s** | the cluster | disable bundled Traefik; we use ingress-nginx for parity with kind |
-| **ingress-nginx** | ingress controller | charts already use `ingressClassName: nginx` |
-| **cert-manager** | TLS certs | `ClusterIssuer` letsencrypt-prod (HTTP-01, or DNS-01 via Cloudflare for wildcards) |
-| **Argo CD** | GitOps engine | app-of-apps pattern; reconciles fuzeinfra + fuzefront |
-| **sealed-secrets** (Bitnami) | secrets in git, safely | encrypt secrets → commit `SealedSecret` → controller decrypts in-cluster |
-| **Argo Image Updater** *(optional)* | auto-bump tags | alternative to CI committing the tag |
+You do **not** `kubectl apply` or `helm upgrade` against prod by hand. Git is the
+only way in. Local dev uses Helm/Skaffold on kind; prod is GitOps-only.
 
 ---
 
-## 3. Image registry: GHCR
+## 1. Release flow (normal change)
 
-Move platform images off Docker Hub to **GitHub Container Registry** (free,
-integrated, private-capable):
-- `ghcr.io/izzywdev/fuzefront-backend`
-- `ghcr.io/izzywdev/fuzefront-frontend`
-- `ghcr.io/izzywdev/fuzefront-clock-app` (example)
+1. Open a PR; `helm-validate.yml` lints + kubeconforms the chart on any
+   `deploy/helm/**` change.
+2. Merge to `master`.
+3. `release.yml` builds the changed images, pushes them to GHCR by commit SHA,
+   then rewrites the `tag:` keys in `deploy/helm/fuzefront/values-prod.yaml` and
+   commits `release: fuzefront images <sha> [skip ci]`.
+4. Argo CD detects the git change and syncs the `fuzefront` Application
+   (`syncPolicy.automated.selfHeal: true`).
+5. `prod-smoke.yml` fires on that `release:` commit (it touches
+   `values-prod.yaml`), waits for the rollout, and polls
+   `https://app.fuzefront.com/api/health` until 200.
 
-CI tags each image with the **git SHA** (immutable) plus `latest`. The cluster
-pins the **SHA** (never `latest`) so deploys are reproducible and Argo sees a
-real diff to sync.
+Check status:
 
----
-
-## 4. CI → CD flow (GitOps, git is the source of truth)
-
-On merge to `master` (new workflow `release.yml`):
-1. Build + push `backend`, `frontend`, `clock-app` to GHCR tagged `:<sha>`.
-2. **Bump the tag in `deploy/helm/fuzefront/values-prod.yaml`** (`backend.image.tag`,
-   `frontend.image.tag`) and commit `[skip ci]`.
-3. Argo CD detects the git change and **syncs** the `fuzefront` Application →
-   rolling update to the new images.
-
-> Why CI-commits-the-tag over Argo Image Updater: git stays the single source of
-> truth (auditable, revertible). Image Updater is a fine alternative if you'd
-> rather not commit on every release.
+```bash
+# Argo app health/sync
+argocd app get fuzefront            # or the Argo UI at argocd.fuzefront.com
+kubectl -n fuzefront get deploy,pods
+# Health over the public ingress
+curl -fsS https://app.fuzefront.com/api/health | jq
+```
 
 ---
 
-## 5. Values overlay (prod)
+## 2. Rollback
 
-New `deploy/helm/fuzefront/values-prod.yaml`:
-- `backend.image.repository: ghcr.io/izzywdev/fuzefront-backend` (+ frontend), `tag: <sha>`
-- `ingress.host: app.fuzefront.com`, `ingress.className: nginx`, TLS enabled
-  (cert-manager annotation + tls secret)
-- `secret.existingSecret: fuzefront-secrets` (provided by a SealedSecret — no
-  plaintext in the chart)
-- `database`: point at the in-cluster FuzeInfra Postgres
-  (`postgres.fuzeinfra.svc.cluster.local`), dedicated `fuzefront_user`
-- resource requests/limits sized for the VPS; `replicas: 2` for backend/frontend
+**Rollback = revert the tag-bump commit. Argo re-syncs to the previous images.**
 
-FuzeInfra gets a prod overlay too (full stack or a curated subset:
-Postgres + Redis + monitoring), with persistence on.
+```bash
+# Find the release commit (subject starts with "release:")
+git log --oneline --grep '^release:' -5
+# Revert it (this re-points values-prod.yaml at the prior SHA)
+git revert --no-edit <release-sha>
+git push origin master
+```
 
----
+Argo CD picks up the revert and rolls the Deployments back to the previous image
+tags. Because the images are still in GHCR (immutable by SHA), the rollback is
+exact and fast. No `helm rollback`, no manual image edits.
 
-## 6. Secrets (no plaintext in git)
-
-Use **sealed-secrets**:
-1. Install the controller in-cluster (generates a keypair).
-2. Locally: `kubeseal` encrypts each secret (JWT, SESSION, DB passwords,
-   `PERMIT_API_KEY`, Authentik secret/bootstrap, GHCR pull token) against the
-   cluster's public key.
-3. Commit the resulting `SealedSecret` manifests; Argo applies them; the
-   controller decrypts into a real `Secret` (`fuzefront-secrets`,
-   `fuzeinfra-secrets`) only inside the cluster.
-
-This keeps the repo safe (ties into the earlier secret-hygiene work) while staying
-fully GitOps.
+If Argo is stuck, force a sync from the UI or `argocd app sync fuzefront`. Never
+edit live resources with `kubectl edit` — `selfHeal` will revert you, and you'll
+have drift from git.
 
 ---
 
-## 7. Data & data-safe upgrades
+## 3. Data safety (`prune: false`)
 
-- **Storage:** k3s `local-path` provisioner (VPS disk) for PVCs to start; move to
-  Contabo block storage if you need to detach/grow volumes independently.
-- **StatefulSets keep their PVCs** across Helm/Argo upgrades — image/config changes
-  never recreate the volume. Configure the Argo Application with
-  `syncOptions: [PrunePropagationPolicy=foreground]` and **exclude PVCs from
-  pruning** (Argo prune ignores resources without the managed label / use
-  `Prune=false` on PVCs) so a sync never deletes data.
-- **Backups:** a `CronJob` runs `pg_dump` (and Redis snapshot if needed) and ships
-  to **Contabo Object Storage** (S3-compatible) nightly; retain N days. Restore
-  runbook documented.
+Both Argo Applications (`fuzefront`, `fuzeinfra`) run with:
 
----
+```yaml
+syncPolicy:
+  automated:
+    prune: false   # never auto-delete; protects FuzeInfra PVCs (Postgres/Redis/Kafka)
+    selfHeal: true
+```
 
-## 8. DNS, TLS, networking
-
-- **Cloudflare** DNS: `app.fuzefront.com` (+ `*.apps.fuzefront.com` for example
-  microfrontends, `argocd.fuzefront.com`, `grafana.fuzefront.com`) → Contabo VPS IP.
-- **cert-manager** issues Let's Encrypt certs per ingress host (DNS-01 via the
-  Cloudflare API token enables a wildcard `*.apps.fuzefront.com` so new apps get
-  TLS automatically).
-- **VPS firewall:** allow 80/443 from anywhere; restrict 22 (SSH) and 6443 (k3s
-  API) to your admin IP. Optionally front with Cloudflare proxy for edge DDoS/TLS.
+- **Stateful data lives in FuzeInfra** (Postgres/Redis/Kafka/Chroma on k3s
+  `local-path`). `prune: false` means an Argo sync never deletes a resource that
+  disappears from git — so a bad chart edit can't wipe a PVC. The trade-off:
+  removing a workload from the chart leaves the old object until you prune it
+  **manually and deliberately** (`argocd app sync fuzefront --prune` or
+  `kubectl delete`), after confirming it's not a datastore.
+- StatefulSets keep their PVCs across image/config changes — upgrades never
+  recreate volumes.
+- **Backups**: a `pg_dump` CronJob (`deploy/backup/`) ships nightly dumps to
+  Contabo Object Storage (S3-compatible). Verify restores periodically.
 
 ---
 
-## 9. Bootstrap sequence (one-time)
+## 4. Adding the 2nd node (node-2)
 
-1. Provision Contabo VPS (Ubuntu 22.04, ~Cloud VPS L: 8 vCPU / 30 GB RAM).
-2. Install k3s with Traefik disabled; fetch kubeconfig.
+The plan sizes prod for **two Contabo nodes**: node-1 (control-plane + the
+DB-heavy FuzeInfra stateful pods on `local-path`) and node-2 (heavy stateless
+compute: LiteLLM / chat / billing). No Longhorn yet — stateful pods stay pinned to
+node-1's disk.
+
+### Join node-2 as a k3s agent
+
+On node-1 (server), get the join token:
+
+```bash
+sudo cat /var/lib/rancher/k3s/server/node-token
+```
+
+On node-2 (fresh Ubuntu), install the agent pointing at node-1:
+
+```bash
+curl -sfL https://get.k3s.io | \
+  K3S_URL=https://<node-1-public-ip>:6443 \
+  K3S_TOKEN=<token-from-above> \
+  sh -
+```
+
+Firewall between nodes (open on both): **6443/TCP** (k3s API), **8472/UDP**
+(Flannel VXLAN), **10250/TCP** (kubelet metrics). If the nodes talk over public
+IPs, switch Flannel to the **WireGuard** backend so pod traffic is encrypted.
+
+Verify + label node-2 so the affinity in `values-prod.yaml` matches:
+
+```bash
+kubectl get nodes -o wide
+# The affinity blocks key on kubernetes.io/hostname=fuzefront-node-2.
+# Either name the host accordingly at install, or relabel:
+kubectl label node <node-2-name> kubernetes.io/hostname=fuzefront-node-2 --overwrite
+```
+
+`values-prod.yaml` gives `litellm`/`chatService`/`billingService` a
+**preferred** (soft) nodeAffinity toward `fuzefront-node-2`, so they schedule
+there when it exists and fall back to node-1 if it doesn't. Stateful FuzeInfra
+pods are unaffected (they pin to node-1 via FuzeInfra's own config).
+
+---
+
+## 5. Secrets — sealed-secrets rotation
+
+All FuzeFront secrets live in the SealedSecret that decrypts to the
+`fuzefront-secrets` Secret in the `fuzefront` namespace (referenced via
+`secret.existingSecret`). Keys include: `JWT_SECRET`, `SESSION_SECRET`,
+`DB_PASSWORD`, `DB_SUPERUSER_PASSWORD`, `PERMIT_API_KEY`,
+`INTERNAL_PROVISION_SECRET`, `AUTHENTIK_SECRET_KEY`,
+`AUTHENTIK_BOOTSTRAP_PASSWORD`, `AUTHENTIK_BOOTSTRAP_TOKEN`,
+`AUTHENTIK_CLIENT_SECRET`, and (when enabled) `SENDGRID_API_KEY` /
+`TWILIO_*` / `SMS_AUTH_SECRET` / `SMTP_PASSWORD`.
+
+### Rotate one or more keys
+
+```bash
+# 1. Fetch the cluster's sealing public cert (one-time; safe to commit/share).
+kubeseal --fetch-cert \
+  --controller-name sealed-secrets \
+  --controller-namespace kube-system > pub-cert.pem
+
+# 2. Build the new Secret locally (do NOT commit this plaintext).
+kubectl create secret generic fuzefront-secrets \
+  --namespace fuzefront \
+  --from-literal=JWT_SECRET="$(openssl rand -hex 32)" \
+  --from-literal=DB_PASSWORD='...' \
+  ...all other keys... \
+  --dry-run=client -o yaml > /tmp/fuzefront-secrets.yaml
+
+# 3. Seal it against the cluster cert.
+kubeseal --cert pub-cert.pem --format yaml \
+  < /tmp/fuzefront-secrets.yaml > deploy/contabo/sealed/fuzefront-secrets.yaml
+
+# 4. Commit ONLY the sealed file + push. Argo applies it; the controller
+#    decrypts into the real Secret in-cluster.
+git add deploy/contabo/sealed/fuzefront-secrets.yaml && git commit && git push
+
+# 5. Roll the pods that read the rotated keys (they read at startup).
+kubectl -n fuzefront rollout restart deploy/fuzefront-backend deploy/fuzefront-security
+```
+
+Notes:
+- The sealed file is safe in git; the plaintext (`/tmp/...`) must never be
+  committed — delete it after sealing.
+- Rotating `DB_PASSWORD` also requires the runtime DB role's password to change;
+  the `db-bootstrap` Job sets the role password to `DB_PASSWORD` on the next
+  upgrade, so seal the new value and let the pre-upgrade Job reconcile it.
+- A full sealing-key rotation (controller keypair) re-encrypts everything —
+  follow the sealed-secrets controller's key-renewal procedure, then re-seal.
+
+---
+
+## 6. Kafka topics
+
+Prod pre-creates the prefixed topics via a Helm post-install/post-upgrade Job
+(`templates/kafka-topics-job.yaml`, gated by `kafkaTopics.enabled: true` in
+`values-prod.yaml`) rather than relying on broker auto-create. The topic set is
+reconciled from the `@fuzefront/shared` `TOPICS` constant plus the planned
+billing/chat events. When that constant changes, edit `kafkaTopics.topics` in
+`values.yaml`. The Job uses `--create --if-not-exists`, so it is safe to re-run on
+every upgrade; it never shrinks partitions/retention.
+
+---
+
+## 7. Observability
+
+- FuzeFront pods carry `prometheus.io/scrape|port|path` annotations (set when
+  `observability.metrics.enabled: true`, on in prod). The backend exposes
+  `/metrics` via prom-client. The FuzeInfra Prometheus auto-discovers them.
+- Dashboards (`deploy/helm/fuzefront/dashboards/*.json`) and alert rules
+  (`deploy/helm/fuzefront/alerts/*.yaml`) ship as ConfigMaps labeled
+  `grafana_dashboard: "1"` / `prometheus_rule: "1"`. The FuzeInfra Grafana sidecar
+  + Prometheus rule mount discover them (those discovery hooks are added in
+  FuzeInfra separately).
+- Logs flow to Loki automatically (Promtail scrapes all namespaces).
+
+---
+
+## Design background
+
+<details>
+<summary>Why this shape (k3s + Argo + GHCR + sealed-secrets)</summary>
+
+- **Contabo gives VPS, not managed Kubernetes** → run lightweight **k3s** (single
+  binary, production-capable, standard Kubernetes). Our `deploy/helm/fuzefront` +
+  the FuzeInfra Helm chart apply unchanged.
+- **Argo CD** makes git the source of truth: the cluster continuously reconciles
+  to what's committed — the cloud analogue of Skaffold locally.
+- **Images**: GHCR (`ghcr.io/izzywdev/fuzefront-*`), tagged by immutable git SHA;
+  the cluster pins the SHA (never `latest`) so deploys are reproducible.
+- **Secrets**: sealed-secrets — encrypt against the cluster's public key, commit
+  the `SealedSecret`, the controller decrypts in-cluster only.
+- **Cluster add-ons** (installed once, then GitOps-managed): ingress-nginx
+  (parity with kind's `ingressClassName: nginx`), cert-manager (`ClusterIssuer
+  letsencrypt-prod`, HTTP-01), sealed-secrets, Argo CD (app-of-apps).
+- **DNS/TLS**: Cloudflare DNS `app.fuzefront.com` + `auth.fuzefront.com` →
+  Contabo VPS IP; cert-manager issues Let's Encrypt certs per ingress host.
+  Firewall: 80/443 open; 22 + 6443 restricted to admin IP.
+
+</details>
+
+<details>
+<summary>Bootstrap sequence (one-time, already done on the live cluster)</summary>
+
+1. Provision Contabo VPS (Ubuntu, ~8 vCPU / 30 GB).
+2. Install k3s (Traefik disabled); fetch kubeconfig.
 3. Install ingress-nginx, cert-manager (+ ClusterIssuer), sealed-secrets, Argo CD.
-4. Point Cloudflare DNS at the VPS IP; create the Cloudflare API token for DNS-01.
+4. Point Cloudflare DNS at the VPS; create the Let's Encrypt account.
 5. Seal secrets (`kubeseal`) and commit the `SealedSecret` manifests.
-6. Apply the **app-of-apps** Argo Application → it creates the `fuzeinfra` and
-   `fuzefront` Applications, which sync the charts.
+6. Apply the app-of-apps Argo Application → it creates `fuzeinfra` + `fuzefront`.
 7. Push to `master` → `release.yml` pushes images + bumps tags → Argo rolls out.
 
-Steps 1–4 can be codified with **Ansible** (VPS + k3s + add-ons) and, if you want
-infra-as-code for the VPS itself, the community **Contabo Terraform provider**.
+Steps 1–4 are codified in `deploy/contabo/` (bootstrap script + ClusterIssuer).
 
----
-
-## 10. Artifacts to create at implementation time
-
-- `deploy/helm/fuzefront/values-prod.yaml` (GHCR images, ingress host + TLS, existingSecret)
-- `deploy/argocd/` — `project.yaml`, `app-of-apps.yaml`, `applications/fuzefront-prod.yaml`
-  (FuzeInfra already ships `argocd/applications/*` to adapt for Contabo)
-- `deploy/contabo/` — Ansible playbook (k3s + ingress-nginx + cert-manager +
-  sealed-secrets + Argo), `ClusterIssuer`, firewall notes, bootstrap README
-- `deploy/backup/postgres-backup-cronjob.yaml` (pg_dump → Contabo S3)
-- `.github/workflows/release.yml` — build + push to GHCR + bump tag in values-prod + commit
-- SealedSecret manifests for `fuzefront-secrets` / `fuzeinfra-secrets`
-
----
-
-## 11. Open decisions (need your input before implementing)
-
-1. **Domain** for the platform (e.g. `app.fuzefront.com`?) and whether to use
-   Cloudflare proxy.
-2. **VPS size / count** — single node to start (simplest), or 3 nodes for HA
-   (needs a real storage story, e.g. Longhorn).
-3. **FuzeInfra scope in prod** — full stack vs Postgres + Redis + monitoring only.
-4. **Registry** — GHCR (recommended) vs Docker Hub vs Contabo-hosted.
-5. **Secrets** — sealed-secrets (recommended) vs SOPS vs External Secrets.
-6. Keep the existing AWS **website** deploy (`deploy.yml`) or retire it.
+</details>

--- a/docs/guides/BUILDING_ON_FUZEFRONT.md
+++ b/docs/guides/BUILDING_ON_FUZEFRONT.md
@@ -1,0 +1,193 @@
+# Building on FuzeFront
+
+How a downstream product runs **on top of** the FuzeFront platform: register a
+micro-frontend into the host shell, consume the shared `@fuzefront/*` packages,
+sign users in via Authentik OIDC SSO, authorize with Permit scopes, and call the
+platform API.
+
+FuzeFront is a **Module-Federation host shell** ("runtime fabric"): a dark-default
+dashboard that discovers, mounts, and fuses remote micro-frontends ("apps") into
+one runtime experience. Your product is one of those apps.
+
+---
+
+## 1. Register a Module-Federation app
+
+The shell discovers apps at runtime via the platform API — **no build-time
+dependency** on your app. Your app exposes a federated module; you register its
+`remoteEntry.js` URL + scope/module with the shell.
+
+### 1a. Expose your app as a remote (Vite)
+
+```ts
+// vite.config.ts (your micro-frontend)
+import federation from '@originjs/vite-plugin-federation'
+
+export default {
+  plugins: [
+    federation({
+      name: 'myApp',                 // becomes the `scope`
+      filename: 'remoteEntry.js',
+      exposes: { './App': './src/App.tsx' },  // becomes the `module`
+      shared: ['react', 'react-dom'], // MUST be shared singletons with the host
+    }),
+  ],
+  build: { target: 'esnext' },
+}
+```
+
+Serve the build with permissive CORS so the shell (a different origin) can fetch
+`remoteEntry.js`.
+
+### 1b. Register it with the platform
+
+```bash
+curl -X POST https://app.fuzefront.com/api/apps/register \
+  -H 'Authorization: Bearer <jwt>' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "name": "My App",
+    "integrationType": "module-federation",
+    "remoteUrl": "https://my-app.example.com/assets/remoteEntry.js",
+    "scope": "myApp",
+    "module": "./App"
+  }'
+```
+
+Fields (`integrationType` is one of `module-federation` | `iframe` |
+`web-component` | `spa`):
+
+| field | meaning |
+|---|---|
+| `name` | display name in the shell |
+| `integrationType` | how the shell mounts it |
+| `remoteUrl` | URL of `remoteEntry.js` (module-federation) or the page (iframe) |
+| `scope` | the `name` from your federation config |
+| `module` | the exposed key, e.g. `./App` |
+
+Apps can self-register on boot and send heartbeats; the SDK wraps this. The shell
+loads the remote on demand using `@originjs/vite-plugin-federation`. React /
+React-DOM are shared singletons for performance, so keep your React major in step
+with the host.
+
+---
+
+## 2. Consume the `@fuzefront/*` packages
+
+FuzeFront publishes reusable packages **privately to GitHub Packages** under the
+`@fuzefront` (and `@izzywdev`) scopes. Consumers authenticate with a scoped
+`.npmrc` + a `GITHUB_TOKEN`/PAT that has `read:packages`.
+
+```ini
+# .npmrc (in the consuming repo; do NOT commit the token)
+@fuzefront:registry=https://npm.pkg.github.com
+@izzywdev:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}
+```
+
+| package | what it gives you |
+|---|---|
+| `@fuzefront/shared` | shared types, Kafka `TOPICS` constant + `FuzeEvent<T>` envelope, typed producer/consumer helpers |
+| `@izzywdev/fuzefront-api-client` | generated TypeScript client for the platform API (auth, apps, health) |
+| `@izzywdev/fuzefront-sdk-react` | React SDK for self-registration, heartbeat, and host context |
+
+If you publish your own reusable package, follow the same convention:
+`publishConfig` → `https://npm.pkg.github.com` with `access: restricted`, never
+public npm.
+
+### Kafka events
+
+If your service consumes/produces platform events, use the shared constants
+rather than string literals:
+
+```ts
+import { TOPICS, FuzeEvent } from '@fuzefront/shared'
+// e.g. TOPICS.IDENTITY_USER_CREATED, TOPICS.NOTIFY_EMAIL_REQUESTED
+```
+
+Topics are prefixed (`identity.*`, `notify.*`, `billing.*`) and pre-created in
+prod by the chart's `kafka-topics-job`. Add new topics there + to the shared
+constant together.
+
+---
+
+## 3. Authentik OIDC SSO
+
+Identity is owned by **Authentik** (`auth.fuzefront.com` in prod). The platform
+backend brokers OIDC; your product gets SSO by sending users through the shell's
+auth, or by registering your own OIDC client in Authentik.
+
+Backend OIDC endpoints:
+
+- `GET /api/auth/oidc/login` — starts the Authorization Code flow (redirects to
+  Authentik).
+- `GET /api/auth/oidc/callback` — exchange + session; the backend issues a JWT.
+- `POST /api/auth/login` — local JWT login (dev / non-SSO).
+
+Prod OIDC config (from `values-prod.yaml`):
+
+- issuer: `https://auth.fuzefront.com/application/o/fuzefront/`
+- redirect: `https://app.fuzefront.com/api/auth/oidc/callback`
+- cookie domain: `fuzefront.com` (session shared across `*.fuzefront.com`)
+
+To SSO your own subdomain product, register an OIDC provider/application in
+Authentik with your redirect URI, and validate the issued JWT against the same
+issuer. Keep your cookie/JWT audience consistent so the shared session works
+across the apex.
+
+---
+
+## 4. Permit scopes (authorization)
+
+Authorization is policy-based via **Permit.io** (a PDP runs in-cluster;
+`permit.enabled: true` in prod). The backend gates routes with a
+`requirePermission(resource, action)` middleware; the SDK degrades gracefully if
+no PDP is reachable (permission-gated routes deny).
+
+To authorize your product's actions:
+
+1. Model your resources/actions/roles in the Permit schema (the chart's
+   `permit-schema-sync` Job applies the FuzeFront schema on upgrade; extend it
+   for your resources).
+2. Call the platform API with a JWT; the backend resolves the user + org context
+   and checks the PDP.
+3. Multi-tenant: permissions are isolated per **organization**; pass/inherit the
+   org context so checks are scoped to the right tenant.
+
+---
+
+## 5. Calling the platform API
+
+- **Base URL**: `https://app.fuzefront.com/api` (prod). In-cluster, the frontend
+  nginx proxies `/api` + `/socket.io` to the backend Services. The browser API
+  base defaults to same-origin — never hardcode `http://…` (mixed-content under
+  TLS).
+- **Auth**: `Authorization: Bearer <jwt>` from OIDC or local login.
+- **Health**: `GET /api/health` → `{ status, database, ... }` (used by the prod
+  smoke check).
+- **Client**: prefer `@izzywdev/fuzefront-api-client` over hand-rolled fetch — it
+  tracks the API surface and types.
+
+```ts
+import { FuzeFrontClient } from '@izzywdev/fuzefront-api-client'
+const client = new FuzeFrontClient({ baseUrl: window.location.origin, token })
+const apps = await client.apps.list()
+```
+
+---
+
+## 6. Design language
+
+FuzeFront is **dark-default** with the **"fuse seam"** motif (indigo→cyan gradient
+marking where the shell joins hosted content). If you build UI that renders inside
+the shell, align to the **fuse seam design system** (`design-system/`): reuse its
+tokens/components, don't hard-code colors/spacing/type, and extend the system
+rather than one-off styling.
+
+---
+
+## See also
+
+- Operational deployment runbook: `docs/deployment/CONTABO_DEPLOYMENT.md`
+- Module Federation deep-dive: `docs/guides/MODULE_FEDERATION_GUIDE.md`
+- Developer guide: `docs/guides/DEVELOPER_GUIDE.md`

--- a/frontend/src/__tests__/AcceptInvitePage.test.tsx
+++ b/frontend/src/__tests__/AcceptInvitePage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import AcceptInvitePage from '../pages/AcceptInvitePage'
 import { AppProvider } from '../lib/shared'

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,6 +66,7 @@
         "passport-openidconnect": "^0.1.1",
         "permitio": "^2.4.0",
         "pg": "^8.11.5",
+        "prom-client": "^15.1.3",
         "socket.io": "^4.7.5",
         "sqlite3": "^5.1.7",
         "swagger-jsdoc": "^6.2.8",
@@ -2860,6 +2861,15 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/@paralleldrive/cuid2": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.2.2.tgz",
@@ -4627,6 +4637,12 @@
       "dependencies": {
         "file-uri-to-path": "1.0.0"
       }
+    },
+    "node_modules/bintrees": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
+      "license": "MIT"
     },
     "node_modules/bl": {
       "version": "4.1.0",
@@ -10960,6 +10976,19 @@
       "integrity": "sha512-n9wh8tvBe5sFmsqlg+XQhaQLumwpqoAUruLwjCopgTmUBjJ/fjtBsJzKleCaIGBOMXYEhp1YfKl4d7rJ5ZKJGA==",
       "license": "MIT"
     },
+    "node_modules/prom-client": {
+      "version": "15.1.3",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
+      "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.4.0",
+        "tdigest": "^0.1.1"
+      },
+      "engines": {
+        "node": "^16 || ^18 || >=20"
+      }
+    },
     "node_modules/promise-inflight": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
@@ -12604,6 +12633,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/tdigest": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "license": "MIT",
+      "dependencies": {
+        "bintrees": "1.0.2"
       }
     },
     "node_modules/test-exclude": {


### PR DESCRIPTION
## Production CD to `app.fuzefront.com` (Contabo k3s + Argo CD) — FuzeFront-side

Implements the FuzeFront-side slices of the approved prod-CD plan. Hardens the
GitOps path that publishes the FuzeFront **app** to `app.fuzefront.com` while the
`fuzefront.com` apex stays on AWS CloudFront (untouched).

**This PR covers Phases B, C, D, E, G, H. Phase A (FuzeInfra delegation) and
Phase F (release.yml matrix + new-service images + their own Argo Applications)
plus live cluster verification are owned by the orchestrator post-merge.**

### Phase B — infra-needs overlay
- `deploy/argocd/applications/fuzeinfra.yaml`: enable `kafka` + `chromadb`
  (event bus + chat-RAG); mongo/neo4j/ES/kafkaUi stay disabled; Postgres/Redis
  stay enabled.

### Phase C — prod app config
- `values-prod.yaml` + `templates/authentik.yaml`: prod Authentik (`auth.fuzefront.com`,
  `oidc.enabled`, prod issuer/redirect, `cookieDomain: fuzefront.com`, ingress +
  `letsencrypt-prod` TLS). `permit.enabled: true` confirmed.
- Resource requests/limits added to every workload that lacked them (email/sms;
  placeholders for billing/chat/litellm).
- `global.scheduling` + per-service `nodeSelector`/`affinity`/`tolerations`
  (default no-op) via a `fuzefront.scheduling` helper; node-2 affinity for
  litellm/chat/billing in prod.
- Secrets are SealedSecret references only — nothing inline.

### Phase D — Kafka topics
- `templates/kafka-topics-job.yaml`: idempotent Helm post-install/post-upgrade
  hook Job creating the prefixed topics (identity/notify/billing) with explicit
  partitions + retention, gated by `kafkaTopics.enabled`.

### Phase E — observability
- `prometheus.io/scrape|port|path` pod annotations (backend/security/applications)
  + a `/metrics` endpoint (prom-client) on the backend.
- Grafana dashboards (`dashboards/*.json`) + Prometheus alert rules
  (`alerts/*.yaml`) shipped as labeled ConfigMaps (rely on FuzeInfra discovery
  hooks added separately).

### Phase G — CI gate
- `.github/workflows/helm-validate.yml`: `helm lint` + `kubeconform` (strict,
  k8s 1.29) of the chart against values-local + values-prod, on PRs touching
  `deploy/helm/**`.

### Phase H — smoke + docs
- `.github/workflows/prod-smoke.yml`: after a `release:` tag-bump, poll
  `https://app.fuzefront.com/api/health` for 200.
- `docs/deployment/CONTABO_DEPLOYMENT.md` → operational runbook (release flow,
  rollback via git revert, `prune:false` data safety, 2nd-node join, sealed-secret
  rotation).
- `docs/guides/BUILDING_ON_FUZEFRONT.md`: downstream products on FuzeFront
  (Module-Federation app registration, `@fuzefront/*` packages, Authentik OIDC
  SSO, Permit scopes, the API).

### Notes
- Continues a watchdog-salvaged checkpoint (`ed0290f`) from a prior credit-killed
  run; Phases B/C were already salvaged there and are verified consistent.
- Deferred to orchestrator: Phase F (release.yml matrix, billing/chat/litellm
  images + their own Argo apps, migration-010 renumber) and live verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
