### PR TITLE
fix(authentik): scrub whitespace from sealed tokens — fix malformed outpost Authorization header

### DIFF
--- a/deploy/contabo/SEAL_PROD_SECRETS.md
+++ b/deploy/contabo/SEAL_PROD_SECRETS.md
@@ -62,6 +62,34 @@ git commit -m "secrets(prod): seal fuzefront-secrets + ghcr-pull for app.fuzefro
 git push
 ```
 
+## ⚠️ Resealing a single value (e.g. `AUTHENTIK_BOOTSTRAP_TOKEN`)
+
+To rotate or repair ONE key without retyping the rest, use the offline merge helper —
+it scrubs **all** whitespace from the value before sealing, so a stray trailing
+newline can never reach the cluster:
+
+```bash
+# regenerate a clean, newline-free token and seal it into fuzefront-secrets in place
+openssl rand -hex 32 | tr -d '[:space:]' > /tmp/ak-token.txt
+deploy/scripts/seal-secret.sh AUTHENTIK_BOOTSTRAP_TOKEN \
+  --in /tmp/ak-token.txt \
+  --scope fuzefront/fuzefront-secrets \
+  --manifest deploy/contabo/sealed/fuzefront-secrets.yaml
+rm -f /tmp/ak-token.txt
+git add deploy/contabo/sealed/fuzefront-secrets.yaml && git commit && git push
+```
+
+> **Why this matters (incident FuzeInfra#103 / FuzeFront#104):** the embedded authentik
+> outpost authenticates to the API with this token. If the sealed value carries a
+> trailing newline/whitespace, authentik stores it on the Token object and the outpost
+> emits it in the `Authorization` header — Go's HTTP client then rejects it with
+> `net/http: invalid header field value for "Authorization"` and loops
+> "Failed to fetch outpost configuration, retrying in 3 seconds" forever. **Never**
+> seal a token with `echo "$TOK" | kubeseal` (echo appends `\n`); always go through
+> `seal-secret.sh` (or `printf '%s'` + `tr -d '[:space:]'`). After resealing, authentik
+> must be **redeployed** so the bootstrap blueprint rewrites the Token object with the
+> clean value. This is GitOps prod — Argo syncs on push; do not hand-apply.
+
 Then tell the agent **"sealed"** — it applies `deploy/contabo/sealed/` to the cluster via
 FuzeInfra's `argocd-register.yml` (which holds the kubeconfig), the controller decrypts
 them, Argo retries the `fuzefront` app (pre-sync hook passes, pods pull), the Ingress is

--- a/deploy/helm/fuzefront/templates/secret.yaml
+++ b/deploy/helm/fuzefront/templates/secret.yaml
@@ -20,14 +20,21 @@ stringData:
   # Shared secret guarding POST /internal/provision (Plan B / consumed by Plan D).
   INTERNAL_PROVISION_SECRET: {{ .Values.secret.internalProvisionSecret | quote }}
   {{- end }}
-  AUTHENTIK_SECRET_KEY: {{ .Values.secret.authentikSecretKey | quote }}
+  # `trim` on the authentik credentials: a stray trailing newline/space here is
+  # invisible but fatal — AUTHENTIK_BOOTSTRAP_TOKEN is what the embedded outpost
+  # uses for its API Authorization header, and Go's HTTP client rejects a header
+  # value containing a control char ("invalid header field value"). These are
+  # tokens/keys that never legitimately contain whitespace, so trimming is safe.
+  # (The prod path uses secret.existingSecret — keep the SealedSecret clean too;
+  # seal-secret.sh now scrubs whitespace at seal time.)
+  AUTHENTIK_SECRET_KEY: {{ .Values.secret.authentikSecretKey | trim | quote }}
   AUTHENTIK_BOOTSTRAP_PASSWORD: {{ .Values.secret.authentikBootstrapPassword | quote }}
-  AUTHENTIK_BOOTSTRAP_TOKEN: {{ .Values.secret.authentikBootstrapToken | quote }}
+  AUTHENTIK_BOOTSTRAP_TOKEN: {{ .Values.secret.authentikBootstrapToken | trim | quote }}
   {{- if .Values.secret.authentikClientId }}
-  AUTHENTIK_CLIENT_ID: {{ .Values.secret.authentikClientId | quote }}
+  AUTHENTIK_CLIENT_ID: {{ .Values.secret.authentikClientId | trim | quote }}
   {{- end }}
   {{- if .Values.secret.authentikClientSecret }}
-  AUTHENTIK_CLIENT_SECRET: {{ .Values.secret.authentikClientSecret | quote }}
+  AUTHENTIK_CLIENT_SECRET: {{ .Values.secret.authentikClientSecret | trim | quote }}
   {{- end }}
   {{- if .Values.secret.sendgridApiKey }}
   SENDGRID_API_KEY: {{ .Values.secret.sendgridApiKey | quote }}

--- a/deploy/scripts/seal-secret.sh
+++ b/deploy/scripts/seal-secret.sh
@@ -61,12 +61,18 @@ else
 fi
 
 # ---- get the value (hidden prompt, or from a file) -----------------------------
+# Strip ALL whitespace (CR, LF, space, tab), not just \r\n. A single stray byte —
+# a trailing newline from `echo`/an editor, or a pasted space — is invisible in the
+# sealed blob but fatal downstream: e.g. a token sealed with a trailing \n makes
+# authentik's embedded outpost emit an Authorization header that Go's HTTP client
+# rejects ("invalid header field value"), looping forever. Secrets/tokens never
+# legitimately contain whitespace, so scrubbing it is always safe here.
 if [ -n "$INFILE" ]; then
-  tr -d '\r\n' < "$INFILE" > "$VAL"
+  tr -d '[:space:]' < "$INFILE" > "$VAL"
 else
   printf 'Paste value for %s (hidden, will not echo): ' "$KEY" >&2
   read -rs _V; echo >&2
-  printf '%s' "$_V" > "$VAL"; unset _V
+  printf '%s' "$_V" | tr -d '[:space:]' > "$VAL"; unset _V
 fi
 [ -s "$VAL" ] || { echo "empty value — aborting" >&2; exit 1; }
 


### PR DESCRIPTION
Fixes the malformed outpost-token config-fetch loop **handed off from FuzeInfra#103** (FuzeInfra crit-alert pipeline → this repo's @claude, see #104).

## Root cause
The embedded authentik outpost authenticates with `AUTHENTIK_BOOTSTRAP_TOKEN`, sourced in prod from the `fuzefront-secrets` SealedSecret. A trailing newline/whitespace in the sealed value is injected verbatim, stored on the Token object, and emitted in the `Authorization` header — Go's HTTP client rejects it (`net/http: invalid header field value`) and the outpost loops its config fetch every ~3s.

## Changes
- `deploy/scripts/seal-secret.sh`: scrub ALL whitespace (`[:space:]`) at seal time, on both input paths.
- `deploy/helm/fuzefront/templates/secret.yaml`: `| trim` the authentik credentials on the inline path.
- `deploy/contabo/SEAL_PROD_SECRETS.md`: document the clean reseal recipe + the echo-pipe warning.

## Follow-up (owner — prod GitOps)
The committed code prevents *future* bad seals, but the **currently-sealed** token still carries the bad byte. Reseal `AUTHENTIK_BOOTSTRAP_TOKEN` with the hardened script and Argo-redeploy authentik to clear the loop.

Refs FuzeInfra#103. Refs #104 (loop NOT yet resolved — see comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)