### PR TITLE
fix(ci): use bubblewrap update to scaffold Android project from local manifest

### DIFF
--- a/.github/workflows/build-android-apk.yml
+++ b/.github/workflows/build-android-apk.yml
@@ -73,7 +73,7 @@ jobs:
             fs.writeFileSync('android/twa-manifest.json', JSON.stringify(m, null, 2));
           "
 
-      - name: Initialise Bubblewrap project
+      - name: Scaffold Android project from TWA manifest
         working-directory: android
         env:
           KEYSTORE_STORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_STORE_PASSWORD }}
@@ -87,8 +87,9 @@ jobs:
             m.signingKey.keyPassword   = process.env.KEYSTORE_KEY_PASSWORD   || m.signingKey.keyPassword;
             fs.writeFileSync('twa-manifest.json', JSON.stringify(m, null, 2));
           "
-          # bubblewrap init reads twa-manifest.json and scaffolds the Android project
-          bubblewrap init --manifest twa-manifest.json --skipPwaValidation
+          # bubblewrap init --manifest only accepts a web manifest URL, not a local path.
+          # bubblewrap update reads the existing twa-manifest.json and scaffolds the project.
+          bubblewrap update --skipPwaValidation
 
       - name: Build APK
         working-directory: android


### PR DESCRIPTION
## Summary

- `bubblewrap init --manifest <path>` in newer bubblewrap versions only accepts a **web manifest URL**, not a local file path — passing `twa-manifest.json` caused `cli ERROR Invalid URL` (exit code 1)
- Replaced with `bubblewrap update --skipPwaValidation`, which reads the existing local `twa-manifest.json` and scaffolds the Android Gradle project without any network fetch
- Updated the step name to "Scaffold Android project from TWA manifest" to reflect what it actually does

## Root cause

Build run #2 failed at step "Initialise Bubblewrap project":
```
Initializing application from Web Manifest:
    -  twa-manifest.json

cli ERROR Invalid URL
```
Bubblewrap treated `twa-manifest.json` (a local filename) as a URL to fetch from the network. The `init --manifest` flag is documented as taking a web manifest URL only.

## Fix

`bubblewrap update` regenerates the Android project from the local `twa-manifest.json` — this is the correct command when the TWA config file already exists in the repo.


---
_Generated by [Claude Code](https://claude.ai/code/session_01U6pWmFjXZ8z3GhH4Awn1Ph)_