### PR TITLE
fix(federated): make Clock mount in prod — host /api/v1/app-registry proxy + loader/shared-React + slug migration + e2e (closes #132)

### DIFF
--- a/backend/applications/src/migrations/004_apps_slug_unique_constraint.ts
+++ b/backend/applications/src/migrations/004_apps_slug_unique_constraint.ts
@@ -1,0 +1,38 @@
+import { Knex } from 'knex'
+
+// applications-service migration 004 — make `apps.slug` a NON-PARTIAL unique
+// index so it can serve as the arbiter for `INSERT … ON CONFLICT (slug)`.
+//
+// Migration 003 created a PARTIAL unique index (`apps_slug_unique`,
+// `WHERE slug IS NOT NULL`). Postgres CANNOT use a partial index for ON CONFLICT
+// arbiter inference, so `ensureBuiltins()` → `upsertBuiltin()` (which does
+// `.onConflict('slug').ignore()`) raised
+//   "there is no unique or exclusion constraint matching the ON CONFLICT specification"
+// on a fresh DB — the built-in Clock never got provisioned until a non-partial
+// `apps_slug_key` was added by hand in prod. This migration adds that index
+// durably so fresh databases and future deploys provision built-ins correctly.
+//
+// NULL slugs remain allowed: in a Postgres unique index NULLs are distinct, so
+// legacy slug-less rows (created by migrations 001/002 before `slug` existed) do
+// not collide. Non-NULL slugs were already unique via the partial index, so
+// building the full unique index cannot fail on existing data.
+//
+// Fully IDEMPOTENT: CREATE UNIQUE INDEX IF NOT EXISTS with the SAME name a hand
+// -applied prod fix used (`apps_slug_key`), so it is a no-op where the index
+// already exists. The now-redundant partial index is dropped.
+
+export async function up(knex: Knex): Promise<void> {
+  // Non-partial unique index on slug — usable as the ON CONFLICT (slug) arbiter.
+  await knex.raw('CREATE UNIQUE INDEX IF NOT EXISTS apps_slug_key ON apps (slug)')
+  // The partial index from migration 003 is now redundant (the full unique index
+  // also enforces non-null uniqueness) and cannot serve ON CONFLICT — drop it.
+  await knex.raw('DROP INDEX IF EXISTS apps_slug_unique')
+}
+
+export async function down(knex: Knex): Promise<void> {
+  // Restore the partial unique index, then drop the non-partial one.
+  await knex.raw(
+    'CREATE UNIQUE INDEX IF NOT EXISTS apps_slug_unique ON apps (slug) WHERE slug IS NOT NULL'
+  )
+  await knex.raw('DROP INDEX IF EXISTS apps_slug_key')
+}

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -11,6 +11,7 @@ import appsRoutes from './routes/apps'
 import organizationsRoutes from './routes/organizations'
 import internalRoutes from './routes/internal'
 import billingRoutes, { billingWebhookRouter } from './routes/billing'
+import appRegistryProxyRoutes from './routes/app-registry'
 import { initializeSocketIO } from './sockets/socketHandler'
 import {
   initializeDatabase,
@@ -273,6 +274,12 @@ app.use('/api/organizations', organizationsRoutes)
 // Billing proxy: browser -> backend -> fuzefront-billing-service:3006 (adds the
 // internal token). Webhook subroute is mounted separately above (raw body).
 app.use('/api/v1/billing', billingRoutes)
+// App-registry proxy: browser -> backend -> fuzefront-applications:3003. The
+// ingress `/api` catch-all + frontend nginx both route the manifest-shaped
+// `/api/v1/app-registry/*` here, so without this the registry client 404s and no
+// federated app (e.g. the built-in Clock) can mount. Forwards the platform JWT
+// verbatim; the applications-service does its own authn/authz.
+app.use('/api/v1/app-registry', appRegistryProxyRoutes)
 // Internal, secret-guarded provisioning endpoint (NOT exposed via public ingress).
 app.use('/internal', internalRoutes)
 

--- a/backend/src/routes/app-registry.ts
+++ b/backend/src/routes/app-registry.ts
@@ -1,0 +1,117 @@
+// Host-backend app-registry proxy.
+//
+// The applications-service (`fuzefront-applications:3003`) owns the FROZEN
+// `/api/v1/app-registry` contract (services/app-registry-service/openapi.yaml) —
+// the manifest-shaped surface the frontend's `@fuzefront/app-registry-client`
+// talks to same-origin.
+//
+// Why this proxy exists: in prod the ingress routes `/api/apps` + `/socket.io`
+// straight to the applications-service, but `/api/v1/app-registry/*` matches
+// only the `/api` catch-all and falls through to THIS host backend (the frontend
+// nginx does the same — its `/api/` block proxies to fuzefront-backend). Without
+// this router the registry client 404s same-origin, the activated-apps list comes
+// back empty, and NO federated app (including the built-in Clock) can mount —
+// the shell sits on the "Loading application…" spinner forever.
+//
+// Trust model: unlike the billing proxy, the applications-service authenticates
+// the SAME platform JWT the browser already holds and does its own per-object
+// authorization (Permit + BOLA filtering in app-registry/service.ts). So this
+// proxy injects NO internal token — it forwards the caller's Authorization
+// header verbatim and relays the upstream status/body unchanged. The heartbeat
+// route authenticates a per-app token, also carried in Authorization, so the
+// same verbatim forwarding covers it.
+import express, { Request, Response } from 'express'
+import axios, { AxiosError, AxiosRequestConfig, Method } from 'axios'
+
+const router = express.Router()
+
+// Cluster-internal base URL of the applications-service. Overridable via env so
+// the same code works locally (compose / port-forward) and in-cluster.
+const APPLICATIONS_SERVICE_URL = (
+  process.env.APPLICATIONS_SERVICE_URL || 'http://fuzefront-applications:3003'
+).replace(/\/+$/, '')
+
+// The applications-service mounts this contract under /api/v1/app-registry.
+const APP_REGISTRY_API_BASE = '/api/v1/app-registry'
+
+// Upstream request timeout (ms). Registry calls are quick; keep a sane ceiling.
+const UPSTREAM_TIMEOUT_MS = parseInt(
+  process.env.APP_REGISTRY_PROXY_TIMEOUT_MS || '15000',
+  10
+)
+
+/**
+ * Forward the request to the applications-service and relay its response back to
+ * the caller unchanged. Within this router `req.url` is the subpath + query
+ * string relative to the mount point (e.g. `/apps?status=activated`), so the
+ * upstream URL reconstructs the full contract path.
+ */
+async function forward(req: Request, res: Response): Promise<void> {
+  const url = `${APPLICATIONS_SERVICE_URL}${APP_REGISTRY_API_BASE}${req.url}`
+
+  const headers: Record<string, string> = {}
+  // Forward the caller's bearer token verbatim — the service authenticates it.
+  const auth = req.headers['authorization']
+  if (typeof auth === 'string') headers['Authorization'] = auth
+
+  // Re-serialize the parsed JSON body for write methods (express.json() already
+  // consumed it upstream of this router). GET/DELETE carry no body.
+  let data: unknown
+  if (
+    req.method !== 'GET' &&
+    req.method !== 'DELETE' &&
+    req.body !== undefined &&
+    !(typeof req.body === 'object' && Object.keys(req.body).length === 0)
+  ) {
+    data = req.body
+    headers['Content-Type'] = 'application/json'
+  }
+
+  const config: AxiosRequestConfig = {
+    method: req.method as Method,
+    url,
+    headers,
+    timeout: UPSTREAM_TIMEOUT_MS,
+    // Never throw on non-2xx — relay the upstream status/body verbatim.
+    validateStatus: () => true,
+    responseType: 'arraybuffer',
+  }
+  if (data !== undefined) config.data = data
+
+  try {
+    const upstream = await axios.request(config)
+
+    const ct = upstream.headers['content-type']
+    if (ct) res.setHeader('Content-Type', ct as string)
+    // registerApp returns the per-app heartbeat token out-of-band in a header —
+    // relay it so the registration UI can capture it.
+    const hb = upstream.headers['x-app-heartbeat-token']
+    if (hb) res.setHeader('X-App-Heartbeat-Token', hb as string)
+
+    res.status(upstream.status).send(Buffer.from(upstream.data))
+  } catch (err) {
+    const ax = err as AxiosError
+    // Connection refused / DNS / timeout — the service is unreachable.
+    console.error(
+      `[app-registry-proxy] upstream error for ${req.method} ${req.url}:`,
+      ax.code || ax.message
+    )
+    res.status(502).json({
+      error: 'app_registry_unavailable',
+      code: ax.code || 'EUPSTREAM',
+    })
+  }
+}
+
+// Catch-all: every method + subpath under the mount is forwarded.
+router.use((req, res) => {
+  void forward(req, res)
+})
+
+export default router
+
+// Exported for tests / introspection.
+export const __appRegistryProxyConfig = {
+  APPLICATIONS_SERVICE_URL,
+  APP_REGISTRY_API_BASE,
+}

--- a/frontend/tests/clock-load.spec.ts
+++ b/frontend/tests/clock-load.spec.ts
@@ -1,8 +1,14 @@
 import { test, expect } from '@playwright/test'
 
-// Real user path: sign in, open the 9-dots launcher, click FuzeClock, and verify
-// the federated remote renders inside the host (no "app unavailable" alert).
-test('FuzeClock loads from the launcher at runtime', async ({ page }) => {
+// Real user path proving the built-in Clock federated app actually MOUNTS (issue
+// #132): sign in, open the 9-dots launcher, click the Clock card, and verify the
+// federated remote renders its own UI inside the host — i.e. the shell is NOT
+// stuck on the "Loading application…" spinner and did NOT fall back to the
+// "Failed to Load App" error.
+//
+// The menu card shows the manifest `menuLabel` ("Clock"); the remote's mounted
+// content shows its own heading ("🕒 FuzeClock") + a note unique to clock-app.
+test('Clock mounts from the launcher at runtime', async ({ page }) => {
   let dialogMessage = ''
   page.on('dialog', d => {
     dialogMessage = d.message()
@@ -28,20 +34,31 @@ test('FuzeClock loads from the launcher at runtime', async ({ page }) => {
     timeout: 10000,
   })
 
-  // --- open the 9-dots launcher and click FuzeClock (the real path) ---
+  // The activated-apps list MUST resolve same-origin (the host /api/v1/app-registry
+  // proxy → applications-service). A 404 here is the #132 root cause and leaves
+  // the launcher empty.
+  await page.waitForResponse(
+    r =>
+      r.url().includes('/api/v1/app-registry/apps') && r.status() === 200,
+    { timeout: 10000 }
+  )
+
+  // --- open the 9-dots launcher and click the Clock card (the real path) ---
   await page.locator('button.app-grid-button').click()
-  await page.getByText('FuzeClock', { exact: true }).first().click()
+  await page.getByText('Clock', { exact: true }).first().click()
 
   // The launcher must NOT have blocked it with an "unavailable" alert.
   await page.waitForTimeout(500)
   expect(dialogMessage, `unexpected dialog popup: "${dialogMessage}"`).toBe('')
 
   // The remote's own content (unique to clock-app) must render — proving the
-  // runtime Module Federation load succeeded inside the host, not the error UI.
+  // runtime Module Federation load + shared-React singleton succeeded inside the
+  // host, not the spinner or the error UI.
   await expect(
     page.getByText('No build-time knowledge of the host')
   ).toBeVisible({ timeout: 20000 })
   await expect(page.getByText('Failed to Load App')).toHaveCount(0)
+  await expect(page.getByText('Loading application...')).toHaveCount(0)
 
   // Surface any console errors for visibility (not a hard failure here).
   if (consoleErrors.length) {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -87,7 +87,17 @@ export default defineConfig({
       // @fuzefront/chat-ui) resolve from source/workspace; listing them here makes
       // the federation plugin read `<aliased-file>/package.json` (ENOTDIR) — so they
       // are bundled into the host directly rather than shared.
-      shared: ['react', 'react-dom'],
+      //
+      // React/react-dom are declared as explicit SINGLETONS (not the bare array
+      // shorthand) so they EXACTLY match the clock-app remote's shared config
+      // (clock-app/vite.config.ts). The host seeds the shared scope with its one
+      // React instance and runtime-loaded remotes (Clock) reuse it across the
+      // federation boundary — a singleton mismatch would let the remote pull its
+      // own React copy and crash on "Invalid hook call" / hang on the spinner.
+      shared: {
+        react: { singleton: true, requiredVersion: '^18.0.0' } as any,
+        'react-dom': { singleton: true, requiredVersion: '^18.0.0' } as any,
+      },
     }),
   ],
   build: {


### PR DESCRIPTION
Closes #132. Cloud-authored; CI gates must verify (sandbox can't build). master deploy-on-push — merge in deploy window.