### PR TITLE
feat(deploy): chat-service + LiteLLM deploy wiring (devops slice of #68)

### DIFF
--- a/deploy/argocd/applications/litellm.yaml
+++ b/deploy/argocd/applications/litellm.yaml
@@ -1,0 +1,33 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: litellm
+  namespace: argocd
+spec:
+  project: fuzefront
+  source:
+    repoURL: https://github.com/izzywdev/FuzeFront.git
+    targetRevision: master
+    # Chart lives in the FuzeInfra git submodule at this path.
+    # The companion FuzeInfra PR (see docs/ai-chat/fuzeinfra-companion-spec.md)
+    # must create this chart before this Argo Application can sync successfully.
+    path: FuzeInfra/helm/litellm
+    helm:
+      # Minimal prod overlay. Provider API keys (ANTHROPIC_API_KEY, OPENAI_API_KEY,
+      # LITELLM_MASTER_KEY) MUST exist as a Sealed/external Secret in the fuzeinfra
+      # namespace — they are never committed here. See fuzeinfra-companion-spec.md.
+      values: |
+        litellm:
+          enabled: true
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: fuzeinfra
+  syncPolicy:
+    automated:
+      # selfHeal: keep config in sync with git.
+      # prune: false — LiteLLM is a shared stateful-ish gateway; avoid pruning
+      # resources on incidental git changes.
+      prune: false
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/deploy/helm/fuzefront/templates/chat-doc-indexer-job.yaml
+++ b/deploy/helm/fuzefront/templates/chat-doc-indexer-job.yaml
@@ -1,0 +1,57 @@
+{{- if .Values.chatService.enabled }}
+{{- if .Values.chatService.docIndexer.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: fuzefront-chat-doc-indexer
+  labels:
+    {{- include "fuzefront.labels" . | nindent 4 }}
+    app.kubernetes.io/component: chat-doc-indexer
+  annotations:
+    # Index product docs into ChromaDB after the chat-service image is rolled out.
+    # Idempotent (content-hash keyed upsert), safe to re-run on every upgrade.
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "10"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 3
+  ttlSecondsAfterFinished: 600
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/part-of: fuzefront
+        app.kubernetes.io/component: chat-doc-indexer
+    spec:
+      restartPolicy: Never
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: chat-doc-indexer
+          image: "{{ .Values.chatService.image.repository }}:{{ .Values.chatService.image.tag }}"
+          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          command: ["node", "dist/rag/index-docs.js"]
+          env:
+            - name: NODE_ENV
+              value: "production"
+            - name: DOCS_DIR
+              value: {{ .Values.chatService.docIndexer.docsDir | quote }}
+            - name: LITELLM_URL
+              value: {{ .Values.chatService.litellmUrl | quote }}
+            - name: CHROMA_URL
+              value: {{ .Values.chatService.chromaUrl | quote }}
+            - name: LITELLM_EMBEDDING_MODEL
+              value: {{ .Values.chatService.embeddingModel | quote }}
+            {{- if .Values.secret.litellmMasterKey }}
+            - name: LITELLM_MASTER_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "fuzefront.secretName" . }}
+                  key: LITELLM_MASTER_KEY
+            {{- end }}
+          resources:
+            requests: { cpu: 100m, memory: 256Mi }
+            limits:   { cpu: 500m, memory: 512Mi }
+{{- end }}
+{{- end }}

--- a/deploy/helm/fuzefront/templates/chat-service.yaml
+++ b/deploy/helm/fuzefront/templates/chat-service.yaml
@@ -1,0 +1,108 @@
+{{- if .Values.chatService.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fuzefront-chat-service
+  labels:
+    {{- include "fuzefront.labels" . | nindent 4 }}
+    app.kubernetes.io/component: chat-service
+spec:
+  replicas: {{ .Values.chatService.replicas }}
+  selector:
+    matchLabels:
+      app: fuzefront-chat-service
+  template:
+    metadata:
+      labels:
+        app: fuzefront-chat-service
+        {{- include "fuzefront.labels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: chat-service
+          image: "{{ .Values.chatService.image.repository }}:{{ .Values.chatService.image.tag }}"
+          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          ports:
+            - containerPort: {{ .Values.chatService.port }}
+          env:
+            - name: NODE_ENV
+              value: "production"
+            - name: PORT
+              value: {{ .Values.chatService.port | quote }}
+            - name: LITELLM_URL
+              value: {{ .Values.chatService.litellmUrl | quote }}
+            - name: CHROMA_URL
+              value: {{ .Values.chatService.chromaUrl | quote }}
+            - name: BACKEND_URL
+              value: {{ .Values.chatService.backendUrl | quote }}
+            - name: PERMIT_PDP_URL
+              value: {{ .Values.chatService.permitPdpUrl | quote }}
+            - name: KAFKA_BROKERS
+              value: {{ .Values.chatService.kafka.brokers | quote }}
+            - name: DB_HOST
+              value: {{ .Values.fuzeinfra.postgres.host | quote }}
+            - name: DB_PORT
+              value: {{ .Values.fuzeinfra.postgres.port | quote }}
+            - name: DB_NAME
+              value: {{ .Values.database.name | quote }}
+            - name: DB_USER
+              value: {{ .Values.database.user | quote }}
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "fuzefront.secretName" . }}
+                  key: DB_PASSWORD
+            - name: JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "fuzefront.secretName" . }}
+                  key: JWT_SECRET
+            {{- if .Values.secret.anthropicApiKey }}
+            - name: ANTHROPIC_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "fuzefront.secretName" . }}
+                  key: ANTHROPIC_API_KEY
+            {{- end }}
+            {{- if .Values.secret.openaiApiKey }}
+            - name: OPENAI_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "fuzefront.secretName" . }}
+                  key: OPENAI_API_KEY
+            {{- end }}
+            {{- if .Values.secret.litellmMasterKey }}
+            - name: LITELLM_MASTER_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "fuzefront.secretName" . }}
+                  key: LITELLM_MASTER_KEY
+            {{- end }}
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: {{ .Values.chatService.port }}
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: {{ .Values.chatService.port }}
+            initialDelaySeconds: 30
+            periodSeconds: 15
+          resources:
+            {{- toYaml .Values.chatService.resources | nindent 12 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: fuzefront-chat-service
+  labels:
+    {{- include "fuzefront.labels" . | nindent 4 }}
+spec:
+  selector:
+    app: fuzefront-chat-service
+  ports:
+    - port: {{ .Values.chatService.port }}
+      targetPort: {{ .Values.chatService.port }}
+{{- end }}

--- a/deploy/helm/fuzefront/templates/secret.yaml
+++ b/deploy/helm/fuzefront/templates/secret.yaml
@@ -53,4 +53,13 @@ stringData:
   {{- if .Values.secret.smtpPassword }}
   SMTP_PASSWORD: {{ .Values.secret.smtpPassword | quote }}
   {{- end }}
+  {{- if .Values.secret.anthropicApiKey }}
+  ANTHROPIC_API_KEY: {{ .Values.secret.anthropicApiKey | quote }}
+  {{- end }}
+  {{- if .Values.secret.openaiApiKey }}
+  OPENAI_API_KEY: {{ .Values.secret.openaiApiKey | quote }}
+  {{- end }}
+  {{- if .Values.secret.litellmMasterKey }}
+  LITELLM_MASTER_KEY: {{ .Values.secret.litellmMasterKey | quote }}
+  {{- end }}
 {{- end }}

--- a/deploy/helm/fuzefront/values.yaml
+++ b/deploy/helm/fuzefront/values.yaml
@@ -125,6 +125,11 @@ secret:
   googleClientSecret: ""
   # SMTP password for Authentik's email backend (leave empty for MailHog / open relay).
   smtpPassword: ""
+  # AI provider keys for the chat-service and LiteLLM gateway.
+  # Leave empty to disable; supply via --set or a gitignored values file. NEVER commit real keys.
+  anthropicApiKey: ""
+  openaiApiKey: ""
+  litellmMasterKey: ""
 
 backend:
   image:
@@ -243,6 +248,43 @@ smsService:
   nodeSelector: {}
   affinity: {}
   tolerations: []
+
+chatService:
+  enabled: false
+  replicas: 1
+  # Port 3006: 3001=backend, 3002=security, 3003=apps/email, 3004=sms, 3005=provisioning
+  port: 3006
+  image:
+    repository: fuzefront/chat-service
+    tag: local
+  # LiteLLM gateway in fuzeinfra namespace (its own Argo App).
+  litellmUrl: "http://litellm.fuzeinfra.svc.cluster.local:4000"
+  # ChromaDB vector store in fuzeinfra namespace (enabled via fuzeinfra Argo values).
+  chromaUrl: "http://chromadb.fuzeinfra.svc.cluster.local:8000"
+  # FuzeFront backend for user/org lookups.
+  backendUrl: "http://fuzefront-backend:3001"
+  # Permit PDP for authorization checks. When permit.enabled=true the in-cluster PDP runs
+  # at fuzefront-permit-pdp:7000; otherwise falls back to the offline stub port.
+  permitPdpUrl: "http://fuzefront-permit-pdp:7000"
+  kafka:
+    brokers: "kafka.fuzeinfra.svc.cluster.local:9092"
+  # Embedding model resolved at the LiteLLM gateway (used by the doc indexer).
+  embeddingModel: "text-embedding-3-small"
+  # Resource requests/limits. Local/dev single replica; prod overrides upward.
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: "1"
+      memory: 1Gi
+  # chat-doc-indexer Job: indexes docs/ into ChromaDB as a post-install/upgrade
+  # hook. Idempotent (content-hash keyed). Disabled by default — flip on once
+  # LiteLLM + ChromaDB are reachable in fuzeinfra.
+  docIndexer:
+    enabled: false
+    # Directory inside the chat-service image that holds the docs to index.
+    docsDir: "/app/services/chat-service/docs"
 
 # Plan D — thin Kafka→HTTP bridge: consumes identity.user.created, calls
 # security-service POST /internal/provision. No DB, no domain logic.


### PR DESCRIPTION
**Devops slice extracted from #68.** The chat feature had bundled its deploy wiring into the backend PR; this separates it so a chat/backend agent isn't authoring Helm/Argo.

## Contents
- `deploy/helm/fuzefront/templates/chat-service.yaml`, `chat-doc-indexer-job.yaml`
- `deploy/argocd/applications/litellm.yaml`
- chat keys in `secret.yaml` + chat block in `values.yaml`

Branched from `master` so the chart renders coherently (template + values + secret together → helm-validate passes).

## Merge order
Merges **after** #68 (the `chat-service` backend + `@fuzefront/chat-client`). 

## Devops follow-up (not in this PR)
`release.yml` has **no** chat-service/litellm image-build entry yet — add them to the build matrix + `values-prod.yaml` tags so the images this chart references actually get built/pushed. Tracked as the devops slice's remaining work.