### PR TITLE
fix(android): serve icons locally during bubblewrap project generation

### DIFF
--- a/.github/workflows/build-android-apk.yml
+++ b/.github/workflows/build-android-apk.yml
@@ -79,17 +79,26 @@ jobs:
           KEYSTORE_STORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_STORE_PASSWORD }}
           KEYSTORE_KEY_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_KEY_PASSWORD }}
         run: |
-          # Patch passwords from secrets (don't store plaintext creds in the manifest)
+          # Patch passwords from secrets and redirect icon URLs to a local HTTP server.
+          # bubblewrap downloads icons during project generation; the prod URL may not be
+          # live yet, so we serve the committed icons from frontend/public locally instead.
           node -e "
             const fs = require('fs');
             const m = JSON.parse(fs.readFileSync('twa-manifest.json','utf8'));
             m.signingKey.storePassword = process.env.KEYSTORE_STORE_PASSWORD || m.signingKey.storePassword;
             m.signingKey.keyPassword   = process.env.KEYSTORE_KEY_PASSWORD   || m.signingKey.keyPassword;
+            m.iconUrl          = 'http://localhost:8080/icons/pwa-512x512.png';
+            m.maskableIconUrl  = 'http://localhost:8080/icons/pwa-maskable-512x512.png';
+            m.monochromeIconUrl = 'http://localhost:8080/icons/pwa-512x512.png';
             fs.writeFileSync('twa-manifest.json', JSON.stringify(m, null, 2));
           "
-          # bubblewrap init --manifest only accepts a web manifest URL, not a local path.
-          # bubblewrap update reads the existing twa-manifest.json and scaffolds the project.
+          # Serve frontend/public so bubblewrap can fetch the icon files
+          python3 -m http.server 8080 --directory ../frontend/public &
+          HTTP_PID=$!
+          sleep 1
+          # bubblewrap update reads twa-manifest.json and scaffolds the Android Gradle project
           bubblewrap update --skipPwaValidation
+          kill $HTTP_PID || true
 
       - name: Build APK
         working-directory: android


### PR DESCRIPTION
## Summary

- `bubblewrap update` downloads icon URLs when scaffolding the Android Gradle project
- `https://app.fuzefront.com/icons/pwa-512x512.png` returns 404 (production PWA not yet deployed), causing build run #3 to fail with `cli ERROR Failed to download icon ... Responded with status 404`
- Fix: patch the icon URLs in `twa-manifest.json` to `http://localhost:8080/icons/...` and start a Python HTTP server serving `frontend/public` (which contains the committed PNG files) for the duration of the `bubblewrap update` call

## What changed

`.github/workflows/build-android-apk.yml` — "Scaffold Android project from TWA manifest" step:
- Before calling `bubblewrap update`, patch `iconUrl`, `maskableIconUrl`, and `monochromeIconUrl` in `twa-manifest.json` to `localhost:8080`
- Start `python3 -m http.server 8080 --directory ../frontend/public` in the background
- Sleep 1 s for the server to be ready
- Run `bubblewrap update --skipPwaValidation` (which now downloads icons from localhost)
- Kill the HTTP server

The committed icons in `frontend/public/icons/` (`pwa-512x512.png`, `pwa-maskable-512x512.png`) are the same files that will eventually be served at the production URL, so the APK icons are correct.

## Test plan

- [ ] Merge to master triggers `build-android-apk.yml` run #4
- [ ] "Scaffold Android project from TWA manifest" step completes without icon 404 error
- [ ] "Build APK" step produces a signed APK
- [ ] APK artifact `fuzefront-android-vN` is uploaded (90-day retention)
- [ ] GitHub Release `android-vN` is created with the APK attached

---
_Generated by [Claude Code](https://claude.ai/code/session_01U6pWmFjXZ8z3GhH4Awn1Ph)_