### PR TITLE
fix(android): absolute keystore path in key.properties; strip ./ from APK path

### DIFF
--- a/.github/workflows/build-android-apk.yml
+++ b/.github/workflows/build-android-apk.yml
@@ -110,9 +110,12 @@ jobs:
         run: |
           # bubblewrap build always prompts interactively for keystore passwords (exit 130,
           # no TTY in CI). Write key.properties directly and invoke Gradle instead.
-          printf 'storePassword=%s\nkeyPassword=%s\nkeyAlias=fuzefront\nstoreFile=./keystore/fuzefront-release.keystore\n' \
+          # Use an absolute storeFile path — Gradle resolves relative paths from android/app/,
+          # not android/, so a relative path would miss the keystore.
+          printf 'storePassword=%s\nkeyPassword=%s\nkeyAlias=fuzefront\nstoreFile=%s/keystore/fuzefront-release.keystore\n' \
             "${KEYSTORE_STORE_PASSWORD:-fuzefront2024}" \
             "${KEYSTORE_KEY_PASSWORD:-fuzefront2024}" \
+            "$(pwd)" \
             > key.properties
           ./gradlew assembleRelease
 
@@ -120,7 +123,12 @@ jobs:
         id: apk
         working-directory: android
         run: |
-          APK=$(find . -name "*.apk" | head -1)
+          # Prefer the signed APK; fall back to any APK. Strip leading "./" so
+          # upload-artifact doesn't reject the path as a relative "." component.
+          APK=$(find . -path "*/release/app-release.apk" | head -1)
+          [ -z "$APK" ] && APK=$(find . -name "*.apk" | grep -v unsigned | head -1)
+          [ -z "$APK" ] && APK=$(find . -name "*.apk" | head -1)
+          APK="${APK#./}"
           echo "path=android/$APK" >> "$GITHUB_OUTPUT"
           echo "Found: $APK"
 


### PR DESCRIPTION
## Summary

Run #7 confirmed that `./gradlew assembleRelease` builds successfully (no more interactive password prompt). Two remaining bugs surfaced:

**Bug 1 — unsigned APK (signing not applied)**
`key.properties` contained `storeFile=./keystore/fuzefront-release.keystore`. Gradle resolves `storeFile` relative to the **module directory** (`android/app/`), not the project root (`android/`), so the keystore was never found and the build silently produced `app-release-unsigned.apk` instead of a signed `app-release.apk`.

Fix: use `$(pwd)/keystore/fuzefront-release.keystore` (absolute path, evaluated while `working-directory: android`).

**Bug 2 — upload-artifact path rejection**
`find .` returns paths like `./app/build/.../app-release-unsigned.apk`. The "Locate signed APK" step prepended `android/`, giving `android/./app/...`. `actions/upload-artifact@v4` rejects patterns with `.` components: `Invalid pattern — relative pathing '.' and '..' is not allowed`.

Fix: prefer `app-release.apk` explicitly, fall back to any non-unsigned APK, strip the leading `./` with `${APK#./}`.

## Test plan

- [ ] Merge triggers `build-android-apk.yml` on master
- [ ] **Build APK** step: `./gradlew assembleRelease` produces `app-release.apk` (signed)
- [ ] **Locate signed APK** step: finds `app/build/outputs/apk/release/app-release.apk`, path output is `android/app/build/...` (no `.` component)
- [ ] **Upload APK artifact** step: `fuzefront-android-vN` artifact uploaded successfully
- [ ] **Create GitHub Release**: `android-vN` release created with signed APK attached

---
_Generated by [Claude Code](https://claude.ai/code/session_01U6pWmFjXZ8z3GhH4Awn1Ph)_