### PR TITLE
fix(billing): param-sensitive checkout idempotency key + Stripe error status mapping

### DIFF
--- a/services/billing-service/src/routes/checkout.ts
+++ b/services/billing-service/src/routes/checkout.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import { Router, Response } from 'express';
 import type Stripe from 'stripe';
 import { z } from 'zod';
@@ -5,6 +6,45 @@ import { CustomerService } from '../services/customer.service';
 import { PlanService } from '../services/plan.service';
 import { BillingRequest, requireActorContext } from '../middleware/auth';
 import { validateBody } from './validate';
+import { sendStripeError } from './stripe-error';
+
+/**
+ * Build the Checkout-Session idempotency key.
+ *
+ * BUG 1 fix — the key MUST incorporate a stable fingerprint of the request
+ * parameters. A purely org+price+user key is OVER-deterministic: Stripe's 24h
+ * idempotency window rejects a reuse with *different* params
+ * ("Keys for idempotent requests can only be used with the same parameters they
+ * were first used with"), which in prod poisoned an org's key for ~24h when the
+ * successUrl/cancelUrl changed.
+ *
+ * By hashing {organizationId, userId, priceId, mode, successUrl, cancelUrl} we
+ * keep TRUE retries idempotent (identical inputs -> identical key, so rapid
+ * double-clicks dedupe to one session) while a changed param set yields a NEW
+ * key — a fresh session instead of a hard Stripe error.
+ */
+export function checkoutIdempotencyKey(parts: {
+  organizationId: string;
+  userId: string;
+  priceId: string;
+  mode: string;
+  successUrl: string;
+  cancelUrl: string;
+}): string {
+  // Order is fixed and explicit so the digest is deterministic across calls.
+  const fingerprint = JSON.stringify([
+    parts.organizationId,
+    parts.userId,
+    parts.priceId,
+    parts.mode,
+    parts.successUrl,
+    parts.cancelUrl,
+  ]);
+  const hash = createHash('sha256').update(fingerprint).digest('hex').slice(0, 16);
+  // Keep the human-readable prefix for log/dashboard correlation; the hash makes
+  // it param-sensitive. (Stripe idempotency keys allow up to 255 chars.)
+  return `checkout-${parts.organizationId}-${parts.priceId}-${parts.userId}-${hash}`;
+}
 
 /**
  * POST /api/v1/billing/checkout — create a hosted Stripe Checkout Session
@@ -83,9 +123,10 @@ export function createCheckoutRouter(deps: CheckoutDeps): Router {
     try {
       const customer = await deps.customers.ensureCustomer('organization', organizationId);
 
+      const mode = 'subscription';
       const session = await deps.stripe.checkout.sessions.create(
         {
-          mode: 'subscription',
+          mode,
           customer: customer.stripeCustomerId,
           line_items: [{ price: priceId, quantity: 1 }],
           success_url: successUrl,
@@ -96,17 +137,29 @@ export function createCheckoutRouter(deps: CheckoutDeps): Router {
           metadata: { organizationId, planId },
           client_reference_id: organizationId,
         },
-        // Idempotency: a retry of the same actor+org+plan won't create a second
-        // Checkout Session (Stripe replays the original response within 24h).
-        { idempotencyKey: `checkout-${organizationId}-${priceId}-${actor.actorUserId}` },
+        // Idempotency: a retry of the SAME actor+org+plan AND SAME params won't
+        // create a second Checkout Session (Stripe replays the original within
+        // 24h). The key embeds a param fingerprint (BUG 1) so a changed
+        // success/cancel URL yields a fresh key instead of a 24h-poisoning
+        // "same parameters" idempotency error.
+        {
+          idempotencyKey: checkoutIdempotencyKey({
+            organizationId,
+            userId: actor.actorUserId,
+            priceId,
+            mode,
+            successUrl,
+            cancelUrl,
+          }),
+        },
       );
 
       return res.status(200).json({ url: session.url, sessionId: session.id });
     } catch (err) {
-      return res.status(502).json({
-        error: 'stripe error',
-        message: err instanceof Error ? err.message : String(err),
-      });
+      // BUG 2: classify Stripe errors. Client/validation/idempotency-conflict
+      // map to 4xx/409 (so Cloudflare/the browser sees the real cause); only
+      // genuine upstream/unknown failures map to 502.
+      return sendStripeError(res, err);
     }
   });
 

--- a/services/billing-service/src/routes/stripe-error.ts
+++ b/services/billing-service/src/routes/stripe-error.ts
@@ -1,0 +1,87 @@
+import type { Response } from 'express';
+
+/**
+ * Maps a Stripe SDK error (or any thrown value) to an appropriate HTTP status
+ * + structured `{ error, code, message }` body.
+ *
+ * WHY: previously ANY Stripe failure was surfaced as a 502. Cloudflare then
+ * renders a generic "error code: 502" that hides the real cause, and — worse —
+ * a *client* error (a card decline, a validation problem, or an idempotency-key
+ * conflict) is not an upstream/gateway failure at all and must not be reported
+ * as one. We classify:
+ *
+ *   - `StripeIdempotencyError` / a `idempotency_error` code  -> 409 Conflict
+ *     (the deterministic key was reused with different params — see BUG 1; this
+ *     is a client/caller problem, retryable with a fresh key, not a 5xx).
+ *   - `StripeInvalidRequestError` and other client (4xx) Stripe errors
+ *     (`StripeCardError`, validation, rate-limit) -> the Stripe `statusCode`
+ *     (400/402/409/429) so the real cause survives to the browser.
+ *   - genuine upstream/unknown failures (`StripeConnectionError`,
+ *     `StripeAPIError`, 5xx, or a non-Stripe throw) -> 502.
+ *
+ * Stripe errors carry a discriminating `type` (e.g. `StripeInvalidRequestError`),
+ * a machine `code` (e.g. `idempotency_error`, `card_declined`), and an HTTP
+ * `statusCode`. We read them defensively so a non-Stripe throw still maps to 502.
+ */
+export interface StripeErrorShape {
+  type?: string;
+  rawType?: string;
+  code?: string;
+  statusCode?: number;
+  message?: string;
+}
+
+export interface MappedStripeError {
+  status: number;
+  body: { error: string; code: string; message: string };
+}
+
+export function mapStripeError(err: unknown): MappedStripeError {
+  const e = (err && typeof err === 'object' ? (err as StripeErrorShape) : {}) || {};
+  const type = e.type || e.rawType || '';
+  const code = e.code || '';
+  const message = err instanceof Error ? err.message : String(err);
+
+  // Idempotency-key conflict: the same key was reused with different params.
+  // Retryable by the caller with a new key — a Conflict, not an upstream error.
+  if (type === 'StripeIdempotencyError' || code === 'idempotency_error') {
+    return {
+      status: 409,
+      body: { error: 'idempotency conflict', code: code || 'idempotency_error', message },
+    };
+  }
+
+  // Client/validation/card errors carry their own 4xx statusCode — forward it
+  // faithfully so the browser sees the real cause (e.g. 402 card_declined).
+  const clientTypes = new Set([
+    'StripeInvalidRequestError',
+    'StripeCardError',
+    'StripeRateLimitError',
+    'StripeIdempotencyError',
+  ]);
+  const statusCode = typeof e.statusCode === 'number' ? e.statusCode : undefined;
+  if (clientTypes.has(type) || (statusCode !== undefined && statusCode >= 400 && statusCode < 500)) {
+    const status = statusCode && statusCode >= 400 && statusCode < 500 ? statusCode : 400;
+    return {
+      status,
+      body: {
+        error: 'stripe request error',
+        code: code || type || 'stripe_invalid_request',
+        message,
+      },
+    };
+  }
+
+  // Genuine upstream/unknown failure (connection error, Stripe 5xx, non-Stripe
+  // throw) -> 502 Bad Gateway.
+  return {
+    status: 502,
+    body: { error: 'stripe error', code: code || type || 'stripe_upstream_error', message },
+  };
+}
+
+/** Convenience: map + write the response in one call. */
+export function sendStripeError(res: Response, err: unknown): Response {
+  const { status, body } = mapStripeError(err);
+  return res.status(status).json(body);
+}

--- a/services/billing-service/tests/routes/checkout.test.ts
+++ b/services/billing-service/tests/routes/checkout.test.ts
@@ -74,6 +74,46 @@ describe('POST /checkout — hosted Stripe Checkout Session', () => {
     expect(opts).toEqual(expect.objectContaining({ idempotencyKey: expect.any(String) }));
   });
 
+  // BUG 1: the idempotency key must be a deterministic function of the request
+  // params. Identical requests -> identical key (dedupe double-clicks); a changed
+  // successUrl -> a DIFFERENT key (no Stripe "same parameters" 24h poisoning).
+  async function postCheckout(app: any, body: Record<string, unknown>) {
+    return request(app)
+      .post(URL)
+      .set(...authHeader())
+      .set(actorOrgHeaders(ORG_ID, USER_ID))
+      .send(body);
+  }
+
+  it('idempotency key: identical params -> SAME key; changed successUrl -> DIFFERENT key (BUG 1)', async () => {
+    const { app, stubs } = buildApp({
+      internalToken: INTERNAL_TOKEN,
+      stubs: { ...orgCustomerStub() },
+    });
+
+    const base = {
+      planId: 'basic',
+      organizationId: ORG_ID,
+      successUrl: 'https://app.fuzefront.com/billing/success',
+      cancelUrl: 'https://app.fuzefront.com/billing/cancel',
+    };
+
+    await postCheckout(app, base);
+    await postCheckout(app, { ...base }); // identical
+    await postCheckout(app, { ...base, successUrl: 'https://app.fuzefront.com/billing/done' });
+
+    const keyOf = (i: number) =>
+      stubs.stripe.checkout.sessions.create.mock.calls[i][1].idempotencyKey as string;
+
+    const k0 = keyOf(0);
+    const k1 = keyOf(1);
+    const k2 = keyOf(2);
+
+    expect(k0).toBe(k1); // identical params -> same key (true retry / dedupe)
+    expect(k2).not.toBe(k0); // changed successUrl -> new key
+    expect(k0).toMatch(/^checkout-/); // human-readable prefix retained
+  });
+
   it('401 when the internal token is missing', async () => {
     const { app } = buildApp({ internalToken: INTERNAL_TOKEN, stubs: { ...orgCustomerStub() } });
     const res = await request(app)
@@ -165,7 +205,7 @@ describe('POST /checkout — hosted Stripe Checkout Session', () => {
     expect(res.status).toBe(400);
   });
 
-  it('502 when Stripe throws creating the session', async () => {
+  it('502 when Stripe throws an unknown/upstream error creating the session', async () => {
     const { app, stubs } = buildApp({ internalToken: INTERNAL_TOKEN, stubs: { ...orgCustomerStub() } });
     stubs.stripe.checkout.sessions.create.mockRejectedValue(new Error('stripe boom'));
     const res = await request(app)
@@ -179,5 +219,69 @@ describe('POST /checkout — hosted Stripe Checkout Session', () => {
         cancelUrl: 'https://a/c',
       });
     expect(res.status).toBe(502);
+    expect(res.body).toEqual(
+      expect.objectContaining({ error: expect.any(String), code: expect.any(String), message: expect.any(String) }),
+    );
+  });
+
+  // BUG 2: an idempotency-key conflict (reuse with different params) is a
+  // CLIENT/caller problem, not an upstream failure -> 409, NOT 502.
+  it('409 when Stripe raises an idempotency_error (BUG 2)', async () => {
+    const { app, stubs } = buildApp({ internalToken: INTERNAL_TOKEN, stubs: { ...orgCustomerStub() } });
+    stubs.stripe.checkout.sessions.create.mockRejectedValue(
+      Object.assign(new Error('Keys for idempotent requests can only be used with the same parameters'), {
+        type: 'StripeIdempotencyError',
+        code: 'idempotency_error',
+        statusCode: 400,
+      }),
+    );
+    const res = await request(app)
+      .post(URL)
+      .set(...authHeader())
+      .set(actorOrgHeaders(ORG_ID))
+      .send({ planId: 'basic', organizationId: ORG_ID, successUrl: 'https://a/s', cancelUrl: 'https://a/c' });
+    expect(res.status).toBe(409);
+    expect(res.body).toEqual(
+      expect.objectContaining({ code: 'idempotency_error', message: expect.stringContaining('same parameters') }),
+    );
+  });
+
+  // BUG 2: a StripeInvalidRequestError / 4xx is a client error -> forward the
+  // Stripe statusCode (here 400), NOT a blanket 502.
+  it('400 when Stripe raises a StripeInvalidRequestError (BUG 2)', async () => {
+    const { app, stubs } = buildApp({ internalToken: INTERNAL_TOKEN, stubs: { ...orgCustomerStub() } });
+    stubs.stripe.checkout.sessions.create.mockRejectedValue(
+      Object.assign(new Error('No such price'), {
+        type: 'StripeInvalidRequestError',
+        code: 'resource_missing',
+        statusCode: 400,
+      }),
+    );
+    const res = await request(app)
+      .post(URL)
+      .set(...authHeader())
+      .set(actorOrgHeaders(ORG_ID))
+      .send({ planId: 'basic', organizationId: ORG_ID, successUrl: 'https://a/s', cancelUrl: 'https://a/c' });
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual(expect.objectContaining({ code: 'resource_missing' }));
+  });
+
+  // BUG 2: a card decline (402) forwards faithfully rather than collapsing to 502.
+  it('402 when Stripe raises a StripeCardError (BUG 2)', async () => {
+    const { app, stubs } = buildApp({ internalToken: INTERNAL_TOKEN, stubs: { ...orgCustomerStub() } });
+    stubs.stripe.checkout.sessions.create.mockRejectedValue(
+      Object.assign(new Error('Your card was declined'), {
+        type: 'StripeCardError',
+        code: 'card_declined',
+        statusCode: 402,
+      }),
+    );
+    const res = await request(app)
+      .post(URL)
+      .set(...authHeader())
+      .set(actorOrgHeaders(ORG_ID))
+      .send({ planId: 'basic', organizationId: ORG_ID, successUrl: 'https://a/s', cancelUrl: 'https://a/c' });
+    expect(res.status).toBe(402);
+    expect(res.body).toEqual(expect.objectContaining({ code: 'card_declined' }));
   });
 });

--- a/services/billing-service/tests/routes/stripe-error.test.ts
+++ b/services/billing-service/tests/routes/stripe-error.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Unit tests for the Stripe-error -> HTTP-status mapper (BUG 2).
+ *
+ * Classifies thrown Stripe SDK errors so the checkout handler returns a faithful
+ * status instead of a blanket 502: idempotency conflict -> 409, client/validation/
+ * card errors -> their 4xx, genuine upstream/unknown -> 502.
+ */
+import { mapStripeError } from '../../src/routes/stripe-error';
+
+describe('mapStripeError', () => {
+  it('idempotency_error -> 409', () => {
+    const m = mapStripeError(
+      Object.assign(new Error('Keys for idempotent requests can only be used with the same parameters'), {
+        type: 'StripeIdempotencyError',
+        code: 'idempotency_error',
+        statusCode: 400,
+      }),
+    );
+    expect(m.status).toBe(409);
+    expect(m.body.code).toBe('idempotency_error');
+    expect(m.body.message).toContain('same parameters');
+  });
+
+  it('StripeInvalidRequestError (400) -> 400', () => {
+    const m = mapStripeError(
+      Object.assign(new Error('No such price'), {
+        type: 'StripeInvalidRequestError',
+        code: 'resource_missing',
+        statusCode: 400,
+      }),
+    );
+    expect(m.status).toBe(400);
+    expect(m.body.code).toBe('resource_missing');
+  });
+
+  it('StripeCardError (402) -> 402 (forwarded faithfully)', () => {
+    const m = mapStripeError(
+      Object.assign(new Error('Your card was declined'), {
+        type: 'StripeCardError',
+        code: 'card_declined',
+        statusCode: 402,
+      }),
+    );
+    expect(m.status).toBe(402);
+    expect(m.body.code).toBe('card_declined');
+  });
+
+  it('StripeRateLimitError (429) -> 429', () => {
+    const m = mapStripeError(
+      Object.assign(new Error('Too many requests'), {
+        type: 'StripeRateLimitError',
+        code: 'rate_limit',
+        statusCode: 429,
+      }),
+    );
+    expect(m.status).toBe(429);
+  });
+
+  it('StripeConnectionError -> 502 (genuine upstream)', () => {
+    const m = mapStripeError(
+      Object.assign(new Error('connection reset'), { type: 'StripeConnectionError' }),
+    );
+    expect(m.status).toBe(502);
+  });
+
+  it('Stripe 5xx (StripeAPIError) -> 502', () => {
+    const m = mapStripeError(
+      Object.assign(new Error('internal'), { type: 'StripeAPIError', statusCode: 500 }),
+    );
+    expect(m.status).toBe(502);
+  });
+
+  it('a plain non-Stripe Error -> 502', () => {
+    const m = mapStripeError(new Error('boom'));
+    expect(m.status).toBe(502);
+    expect(m.body.message).toBe('boom');
+  });
+
+  it('always returns a structured {error, code, message} body', () => {
+    const m = mapStripeError('weird string throw');
+    expect(m.body).toEqual(
+      expect.objectContaining({ error: expect.any(String), code: expect.any(String), message: expect.any(String) }),
+    );
+  });
+});


### PR DESCRIPTION
## Two robustness bugs in the billing checkout path

### BUG 1 — Idempotency-key over-determinism
The hosted-Checkout handler built a DETERMINISTIC idempotency key of the form `checkout-{org}-{price}-{user}` that ignored the request params. Reusing org+price+user within Stripe's 24h window with a DIFFERENT `successUrl`/`cancelUrl` made Stripe reject it (`Keys for idempotent requests can only be used with the same parameters they were first used with`), poisoning the org's key for ~24h.

**Fix:** the key now embeds a stable sha256 fingerprint of `{organizationId, userId, priceId, mode, successUrl, cancelUrl}` (`checkoutIdempotencyKey()` in `services/billing-service/src/routes/checkout.ts`). Identical inputs -> identical key (true retries / double-clicks still dedupe to one session); a changed param set -> a NEW key (fresh session, no hard error). Human-readable `checkout-...` prefix retained for dashboard correlation.

### BUG 2 — Stripe errors collapsed to HTTP 502
Any Stripe failure (idempotency conflict, card decline, validation) surfaced as 502, which Cloudflare renders as a generic "error code: 502" hiding the real cause.

**Fix:** new `mapStripeError()` (`services/billing-service/src/routes/stripe-error.ts`) classifies:
- idempotency conflict (`StripeIdempotencyError` / `idempotency_error`) -> **409**
- client/validation/card/rate-limit (`StripeInvalidRequestError`, `StripeCardError`, ... / Stripe 4xx) -> the **Stripe 4xx** (400/402/429) faithfully
- genuine upstream/unknown (connection error, Stripe 5xx, non-Stripe throw) -> **502**

All responses use a structured `{ error, code, message }` body. The host-backend proxy (`backend/src/routes/billing.ts`) already forwards the upstream status verbatim (`res.status(upstream.status)`, `validateStatus: () => true`), so a 409/400/402 is NOT collapsed to 502 — no proxy change required.

## Tests
- `tests/routes/checkout.test.ts`: identical params -> same key; changed `successUrl` -> different key; idempotency_error->409, StripeInvalidRequestError->400, StripeCardError->402, unknown->502.
- `tests/routes/stripe-error.test.ts`: focused `mapStripeError` unit suite.

## Verification
- `npm run build` (billing-service tsc): clean.
- `npx jest tests/routes/checkout.test.ts tests/routes/stripe-error.test.ts`: 20/20 pass.
- Full suite: only 3 PRE-EXISTING contract failures remain (webhook raw-body, getHealth path, updateSubscription empty-body) — unrelated to this slice; verified they fail identically on the base.

## Out of scope (NOT in this PR)
Frontend/CheckoutModal, deploy charts, Permit/PDP layer, the independent contract test suite (test-engineer), docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)