### PR TITLE
feat(infra): declarative node-request + dispatch-to-FuzeInfra reconcile loop

### DIFF
--- a/.github/workflows/infra-dispatch.yml
+++ b/.github/workflows/infra-dispatch.yml
@@ -1,0 +1,58 @@
+name: Infra request → FuzeInfra
+
+# Event-driven, decoupled IaC: when FuzeFront's declarative infra/deploy intent
+# changes (deploy/terraform/** = node/infra requests, deploy/argocd/** = Argo
+# Applications), notify FuzeInfra (the cluster owner + sole credential holder) to
+# reconcile it into the live cluster. FuzeFront holds NO Contabo/cluster creds —
+# only FUZEINFRA_DISPATCH_TOKEN, a narrowly-scoped PAT/App token whose ONLY power
+# is to fire a repository_dispatch on izzywdev/FuzeInfra.
+#
+# FuzeInfra's `on: repository_dispatch: types: [infra-request]` handler then:
+#   - validates the request against its whitelist → auto-applies if it matches,
+#     else opens a gated PR/approval (terraform plan);
+#   - runs `terraform apply` (Contabo provider) to provision + k3s-join + label
+#     the node, using ITS secrets + TF state;
+#   - applies/syncs the changed Argo Applications.
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'deploy/terraform/**'
+      - 'deploy/argocd/**'
+  workflow_dispatch: {}
+
+concurrency:
+  group: infra-dispatch
+  cancel-in-progress: false
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Compute changed infra paths
+        id: changed
+        run: |
+          base="${{ github.event.before }}"
+          if [ -z "$base" ] || ! git cat-file -e "$base^{commit}" 2>/dev/null; then base="HEAD~1"; fi
+          changed=$(git diff --name-only "$base" HEAD -- deploy/terraform deploy/argocd | tr '\n' ',' | sed 's/,$//')
+          echo "paths=$changed" >> "$GITHUB_OUTPUT"
+          echo "changed: $changed"
+
+      - name: Dispatch infra-request to FuzeInfra
+        env:
+          GH_TOKEN: ${{ secrets.FUZEINFRA_DISPATCH_TOKEN }}
+        run: |
+          if [ -z "${GH_TOKEN}" ]; then
+            echo "::error::FUZEINFRA_DISPATCH_TOKEN not set — cannot dispatch to FuzeInfra."
+            exit 1
+          fi
+          gh api repos/izzywdev/FuzeInfra/dispatches \
+            -f event_type=infra-request \
+            -F "client_payload[repo]=${{ github.repository }}" \
+            -F "client_payload[ref]=${{ github.sha }}" \
+            -F "client_payload[changed]=${{ steps.changed.outputs.paths }}"
+          echo "Dispatched infra-request → izzywdev/FuzeInfra (ref ${{ github.sha }})."

--- a/deploy/terraform/README.md
+++ b/deploy/terraform/README.md
@@ -1,0 +1,38 @@
+# FuzeFront infra requests (declare here → FuzeInfra reconciles)
+
+FuzeFront is **GitOps-only** and holds **no Contabo or cluster credentials**. To get
+infrastructure (e.g. a worker node), we *declare* a request here; **FuzeInfra** (the
+cluster owner + sole credential holder) applies it. This keeps the repos decoupled and
+scales as more services are added.
+
+## How it works
+1. Edit a request under `deploy/terraform/**` (or an Argo app under `deploy/argocd/**`) and merge to `master`.
+2. `.github/workflows/infra-dispatch.yml` detects the change and fires a `repository_dispatch`
+   (`event_type: infra-request`) to `izzywdev/FuzeInfra`, using the scoped `FUZEINFRA_DISPATCH_TOKEN`
+   secret (its only power is to trigger that dispatch — no cloud/cluster access).
+3. FuzeInfra's `repository_dispatch: infra-request` handler (holds the Contabo creds, the k3s
+   server URL + join token, and the TF state backend) checks the request against its **whitelist**:
+   - **whitelisted** (allowed `product_id` / `region` / `role`) → **auto-applies** (`terraform apply`),
+     provisions the Contabo node, cloud-init `k3s agent`-joins + labels it, syncs the Argo apps;
+   - **non-whitelisted** → opens a gated PR with `terraform plan` for human approval.
+
+## What FuzeFront declares vs what FuzeInfra injects
+| Declared here (FuzeFront) | Injected by FuzeInfra at apply (never here) |
+|---|---|
+| node `name`, `product_id`, `region`, `role`, `labels` | Contabo OAuth2 creds |
+| which Argo Applications exist (`deploy/argocd/`) | k3s server URL + node join token |
+| | TF state backend |
+
+The `contabo-k3s-node` module is owned/published by **FuzeInfra** (`modules/contabo-k3s-node`).
+
+## Whitelist (auto-apply allow-list — enforced by FuzeInfra)
+Requests matching ALL of these auto-apply; anything else needs approval:
+- `product_id` ∈ FuzeInfra's approved tiers (e.g. the ~8vCPU/30GB workload tier)
+- `region` == the existing cluster's region (`EU`)
+- `role` ∈ {`workload`} (stateful roles are not auto-grantable — they need a storage story)
+- node count delta within a bounded cap per request
+
+## Adding capacity
+Edit `node-request.tf` (add/adjust an entry within the whitelist) → merge → the node appears and is
+labeled so FuzeFront's `nodeSelector`/affinity (in the Helm chart) schedules the heavy stateless
+services (LiteLLM/chat/billing) onto it; stateful pods stay on node-1 (`local-path`).

--- a/deploy/terraform/node-request.tf
+++ b/deploy/terraform/node-request.tf
@@ -1,0 +1,45 @@
+# =============================================================================
+# FuzeFront infra REQUEST — declarative "please give me a node" (GitOps IaC).
+#
+# FuzeFront does NOT provision anything and holds NO Contabo/cluster credentials.
+# It only DECLARES what it needs. On change to deploy/terraform/** (or
+# deploy/argocd/**), .github/workflows/infra-dispatch.yml fires a
+# repository_dispatch to FuzeInfra; FuzeInfra's handler (the sole credential
+# holder) runs `terraform apply` against the module below, joins+labels the node
+# into the existing k3s cluster, and syncs the Argo apps.
+#
+# The module lives in FuzeInfra (the cluster owner). The Contabo provider creds,
+# the k3s server URL + join token, and the TF state backend are all injected by
+# FuzeInfra's handler at apply time — never committed here.
+#
+# Allowed request shapes are whitelisted by FuzeInfra's handler (auto-applied);
+# anything outside the whitelist requires manual approval. See README.md.
+# =============================================================================
+
+module "fuzefront_nodes" {
+  # FuzeInfra owns the contabo-k3s-node module (provider + cloud-init k3s agent
+  # join + node labeling). Pinned by ref; FuzeInfra publishes/updates it.
+  source = "git::https://github.com/izzywdev/FuzeInfra.git//modules/contabo-k3s-node?ref=main"
+
+  # The whitelisted request: a single workload worker node to offload the
+  # heavy stateless services (LiteLLM / chat / billing) off the primary node.
+  # Stateful pods stay on node-1 (local-path); see deploy/helm/fuzefront node
+  # affinity (added in the prod-CD chart).
+  requests = [
+    {
+      name       = "fuzefront-worker-2"
+      product_id = "V92"        # ~8 vCPU / 30 GB (whitelisted tier); adjust within the allow-list
+      region     = "EU"         # must match the existing FuzeInfra cluster region
+      role       = "workload"   # → node label node-role=workload (FuzeFront affinity targets this)
+      labels = {
+        "node-role"            = "workload"
+        "app.fuzefront.com/by" = "fuzefront"
+      }
+    }
+  ]
+
+  # Injected by FuzeInfra's handler (NOT defined/committed here):
+  #   oauth2_client_id / oauth2_client_secret / oauth2_user / oauth2_pass  (Contabo)
+  #   k3s_server_url / k3s_node_token                                      (existing cluster)
+  #   backend config                                                       (TF state in FuzeInfra)
+}

--- a/frontend/src/components/WorkspaceProvisioningGate.tsx
+++ b/frontend/src/components/WorkspaceProvisioningGate.tsx
@@ -112,7 +112,6 @@ export function WorkspaceProvisioningGate({
       cancelled = true
       stopPolling()
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   if (gateState === 'ready') {


### PR DESCRIPTION
Decoupled IaC-as-a-service: FuzeFront *declares* infra (deploy/terraform node-request → FuzeInfra-owned `contabo-k3s-node` module) + Argo apps; CI watches `deploy/terraform/**`+`deploy/argocd/**` and fires a `repository_dispatch: infra-request` to FuzeInfra, which (sole credential holder) terraform-applies + k3s-joins + labels the node and syncs Argo. FuzeFront holds NO Contabo/cluster creds — only the scoped `FUZEINFRA_DISPATCH_TOKEN`. Gating: whitelist auto-apply (see deploy/terraform/README.md). Companion FuzeInfra handler tracked separately. Build-vs-adopt: TF+dispatch now (official contabo/contabo provider); Crossplane provider-terraform is the later upgrade (module designed to drop in).