### PR TITLE
fix(ci): backend release image build context (repo root)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,8 @@ jobs:
       - name: Build & push backend
         uses: docker/build-push-action@v5
         with:
-          context: ./backend
+          context: .
+          file: backend/Dockerfile
           push: true
           tags: |
             ghcr.io/izzywdev/fuzefront-backend:${{ steps.tag.outputs.sha }}


### PR DESCRIPTION
release.yml built the backend image with `context: ./backend`, but backend/Dockerfile is monorepo-style (COPYs `shared/` + `backend/` from root) → 'not found' build failure. Switch to `context: .` + `file: backend/Dockerfile` (matches the services). Unblocks the GitOps image build/tag-bump.