### PR TITLE
feat(android): expand APK build triggers + document mobile SDLC policy

### DIFF
--- a/.github/workflows/build-android-apk.yml
+++ b/.github/workflows/build-android-apk.yml
@@ -5,9 +5,14 @@ on:
     branches: [master, main]
     paths:
       - 'android/**'
-      - 'frontend/public/.well-known/assetlinks.json'
-      - 'frontend/public/manifest.webmanifest'
-      - 'frontend/public/icons/**'
+      - 'frontend/**'
+      - '.github/workflows/build-android-apk.yml'
+  pull_request:
+    branches: [master, main]
+    paths:
+      - 'android/**'
+      - 'frontend/public/**'
+      - 'frontend/src/**'
       - '.github/workflows/build-android-apk.yml'
   workflow_dispatch:
     inputs:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,30 @@ The family flag standard is **Unleash** (self-hosted OSS) consumed via **OpenFea
 - `backend-engineer` + `frontend-engineer` plan with flags: wrap new/risky work in a flag **default OFF**, gate **both** server logic and UI, **test both states**, retire stale flags (owner + removal criterion each). A **permission** flag is rollout convenience — real authz stays in **Permit**, never the flag.
 - See the `feature-flags` skill (`.claude/skills/feature-flags/`).
 
+## Android / TWA mobile package
+
+FuzeFront ships a signed Android APK (Trusted Web Activity) that wraps `https://app.fuzefront.com`. CI handles all building and signing — no manual steps.
+
+### CI behaviour
+- **Any `frontend/**` push to `master`** triggers `build-android-apk.yml`: builds a signed APK and creates a GitHub Release (`android-vN`).
+- **Any PR** touching `android/**`, `frontend/public/**`, or `frontend/src/**` also runs the build and uploads a `fuzefront-android-vN` artifact for pre-merge testing — but does **not** publish a Release.
+- `workflow_dispatch` is available on the workflow for manual builds with a custom version code.
+
+### Key identity files — keep in sync
+| File | Purpose |
+|------|---------|
+| `android/twa-manifest.json` | Bubblewrap TWA config (host, colors, SHA-256 fingerprint) |
+| `frontend/public/.well-known/assetlinks.json` | Digital Asset Links (same fingerprint as above) |
+| `frontend/public/manifest.webmanifest` | Static PWA manifest served during scaffold |
+| `frontend/public/icons/pwa-{192,512,maskable-*}.png` | App icons |
+
+If you rotate the signing keystore or change the key alias, all four files must be updated and `ANDROID_KEYSTORE_B64` / `ANDROID_KEYSTORE_STORE_PASSWORD` / `ANDROID_KEYSTORE_KEY_PASSWORD` GitHub Secrets must be rotated.
+
+### Agent ownership
+- `devops-engineer` — CI/signing pipeline (`android/**`, `build-android-apk.yml`)
+- `frontend-engineer` — PWA manifest and icons (`frontend/public/`)
+- **Never commit `android/keystore/*.keystore`** — gitignored; stored only in `ANDROID_KEYSTORE_B64`.
+
 ## Done
 
 Finish work as a **merged PR**, not local commits — but respect the deploy window above. Every domain agent reports `SCOPE DONE (verified)` + `OUT OF SCOPE — NOT DONE`; only the orchestrator calls a feature complete.


### PR DESCRIPTION
## Summary

- **Expand APK build coverage**: `frontend/**` push to master now triggers a new signed APK + GitHub Release, not just icon/manifest/assetlinks changes
- **PR-time APK artifacts**: any PR touching `android/**`, `frontend/public/**`, or `frontend/src/**` builds and uploads a signed APK for pre-merge testing (no public Release — the existing `if: github.ref == 'refs/heads/master'` condition already gates that)
- **SDLC documentation**: `CLAUDE.md` now has an "Android / TWA mobile package" section covering CI behaviour, the four identity files to keep in sync, and agent ownership

## Changes

### `.github/workflows/build-android-apk.yml` — triggers only, no job changes

```yaml
# Before
on:
  push:
    branches: [master, main]
    paths:
      - 'android/**'
      - 'frontend/public/.well-known/assetlinks.json'
      - 'frontend/public/manifest.webmanifest'
      - 'frontend/public/icons/**'
      - '.github/workflows/build-android-apk.yml'

# After
on:
  push:
    branches: [master, main]
    paths:
      - 'android/**'
      - 'frontend/**'           # ← all frontend changes now rebuild the APK
      - '.github/workflows/build-android-apk.yml'
  pull_request:                 # ← new: artifact on PRs, no Release
    branches: [master, main]
    paths:
      - 'android/**'
      - 'frontend/public/**'
      - 'frontend/src/**'
      - '.github/workflows/build-android-apk.yml'
```

### `CLAUDE.md`

New section documenting the mobile packaging policy, CI behaviour, identity files, and agent ownership.

## Test plan

- [ ] This PR itself (touches the workflow file) triggers `Build Android APK (TWA)` as a PR check — artifact uploaded, no Release created
- [ ] Merge to master → new GitHub Release `android-vN` appears
- [ ] Future frontend PRs that touch `frontend/src/**` or `frontend/public/**` will also show APK build in their checks

---
_Generated by [Claude Code](https://claude.ai/code/session_01U6pWmFjXZ8z3GhH4Awn1Ph)_