### PR TITLE
feat(billing): per-service-DB boundary hardening — billing_svc role + backend projection

### DIFF
--- a/backend/security/src/migrations/011_add_billing_to_entities.ts
+++ b/backend/security/src/migrations/011_add_billing_to_entities.ts
@@ -1,11 +1,14 @@
 import { Knex } from 'knex'
 
 /**
- * Migration 010 — billing columns on public-schema entities.
+ * Migration 011 — billing columns on public-schema entities.
+ * (Renumbered 010 -> 011 to avoid colliding with the identity track's
+ * 010_create_api_tokens_table once both merge.)
  *
  * Adds the four billing hot-path cache columns to both `users` and
- * `organizations`.  These are written back by the billing-service and read
- * by the backend for plan-gated UI hints.
+ * `organizations`. These are maintained by the BACKEND's plan-state projection
+ * (which consumes billing.subscription.changed) and read for plan-gated UI
+ * hints. billing-service never writes these columns directly.
  *
  * Columns:
  *   stripe_customer_id   TEXT, nullable

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -17,6 +17,10 @@ import {
   checkDatabaseHealth,
 } from './config/database'
 import { oidcService } from './services/oidc'
+import {
+  startBillingProjection,
+  stopBillingProjection,
+} from './services/billingProjection'
 
 // Load environment variables
 dotenv.config()
@@ -369,6 +373,13 @@ function gracefulShutdown(signal: string) {
     io.close(async () => {
       console.log('✅ Socket.IO server closed')
 
+      // Stop the billing plan-state projection consumer.
+      try {
+        await stopBillingProjection()
+      } catch (error) {
+        console.error('❌ Error stopping billing projection:', error)
+      }
+
       // Close database connections
       try {
         await closeDatabase()
@@ -483,6 +494,10 @@ async function startServer() {
       console.error('❌ Failed to initialize OIDC service:', error)
       console.log('⚠️  Continuing with local authentication only')
     }
+
+    // Start the billing plan-state projection (consumes
+    // billing.subscription.changed; no-op when Kafka is disabled).
+    await startBillingProjection()
 
     const portNumber = typeof PORT === 'string' ? parseInt(PORT, 10) : PORT
     const availablePort = await findAvailablePort(portNumber)

--- a/backend/src/migrations/011_add_billing_to_entities.ts
+++ b/backend/src/migrations/011_add_billing_to_entities.ts
@@ -1,18 +1,17 @@
 import { Knex } from 'knex'
 
-// ⚠️ MIGRATION NUMBER COLLISION (must resolve before merging both tracks):
-// The identity track (feature/api-tokens) also adds a `010_*` migration
-// (`010_api_tokens`). Knex applies migrations by filename order, so two `010_*`
-// files in the same dir will collide / double-apply ordering. Final integration
-// MUST renumber ONE of the two `010` migrations (this one or `010_api_tokens`)
-// to a unique sequence number. Tracked in PR #66.
+// MIGRATION NUMBER COLLISION RESOLVED:
+// The identity track owns `010_create_api_tokens_table`. This billing migration
+// was renumbered 010 -> 011 so both tracks have a unique, ordered sequence
+// number once merged. Do not renumber back to 010.
 
 /**
- * Migration 010 — billing columns on public-schema entities.
+ * Migration 011 — billing columns on public-schema entities.
  *
  * Adds the four billing hot-path cache columns to both `users` and
- * `organizations`.  These are written back by the billing-service and read
- * by the backend for plan-gated UI hints.
+ * `organizations`. These are maintained by the BACKEND's plan-state projection
+ * (which consumes billing.subscription.changed) and read for plan-gated UI
+ * hints. billing-service never writes these columns directly.
  *
  * Columns:
  *   stripe_customer_id   TEXT, nullable

--- a/backend/src/scripts/db-bootstrap.ts
+++ b/backend/src/scripts/db-bootstrap.ts
@@ -52,8 +52,16 @@ async function bootstrap(): Promise<void> {
   const superUser = req('DB_SUPERUSER')
   const superPassword = req('DB_SUPERUSER_PASSWORD')
 
+  // Optional least-privilege role for the billing-service. Gated on
+  // BILLING_DB_PASSWORD being present so existing installs (no billing) are a
+  // no-op. The role is granted ONLY on the `billing` schema — never on
+  // public.users / public.organizations (per-service-DB boundary).
+  const billingUser = process.env.BILLING_DB_USER || 'billing_svc'
+  const billingPassword = process.env.BILLING_DB_PASSWORD
+
   console.log(
-    `🔧 DB bootstrap: host=${host}:${port} db=${dbName} appUser=${appUser} superUser=${superUser}`
+    `🔧 DB bootstrap: host=${host}:${port} db=${dbName} appUser=${appUser} superUser=${superUser}` +
+      (billingPassword ? ` billingUser=${billingUser}` : '')
   )
 
   // --- Step 1 & 2: connect to the default DB to create DATABASE + ROLE. ---
@@ -115,6 +123,32 @@ async function bootstrap(): Promise<void> {
     await admin.query(
       `GRANT CONNECT ON DATABASE ${ident(dbName)} TO ${ident(appUser)}`
     )
+
+    // --- Optional billing_svc role (least-privilege, billing schema only) ---
+    if (billingPassword) {
+      const billingRoleExists = await admin.query(
+        'SELECT 1 FROM pg_roles WHERE rolname = $1',
+        [billingUser]
+      )
+      if (billingRoleExists.rows.length === 0) {
+        console.log(`📝 Creating least-privilege billing role ${billingUser}...`)
+        await admin.query(
+          `CREATE ROLE ${ident(billingUser)} WITH LOGIN PASSWORD ${literal(
+            billingPassword
+          )} NOSUPERUSER NOCREATEDB NOCREATEROLE`
+        )
+      } else {
+        console.log(`✅ Role ${billingUser} exists — syncing password/attributes`)
+        await admin.query(
+          `ALTER ROLE ${ident(billingUser)} WITH LOGIN PASSWORD ${literal(
+            billingPassword
+          )} NOSUPERUSER NOCREATEDB NOCREATEROLE`
+        )
+      }
+      await admin.query(
+        `GRANT CONNECT ON DATABASE ${ident(dbName)} TO ${ident(billingUser)}`
+      )
+    }
   } finally {
     await admin.end()
   }
@@ -139,6 +173,52 @@ async function bootstrap(): Promise<void> {
     // sequences, etc.) without any cluster-level privilege.
     await dbAdmin.query(`ALTER SCHEMA public OWNER TO ${ident(appUser)}`)
     await dbAdmin.query(`GRANT ALL ON SCHEMA public TO ${ident(appUser)}`)
+
+    // --- billing_svc: own the `billing` schema; NOTHING on public ---
+    if (billingPassword) {
+      console.log(
+        `🔑 Provisioning schema billing owned by ${billingUser} (no public.* grants)...`
+      )
+      // The billing-service runs its own 001 migration (CREATE SCHEMA / tables).
+      // Owning the dedicated schema lets it do that with zero privileges on the
+      // platform's public tables. Create the schema up front and hand ownership
+      // to billing_svc; if billing-service already created it (e.g. on a prior
+      // boot), just re-assign ownership. Idempotent.
+      await dbAdmin.query(`GRANT ${ident(billingUser)} TO CURRENT_USER`)
+      await dbAdmin.query(
+        `CREATE SCHEMA IF NOT EXISTS billing AUTHORIZATION ${ident(billingUser)}`
+      )
+      await dbAdmin.query(`ALTER SCHEMA billing OWNER TO ${ident(billingUser)}`)
+      await dbAdmin.query(
+        `GRANT USAGE, CREATE ON SCHEMA billing TO ${ident(billingUser)}`
+      )
+      // DML on any existing + future billing objects (the service owns them, but
+      // be explicit so a re-grant after an ownership change stays consistent).
+      await dbAdmin.query(
+        `GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA billing TO ${ident(
+          billingUser
+        )}`
+      )
+      await dbAdmin.query(
+        `GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA billing TO ${ident(
+          billingUser
+        )}`
+      )
+      await dbAdmin.query(
+        `ALTER DEFAULT PRIVILEGES IN SCHEMA billing GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO ${ident(
+          billingUser
+        )}`
+      )
+      await dbAdmin.query(
+        `ALTER DEFAULT PRIVILEGES IN SCHEMA billing GRANT USAGE, SELECT ON SEQUENCES TO ${ident(
+          billingUser
+        )}`
+      )
+      // Defensive: billing_svc must NOT be able to touch the platform's public
+      // tables. It was never granted public, but revoke any inherited PUBLIC
+      // grant on the public schema to be explicit about the boundary.
+      await dbAdmin.query(`REVOKE ALL ON SCHEMA public FROM ${ident(billingUser)}`)
+    }
   } finally {
     await dbAdmin.end()
   }

--- a/backend/src/services/billingProjection.ts
+++ b/backend/src/services/billingProjection.ts
@@ -1,0 +1,113 @@
+import {
+  createKafkaClient,
+  TypedConsumer,
+  TOPICS,
+  billingSubscriptionChangedSchemaV1,
+  BillingSubscriptionChangedPayloadV1,
+} from '@fuzefront/shared/kafka'
+import { db } from '../config/database'
+
+/**
+ * Backend plan-state projection.
+ *
+ * Per the per-service-DB boundary, billing-service owns ONLY the `billing`
+ * schema and never writes the platform's public.users / public.organizations
+ * tables. Instead it emits `billing.subscription.changed`; the backend (which
+ * owns the public schema) consumes that event here and projects the plan-state
+ * hot-path cache columns onto the right entity.
+ *
+ * Entities are referenced by `(entityType, entityId)` only — the event carries
+ * both, and `entityId` is the primary key of the `users` / `organizations`
+ * row.
+ *
+ * Degrades gracefully: when KAFKA_BROKERS is unset the projection is a no-op
+ * (the columns simply stay at their migration defaults), matching how the rest
+ * of the backend tolerates a missing broker.
+ */
+
+let consumer: TypedConsumer | null = null
+
+function kafkaEnabled(): boolean {
+  return !!process.env.KAFKA_BROKERS
+}
+
+/**
+ * Applies a single subscription-changed payload to the public projection.
+ * Exported for unit testing without a broker. Returns the number of rows
+ * updated (0 when the entity is unknown).
+ */
+export async function applySubscriptionChanged(
+  payload: BillingSubscriptionChangedPayloadV1
+): Promise<number> {
+  const table = payload.entityType === 'user' ? 'users' : 'organizations'
+  const updated = await db(table)
+    .where({ id: payload.entityId })
+    .update({
+      billing_plan_tier: payload.planTier,
+      billing_plan_status: payload.status,
+    })
+  return updated
+}
+
+/**
+ * Starts the background consumer. Safe to call once at server startup; returns
+ * immediately (no-op) when Kafka is disabled. Never throws into the caller —
+ * a broker failure must not take down the API.
+ */
+export async function startBillingProjection(): Promise<void> {
+  if (!kafkaEnabled()) {
+    console.log(
+      'ℹ️ Kafka disabled — billing plan-state projection not started (KAFKA_BROKERS unset)'
+    )
+    return
+  }
+
+  try {
+    const brokers = (process.env.KAFKA_BROKERS as string)
+      .split(',')
+      .map(b => b.trim())
+      .filter(Boolean)
+    const kafka = createKafkaClient({
+      clientId: process.env.KAFKA_CLIENT_ID || 'fuzefront-backend',
+      brokers,
+    })
+    consumer = new TypedConsumer(
+      kafka,
+      process.env.KAFKA_GROUP_ID || 'fuzefront-backend-billing-projection'
+    )
+    await consumer.connect()
+    await consumer.subscribe(TOPICS.BILLING_SUBSCRIPTION_CHANGED)
+    // Run the loop in the background; the handler projects each event.
+    void consumer.run(async event => {
+      try {
+        const rows = await applySubscriptionChanged(event.payload)
+        if (rows === 0) {
+          console.warn(
+            `[billing-projection] no ${event.payload.entityType} row for ${event.payload.entityId}`
+          )
+        }
+      } catch (err) {
+        console.error('[billing-projection] failed to apply event:', err)
+      }
+    }, billingSubscriptionChangedSchemaV1)
+    console.log(
+      `📥 Billing plan-state projection consuming ${TOPICS.BILLING_SUBSCRIPTION_CHANGED}`
+    )
+  } catch (err) {
+    console.error(
+      '⚠️ Failed to start billing plan-state projection (continuing without it):',
+      err
+    )
+  }
+}
+
+/** Disconnect the projection consumer (graceful shutdown). */
+export async function stopBillingProjection(): Promise<void> {
+  if (consumer) {
+    try {
+      await consumer.disconnect()
+    } finally {
+      consumer = null
+    }
+  }
+}

--- a/backend/tests/billing-projection.test.ts
+++ b/backend/tests/billing-projection.test.ts
@@ -1,0 +1,70 @@
+// Unit tests for the backend billing plan-state projection. No broker / no DB:
+// the knex `db` export is mocked with a chainable stub so we assert the exact
+// table + update payload, keyed by (entityType, entityId).
+
+const updateMock = jest.fn().mockResolvedValue(1)
+const whereMock = jest.fn(() => ({ update: updateMock }))
+const dbMock = jest.fn(() => ({ where: whereMock }))
+
+jest.mock('../src/config/database', () => ({
+  db: (table: string) => (dbMock as unknown as (t: string) => unknown)(table),
+}))
+
+import { applySubscriptionChanged } from '../src/services/billingProjection'
+
+describe('applySubscriptionChanged', () => {
+  beforeEach(() => {
+    updateMock.mockClear()
+    whereMock.mockClear()
+    dbMock.mockClear()
+    updateMock.mockResolvedValue(1)
+  })
+
+  it('projects a user subscription onto public.users by id', async () => {
+    const rows = await applySubscriptionChanged({
+      entityType: 'user',
+      entityId: '11111111-1111-1111-1111-111111111111',
+      planTier: 'pro',
+      status: 'active',
+      stripeSubscriptionId: 'sub_1',
+    })
+
+    expect(dbMock).toHaveBeenCalledWith('users')
+    expect(whereMock).toHaveBeenCalledWith({
+      id: '11111111-1111-1111-1111-111111111111',
+    })
+    expect(updateMock).toHaveBeenCalledWith({
+      billing_plan_tier: 'pro',
+      billing_plan_status: 'active',
+    })
+    expect(rows).toBe(1)
+  })
+
+  it('projects an organization subscription onto public.organizations', async () => {
+    await applySubscriptionChanged({
+      entityType: 'organization',
+      entityId: '22222222-2222-2222-2222-222222222222',
+      planTier: 'starter',
+      status: 'past_due',
+      stripeSubscriptionId: 'sub_2',
+    })
+
+    expect(dbMock).toHaveBeenCalledWith('organizations')
+    expect(updateMock).toHaveBeenCalledWith({
+      billing_plan_tier: 'starter',
+      billing_plan_status: 'past_due',
+    })
+  })
+
+  it('returns 0 when no entity row matches (unknown entity)', async () => {
+    updateMock.mockResolvedValueOnce(0)
+    const rows = await applySubscriptionChanged({
+      entityType: 'user',
+      entityId: '33333333-3333-3333-3333-333333333333',
+      planTier: 'free',
+      status: 'canceled',
+      stripeSubscriptionId: 'sub_3',
+    })
+    expect(rows).toBe(0)
+  })
+})

--- a/deploy/helm/fuzefront/templates/billing-service.yaml
+++ b/deploy/helm/fuzefront/templates/billing-service.yaml
@@ -36,16 +36,29 @@ spec:
               value: {{ .Values.billingService.kafka.groupId | quote }}
             - name: BILLING_METER_FLUSH_INTERVAL_SEC
               value: {{ .Values.billingService.meterFlushIntervalSec | quote }}
-            # DB connection: billing-service connects with the least-privilege
-            # billing_svc role (granted on schema `billing` + read on public).
-            # DB_PASSWORD comes from the chart Secret; assembled into DATABASE_URL.
+            # DB connection. When secret.billingDbPassword is set, connect with
+            # the least-privilege billing_svc role (granted ONLY on schema
+            # `billing` — never on public.users/organizations; the backend owns
+            # the public plan-state projection). Otherwise fall back to the
+            # shared runtime role so existing installs keep working. The password
+            # is assembled into DATABASE_URL at runtime.
+            {{- if .Values.secret.billingDbPassword }}
+            - name: BILLING_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "fuzefront.secretName" . }}
+                  key: BILLING_DB_PASSWORD
+            - name: DATABASE_URL
+              value: "postgresql://{{ .Values.billingService.dbUser }}:$(BILLING_DB_PASSWORD)@{{ .Values.fuzeinfra.postgres.host }}:{{ .Values.fuzeinfra.postgres.port }}/{{ .Values.database.name }}"
+            {{- else }}
             - name: DB_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "fuzefront.secretName" . }}
                   key: DB_PASSWORD
             - name: DATABASE_URL
-              value: "postgresql://{{ .Values.billingService.dbUser }}:$(DB_PASSWORD)@{{ .Values.fuzeinfra.postgres.host }}:{{ .Values.fuzeinfra.postgres.port }}/{{ .Values.database.name }}"
+              value: "postgresql://{{ .Values.database.user }}:$(DB_PASSWORD)@{{ .Values.fuzeinfra.postgres.host }}:{{ .Values.fuzeinfra.postgres.port }}/{{ .Values.database.name }}"
+            {{- end }}
             {{- if .Values.secret.stripeSecretKey }}
             - name: STRIPE_SECRET_KEY
               valueFrom:

--- a/deploy/helm/fuzefront/templates/db-bootstrap-job.yaml
+++ b/deploy/helm/fuzefront/templates/db-bootstrap-job.yaml
@@ -64,6 +64,18 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.database.bootstrap.superuser.secretName | default (include "fuzefront.secretName" .) }}
                   key: {{ .Values.database.bootstrap.superuser.secretKey | quote }}
+            {{- if .Values.secret.billingDbPassword }}
+            # Optional least-privilege billing_svc role. When BILLING_DB_PASSWORD
+            # is set, the bootstrap creates/syncs the role and provisions the
+            # `billing` schema owned by it (no public.* grants). No-op otherwise.
+            - name: BILLING_DB_USER
+              value: {{ .Values.billingService.dbUser | quote }}
+            - name: BILLING_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "fuzefront.secretName" . }}
+                  key: BILLING_DB_PASSWORD
+            {{- end }}
           resources:
             requests: { cpu: 50m, memory: 128Mi }
             limits:   { cpu: 250m, memory: 256Mi }

--- a/deploy/helm/fuzefront/templates/secret.yaml
+++ b/deploy/helm/fuzefront/templates/secret.yaml
@@ -65,4 +65,10 @@ stringData:
   {{- if .Values.secret.billingInternalToken }}
   BILLING_INTERNAL_TOKEN: {{ .Values.secret.billingInternalToken | quote }}
   {{- end }}
+  {{- if .Values.secret.billingDbPassword }}
+  # Password for the least-privilege billing_svc Postgres role. Consumed by the
+  # db-bootstrap Job (to create/sync the role) and by the billing-service
+  # Deployment (to connect). Role is granted ONLY on the `billing` schema.
+  BILLING_DB_PASSWORD: {{ .Values.secret.billingDbPassword | quote }}
+  {{- end }}
 {{- end }}

--- a/deploy/helm/fuzefront/values.yaml
+++ b/deploy/helm/fuzefront/values.yaml
@@ -111,6 +111,12 @@ secret:
   # Internal Bearer token the backend/billing-client present to billing-service.
   # DEV-ONLY default — override with a long random value (or SealedSecret) in real deployments.
   billingInternalToken: "dev-billing-internal-token-change-me"
+  # Password for the least-privilege billing_svc Postgres role. When set, the
+  # db-bootstrap Job creates/syncs the role + provisions the `billing` schema
+  # owned by it (no public.* grants), and billing-service connects as billing_svc.
+  # Leave empty to fall back to the shared runtime role (database.user). DEV-ONLY
+  # default below — override/seal in real deployments.
+  billingDbPassword: "dev-billing-svc-change-me"
 
 backend:
   image:
@@ -223,9 +229,11 @@ provisioningService:
 # Billing & payments microservice (Stripe). Independently-lifecycled — has its
 # OWN Argo Application (deploy/argocd/applications/billing.yaml). Disabled by
 # default; enable in values-local (test-mode Stripe keys) / values-prod.
-# Connects to Postgres with the least-privilege billing_svc role (schema
-# `billing` + read on public.users/organizations). Secrets (STRIPE_SECRET_KEY,
-# STRIPE_WEBHOOK_SECRET, BILLING_INTERNAL_TOKEN) come from the chart Secret.
+# Connects to Postgres with the least-privilege billing_svc role, granted ONLY
+# on the `billing` schema — never on public.users/organizations. The backend
+# owns the public plan-state projection (consumes billing.subscription.changed).
+# Secrets (STRIPE_SECRET_KEY, STRIPE_WEBHOOK_SECRET, BILLING_INTERNAL_TOKEN,
+# BILLING_DB_PASSWORD) come from the chart Secret.
 billingService:
   enabled: false
   replicas: 1
@@ -233,9 +241,9 @@ billingService:
   image:
     repository: fuzefront/billing-service
     tag: local
-  # Least-privilege DB role for billing-service (see db-bootstrap-job; role
-  # creation is a follow-up task — uses fuzefront_user until then).
-  dbUser: fuzefront_user
+  # Least-privilege DB role for billing-service, created by the db-bootstrap Job
+  # when secret.billingDbPassword is set (granted only on the `billing` schema).
+  dbUser: billing_svc
   meterFlushIntervalSec: 60
   permitPdpUrl: "http://fuzefront-permit-pdp:7766"
   kafka:

--- a/services/billing-service/src/handlers/invoice-failed.ts
+++ b/services/billing-service/src/handlers/invoice-failed.ts
@@ -3,7 +3,9 @@ import { HandlerContext } from './types';
 
 /**
  * Handles `invoice.payment_failed` (dunning): mark the entity `past_due`, sync
- * Permit + cache, and emit billing.payment.failed so email-service can notify.
+ * Permit, emit billing.subscription.changed (so the backend projects `past_due`
+ * onto its public plan-state tables — billing-service never writes public.*),
+ * and emit billing.payment.failed so email-service can notify.
  * Stripe Smart Retries handle the actual retry schedule; final failure arrives
  * as customer.subscription.deleted (handled separately → downgrade to free).
  */
@@ -32,12 +34,14 @@ export async function handleInvoiceFailed(
     status: 'past_due',
   });
 
-  await ctx.writePlanCache({
-    entityType: entity.entityType,
+  // Emit the status change so the backend projection moves the entity to
+  // past_due (billing-service owns only the billing schema; no public.* write).
+  await ctx.emitter.subscriptionChanged({
     entityId: entity.entityId,
+    entityType: entity.entityType,
     planTier,
     status: 'past_due',
-    trialEnd: existing?.trialEnd ?? null,
+    stripeSubscriptionId: existing?.stripeSubscriptionId ?? '',
   });
 
   await ctx.emitter.paymentFailed({

--- a/services/billing-service/src/handlers/invoice-paid.ts
+++ b/services/billing-service/src/handlers/invoice-paid.ts
@@ -3,7 +3,9 @@ import { HandlerContext } from './types';
 
 /**
  * Handles `invoice.payment_succeeded`: a successful charge moves the entity
- * back to `active` (e.g. recovering from past_due) and refreshes Permit + cache.
+ * back to `active` (e.g. recovering from past_due), refreshes Permit, and emits
+ * billing.subscription.changed so the backend projects `active` onto its
+ * public plan-state tables. billing-service never writes public.* directly.
  */
 export async function handleInvoicePaid(
   event: Stripe.Event,
@@ -28,14 +30,6 @@ export async function handleInvoicePaid(
     entityId: entity.entityId,
     planTier,
     status: 'active',
-  });
-
-  await ctx.writePlanCache({
-    entityType: entity.entityType,
-    entityId: entity.entityId,
-    planTier,
-    status: 'active',
-    trialEnd: existing?.trialEnd ?? null,
   });
 
   await ctx.emitter.subscriptionChanged({

--- a/services/billing-service/src/handlers/subscription-updated.ts
+++ b/services/billing-service/src/handlers/subscription-updated.ts
@@ -8,9 +8,10 @@ import { EntityType } from '../types';
  *
  *  1. Resolve the local customer + entity from the Stripe customer id.
  *  2. Map status: a `deleted` event downgrades the entity to the free tier.
- *  3. Upsert the local subscription mirror.
- *  4. Sync the plan to Permit + write the public hot-path cache.
- *  5. Emit billing.subscription.changed.
+ *  3. Upsert the local subscription mirror (billing schema only).
+ *  4. Sync the plan to Permit.
+ *  5. Emit billing.subscription.changed (the backend projects this onto
+ *     public.users/organizations — billing-service never writes those tables).
  */
 export async function handleSubscriptionUpdated(
   event: Stripe.Event,
@@ -48,14 +49,9 @@ export async function handleSubscriptionUpdated(
     seatQuantity,
   });
 
-  await ctx.writePlanCache({
-    entityType: entity.entityType,
-    entityId: entity.entityId,
-    planTier,
-    status,
-    trialEnd: sub.trial_end ? new Date(sub.trial_end * 1000).toISOString() : null,
-  });
-
+  // NOTE: we deliberately do NOT write public.users/organizations here.
+  // billing-service owns only the `billing` schema; the backend maintains the
+  // public plan-state projection by consuming the event emitted below.
   await ctx.emitter.subscriptionChanged({
     entityId: entity.entityId,
     entityType: entity.entityType,

--- a/services/billing-service/src/handlers/types.ts
+++ b/services/billing-service/src/handlers/types.ts
@@ -8,6 +8,13 @@ import { BillingEventEmitter } from '../kafka/producer';
 /**
  * Dependencies passed to every webhook handler. Injected so handlers are
  * unit-testable with fakes (no DB / Stripe / Kafka / Permit needed).
+ *
+ * NOTE (per-service-DB boundary): handlers MUST NOT write to the platform's
+ * public.users / public.organizations tables. billing-service owns only the
+ * `billing` schema. Plan-state for those public entities is maintained by the
+ * BACKEND, which consumes the `billing.subscription.changed` event emitted here
+ * and projects it onto its own tables. The handler's job is: mirror locally,
+ * sync Permit, and emit the event.
  */
 export interface HandlerContext {
   customers: CustomerRepository;
@@ -15,14 +22,6 @@ export interface HandlerContext {
   plans: PlanRepository;
   permit: PermitSyncService;
   emitter: BillingEventEmitter;
-  /** Writes the plan-tier hot-path cache columns back to public.users/organizations. */
-  writePlanCache: (args: {
-    entityType: 'user' | 'organization';
-    entityId: string;
-    planTier: string;
-    status: string;
-    trialEnd: string | null;
-  }) => Promise<void>;
 }
 
 export type StripeEventHandler = (

--- a/services/billing-service/src/index.ts
+++ b/services/billing-service/src/index.ts
@@ -87,23 +87,15 @@ async function main() {
   flushTimer.unref?.();
 
   // --- Handler context ---
-  const writePlanCache: HandlerContext['writePlanCache'] = async (args) => {
-    const table = args.entityType === 'user' ? 'users' : 'organizations';
-    await pool!.query(
-      `UPDATE public.${table}
-          SET billing_plan_tier = $2, billing_plan_status = $3, trial_ends_at = $4
-        WHERE id = $1`,
-      [args.entityId, args.planTier, args.status, args.trialEnd],
-    );
-  };
-
+  // billing-service owns only the `billing` schema. It never writes
+  // public.users / public.organizations — the backend maintains that
+  // projection by consuming billing.subscription.changed.
   const ctx: HandlerContext = {
     customers: customerRepo,
     subscriptions: subscriptionRepo,
     plans: planRepo,
     permit,
     emitter,
-    writePlanCache,
   };
 
   // --- HTTP ---

--- a/services/billing-service/tests/handlers/subscription-updated.test.ts
+++ b/services/billing-service/tests/handlers/subscription-updated.test.ts
@@ -11,7 +11,6 @@ function makeCtx() {
     plans: { findByPriceId: jest.fn().mockResolvedValue({ tierName: 'pro' }) },
     permit: { syncPlanToPermit: jest.fn().mockResolvedValue(true) },
     emitter: { subscriptionChanged: jest.fn().mockResolvedValue(undefined) },
-    writePlanCache: jest.fn().mockResolvedValue(undefined),
   } as any;
 }
 
@@ -32,7 +31,7 @@ function subEvent(type: string, overrides: any = {}) {
 }
 
 describe('handleSubscriptionUpdated', () => {
-  it('on updated: upserts mirror, syncs Permit, writes cache, emits event', async () => {
+  it('on updated: upserts mirror, syncs Permit, emits event (no public-table write)', async () => {
     const ctx = makeCtx();
     await handleSubscriptionUpdated(subEvent('customer.subscription.updated'), ctx);
 
@@ -40,9 +39,9 @@ describe('handleSubscriptionUpdated', () => {
     expect(ctx.permit.syncPlanToPermit).toHaveBeenCalledWith(
       expect.objectContaining({ entityType: 'organization', entityId: 'org-1', planTier: 'pro', status: 'active', seatQuantity: 3 }),
     );
-    expect(ctx.writePlanCache).toHaveBeenCalledWith(
-      expect.objectContaining({ planTier: 'pro', status: 'active' }),
-    );
+    // The handler must NOT carry any writePlanCache dependency — plan-state for
+    // public.users/organizations is projected by the backend from the event.
+    expect((ctx as Record<string, unknown>).writePlanCache).toBeUndefined();
     expect(ctx.emitter.subscriptionChanged).toHaveBeenCalledWith(
       expect.objectContaining({ planTier: 'pro', status: 'active', stripeSubscriptionId: 'sub_1' }),
     );

--- a/services/billing-service/tests/routes/webhooks.test.ts
+++ b/services/billing-service/tests/routes/webhooks.test.ts
@@ -24,7 +24,6 @@ const baseCtx: any = {
   plans: {},
   permit: {},
   emitter: {},
-  writePlanCache: jest.fn(),
 };
 
 describe('POST /api/v1/billing/webhooks/stripe', () => {


### PR DESCRIPTION
## Billing boundary hardening (per-service-DB direction)

billing-service must own ONLY the `billing` schema and never write the platform's public tables. This PR enforces that.

### 1. Least-privilege `billing_svc` Postgres role
- `backend/src/scripts/db-bootstrap.ts`: idempotently creates/syncs a `billing_svc` LOGIN role (NOSUPERUSER/NOCREATEDB/NOCREATEROLE) and provisions a `billing` schema **owned by it** (`CREATE SCHEMA ... AUTHORIZATION billing_svc`) with USAGE/CREATE + DML + default privileges on that schema only. Explicitly `REVOKE ALL ON SCHEMA public FROM billing_svc`. Gated on `BILLING_DB_PASSWORD` so existing installs are a no-op.
- Helm: `db-bootstrap-job.yaml` passes `BILLING_DB_USER`/`BILLING_DB_PASSWORD`; `secret.yaml` adds `BILLING_DB_PASSWORD`; `values.yaml` adds `secret.billingDbPassword`, sets `billingService.dbUser: billing_svc`, and the billing-service `DATABASE_URL` now connects as `billing_svc` (falls back to the shared role when the password is unset).

### 2. Removed cross-schema writes from billing-service
- Deleted `writePlanCache` from `HandlerContext` (`handlers/types.ts`), its definition in `index.ts`, and every call (`subscription-updated`, `invoice-paid`, `invoice-failed`). `invoice-failed` now also emits `billing.subscription.changed` (status `past_due`) so the projection still gets the status change. Handlers continue to mirror the billing schema, sync Permit, and emit events.
- Grep proof: no remaining `public.users`/`public.organizations`/`writePlanCache`/`UPDATE public` in `services/billing-service/src` (only doc comments).

### 3. Backend plan-state projection
- New `backend/src/services/billingProjection.ts` consumes `billing.subscription.changed` (shared `TypedConsumer` + `billingSubscriptionChangedSchemaV1`) and updates `billing_plan_tier`/`billing_plan_status` on `users`/`organizations`, keyed by `(entityType, entityId)`. Degrades to a no-op when Kafka is disabled. Wired into `startServer` + graceful shutdown.
- Unit tests `backend/tests/billing-projection.test.ts` (mocked knex, no DB/broker).

### 4. Migration 010 collision resolved
- Renumbered `010_add_billing_to_entities` -> **`011_add_billing_to_entities`** in both `backend/src/migrations/` and `backend/security/src/migrations/` (the identity track owns `010_create_api_tokens_table`). Columns unchanged; the WRITER moved from billing-service to the backend projection. Comments updated.

### Verification (Linux/CI for tsc+jest; locally for Helm)
- `helm template ... --set billingService.enabled=true` → renders rc=0; `DATABASE_URL` = `postgresql://billing_svc:$(BILLING_DB_PASSWORD)@...`; with `secret.billingDbPassword=""` it falls back to `fuzefront_user:$(DB_PASSWORD)`.
- billing-service tsc/jest + backend tsc/jest to be confirmed green by CI (local Windows env has the `os=linux` npmrc pin that breaks native installs).

Base: `feature/billing-payments` (PR #66).