### PR TITLE
fix(android): sign APK explicitly with apksigner after Gradle build

### DIFF
--- a/.github/workflows/build-android-apk.yml
+++ b/.github/workflows/build-android-apk.yml
@@ -108,26 +108,31 @@ jobs:
           KEYSTORE_STORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_STORE_PASSWORD }}
           KEYSTORE_KEY_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_KEY_PASSWORD }}
         run: |
-          # bubblewrap build always prompts interactively for keystore passwords (exit 130,
-          # no TTY in CI). Write key.properties directly and invoke Gradle instead.
-          # Use an absolute storeFile path — Gradle resolves relative paths from android/app/,
-          # not android/, so a relative path would miss the keystore.
-          printf 'storePassword=%s\nkeyPassword=%s\nkeyAlias=fuzefront\nstoreFile=%s/keystore/fuzefront-release.keystore\n' \
-            "${KEYSTORE_STORE_PASSWORD:-fuzefront2024}" \
-            "${KEYSTORE_KEY_PASSWORD:-fuzefront2024}" \
-            "$(pwd)" \
-            > key.properties
+          # Gradle signing via key.properties doesn't apply (bubblewrap template quirk).
+          # Build the unsigned APK then sign it explicitly with apksigner.
           ./gradlew assembleRelease
+
+          UNSIGNED="app/build/outputs/apk/release/app-release-unsigned.apk"
+          SIGNED="app/build/outputs/apk/release/app-release.apk"
+          BUILD_TOOLS=$(ls "$ANDROID_HOME/build-tools/" | sort -V | tail -1)
+          APKSIGNER="$ANDROID_HOME/build-tools/$BUILD_TOOLS/apksigner"
+
+          "$APKSIGNER" sign \
+            --ks ./keystore/fuzefront-release.keystore \
+            --ks-pass "pass:${KEYSTORE_STORE_PASSWORD:-fuzefront2024}" \
+            --key-pass "pass:${KEYSTORE_KEY_PASSWORD:-fuzefront2024}" \
+            --ks-key-alias fuzefront \
+            --out "$SIGNED" \
+            "$UNSIGNED"
+
+          "$APKSIGNER" verify --verbose "$SIGNED"
 
       - name: Locate signed APK
         id: apk
         working-directory: android
         run: |
-          # Prefer the signed APK; fall back to any APK. Strip leading "./" so
-          # upload-artifact doesn't reject the path as a relative "." component.
           APK=$(find . -path "*/release/app-release.apk" | head -1)
           [ -z "$APK" ] && APK=$(find . -name "*.apk" | grep -v unsigned | head -1)
-          [ -z "$APK" ] && APK=$(find . -name "*.apk" | head -1)
           APK="${APK#./}"
           echo "path=android/$APK" >> "$GITHUB_OUTPUT"
           echo "Found: $APK"


### PR DESCRIPTION
## Summary

Run #8 confirmed the Gradle build succeeds but signing is silently skipped by the bubblewrap-generated `app/build.gradle` — it always produces `app-release-unsigned.apk`, which Android rejects with "package appears to be invalid".

Rather than debugging the Gradle signing template, this PR takes the reliable path: build the unsigned APK with `./gradlew assembleRelease` then sign it explicitly with `apksigner` (ships with Android build-tools, already installed by `android-actions/setup-android`).

```bash
APKSIGNER="$ANDROID_HOME/build-tools/$BUILD_TOOLS/apksigner"
"$APKSIGNER" sign \
  --ks ./keystore/fuzefront-release.keystore \
  --ks-pass "pass:${KEYSTORE_STORE_PASSWORD}" \
  --key-pass "pass:${KEYSTORE_KEY_PASSWORD}" \
  --ks-key-alias fuzefront \
  --out app-release.apk \
  app-release-unsigned.apk
"$APKSIGNER" verify --verbose app-release.apk
```

The verify step will fail the CI job if the signature is invalid, giving early feedback.

## Test plan

- [ ] Merge triggers `build-android-apk.yml` on master
- [ ] **Build APK** step: `assembleRelease` + `apksigner sign` + `apksigner verify` all pass
- [ ] **Locate signed APK** finds `app-release.apk` (not unsigned)
- [ ] **Upload APK artifact**: `fuzefront-android-vN` uploaded
- [ ] **GitHub Release** `android-vN` created with signed APK
- [ ] APK installs successfully on Android device

---
_Generated by [Claude Code](https://claude.ai/code/session_01U6pWmFjXZ8z3GhH4Awn1Ph)_