### PR TITLE
fix(android): re-patch signing passwords before bubblewrap build

### DIFF
--- a/.github/workflows/build-android-apk.yml
+++ b/.github/workflows/build-android-apk.yml
@@ -104,7 +104,20 @@ jobs:
 
       - name: Build APK
         working-directory: android
-        run: bubblewrap build --skipPwaValidation
+        env:
+          KEYSTORE_STORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_STORE_PASSWORD }}
+          KEYSTORE_KEY_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_KEY_PASSWORD }}
+        run: |
+          # bubblewrap update clears signingKey passwords from twa-manifest.json; re-patch
+          # them here so bubblewrap build can sign non-interactively (no TTY in CI).
+          node -e "
+            const fs = require('fs');
+            const m = JSON.parse(fs.readFileSync('twa-manifest.json','utf8'));
+            m.signingKey.storePassword = process.env.KEYSTORE_STORE_PASSWORD || m.signingKey.storePassword;
+            m.signingKey.keyPassword   = process.env.KEYSTORE_KEY_PASSWORD   || m.signingKey.keyPassword;
+            fs.writeFileSync('twa-manifest.json', JSON.stringify(m, null, 2));
+          "
+          bubblewrap build --skipPwaValidation
 
       - name: Locate signed APK
         id: apk


### PR DESCRIPTION
## Summary

Run #5 revealed the next layer: `bubblewrap update` **clears** `signingKey.storePassword` and `keyPassword` from `twa-manifest.json` when it regenerates the Android project. By the time `bubblewrap build` runs, the password fields are empty so it falls back to an interactive TTY prompt — which fails with exit 130 (no TTY in CI).

Fix: re-apply both passwords from the GitHub Secrets immediately before calling `bubblewrap build`, using the same node patch already used in the scaffold step.

## Progress so far

| Run | Step that failed | Fix |
|-----|-----------------|-----|
| #1 | `bubblewrap init` hung on JDK prompt | Pre-configure `~/.bubblewrap/config.json` + Android SDK action |
| #2 | `Invalid URL` from local path passed as manifest URL | Switch to `bubblewrap update` |
| #3 | Icon 404 from `app.fuzefront.com` | Serve icons from local HTTP server |
| #4 | Web manifest 404 / JSON parse error | Add `frontend/public/manifest.webmanifest`, patch `webManifestUrl` |
| #5 | `bubblewrap build` prompts for keystore password (exit 130) | **This PR** — re-patch passwords before build |

## Test plan

- [ ] Merge triggers APK build run #6
- [ ] Step 10 (Scaffold) passes — all icon + manifest GETs return 200
- [ ] Step 11 (Build APK) completes without password prompt
- [ ] Signed APK artifact `fuzefront-android-v6` uploaded
- [ ] GitHub Release `android-v6` created

---
_Generated by [Claude Code](https://claude.ai/code/session_01U6pWmFjXZ8z3GhH4Awn1Ph)_