### PR TITLE
fix(e2e): repair Playwright sign-in flow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -68,7 +68,7 @@ jobs:
           cd backend
           node dist/index.js > /tmp/backend.log 2>&1 &
           echo "Waiting for backend /health..."
-          for i in $(seq 1 60); do
+          for _ in $(seq 1 60); do
             if curl -fsS http://localhost:3001/health >/dev/null 2>&1; then echo "backend up"; exit 0; fi
             sleep 2
           done
@@ -131,7 +131,7 @@ jobs:
           npm ci --include=dev   # need vite/@playwright (devDeps) despite NODE_ENV=production
           npm run build
           npx vite preview --port 4173 --host 127.0.0.1 > /tmp/frontend.log 2>&1 &
-          for i in $(seq 1 30); do
+          for _ in $(seq 1 30); do
             if curl -fsS http://localhost:4173 >/dev/null 2>&1; then echo "frontend up"; exit 0; fi
             sleep 2
           done
@@ -144,7 +144,7 @@ jobs:
           npm install --include=dev   # need vite (devDep) despite NODE_ENV=production
           VITE_HUB_API_URL=http://localhost:3001 VITE_PUBLIC_URL=http://localhost:4174 npm run build
           npx vite preview --port 4174 --host 127.0.0.1 > /tmp/clock.log 2>&1 &
-          for i in $(seq 1 30); do
+          for _ in $(seq 1 30); do
             if curl -fsS http://localhost:4174/assets/remoteEntry.js >/dev/null 2>&1; then echo "clock-app up"; break; fi
             sleep 2
           done

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -74,11 +74,19 @@ jobs:
           done
           echo "backend failed to start"; cat /tmp/backend.log; exit 1
 
-      - name: Create admin user
+      # Seed a FULLY-PROVISIONED admin: user + personal org + active owner
+      # membership. The authenticated shell sits behind WorkspaceProvisioningGate
+      # (frontend/src/components/WorkspaceProvisioningGate.tsx), which only renders
+      # the app layout once the user has a personal org. Real logins provision that
+      # org asynchronously (fire-and-forget self-heal on login); seeding it directly
+      # makes the gate open immediately, so the e2e is deterministic instead of
+      # racing a background job (and tolerant of Permit/Kafka being absent in CI).
+      - name: Create admin user (provisioned with personal org)
         working-directory: backend
         run: |
           node -e '
             const bcrypt = require("bcrypt");
+            const crypto = require("crypto");
             const knex = require("knex")({
               client: "pg",
               connection: { host: process.env.DB_HOST, port: +process.env.DB_PORT,
@@ -86,10 +94,32 @@ jobs:
             });
             (async () => {
               const password_hash = await bcrypt.hash("admin123", 10);
-              await knex("users").insert({ email: "admin@fuzefront.dev", password_hash,
+              const [u] = await knex("users").insert({ email: "admin@fuzefront.dev", password_hash,
                 first_name: "Admin", last_name: "User", roles: JSON.stringify(["admin","user"]) })
-                .onConflict("email").merge({ password_hash });
-              console.log("admin user ready");
+                .onConflict("email").merge({ password_hash }).returning("id");
+              const userId = u.id || u;
+              console.log("admin user ready", userId);
+
+              // Mirror ensurePersonalOrg(): one active personal org owned by the user.
+              const existing = await knex("organizations")
+                .where({ owner_id: userId, type: "personal" }).first();
+              if (!existing) {
+                const orgId = crypto.randomUUID();
+                await knex.transaction(async trx => {
+                  await trx("organizations").insert({ id: orgId, name: "Personal",
+                    slug: "personal-" + userId, parent_id: null, owner_id: userId,
+                    type: "personal", settings: JSON.stringify({}),
+                    metadata: JSON.stringify({ personal: true }), is_active: true,
+                    provisioning_state: "active" });
+                  await trx("organization_memberships").insert({ id: crypto.randomUUID(),
+                    user_id: userId, organization_id: orgId, role: "owner", status: "active",
+                    joined_at: new Date(), permissions: JSON.stringify({}),
+                    metadata: JSON.stringify({}) });
+                });
+                console.log("personal org provisioned", orgId);
+              } else {
+                console.log("personal org already present", existing.id);
+              }
               await knex.destroy();
             })().catch(e => { console.error(e); process.exit(1); });
           '

--- a/backend/src/routes/organizations.ts
+++ b/backend/src/routes/organizations.ts
@@ -283,8 +283,15 @@ router.get('/', authenticateToken, async (req: any, res) => {
       }
     }
 
+    // `is_active` defaults to the boolean `true` (when no query param is sent),
+    // but arrives as a string when it IS sent. Comparing `true === 'true'`
+    // yields false, which previously filtered to is_active=false and hid every
+    // active org (including the user's personal org) — leaving the frontend
+    // WorkspaceProvisioningGate stuck on "Creating your workspace…". Coerce both
+    // shapes: treat boolean true and the string 'true' as active.
     if (is_active !== undefined) {
-      query = query.where('organizations.is_active', is_active === 'true')
+      const wantActive = is_active === true || is_active === 'true'
+      query = query.where('organizations.is_active', wantActive)
     }
 
     if (search) {

--- a/backend/src/routes/organizations.ts
+++ b/backend/src/routes/organizations.ts
@@ -11,6 +11,24 @@ import { reconcileOrganizationProvisioning } from '../services/organizationProvi
 
 const router = express.Router()
 
+// `settings`/`metadata` are jsonb columns. The `pg` driver already parses jsonb
+// into JS objects on read, so calling JSON.parse() on them throws
+// ("[object Object]" is not valid JSON) and 500s the route. Older code paths /
+// other drivers (e.g. sqlite) may hand back a string instead, so accept both:
+// pass objects through, parse strings, and fall back to {} on anything invalid.
+function parseJsonColumn(value: unknown): Record<string, any> {
+  if (value == null) return {}
+  if (typeof value === 'object') return value as Record<string, any>
+  if (typeof value === 'string') {
+    try {
+      return JSON.parse(value)
+    } catch {
+      return {}
+    }
+  }
+  return {}
+}
+
 // Input validation helpers
 function validateOrganizationInput(data: any) {
   const errors: string[] = []
@@ -164,8 +182,8 @@ router.post('/', authenticateToken, async (req: any, res) => {
       parent_id: newOrganization.parent_id,
       owner_id: newOrganization.owner_id,
       type: newOrganization.type,
-      settings: JSON.parse(newOrganization.settings || '{}'),
-      metadata: JSON.parse(newOrganization.metadata || '{}'),
+      settings: parseJsonColumn(newOrganization.settings),
+      metadata: parseJsonColumn(newOrganization.metadata),
       is_active: newOrganization.is_active,
       created_at: newOrganization.created_at,
       updated_at: newOrganization.updated_at,
@@ -298,8 +316,8 @@ router.get('/', authenticateToken, async (req: any, res) => {
       parent_id: org.parent_id,
       owner_id: org.owner_id,
       type: org.type,
-      settings: JSON.parse(org.settings || '{}'),
-      metadata: JSON.parse(org.metadata || '{}'),
+      settings: parseJsonColumn(org.settings),
+      metadata: parseJsonColumn(org.metadata),
       is_active: org.is_active,
       created_at: org.created_at,
       updated_at: org.updated_at,
@@ -374,8 +392,8 @@ router.get(
         parent_id: organization.parent_id,
         owner_id: organization.owner_id,
         type: organization.type,
-        settings: JSON.parse(organization.settings || '{}'),
-        metadata: JSON.parse(organization.metadata || '{}'),
+        settings: parseJsonColumn(organization.settings),
+        metadata: parseJsonColumn(organization.metadata),
         is_active: organization.is_active,
         created_at: organization.created_at,
         updated_at: organization.updated_at,
@@ -459,8 +477,8 @@ router.put(
         parent_id: updatedOrganization.parent_id,
         owner_id: updatedOrganization.owner_id,
         type: updatedOrganization.type,
-        settings: JSON.parse(updatedOrganization.settings || '{}'),
-        metadata: JSON.parse(updatedOrganization.metadata || '{}'),
+        settings: parseJsonColumn(updatedOrganization.settings),
+        metadata: parseJsonColumn(updatedOrganization.metadata),
         is_active: updatedOrganization.is_active,
         created_at: updatedOrganization.created_at,
         updated_at: updatedOrganization.updated_at,


### PR DESCRIPTION
## Problem

The `E2E (sign-in)` check (`.github/workflows/e2e.yml`) has failed on every PR and on `master` push — pre-existing, not introduced by any one PR. Both specs (`auth-simple.spec.ts`, `clock-load.spec.ts`) get past login (200 + token set, login form gone) but the page is stuck on the **"Creating your workspace…"** card (confirmed from the Playwright artifact's `error-context.md` page snapshot), so `.app-layout` / `.top-bar` / `.main-content` / `button.app-grid-button` never render.

## Root cause

The authenticated shell renders behind `WorkspaceProvisioningGate` (`frontend/src/components/WorkspaceProvisioningGate.tsx`, added in PR #59 — after these specs were written). It only mounts the app `Layout` once `GET /organizations` returns the user's **personal** org; otherwise it shows the provisioning card and polls for 30s.

Three compounding bugs kept that gate from ever opening:

1. **`GET /organizations` hid all active orgs.** The `is_active` filter defaults to the boolean `true` but compared `is_active === 'true'` — `true === 'true'` is `false` — so with no query param (exactly how the gate calls it) the route filtered `WHERE is_active = false` and returned **zero** active orgs. This is the primary blocker: the gate never saw any personal org and stayed on the loading card forever.
2. **`GET /organizations` 500s on jsonb.** `settings`/`metadata` are `jsonb`; the `pg` driver returns them already parsed as objects, so `JSON.parse(org.settings)` throws (`'[object Object]' is not valid JSON`) the moment any org row is returned — which would flip the gate to its error state once bug #1 was fixed.
3. **The e2e seeded a bare user** and relied on the login path's fire-and-forget self-heal provisioning to create the personal org within the test window — racy even with the route fixed.

## Fix

- `backend/src/routes/organizations.ts`: coerce `is_active` (boolean `true` or string `'true'` ⇒ active); add `parseJsonColumn()` that passes objects through and only `JSON.parse`es strings, applied to all four settings/metadata reads.
- `.github/workflows/e2e.yml`: seed the admin **fully provisioned** (user + personal org + active owner membership, mirroring `ensurePersonalOrg`) so the gate opens deterministically and the test doesn't race an async background job (and tolerates Permit/Kafka being absent in CI). Also `for _ in` instead of `for i in` so actionlint is clean.

The real login → gate → `GET /organizations` → shell → federated-load path is still exercised end to end; no tests were skipped or weakened.

## Verification

- Reproduced against a CI-equivalent Postgres (`postgres:15`, same env): migrations apply; with the original route, the gate's query returns **0 rows / no personal org** (matches CI). With the `is_active` fix it returns the personal org; with the jsonb fix the transform no longer throws.
- `actionlint` on `.github/workflows/e2e.yml` → **exit 0**.
- Full `E2E (sign-in)` workflow re-run on this PR (see checks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)