### PR TITLE
fix(android): bypass bubblewrap build prompt — use Gradle directly

### DIFF
--- a/.github/workflows/build-android-apk.yml
+++ b/.github/workflows/build-android-apk.yml
@@ -108,16 +108,13 @@ jobs:
           KEYSTORE_STORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_STORE_PASSWORD }}
           KEYSTORE_KEY_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_KEY_PASSWORD }}
         run: |
-          # bubblewrap update clears signingKey passwords from twa-manifest.json; re-patch
-          # them here so bubblewrap build can sign non-interactively (no TTY in CI).
-          node -e "
-            const fs = require('fs');
-            const m = JSON.parse(fs.readFileSync('twa-manifest.json','utf8'));
-            m.signingKey.storePassword = process.env.KEYSTORE_STORE_PASSWORD || m.signingKey.storePassword;
-            m.signingKey.keyPassword   = process.env.KEYSTORE_KEY_PASSWORD   || m.signingKey.keyPassword;
-            fs.writeFileSync('twa-manifest.json', JSON.stringify(m, null, 2));
-          "
-          bubblewrap build --skipPwaValidation
+          # bubblewrap build always prompts interactively for keystore passwords (exit 130,
+          # no TTY in CI). Write key.properties directly and invoke Gradle instead.
+          printf 'storePassword=%s\nkeyPassword=%s\nkeyAlias=fuzefront\nstoreFile=./keystore/fuzefront-release.keystore\n' \
+            "${KEYSTORE_STORE_PASSWORD:-fuzefront2024}" \
+            "${KEYSTORE_KEY_PASSWORD:-fuzefront2024}" \
+            > key.properties
+          ./gradlew assembleRelease
 
       - name: Locate signed APK
         id: apk


### PR DESCRIPTION
## Summary

- `bubblewrap build` unconditionally calls `inquirer.prompt()` for keystore passwords, exiting 130 (no TTY) in every CI run regardless of what signing credentials are set in `twa-manifest.json`
- Replace the broken `bubblewrap build --skipPwaValidation` call with a direct Gradle invocation: write `key.properties` from the `ANDROID_KEYSTORE_STORE_PASSWORD` / `ANDROID_KEYSTORE_KEY_PASSWORD` secrets, then run `./gradlew assembleRelease`
- The `bubblewrap update` step (unchanged, already working) scaffolds the full Gradle project including the wrapper script before this step runs

## What changed

`.github/workflows/build-android-apk.yml` — **Build APK** step only:

**Before (broken):**
```yaml
run: |
  node -e "... re-patch twa-manifest.json signingKey passwords ..."
  bubblewrap build --skipPwaValidation   # always prompts → exit 130
```

**After:**
```yaml
run: |
  printf 'storePassword=%s\nkeyPassword=%s\nkeyAlias=fuzefront\nstoreFile=./keystore/fuzefront-release.keystore\n' \
    "${KEYSTORE_STORE_PASSWORD:-fuzefront2024}" \
    "${KEYSTORE_KEY_PASSWORD:-fuzefront2024}" \
    > key.properties
  ./gradlew assembleRelease
```

## Test plan

- [ ] Merge to master triggers `build-android-apk.yml`
- [ ] **Scaffold Android project** step completes (bubblewrap update — already passing)
- [ ] **Build APK** step completes without password prompt
- [ ] `fuzefront-android-vN` artifact uploaded (signed APK)
- [ ] GitHub Release `android-vN` created with APK attached

---
_Generated by [Claude Code](https://claude.ai/code/session_01U6pWmFjXZ8z3GhH4Awn1Ph)_