### PR TITLE
fix(billing-db): least-privilege-runnable migration + bootstrap grants

### DIFF
--- a/deploy/helm/fuzefront/templates/billing-db-bootstrap-job.yaml
+++ b/deploy/helm/fuzefront/templates/billing-db-bootstrap-job.yaml
@@ -51,10 +51,35 @@ spec:
                 END IF;
               END
               $do$;
+              -- pgcrypto: created here by the SUPERUSER. billing_svc (NOSUPERUSER,
+              -- non-DB-owner) CANNOT run CREATE EXTENSION at migration time, so the
+              -- migration must not — it would fail "permission denied to create
+              -- extension". (gen_random_uuid() is core in PG13+ so this is belt-and-
+              -- suspenders, but keep it for any future pgcrypto use.)
+              CREATE EXTENSION IF NOT EXISTS pgcrypto;
+              -- billing_svc OWNS the `billing` schema (so it can run its own table
+              -- migrations: CREATE TABLE/sequences inside `billing`). Idempotent.
               CREATE SCHEMA IF NOT EXISTS billing AUTHORIZATION billing_svc;
               GRANT USAGE ON SCHEMA public TO billing_svc;
+              -- Least-privilege cross-schema write: billing-service's writePlanCache
+              -- UPDATEs the billing cache columns on public.users / public.organizations
+              -- (owned by the identity/security service, not billing). Grant SELECT+UPDATE
+              -- on exactly those two tables — NOT blanket grants on the public schema.
+              -- Guarded with to_regclass so this is a no-op (not a hard pre-install
+              -- failure) if the identity migrations haven't created the tables yet; the
+              -- grant is re-applied on the next pre-upgrade sync once they exist.
+              DO $grant$
+              BEGIN
+                IF to_regclass('public.users') IS NOT NULL THEN
+                  EXECUTE 'GRANT SELECT, UPDATE ON public.users TO billing_svc';
+                END IF;
+                IF to_regclass('public.organizations') IS NOT NULL THEN
+                  EXECUTE 'GRANT SELECT, UPDATE ON public.organizations TO billing_svc';
+                END IF;
+              END
+              $grant$;
               SQL
-              echo "billing_svc role + billing schema ensured"
+              echo "billing_svc role + billing schema + pgcrypto + public grants ensured"
           env:
             - name: DB_HOST
               value: {{ .Values.fuzeinfra.postgres.host | quote }}

--- a/services/billing-service/src/migrations/001_billing_schema.sql
+++ b/services/billing-service/src/migrations/001_billing_schema.sql
@@ -1,9 +1,19 @@
 -- Migration 001: billing schema
--- Idempotent: safe to re-run (all CREATE statements use IF NOT EXISTS)
-
-CREATE EXTENSION IF NOT EXISTS pgcrypto;
-
-CREATE SCHEMA IF NOT EXISTS billing;
+-- Idempotent: safe to re-run (all CREATE statements use IF NOT EXISTS).
+--
+-- LEAST-PRIVILEGE: this migration is executed at billing-service startup by the
+-- runtime role `billing_svc`, which is NOSUPERUSER and is NOT the platform
+-- database owner — it only OWNS the `billing` schema (granted by the pre-install
+-- billing-db-bootstrap Job via CREATE SCHEMA billing AUTHORIZATION billing_svc).
+-- So this file MUST NOT contain database-level DDL billing_svc cannot run:
+--   * CREATE EXTENSION -> "permission denied to create extension" (needs CREATE
+--                         on the DB / superuser). The bootstrap Job creates
+--                         pgcrypto as the superuser instead.
+--   * CREATE SCHEMA    -> "permission denied for database" (needs CREATE on the
+--                         DB). The bootstrap Job creates the `billing` schema.
+-- Both were empirically reproduced against postgres:15 as billing_svc and moved
+-- into the bootstrap. gen_random_uuid() is CORE in PostgreSQL 13+ (FuzeInfra runs
+-- postgres:15), so the UUID defaults below need no pgcrypto dependency.
 
 -- billing.customers
 -- Links platform entities (users / organizations) to Stripe customers.

--- a/services/billing-service/tests/db.test.ts
+++ b/services/billing-service/tests/db.test.ts
@@ -29,12 +29,29 @@ describe('001_billing_schema.sql — DDL shape', () => {
     expect(sql.length).toBeGreaterThan(0);
   });
 
-  it('creates the pgcrypto extension idempotently', () => {
-    expect(sql).toMatch(/CREATE EXTENSION IF NOT EXISTS pgcrypto/i);
+  // LEAST-PRIVILEGE: the migration is run by the NOSUPERUSER runtime role
+  // billing_svc, which cannot run CREATE EXTENSION (permission denied to create
+  // extension) or CREATE SCHEMA (permission denied for database). Those are the
+  // superuser billing-db-bootstrap Job's responsibility — the migration MUST NOT
+  // contain them, else it fails and billing runs degraded with no tables.
+  // Strip SQL line comments so the explanatory header (which mentions these
+  // statements by name) does not trip the "must not contain" assertions.
+  const executableSql = () =>
+    sql
+      .split('\n')
+      .filter((line) => !line.trim().startsWith('--'))
+      .join('\n');
+
+  it('does NOT run CREATE EXTENSION (bootstrap superuser does it)', () => {
+    expect(executableSql()).not.toMatch(/CREATE\s+EXTENSION/i);
   });
 
-  it('creates billing schema idempotently', () => {
-    expect(sql).toMatch(/CREATE SCHEMA IF NOT EXISTS billing/i);
+  it('does NOT run CREATE SCHEMA (bootstrap creates billing schema)', () => {
+    expect(executableSql()).not.toMatch(/CREATE\s+SCHEMA/i);
+  });
+
+  it('uses core gen_random_uuid() for UUID defaults (no pgcrypto dependency)', () => {
+    expect(sql).toMatch(/gen_random_uuid\(\)/i);
   });
 
   it('creates billing.customers table idempotently', () => {


### PR DESCRIPTION
## Data-tier slice: billing-service Postgres provisioning/migration/connection

Verified the billing-service data tier (role + schema + migration + connection wiring) end-to-end against a live `postgres:15` (the version FuzeInfra provides) and fixed three least-privilege defects that would have left billing running degraded with **no tables**.

### Defects found (empirically reproduced as `billing_svc`)
The migration is run at service startup BY the runtime role `billing_svc` (NOSUPERUSER, non-DB-owner, owns only the `billing` schema). As that role:
- `CREATE EXTENSION IF NOT EXISTS pgcrypto` → **permission denied to create extension**
- `CREATE SCHEMA IF NOT EXISTS billing` → **permission denied for database**
- `UPDATE public.users` (the `writePlanCache` path in index.ts) → **permission denied for table users**

`index.ts` swallows the migration error (`catch … continuing`), so this fails silently.

### Fix (data-tier only)
- **`001_billing_schema.sql`**: removed `CREATE EXTENSION` + `CREATE SCHEMA` (DB-level DDL only the superuser can run). `gen_random_uuid()` is core in PG13+, so UUID defaults need no pgcrypto.
- **`billing-db-bootstrap-job.yaml`** (runs as superuser, pre-install/pre-upgrade): now `CREATE EXTENSION IF NOT EXISTS pgcrypto` and grants `billing_svc` `SELECT, UPDATE` on **exactly** `public.users` + `public.organizations` (`to_regclass`-guarded → no-op, not a hard pre-install failure, before the identity migrations create those tables). No blanket public grant.
- **`db.test.ts`**: updated the two shape assertions that enshrined the buggy privileged DDL to assert it is absent.

### Verification
- Bootstrap idempotent (run x2 clean); migration idempotent as `billing_svc` (x2, 5 tables).
- `writePlanCache` UPDATE on users/organizations now succeeds; negative check: `billing_svc` still denied on `public.sessions` (scoped grant holds).
- Role is NOSUPERUSER/NOCREATEDB/NOCREATEROLE; guarded grant exits 0 when platform tables absent.
- `helm template` (default + values-prod, billing enabled) renders bootstrap Job + service; gating verified (disabled → 0 objects). **kubeconform -strict: 3/3 Valid.**
- Connection-wiring consistency confirmed: bootstrap and service share `fuzeinfra.postgres.host`, `database.name` (`fuzefront_platform`), role `billing_svc`, and the **same** `billing-secrets/BILLING_DB_PASSWORD` (the #1 password-mismatch failure mode is closed). No duplicate migration ordinals in billing's dir (only `001`); the `010`/`011` divergence is the identity/security knex runners, out of scope.

## OUT OF SCOPE — NOT DONE
- Stripe/payment handlers, routes, business logic (billing-payments-engineer).
- Helm/Argo/CI/SealedSecret scaffolding & the actual sealing of `billing-secrets` (devops-engineer).
- The live prod role-creation + migration RUN is a GitOps/operator step (never hand-run).
- Full jest suite execution needs `npm ci` (deps not installed in worktree); assertion logic validated standalone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)