### PR TITLE
feat(auth): Sign in with Google via Authentik

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,14 @@ AUTHENTIK_BOOTSTRAP_PASSWORD=
 AUTHENTIK_BOOTSTRAP_TOKEN=
 AUTHENTIK_BOOTSTRAP_EMAIL=
 
+# Google OAuth2 — Sign in with Google via Authentik
+# Create credentials at https://console.cloud.google.com/apis/credentials
+# App type: Web application
+# Authorized redirect URI: https://auth.fuzefront.dev.local/source/oauth/callback/google/
+# Leave empty to disable Google sign-in (the Authentik source is inert when these are unset)
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+
 # Permit.io Configuration
 PERMIT_API_KEY=
 PERMIT_PDP_URL=

--- a/.github/workflows/helm-validate.yml
+++ b/.github/workflows/helm-validate.yml
@@ -64,6 +64,7 @@ jobs:
 
           # Strict: reject unknown fields. Skip CRDs cert-manager/sealed-secrets
           # owns (not in upstream k8s schemas). Helm hooks render as plain Jobs.
+          # Middleware is a Traefik CRD instance — no upstream k8s schema exists.
           #
           # Exclude authentik-blueprints.yaml: that ConfigMap's `data` keys embed
           # multi-document Authentik blueprint YAML with custom tags (!Env/!Find)
@@ -74,6 +75,7 @@ jobs:
             -kubernetes-version 1.29.0 \
             -schema-location default \
             -skip CustomResourceDefinition \
+            -skip Middleware \
             -ignore-filename-pattern 'authentik-blueprints' \
             -summary \
             rendered/fuzefront/templates/

--- a/deploy/helm/fuzefront/authentik/blueprints/source-google.yaml
+++ b/deploy/helm/fuzefront/authentik/blueprints/source-google.yaml
@@ -4,14 +4,19 @@
 # strategy, so a user who signs up with password and then signs in with Google
 # (same email) is merged into one account rather than creating a duplicate.
 #
-# Prerequisites: create a Google OAuth2 app at console.cloud.google.com,
-# add Authorized redirect URI:
-#   https://auth.fuzefront.dev.local/source/oauth/callback/google/
+# Prerequisites: create a Google OAuth2 app at console.cloud.google.com
+# (APIs & Services → Credentials → OAuth 2.0 Client ID, type: Web application)
+# and add ALL of the following Authorized redirect URIs:
+#   Local dev:  https://auth.fuzefront.dev.local/source/oauth/callback/google/
+#   Production: https://auth.fuzefront.com/source/oauth/callback/google/
 #
-# Set real consumer_key/secret via Helm values:
-#   authentik.blueprints.googleClientId / authentik.blueprints.googleClientSecret
-# (backed by SealedSecret in prod). The placeholders below disable the source
-# in dev until real creds are provided — Authentik skips sources with empty keys.
+# Supply credentials via:
+#   Helm (k8s):        secret.googleClientId / secret.googleClientSecret in values
+#                      (use SealedSecret for prod — see deploy/contabo/sealed-secrets/)
+#   Docker Compose:    GOOGLE_CLIENT_ID / GOOGLE_CLIENT_SECRET in .env
+#
+# Leave credentials empty to disable Google sign-in — the source is inert when
+# consumer_key is an empty string, so no button appears on the login page.
 version: 1
 metadata:
   name: FuzeFront Google OAuth Source

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -190,9 +190,14 @@ services:
       AUTHENTIK_BOOTSTRAP_PASSWORD: ${AUTHENTIK_BOOTSTRAP_PASSWORD:-admin123}
       AUTHENTIK_BOOTSTRAP_TOKEN: ${AUTHENTIK_BOOTSTRAP_TOKEN:-bootstrap-token-change-me}
       AUTHENTIK_BOOTSTRAP_EMAIL: ${AUTHENTIK_BOOTSTRAP_EMAIL:-admin@fuzefront.local}
+      # Google OAuth2 source — leave empty to disable (source blueprint is inert when empty)
+      GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID:-}
+      GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET:-}
     volumes:
       - authentik_media:/media
       - authentik_custom_templates:/templates
+      # Mount blueprints so Authentik auto-discovers and applies them on startup
+      - ./deploy/helm/fuzefront/authentik/blueprints:/blueprints/fuzefront:ro
     ports:
       - '${AUTHENTIK_PORT:-9000}:9000'
       - '${AUTHENTIK_SSL_PORT:-9443}:9443'
@@ -231,10 +236,15 @@ services:
       AUTHENTIK_SECRET_KEY: ${AUTHENTIK_SECRET_KEY:-authentik-fuzefront-dev-secret-key-change-in-production}
       AUTHENTIK_LOG_LEVEL: info
       AUTHENTIK_ERROR_REPORTING__ENABLED: false
+      # Google OAuth2 source — leave empty to disable (source blueprint is inert when empty)
+      GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID:-}
+      GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET:-}
     volumes:
       - authentik_media:/media
       - authentik_custom_templates:/templates
       - authentik_certs:/certs
+      # Mount blueprints so Authentik auto-discovers and applies them on startup
+      - ./deploy/helm/fuzefront/authentik/blueprints:/blueprints/fuzefront:ro
     networks:
       - FuzeInfra # Connect to shared infrastructure
       - fuzefront


### PR DESCRIPTION
## Summary

- **Wire Google env vars into Docker Compose** — `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` are now passed into both `authentik-server` and `authentik-worker` containers (optional, default empty). Previously these were never injected, so the blueprint's `!Env` resolver silently returned `""` and the Google source was permanently disabled even when creds were set.
- **Mount blueprints directory in Docker Compose** — both Authentik containers now mount `./deploy/helm/fuzefront/authentik/blueprints` at `/blueprints/fuzefront` so the worker auto-discovers and applies `source-google.yaml` on startup (mirrors how the Helm chart ConfigMap works in k8s).
- **Document credentials in `.env.example`** — added `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` with Google Cloud Console setup steps and the correct local redirect URI.
- **Fix blueprint comment** — corrected the Helm values path (`secret.googleClientId`, not `authentik.blueprints.*`), added the production callback URI alongside the local one.

## How Google Sign-In works end-to-end

1. User clicks **Sign in with Google** on the Authentik-hosted login page (button appears automatically once `consumer_key` is non-empty).
2. Authentik redirects to Google OAuth consent screen.
3. Google redirects back to `https://auth.<domain>/source/oauth/callback/google/`.
4. Authentik matches or creates the user (`link_by_email` — merges if the same email already exists with a password account).
5. Authentik issues the OIDC session and redirects the user through the normal FuzeFront OIDC callback flow.

No frontend changes needed — the button lives on Authentik's hosted login page.

## Setup required before enabling

**Google Cloud Console** (`console.cloud.google.com` → APIs & Services → Credentials → OAuth 2.0 Client ID):
- Application type: **Web application**
- Authorized redirect URIs:
  - `https://auth.fuzefront.dev.local/source/oauth/callback/google/` (local)
  - `https://auth.fuzefront.com/source/oauth/callback/google/` (prod)

**Local Docker Compose:** set `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` in `.env`.

**Kubernetes (local kind):** pass via `--set secret.googleClientId=... --set secret.googleClientSecret=...` or a gitignored values override file.

**Production:** add `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` to the `fuzefront-secrets` SealedSecret (see `deploy/contabo/sealed-secrets/`).

## Test plan

- [ ] Set real Google OAuth creds in `.env`, restart `docker-compose up authentik-server authentik-worker`
- [ ] Verify Authentik login page shows "Sign in with Google" button
- [ ] Complete a Google sign-in — confirm redirect back to FuzeFront and user appears in Authentik admin
- [ ] Sign in with the same email via password first, then via Google — confirm accounts are merged (not duplicated)
- [ ] Leave creds empty, restart — confirm no Google button appears and no errors in worker logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R4AUD2d6aFpPT67pnLhQGk

---
_Generated by [Claude Code](https://claude.ai/code/session_01R4AUD2d6aFpPT67pnLhQGk)_