### PR TITLE
fix(ci): make Android APK bubblewrap init non-interactive

### DIFF
--- a/.github/workflows/build-android-apk.yml
+++ b/.github/workflows/build-android-apk.yml
@@ -35,8 +35,17 @@ jobs:
         with:
           node-version: '20'
 
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+
       - name: Install Bubblewrap CLI
         run: npm install -g @bubblewrap/cli
+
+      - name: Pre-configure Bubblewrap to skip interactive JDK/SDK prompts
+        run: |
+          mkdir -p ~/.bubblewrap
+          printf '{"jdkPath":"%s","androidSdkPath":"%s"}\n' "$JAVA_HOME" "$ANDROID_HOME" \
+            > ~/.bubblewrap/config.json
 
       - name: Restore keystore from secret
         env:

--- a/.github/workflows/build-android-apk.yml
+++ b/.github/workflows/build-android-apk.yml
@@ -36,7 +36,7 @@ jobs:
           node-version: '20'
 
       - name: Set up Android SDK
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3
 
       - name: Install Bubblewrap CLI
         run: npm install -g @bubblewrap/cli


### PR DESCRIPTION
## Summary

- Add `android-actions/setup-android@v3` to install the Android SDK on the CI runner
- Pre-create `~/.bubblewrap/config.json` pointing to `$JAVA_HOME` and `$ANDROID_HOME` so `bubblewrap init` skips the interactive "Do you want Bubblewrap to install the JDK?" prompt that caused exit 130 in run #1

## Root cause

`bubblewrap init` opens an interactive prompt on its first run asking whether to install a JDK. In a headless CI environment there is no TTY, so it hangs and is killed (exit 130). The fix pre-configures the bubblewrap user config so no prompt is shown.

## Test plan

- [ ] `Build Android APK (TWA)` workflow completes successfully after merge
- [ ] Signed APK artifact is uploaded to the run
- [ ] GitHub Release `android-v<N>` is created with the APK attached

---
_Generated by [Claude Code](https://claude.ai/code/session_01U6pWmFjXZ8z3GhH4Awn1Ph)_