### PR TITLE
ci(ds): enforcing gate-ds-conformance (changed-lines ratchet) + pagination + frontend-build gates

### DIFF
--- a/.claude/skills/design-system-conformance/SKILL.md
+++ b/.claude/skills/design-system-conformance/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: design-system-conformance
+description: Use when creating or reviewing UI / a design system. Enforces tokens-only (no raw hex/px/font), reuse-over-reinvent, and detecting code that should be EXTRACTED into a new DS primitive. The procedure behind gate-ds-conformance.
+---
+
+# design-system-conformance
+
+Use when building or reviewing **any** UI. Pairs with `design-system-inheritance`: inheritance says *extend the base, don't fork*; conformance says *use the tokens, don't reinvent, extract the duplicates*. This is the procedure behind the CI gate `gate-ds-conformance` (CLAUDE.baseline.md §6).
+
+## Tokens-only rule
+Feature code carries **no raw design values**. The gate hard-fails, in any UI file outside the DS package:
+- raw color literals: `#hex`, `rgb()/rgba()`, `hsl()/hsla()`
+- hard-coded spacing/sizing/type in `px` outside the token scale (`padding/margin/gap/width/height/font-size/line-height/border-radius: 12px`)
+- raw `font-family` strings
+
+Every color/spacing/type/radius comes from a **DS token** (`var(--ds-*)`, `tokens.*`, `theme.*`, `$token`, `@apply`). Two carve-outs the gate honors:
+- The **DS package itself is excluded** (`design-system/`, `packages/design-system/`, `tokens/`) — that is where token *definitions* legitimately live.
+- A rare, justified literal can be exempted with an inline escape comment containing `ds-conformance-disable` (also `-ignore`/`-allow`). Use sparingly; it is a documented exception, not an off-switch.
+
+## Reuse over reinvent
+Before writing a styled block, **search the DS for an existing primitive** and compose/extend it. Do not hand-roll a parallel button/card/field next to one the DS already ships. If what you need is missing, it belongs *in the DS* — see extraction below, not a one-off in feature code.
+
+## Detecting EXTRACTION candidates
+When the same ad-hoc styled block recurs across **>1 feature file** (≥ threshold, default 3), it should become a DS primitive. The gate fingerprints normalized styled blocks (whitespace/numbers stripped, so `p-4` and `p-6` collapse) and, on push to the default branch with `--emit-issues`, opens **one idempotent GitHub issue per candidate**:
+- label `ds-extraction`, stable marker `ds-fp:<hash>` (de-dupes across open+closed issues), mentions `@claude`
+- includes the recurring locations and a **proposed component spec**: props/variants/states/tokens + acceptance criteria.
+
+**Responding to such an issue:** `frontend-engineer` (the **sole** editor of `design-system/`) adds the primitive to the DS package, **tokens-only**, with a11y + RTL + a unit test, then refactors every listed call site to consume it. Extraction is design work — the gate only signals it.
+
+## CI gate
+`gate-ds-conformance` **hard-fails** raw values (exit 1); extraction issues are **advisory** (non-fatal — exit 0). First pass per repo is report-only (`|| true`); ratchet to enforcing once feature code is clean. See `verification-protocol` for proving the gate actually ran green.
+
+## Onboarding an existing repo into the Fuse design system (bidirectional)
+When bringing an **already-built** repo onto the family DS, the model is **bidirectional** — the repo-local DS *extends* the base (down) **and** worthy local primitives *graduate* to the base (up). Owned by the repo's `frontend-engineer` (sole DS owner). Baseline §6.2.
+
+1. **Build a repo-local DS if none exists.** Derive it from the repo's existing UI: harvest recurring colors/spacing/type into tokens and repeated blocks into components — run `gate_ds_conformance.py` (it surfaces both raw-value hotspots and the duplicated-block extraction candidates) to seed the inventory. This package becomes the repo's single styling source of truth.
+2. **Up-propagate (graduate to the base).** For each local primitive that should be a **global Fuze-family primitive**, open a promotion candidate using the **same `@claude` extraction-issue mechanism** (`ds-extraction` label + `ds-fp` fingerprint, idempotent) — one issue per candidate — routed to **FuzeFront's** frontend-engineer to land it in the base `@fuzefront/design-system` via PR. (Drive this manually or by pointing the gate's detector at the repo; the issue body's proposed-spec format is identical.)
+3. **Down-project (the base into the repo).** Make the repo-local DS **import and re-export / compose** the base tokens+primitives so the repo inherits the canonical look (unified Fuse experience) and keeps only its product-specific layer on top. Never copy or redefine a base primitive locally.
+4. **Graduation contract — what graduates vs stays local:**
+   - **Graduates** when generic/cross-product, free of product-specific business logic, and plausibly reused by ≥2 family repos (Button, Field, Modal, color/spacing/type tokens).
+   - **Stays local** when product-specific (domain widget, one-app layout, app-branded composition). When in doubt, keep it local until a second consumer appears, then graduate.
+   - `gate-ds-conformance` enforces **extends-not-forks**: shadowing/redefining a base primitive locally is a violation, not an extension — fix it upstream in the base or compose it, don't fork.
+
+Net steady state: **repo-local = base (inherited, down-projected) + thin product layer; worthy product primitives graduate up to the base.** Keep the inheritance layering explicit so a base upgrade flows through without a fork to reconcile.
+
+## Done checklist
+- [ ] No raw `#hex` / `rgb()` / `hsl()` / `px` spacing-size-type / `font-family` in feature code — all values are DS tokens.
+- [ ] Each escape (`ds-conformance-disable`) is a justified, documented exception — not a blanket bypass.
+- [ ] Reused existing DS primitives; no parallel hand-rolled component beside one the DS already has.
+- [ ] Any open `ds-extraction` issue triggered by this code is addressed (primitive added to DS + call sites refactored) or explicitly deferred.
+- [ ] `gate-ds-conformance` is green (no hard violations); confirmed via the actual run, not assumed.

--- a/.claude/skills/ui-frame-contract/SKILL.md
+++ b/.claude/skills/ui-frame-contract/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: ui-frame-contract
+description: Use in the frontend-design phase, before feature-UI implementation. Produce static HTML frame(s) — a single page or a SEQUENCE demonstrating the flow — as approved artifacts frozen with the API contract; Playwright later runs against them as pre-production verification.
+---
+
+# ui-frame-contract
+
+The frontend-design phase produces static **HTML frames** of the expected UI before any feature-UI is implemented. These approved frames are part of the contract freeze (alongside the OpenAPI/event contract) — the visual source of truth the implementation is checked against, so visual/structural drift is caught against a frozen artifact rather than discovered after the fact.
+
+## When
+The frontend-design phase, **before** feature-UI implementation. Authored by `frontend-engineer`; part of the contract freeze the parallel fan-out depends on (the gate). Pairs with `api-contract-first` and `frontend-design`.
+
+## What a frame is
+A static, self-contained **HTML file** rendering the expected UI of one screen, **design-system-first** — it links the design system's stylesheet and uses only DS tokens/styles, **no raw hex/rgb, raw px spacing, or one-off type** (consistent with `design-system-conformance`). A feature may be a **single page** or an **ordered SEQUENCE** of frames demonstrating the process/flow — e.g. login → create-org → billing → checkout. The sequence shows the flow, not just isolated screens.
+
+## Where they live + manifest
+Frames live at **`design/frames/<feature>/*.html`** plus **`design/frames/<feature>/manifest.json`**. The manifest holds an ordered `frames` array plus top-level approval fields:
+
+```json
+{
+  "approved": true,
+  "approvedBy": "<name>",
+  "approvedAt": "<ISO date>",
+  "frames": [
+    { "id": "login", "file": "01-login.html", "title": "Sign in", "route": "/login", "acceptanceNotes": "..." }
+  ]
+}
+```
+
+The **`approved: true`** marker (with approver + date) is what **freezes** the frames.
+
+## Procedure
+
+1. **Derive the screens/states** from the user story — the pages and the order of the flow.
+2. **Build the frame(s) design-system-first** at `design/frames/<feature>/*.html`, linking the DS stylesheet; write the ordered `manifest.json`.
+3. **Review and approve** — set the approval marker (`approved: true` + `approvedBy` + `approvedAt`).
+4. **Freeze WITH the contract PR.** `contract-designer`'s frozen contract **includes** the approved frames; the contract PR is **not a valid gate** until the frames exist and are approved.
+
+## Playwright against frames
+`frontend-test-engineer` runs **Playwright against the approved frames** for visual/structural assertions as **pre-production** verification — in **addition** to the built app and the live app. The frames are the visual source of truth the implementation is checked against, not a replacement for app/live e2e.
+
+## Done checklist
+- [ ] frame(s) at `design/frames/<feature>/*.html`, design-system-first (no raw values)
+- [ ] single page or ordered SEQUENCE covering the flow
+- [ ] `manifest.json` with ordered `frames` (id/file/title/route/acceptanceNotes)
+- [ ] approval marker set (`approved: true` + approver + date)
+- [ ] frozen WITH the contract PR (`contract-designer`'s gate includes them)
+- [ ] `frontend-test-engineer` can run Playwright against the frames pre-production

--- a/.github/workflows/harden-gate.yml
+++ b/.github/workflows/harden-gate.yml
@@ -222,3 +222,72 @@ jobs:
           done
           [ "$findings" = "0" ] && echo "gate-version: OK (no unbumped package/contract changes)" || echo "gate-version: findings above (report-only — will gate once ratcheted)"
           exit 0
+
+  gate-ds-conformance:
+    # Design-system conformance (CLAUDE.baseline.md §6). ENFORCING via a CHANGED-LINES ratchet:
+    # on a pull_request it scans ONLY the lines this PR added/modified and FAILS on any raw
+    # design value (hex/rgb/hsl/px-spacing/font-family) — blocking NEW mess without failing on
+    # the ~178 pre-existing findings and needing no baseline file. On push to the default branch
+    # it runs a full scan report-only + opens idempotent ds-extraction issues (advisory).
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_REPOSITORY: ${{ github.repository }}
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+      - uses: actions/setup-python@v5
+        with: { python-version: '3.12' }
+      - name: DS conformance (PR = changed-lines ratchet, enforcing; push = full scan, advisory)
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            git fetch origin "${{ github.base_ref }}"
+            GATE_BASE_REF="origin/${{ github.base_ref }}" python scripts/gate_ds_conformance.py . --changed-only
+          else
+            python scripts/gate_ds_conformance.py . --emit-issues || true
+          fi
+
+  gate-pagination:
+    # Pagination standard (CLAUDE.baseline.md §4.1). Report-only first pass; ratchet to enforcing
+    # per repo once the billing-service contract annotates/allowlists its collection GETs.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: '3.12' }
+      - name: Pagination gate (report-only)
+        shell: bash
+        run: |
+          pip install -q pyyaml
+          python scripts/gate_pagination.py . || true
+
+  gate-frontend-build:
+    # ENFORCING: the REAL frontend (vite/PWA) build must succeed. The root `gate-build` job is
+    # report-only and only builds the root package.json — it never fails the actual frontend build,
+    # which let an unbalanced-brace in frontend/src/index.css break the prod build for 3 releases
+    # (hotfixed in 4428db9). NO `|| true` / `exit 0` here: vite/postcss/tsc errors fail the build.
+    # Mirrors the ci.yml build job order (root npm ci -> frontend npm ci -> chat-client+chat-ui
+    # dist -> vite build). GITHUB_TOKEN satisfies frontend/.npmrc (@fuzefront/* from GH Packages).
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - name: Install root workspaces
+        run: npm ci
+      - name: Install frontend deps
+        run: cd frontend && npm ci
+      - name: Build chat-client + chat-ui (frontend bundles their dist)
+        run: |
+          npm run -w @fuzefront/chat-client build
+          npm run -w @fuzefront/chat-ui build
+      - name: Build frontend (vite build — MUST pass)
+        run: cd frontend && npm run build

--- a/docs/pagination-standard.md
+++ b/docs/pagination-standard.md
@@ -1,0 +1,44 @@
+# Pagination standard (FuzeFront)
+
+FuzeFront inherits the family-wide pagination standard from the FuzeSDLC baseline (§4.1). This page is the FuzeFront-facing summary; the full reference is `governance/pagination-standard.md` (vendored from FuzeSDLC).
+
+## The rule
+
+Every **LIST / collection GET** that can return an unbounded number of rows MUST paginate — in the OpenAPI contract and in the implementation.
+
+- **Request params:** `limit` (with a declared **default** and an enforced **max**) **and** either `cursor` (preferred — opaque, server-issued) **or** `offset` (fallback).
+- **Response envelope:**
+  ```json
+  { "items": [ ... ], "page": { "nextCursor": "<string|null>", "hasMore": true, "total": 123 } }
+  ```
+  `nextCursor: null` ⇒ last page. `total` is optional (omit when counting is expensive). Offset-style endpoints may use `{ "offset", "limit", "hasMore", "total?" }` instead.
+- **`limit` is enforced server-side** (a request over the max is clamped, never honored unbounded); the cursor walks the full set deterministically (no gaps/dupes under concurrent writes).
+
+## Exemptions
+
+An endpoint is exempt only when its result set is **inherently bounded or a singleton** (single-resource GET `/x/{id}`, a fixed small enum/lookup, an aggregate/scalar, or a hard server-capped feed). Declare it, don't silently skip it:
+
+- Annotate the OpenAPI operation with `x-pagination: exempt` (+ `x-pagination-reason: "<why>"`), **or**
+- list `GET /path` in `governance/pagination-allowlist.txt` (one per line, `#` comments allowed) — use only when you cannot edit the operation object.
+
+## CI enforcement (`gate-pagination`)
+
+The `gate-pagination` job in `.github/workflows/harden-gate.yml` runs `scripts/gate_pagination.py`, which parses the repo's OpenAPI/Swagger contracts and **fails** any unbounded collection GET lacking the params + envelope unless exempt. It is **report-only in the first pass** (`|| true`); it will be ratcheted to enforcing once the existing contracts are annotated.
+
+### Current FuzeFront findings (first-pass, advisory)
+
+As of this gate's introduction, `gate-pagination` flags these in `services/billing-service/openapi.yaml`:
+
+- `GET /plans` — likely a genuine **exemption** (a closed, small set of plan tiers that does not grow with user data) → annotate `x-pagination: exempt`.
+- `GET /subscriptions` — should **paginate** (a tenant can accrue unbounded subscription rows).
+
+These are owned by `billing-payments-engineer` / `contract-designer` to resolve in the billing-service contract — not addressed here (this change is governance/CI only and does not touch the live billing flow).
+
+## Ownership
+
+- `contract-designer` declares pagination (or the exemption) in the OpenAPI contract.
+- `backend-engineer` implements it + unit-tests the limit clamp, envelope, and cursor walk.
+- `test-engineer` independently asserts params + envelope + limit-enforcement + cursor-walk on every paginated endpoint.
+- `frontend-engineer` builds the pager / infinite-scroll UI wired to the cursor envelope.
+
+Policy owned by `platform-governance` (FuzeSDLC baseline §4.1).

--- a/governance/pagination-allowlist.txt
+++ b/governance/pagination-allowlist.txt
@@ -1,0 +1,16 @@
+# pagination-allowlist — gate-pagination exemptions (governance/pagination-standard.md §3)
+#
+# List collection GET routes that are EXEMPT from the pagination standard because their
+# result set is inherently bounded or a singleton (fixed enum/lookup, aggregate/scalar,
+# hard server-capped feed). Prefer annotating the OpenAPI operation with
+# `x-pagination: exempt` (+ `x-pagination-reason`) instead; use this file only when you
+# cannot edit the operation object (e.g. a vendored/generated spec).
+#
+# Format:
+#   - one route per line, as `GET /path` (matched case-insensitively against the spec route)
+#   - `#` begins a comment; blank lines are ignored
+#
+# Example (remove — illustrative only):
+#   GET /v1/plan-tiers      # closed enum of 7 plan tiers, never grows with user data
+#
+# (Empty by default — no exemptions.)

--- a/governance/pagination-standard.md
+++ b/governance/pagination-standard.md
@@ -1,0 +1,171 @@
+# Pagination standard (enforced)
+
+The canonical pagination standard for the Fuze family. The policy summary is `CLAUDE.baseline.md` §4.1; this is the full reference that §4.1 and the agent defs point to. Policy owned by `platform-governance`; enforced by **`gate-pagination`** (`scripts/gate_pagination.py`, run from `harden-gate.yml`). Where this doc and §4.1 ever disagree, the **wire contract in §4.1 wins** — this doc only elaborates it.
+
+## 1. Rule
+
+Every **LIST / collection GET** that can return an unbounded number of rows **MUST** paginate — in the contract **and** in the implementation. "Unbounded" means the row count grows with data the caller does not control (all orgs, all events, all messages, search hits). A collection GET that returns "all of X" with no `limit` is a defect, even if X is small *today*.
+
+### Wire contract (canonical — identical to §4.1)
+
+**Request params:**
+- `limit` — integer, with a declared **default** and an enforced **max**.
+- **and either** `cursor` — preferred; an opaque, server-issued string — **or** `offset` — integer; only where cursoring is impractical.
+
+**Response envelope:**
+```json
+{
+  "items": [ /* ... the page of rows ... */ ],
+  "page": {
+    "nextCursor": "<string|null>",
+    "hasMore": false,
+    "total": 0
+  }
+}
+```
+- `nextCursor: null` ⇒ this is the last page.
+- `hasMore` ⇒ a further page exists.
+- `total` is **optional** — omit it when counting the full set is expensive.
+- The **offset variant** carries `page: { "offset", "limit", "hasMore", "total?" }` instead of `nextCursor`.
+
+**Server-side enforcement:**
+- `limit` is enforced server-side: a request over the max is **clamped to the max** — never honored unbounded, never trusted from the client.
+- The cursor walks the **full set deterministically**, with **no gaps and no duplicates**, even under concurrent writes.
+
+### Compliant OpenAPI snippet
+
+A cursor-paginated collection GET — request params plus the shared envelope schema:
+
+```yaml
+paths:
+  /v1/orgs/{orgId}/members:
+    get:
+      operationId: listOrgMembers
+      summary: List members of an organization
+      parameters:
+        - { name: orgId, in: path, required: true, schema: { type: string } }
+        - name: limit
+          in: query
+          schema: { type: integer, default: 50, maximum: 200 }   # default + enforced max
+        - name: cursor
+          in: query
+          required: false
+          schema: { type: string }                                # opaque, server-issued
+      responses:
+        '200':
+          description: A page of members
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/MemberPage' }
+
+components:
+  schemas:
+    Page:
+      type: object
+      required: [nextCursor, hasMore]
+      properties:
+        nextCursor: { type: string, nullable: true }   # null ⇒ last page
+        hasMore:    { type: boolean }
+        total:      { type: integer }                   # optional
+    MemberPage:
+      type: object
+      required: [items, page]
+      properties:
+        items:
+          type: array
+          items: { $ref: '#/components/schemas/Member' }
+        page: { $ref: '#/components/schemas/Page' }
+```
+
+### Compliant JSON response
+
+```json
+{
+  "items": [
+    { "id": "mbr_01H...", "email": "ada@example.com", "role": "owner" },
+    { "id": "mbr_01H...", "email": "grace@example.com", "role": "admin" }
+  ],
+  "page": {
+    "nextCursor": "eyJsYXN0SWQiOiJtYnJfMDFILi4uIiwibGFzdFNvcnRWYWwiOiIyMDI2LTA2LTI5VDExOjAyOjAzWiJ9",
+    "hasMore": true
+  }
+}
+```
+
+The next request repeats with `?limit=50&cursor=eyJsYXN0SWQ...`. When the server returns `"nextCursor": null` (or `"hasMore": false`), the walk is complete.
+
+## 2. Cursor vs offset
+
+**Default to cursor.** Use `offset` only as a fallback.
+
+| | Cursor (preferred) | Offset (fallback) |
+|---|---|---|
+| Stable under concurrent writes | Yes — keys off a value, not a position; inserts/deletes don't shift the window | No — a row inserted/deleted before the window causes a skipped or duplicated row |
+| Deep-page cost | Constant — `WHERE (sort_key, id) > (?, ?)` rides an index | Degrades — `OFFSET n` scans and discards `n` rows |
+| Jump to arbitrary page N | No (sequential walk only) | Yes |
+| Good for | Any large or actively-written set: feeds, events, search, audit logs, members | Small **bounded** sets, or admin tables where "go to page N" is a real requirement and the set is small |
+
+**Opaque cursors.** A cursor is an **opaque, server-issued token** — the client treats it as a blob and echoes it back unmodified. It encodes the **sort key + a tiebreaker** so the walk is deterministic (the tiebreaker, usually the primary id, breaks ties when the sort key is non-unique — without it, rows sharing a sort value can be skipped or repeated). A typical implementation is `base64({ "lastId": ..., "lastSortVal": ... })`.
+
+- **Never leak internals** through the cursor: no raw SQL `OFFSET`, no internal row numbers, no DB primary keys the client could enumerate or tamper with for unauthorized access. If the cursor's integrity matters, sign or encrypt it. The client must not be able to forge a cursor that reads outside its authorization scope.
+- Treat a malformed/expired cursor as a `400`, not a silent reset to page 1.
+
+## 3. Exemptions
+
+An endpoint is exempt **only** when its result set is **inherently bounded or a singleton**:
+
+- **Single-resource GET** — `GET /x/{id}` (returns one object). The gate already skips `/{id}` tails.
+- **Fixed-small enum / lookup** — e.g. `GET /currencies`, `GET /plan-tiers`: a closed, small set that does not grow with user data.
+- **Aggregate / scalar** — a count, a sum, a single computed object.
+- **Hard server-capped feed** — an endpoint that returns at most a fixed small N by design (e.g. "top 10").
+
+Exemption is **annotated, never silent.** A collection GET that is genuinely bounded but trips the heuristic must declare *why* — so the next reader (and the gate) sees an explicit decision, not an oversight. Two ways to annotate:
+
+**A. Vendor extension on the OpenAPI operation** (preferred — lives with the contract):
+```yaml
+  /v1/plan-tiers:
+    get:
+      operationId: listPlanTiers
+      summary: List the fixed set of subscription plan tiers
+      x-pagination: exempt
+      x-pagination-reason: closed enum of 7 plan tiers, never grows with user data
+      responses:
+        '200': { description: All plan tiers, ... }
+```
+
+**B. Repo allowlist** — list the route in either:
+- `governance/pagination-allowlist.txt`, **or**
+- `.fuze/pagination-allowlist.txt`
+
+one `GET /path` per line; `#` introduces a comment; blank lines ignored. The path must match the route as written in the spec (e.g. `GET /v1/plan-tiers`). Matching is case-insensitive. A starter (empty) allowlist ships at `governance/pagination-allowlist.txt`.
+
+Prefer the **`x-pagination` annotation** (the contract is the source of truth and travels with the spec); reserve the allowlist for cases where you can't edit the operation object (e.g. a vendored/generated spec).
+
+## 4. CI enforcement
+
+`gate-pagination` is a job in `harden-gate.yml`. It runs `scripts/gate_pagination.py` (it probes `scripts/`, `.fuze/`, then `.github/scripts/` for the script; if none is found it warns and passes). The script:
+
+1. **Finds every OpenAPI/Swagger spec** in the repo (by filename pattern or a cheap content sniff for an `openapi:`/`swagger:` key), pruning `node_modules`, `dist`, `vendor`, etc. **No spec found ⇒ pass** (report-only-friendly).
+2. For each `paths.*.get`, decides whether it is a **collection GET** (the heuristic below).
+3. For each collection GET that is **not exempt**, FAILS it if it is missing any of: the `limit` param, a `cursor` **or** `offset` param, or the `{ items, page }` response envelope. The failure message names exactly what's missing.
+
+**Collection-GET heuristic** (an operation is treated as a collection GET when):
+- its method is `get`, **and** the path does **not** end in a path-param tail (`/{id}`) — singletons are skipped; **and** any one of:
+  - the 2xx response schema is an **array**, **or**
+  - the 2xx response schema is already a **`{ items, page }` envelope**, **or**
+  - the `operationId` / `summary` is **list-like** (`list`, `search`, `index`, `all`, `feed`, `collection`, `query`), **or**
+  - the path has a **plural segment** (a segment ending in `s` that isn't a `{param}`).
+
+This is deliberately broad so it errs toward *flagging*: a genuinely-bounded endpoint that trips it is silenced with one `x-pagination: exempt` line (§3), which is the intended, visible escape hatch. A malformed spec is a report-only `::warning` (the gate does not crash on bad YAML/JSON).
+
+**Roll-out.** The first pass is **report-only** (`python "$SCRIPT" . || true`) — it surfaces violations as annotations without breaking the build, so a repo can annotate/allowlist its existing endpoints. It is **ratcheted to enforcing per-repo** by removing the `|| true`, once that repo's contracts are clean. Treat report-only output as a punch-list, not as permission to skip.
+
+## 5. Ownership
+
+Pagination is designed into the contract and verified end-to-end — not bolted on:
+
+- **`contract-designer`** — **declares** pagination in the contract: the `limit`/`cursor`|`offset` params, the `{ items, page }` envelope schema, the default + max, and any `x-pagination: exempt` annotations. The contract PR is not valid if a collection GET lacks pagination or an exemption.
+- **`backend-engineer`** — **implements** it: clamps `limit` to the max server-side, builds opaque deterministic cursors (sort key + tiebreaker), and covers limit-clamping + cursor-walk in its own unit tests.
+- **`test-engineer`** — **independently asserts**, on every paginated endpoint: the params + envelope are present, the limit is enforced (an over-max request is clamped), and the cursor **walks the full set with no gaps/dupes**. This is the objective verification — the backend does not grade its own pagination.
+- **`frontend-engineer`** — builds the **pager / infinite-scroll UI** wired to the cursor envelope (consume `nextCursor`/`hasMore`, request the next page; never assume offset math), design-system-first.
+- **`platform-governance`** — owns this **policy**, the gate, and its propagation across repos.

--- a/scripts/gate_ds_conformance.py
+++ b/scripts/gate_ds_conformance.py
@@ -1,0 +1,388 @@
+#!/usr/bin/env python3
+"""gate-ds-conformance — design-system conformance gate (CLAUDE.baseline.md §6).
+
+Two responsibilities:
+  1. HARD FAIL on conformance violations in UI feature code (outside the DS package):
+       - raw color literals: #hex, rgb()/rgba(), hsl()/hsla()
+       - hard-coded spacing/sizing in px outside the token scale (e.g. padding/margin/gap/width: 12px)
+       - raw font-size / font-family literals outside tokens
+  2. EXTRACTION SIGNAL (does NOT fail the build): when a UI pattern recurs / is duplicated
+     across feature files (the same ad-hoc styled block appears >= THRESHOLD times), it should
+     become a DS primitive. With --emit-issues + a GH token, opens ONE idempotent GitHub issue
+     per proposed component (label `ds-extraction` + a stable fingerprint marker), mentioning
+     @claude, with locations + a proposed spec + acceptance criteria. Idempotent: it searches
+     existing open+closed issues for the fingerprint marker and skips if present.
+
+Scope: scans the UI feature dirs (default: frontend/, apps/, packages/ui*, src/) and EXCLUDES
+the design-system package itself (design-system/, packages/design-system/, **/design-system/**)
+where raw token *definitions* legitimately live.
+
+Ratchet mode: with --changed-only, only violations on lines ADDED/MODIFIED by the current PR
+(computed from `git diff --unified=0 <GATE_BASE_REF>...HEAD`, default base origin/master) are
+reported. This blocks NEW raw-design values without failing on the pre-existing findings, and
+needs no baseline file. If the diff can't be computed (no base), it falls back to a full scan.
+
+Usage:
+  gate_ds_conformance.py [root] [--changed-only] [--emit-issues] [--repo owner/name] [--threshold N]
+Env: GATE_BASE_REF (changed-only base ref, default origin/master);
+     GH_TOKEN or GITHUB_TOKEN + GITHUB_REPOSITORY (for issue creation).
+Exit 0 = conforms (extraction issues are non-fatal); exit 1 = hard violation.
+"""
+from __future__ import annotations
+import fnmatch
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+from collections import defaultdict
+
+UI_EXT = (".tsx", ".jsx", ".ts", ".js", ".vue", ".svelte", ".css", ".scss", ".less")
+SCAN_DIRS = ["frontend", "apps", "src", "packages"]
+# Any path containing one of these segments is the DS package itself — exclude from feature checks.
+DS_EXCLUDE_SEGMENTS = ("design-system", "design_system", "ds-tokens", "tokens")
+SKIP_DIRS = {".git", "node_modules", "dist", "build", ".venv", "vendor",
+             "__pycache__", "coverage", ".next", "storybook-static", "__snapshots__"}
+# Feature-path globs that are NOT hand-authored feature UI: config, type decls, contract-frozen
+# generated stubs, and test files. Matched against the forward-slash relative path. These are
+# skipped to cut false positives on the hard-fail path.
+SKIP_FEATURE_GLOBS = (
+    "*.config.*",
+    "*.d.ts",
+    "packages/*/src/*",   # contract-frozen generated client stubs
+    "*.test.*",
+    "*/__tests__/*",
+)
+
+HEX_RE = re.compile(r"#[0-9a-fA-F]{3,8}\b")
+RGB_RE = re.compile(r"\brgba?\(", re.I)
+HSL_RE = re.compile(r"\bhsla?\(", re.I)
+# spacing/sizing px literals on layout properties (allow 0px / 1px hairline)
+PX_PROP_RE = re.compile(
+    r"\b(padding|margin|gap|width|height|top|left|right|bottom|font-size|line-height|border-radius)"
+    r"[^\n;{}]*?:\s*(\d{2,})px",
+    re.I,
+)
+# raw font-family string (not a var/token)
+FONT_FAMILY_RE = re.compile(r"font-family\s*:\s*[\"']?[A-Za-z]", re.I)
+# allow lines that clearly use a token/var
+TOKEN_HINT_RE = re.compile(r"(var\(--|tokens?\.|theme\.|\$[a-z]|@apply|colors?\.|spacing\.|--ds-)", re.I)
+DISABLE_RE = re.compile(r"ds-conformance[- ]?(disable|ignore|allow)", re.I)
+
+# @@ -a,b +c,d @@  — capture the +c[,d] added-line range
+HUNK_RE = re.compile(r"^@@\s+-\d+(?:,\d+)?\s+\+(\d+)(?:,(\d+))?\s+@@")
+
+
+def _skip_feature_path(rel: str) -> bool:
+    """True if the (forward-slash) relative path is config/type-decl/generated-stub/test — not
+    hand-authored feature UI. Cuts false positives on the hard-fail path."""
+    relf = rel.replace("\\", "/")
+    return any(fnmatch.fnmatch(relf, g) for g in SKIP_FEATURE_GLOBS)
+
+
+def _hex_is_color(line: str) -> bool:
+    """True only if some #… token on the line has a hex LETTER (a-f). An all-decimal match like
+    `#117` is almost always an issue/PR ref, not a CSS color — skip it (baseline heuristic)."""
+    for m in HEX_RE.finditer(line):
+        digits = m.group()[1:]
+        if any(c in "abcdefABCDEF" for c in digits):
+            return True
+    return False
+
+
+def _git_ui_files(root: str) -> list[str] | None:
+    """Tracked UI files via git (fast, skips build/untracked noise). None if git unavailable."""
+    try:
+        res = subprocess.run(
+            ["git", "-C", root, "ls-files"] + [f"*{e}" for e in UI_EXT] + [f"**/*{e}" for e in UI_EXT],
+            capture_output=True, text=True, timeout=60,
+        )
+        if res.returncode == 0:
+            return [p for p in res.stdout.splitlines() if p.strip()]
+    except Exception:
+        pass
+    return None
+
+
+def changed_lines(root: str, base_ref: str) -> dict[str, set[int]] | None:
+    """Map of {forward-slash relpath -> {added/modified line numbers}} from
+    `git diff --unified=0 <base_ref>...HEAD`. None if the diff can't be computed."""
+    try:
+        res = subprocess.run(
+            ["git", "-C", root, "diff", "--unified=0", f"{base_ref}...HEAD"],
+            capture_output=True, text=True, timeout=90,
+        )
+    except Exception as e:
+        print(f"::warning title=gate-ds-conformance::changed-only diff failed to run: {e}")
+        return None
+    if res.returncode != 0:
+        print(f"::warning title=gate-ds-conformance::changed-only diff error "
+              f"(base '{base_ref}'): {res.stderr.strip()[:200]}")
+        return None
+    out: dict[str, set[int]] = defaultdict(set)
+    cur: str | None = None
+    for line in res.stdout.splitlines():
+        if line.startswith("+++ "):
+            p = line[4:].strip()
+            if p == "/dev/null":
+                cur = None
+            else:
+                cur = p[2:] if (p.startswith("a/") or p.startswith("b/")) else p
+            continue
+        if line.startswith("@@") and cur is not None:
+            m = HUNK_RE.match(line)
+            if not m:
+                continue
+            start = int(m.group(1))
+            count = int(m.group(2)) if m.group(2) is not None else 1
+            for ln in range(start, start + count):
+                out[cur].add(ln)
+    return dict(out)
+
+
+def iter_ui_files(root: str):
+    tracked = _git_ui_files(root)
+    if tracked is not None:
+        for rel in tracked:
+            reln = rel.replace("\\", "/")
+            top = reln.split("/", 1)[0]
+            if SCAN_DIRS and top not in SCAN_DIRS:
+                continue
+            segs = reln.lower().split("/")
+            if any(seg in DS_EXCLUDE_SEGMENTS for seg in segs):
+                continue  # DS package — tokens defined here
+            if any(seg in SKIP_DIRS for seg in segs):
+                continue
+            yield os.path.join(root, *reln.split("/"))
+        return
+    for base in SCAN_DIRS:
+        start = os.path.join(root, base)
+        if not os.path.isdir(start):
+            continue
+        for dirpath, dirnames, filenames in os.walk(start):
+            dirnames[:] = [d for d in dirnames if d not in SKIP_DIRS]
+            rel = os.path.relpath(dirpath, root).replace("\\", "/").lower()
+            if any(seg in rel.split("/") for seg in DS_EXCLUDE_SEGMENTS):
+                continue  # inside the DS package — tokens are defined here
+            for fn in filenames:
+                if fn.endswith(UI_EXT):
+                    yield os.path.join(dirpath, fn)
+
+
+def scan_violations(root: str, changed: dict[str, set[int]] | None = None) -> list[str]:
+    """Scan feature UI for raw design values. When `changed` is provided (ratchet mode), only
+    violations on added/modified (file,line) pairs are reported."""
+    violations = []
+    for path in iter_ui_files(root):
+        rel = os.path.relpath(path, root)
+        relf = rel.replace("\\", "/")
+        if _skip_feature_path(relf):
+            continue
+        if changed is not None and relf not in changed:
+            continue  # ratchet: file not touched by this PR
+        try:
+            with open(path, "r", encoding="utf-8", errors="ignore") as f:
+                lines = f.readlines()
+        except OSError:
+            continue
+        for i, line in enumerate(lines, 1):
+            if changed is not None and i not in changed.get(relf, ()):
+                continue  # ratchet: line not added/modified by this PR
+            if DISABLE_RE.search(line):
+                continue
+            stripped = line.strip()
+            if stripped.startswith(("//", "*", "/*", "#")):
+                continue
+            hits = []
+            if _hex_is_color(line) and not TOKEN_HINT_RE.search(line):
+                hits.append("raw hex color")
+            if RGB_RE.search(line) and not TOKEN_HINT_RE.search(line):
+                hits.append("raw rgb()/rgba()")
+            if HSL_RE.search(line) and not TOKEN_HINT_RE.search(line):
+                hits.append("raw hsl()/hsla()")
+            if PX_PROP_RE.search(line) and not TOKEN_HINT_RE.search(line):
+                hits.append("hard-coded px spacing/size outside token scale")
+            if FONT_FAMILY_RE.search(line) and not TOKEN_HINT_RE.search(line):
+                hits.append("raw font-family outside tokens")
+            if hits:
+                violations.append(f"{rel}:{i}: {', '.join(hits)} -> {stripped[:80]}")
+    return violations
+
+
+# ---- extraction-candidate detection (duplicate styled blocks) -------------------------
+
+STYLED_BLOCK_RE = re.compile(r"(className=\{?[\"'`][^\"'`]{8,}[\"'`]|styled\.\w+`[^`]{20,}`)", re.S)
+
+
+def normalize(block: str) -> str:
+    # strip whitespace + numbers so "p-4" and "p-6" collapse to the same shape
+    return re.sub(r"\d+", "#", re.sub(r"\s+", " ", block)).strip().lower()
+
+
+def detect_extraction_candidates(root: str, threshold: int) -> dict[str, dict]:
+    buckets: dict[str, list[str]] = defaultdict(list)
+    samples: dict[str, str] = {}
+    for path in iter_ui_files(root):
+        if not path.endswith((".tsx", ".jsx", ".vue", ".svelte")):
+            continue
+        try:
+            with open(path, "r", encoding="utf-8", errors="ignore") as f:
+                text = f.read()
+        except OSError:
+            continue
+        rel = os.path.relpath(path, root)
+        for m in STYLED_BLOCK_RE.finditer(text):
+            norm = normalize(m.group(0))
+            if len(norm) < 12:
+                continue
+            line = text[: m.start()].count("\n") + 1
+            buckets[norm].append(f"{rel}:{line}")
+            samples.setdefault(norm, m.group(0)[:160])
+    out = {}
+    for norm, locs in buckets.items():
+        uniq = sorted(set(locs))
+        # recurring AND across >1 file = an extraction signal
+        if len(uniq) >= threshold and len({l.split(":")[0] for l in uniq}) >= 2:
+            fp = hashlib.sha1(norm.encode()).hexdigest()[:12]
+            out[fp] = {"fingerprint": fp, "locations": uniq, "sample": samples[norm]}
+    return out
+
+
+def gh_issue_exists(repo: str, fp: str) -> bool:
+    marker = f"ds-fp:{fp}"
+    try:
+        res = subprocess.run(
+            ["gh", "issue", "list", "-R", repo, "--label", "ds-extraction",
+             "--state", "all", "--search", marker, "--json", "number", "--limit", "50"],
+            capture_output=True, text=True, timeout=60,
+        )
+        if res.returncode != 0:
+            print(f"::warning title=gate-ds-conformance::gh issue list failed: {res.stderr.strip()}")
+            return True  # fail safe: do NOT create a dup if we can't verify
+        return bool(json.loads(res.stdout or "[]"))
+    except Exception as e:
+        print(f"::warning title=gate-ds-conformance::issue-search error: {e}")
+        return True
+
+
+def ensure_label(repo: str):
+    subprocess.run(
+        ["gh", "label", "create", "ds-extraction", "-R", repo,
+         "--color", "5319e7", "--description", "Candidate UI pattern to extract into the design system"],
+        capture_output=True, text=True,
+    )
+
+
+def open_extraction_issue(repo: str, cand: dict) -> str | None:
+    fp = cand["fingerprint"]
+    if gh_issue_exists(repo, fp):
+        print(f"gate-ds-conformance: extraction issue for ds-fp:{fp} already exists — skipping (idempotent)")
+        return None
+    ensure_label(repo)
+    locs = "\n".join(f"- `{l}`" for l in cand["locations"][:20])
+    title = f"DS extraction: recurring UI pattern (ds-fp:{fp})"
+    body = f"""@claude — `gate-ds-conformance` detected a UI pattern duplicated across the codebase that **should be extracted into a design-system primitive** (CLAUDE.baseline.md §6).
+
+<!-- ds-fp:{fp} -->
+**Stable marker:** `ds-fp:{fp}` (do not edit — used for idempotent de-duplication)
+
+### Where it recurs
+{locs}
+
+### Sample
+```
+{cand["sample"]}
+```
+
+### Proposed component spec (refine before building)
+- **Name:** `<PascalCaseComponent>` (in the repo design-system package — `frontend-engineer` is the sole owner of `design-system/`)
+- **Props:** derive from the variation across the call sites above.
+- **Variants:** the distinct visual variations seen at the locations.
+- **States:** default / hover / focus / active / disabled / loading as applicable.
+- **Tokens:** must consume DS tokens only (color/spacing/type/radius) — zero raw values.
+
+### Acceptance criteria
+- [ ] Component added to the design-system package (not one-off in feature code), tokens-only.
+- [ ] All listed call sites refactored to use it.
+- [ ] a11y + RTL covered; unit test in the DS package.
+- [ ] `gate-ds-conformance` stays green after refactor.
+
+_Filed automatically; owner is `frontend-engineer`. Extraction is design work, not done by this gate._
+"""
+    try:
+        res = subprocess.run(
+            ["gh", "issue", "create", "-R", repo, "--title", title,
+             "--body", body, "--label", "ds-extraction"],
+            capture_output=True, text=True, timeout=60,
+        )
+        if res.returncode == 0:
+            url = res.stdout.strip().splitlines()[-1] if res.stdout.strip() else "(created)"
+            print(f"gate-ds-conformance: opened extraction issue {url}")
+            return url
+        print(f"::warning title=gate-ds-conformance::gh issue create failed: {res.stderr.strip()}")
+    except Exception as e:
+        print(f"::warning title=gate-ds-conformance::issue-create error: {e}")
+    return None
+
+
+def main() -> int:
+    args = sys.argv[1:]
+    emit = "--emit-issues" in args
+    changed_only = "--changed-only" in args
+    args = [a for a in args if a not in ("--emit-issues", "--changed-only")]
+    repo = None
+    threshold = 3
+    pos = []
+    it = iter(args)
+    for a in it:
+        if a == "--repo":
+            repo = next(it, None)
+        elif a == "--threshold":
+            threshold = int(next(it, "3"))
+        else:
+            pos.append(a)
+    root = pos[0] if pos else "."
+    repo = repo or os.environ.get("GITHUB_REPOSITORY")
+
+    changed = None
+    if changed_only:
+        base_ref = os.environ.get("GATE_BASE_REF", "origin/master")
+        changed = changed_lines(root, base_ref)
+        if changed is None:
+            print("::warning title=gate-ds-conformance::--changed-only requested but diff "
+                  f"unavailable (base '{base_ref}') — falling back to FULL scan")
+        else:
+            touched = sum(len(v) for v in changed.values())
+            print(f"gate-ds-conformance: changed-only ratchet vs '{base_ref}' — "
+                  f"{len(changed)} file(s), {touched} added/modified line(s)")
+
+    violations = scan_violations(root, changed)
+    # extraction candidates are advisory — compute always, emit issues only when asked
+    candidates = detect_extraction_candidates(root, threshold)
+    if candidates:
+        print(f"gate-ds-conformance: {len(candidates)} extraction candidate(s) detected (advisory).")
+        if emit and repo and (os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")):
+            for cand in candidates.values():
+                open_extraction_issue(repo, cand)
+        elif emit:
+            print("::warning title=gate-ds-conformance::--emit-issues set but no repo/token — skipping issue creation")
+        else:
+            for fp, c in candidates.items():
+                print(f"  - ds-fp:{fp} @ {', '.join(c['locations'][:5])}")
+
+    if violations:
+        scope = "changed lines" if changed is not None else "feature code"
+        print(f"::error title=gate-ds-conformance::raw design values found in {scope} (use DS tokens)")
+        for v in violations[:200]:
+            print(f"  - {v}")
+        print(f"\ngate-ds-conformance FAILED: {len(violations)} hard conformance violation(s) "
+              "(CLAUDE.baseline.md §6). Use design-system tokens/components, not raw values.")
+        return 1
+    ok_scope = "changed lines" if changed is not None else "feature code"
+    print(f"gate-ds-conformance: no raw design values in {ok_scope}. OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/gate_pagination.py
+++ b/scripts/gate_pagination.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""gate-pagination — enforce the canonical pagination standard (CLAUDE.baseline.md §4.1).
+
+Inspects OpenAPI/Swagger contract(s) in the repo and FAILS when a collection GET
+(an unbounded LIST endpoint) lacks pagination, unless it is annotated exempt.
+
+A collection GET must declare:
+  - request params: `limit` AND (`cursor` OR `offset`)
+  - a paginated response envelope: a 2xx JSON schema with an `items` array and a `page` object
+Exemption: the operation carries `x-pagination: exempt`, OR the route is listed in the
+allowlist (governance/pagination-allowlist.txt or .fuze/pagination-allowlist.txt),
+one `METHOD /path` per line.
+
+Heuristic for "collection GET": method == get, path does NOT end in a path param
+(`/{id}`), AND the operationId/path/summary look list-like (plural noun, "list",
+"search", "/items", etc.) OR the 2xx response is an array. Singletons / scalars /
+bounded lookups are treated as non-collection and skipped (and may also be marked
+exempt explicitly to silence a false positive).
+
+Usage: gate_pagination.py [root]      (default root = .)
+Exit 0 = pass / no contracts found (report-only-friendly); exit 1 = hard violation.
+Requires PyYAML (pip install pyyaml). JSON specs work with no extra deps.
+"""
+from __future__ import annotations
+import json
+import os
+import re
+import sys
+
+try:
+    import yaml  # type: ignore
+except Exception:  # pragma: no cover
+    yaml = None
+
+SPEC_NAME_RE = re.compile(r"(openapi|swagger).*\.(ya?ml|json)$", re.I)
+ALLOWLIST_PATHS = [
+    "governance/pagination-allowlist.txt",
+    ".fuze/pagination-allowlist.txt",
+]
+LIST_HINT_RE = re.compile(r"(list|search|index|all|feed|collection|query)", re.I)
+# plural-ish: path segment ends with 's' and is not a {param}
+PLURAL_SEG_RE = re.compile(r"/[a-z0-9_-]+s(/|$)", re.I)
+PATH_PARAM_TAIL_RE = re.compile(r"\{[^}]+\}/?$")
+
+
+PRUNE_DIRS = {
+    ".git", "node_modules", "dist", "build", ".venv", "venv", "vendor", "__pycache__",
+    "coverage", ".next", ".terraform", ".turbo", ".cache", "out", "target",
+    "storybook-static", "playwright-report", "test-results",
+}
+
+
+def _candidate_files(root: str) -> list[str]:
+    """Enumerate yaml/yml/json candidates. Prefer `git ls-files` (tracked files only — fast,
+    skips all build/untracked noise in a large monorepo); fall back to a pruned os.walk."""
+    import subprocess
+    try:
+        res = subprocess.run(
+            ["git", "-C", root, "ls-files", "--",
+             "*.yaml", "*.yml", "*.json", "**/*.yaml", "**/*.yml", "**/*.json"],
+            capture_output=True, text=True, timeout=60,
+        )
+        if res.returncode == 0 and res.stdout.strip():
+            files = [os.path.join(root, p) for p in res.stdout.splitlines() if p.strip()]
+            # still drop anything under a prune dir (e.g. tracked dist/)
+            return [
+                f for f in files
+                if not any(seg in PRUNE_DIRS for seg in f.replace("\\", "/").split("/"))
+            ]
+    except Exception:
+        pass
+    out = []
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [
+            d for d in dirnames
+            if d not in PRUNE_DIRS
+            and not d.startswith(("playwright-report", "test-results", ".terraform"))
+        ]
+        for fn in filenames:
+            if fn.endswith((".yaml", ".yml", ".json")):
+                out.append(os.path.join(dirpath, fn))
+    return out
+
+
+def find_specs(root: str) -> list[str]:
+    out = []
+    for p in _candidate_files(root):
+        fn = os.path.basename(p)
+        if SPEC_NAME_RE.search(fn) or fn in ("openapi.yaml", "openapi.yml", "openapi.json"):
+            out.append(p)
+            continue
+        try:
+            with open(p, "r", encoding="utf-8", errors="ignore") as f:
+                head = f.read(400)
+            if re.search(r'["\']?(openapi|swagger)["\']?\s*:', head):
+                out.append(p)
+        except OSError:
+            pass
+    return sorted(set(out))
+
+
+def load_spec(path: str):
+    with open(path, "r", encoding="utf-8", errors="ignore") as f:
+        text = f.read()
+    if path.endswith(".json"):
+        return json.loads(text)
+    if yaml is None:
+        # last-resort: try json (some .yaml are actually json)
+        return json.loads(text)
+    return yaml.safe_load(text)
+
+
+def load_allowlist(root: str) -> set[str]:
+    allow = set()
+    for rel in ALLOWLIST_PATHS:
+        p = os.path.join(root, rel)
+        if os.path.isfile(p):
+            with open(p, "r", encoding="utf-8", errors="ignore") as f:
+                for line in f:
+                    line = line.split("#", 1)[0].strip()
+                    if line:
+                        allow.add(line.lower())
+    return allow
+
+
+def _schema_is_array(schema: dict) -> bool:
+    if not isinstance(schema, dict):
+        return False
+    if schema.get("type") == "array":
+        return True
+    # allOf/oneOf/anyOf
+    for k in ("allOf", "oneOf", "anyOf"):
+        for sub in schema.get(k, []) or []:
+            if isinstance(sub, dict) and sub.get("type") == "array":
+                return True
+    return False
+
+
+def _resp_2xx_schema(op: dict) -> dict | None:
+    resps = op.get("responses", {}) or {}
+    for code, body in resps.items():
+        if str(code).startswith("2"):
+            content = (body or {}).get("content", {}) or {}
+            for _, media in content.items():
+                if isinstance(media, dict) and "schema" in media:
+                    return media["schema"]
+    return None
+
+
+def _has_envelope(schema: dict) -> bool:
+    """A {items:[], page:{}} envelope (resolved or inline)."""
+    if not isinstance(schema, dict):
+        return False
+    props = schema.get("properties", {}) or {}
+    has_items = "items" in props and _schema_is_array(props.get("items", {}))
+    has_page = "page" in props
+    if has_items and has_page:
+        return True
+    # composed envelope
+    for k in ("allOf", "oneOf", "anyOf"):
+        for sub in schema.get(k, []) or []:
+            if _has_envelope(sub):
+                return True
+    return False
+
+
+def _param_names(op: dict, path_item: dict) -> set[str]:
+    names = set()
+    for p in (path_item.get("parameters", []) or []) + (op.get("parameters", []) or []):
+        if isinstance(p, dict) and p.get("in") in (None, "query"):
+            n = p.get("name")
+            if n:
+                names.add(n)
+    return {n.lower() for n in names}
+
+
+def is_collection_get(path: str, op: dict, resp_schema: dict | None) -> bool:
+    if PATH_PARAM_TAIL_RE.search(path):
+        return False  # /x/{id} singleton
+    opid = (op.get("operationId") or "").lower()
+    summary = (op.get("summary") or "").lower()
+    if _schema_is_array(resp_schema or {}):
+        return True
+    if _has_envelope(resp_schema or {}):
+        return True
+    if LIST_HINT_RE.search(opid) or LIST_HINT_RE.search(summary):
+        return True
+    if PLURAL_SEG_RE.search(path):
+        return True
+    return False
+
+
+def check_spec(path: str, allow: set[str]) -> list[str]:
+    violations = []
+    try:
+        spec = load_spec(path)
+    except Exception as e:  # malformed yaml/json — report-only skip, don't crash the gate
+        print(f"::warning title=gate-pagination::could not parse {path}: {e}")
+        return []
+    if not isinstance(spec, dict):
+        return []
+    paths = spec.get("paths", {}) or {}
+    for route, path_item in paths.items():
+        if not isinstance(path_item, dict):
+            continue
+        op = path_item.get("get")
+        if not isinstance(op, dict):
+            continue
+        # explicit exemption
+        if str(op.get("x-pagination", "")).lower() == "exempt":
+            continue
+        if f"get {route}".lower() in allow:
+            continue
+        resp_schema = _resp_2xx_schema(op)
+        if not is_collection_get(route, op, resp_schema):
+            continue
+        params = _param_names(op, path_item)
+        has_limit = "limit" in params
+        has_walk = "cursor" in params or "offset" in params
+        has_env = _has_envelope(resp_schema or {})
+        missing = []
+        if not has_limit:
+            missing.append("`limit`")
+        if not has_walk:
+            missing.append("`cursor` or `offset`")
+        if not has_env:
+            missing.append("`{items, page}` response envelope")
+        if missing:
+            violations.append(
+                f"{os.path.relpath(path)} :: GET {route} — unbounded collection missing "
+                f"{', '.join(missing)} (add them per pagination standard, or annotate "
+                f"`x-pagination: exempt` if bounded/singleton)"
+            )
+    return violations
+
+
+def main() -> int:
+    root = sys.argv[1] if len(sys.argv) > 1 else "."
+    specs = find_specs(root)
+    if not specs:
+        print("gate-pagination: no OpenAPI/Swagger contract found — nothing to check (pass)")
+        return 0
+    allow = load_allowlist(root)
+    all_v: list[str] = []
+    for s in specs:
+        all_v.extend(check_spec(s, allow))
+    if all_v:
+        print("::error title=gate-pagination::unbounded collection endpoint(s) lack pagination")
+        for v in all_v:
+            print(f"  - {v}")
+        print(
+            f"\ngate-pagination FAILED: {len(all_v)} endpoint(s) violate the pagination standard "
+            "(CLAUDE.baseline.md §4.1)."
+        )
+        return 1
+    print(f"gate-pagination: checked {len(specs)} spec(s) — all collection GETs paginate or are exempt. OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Enforcing design-system conformance gate — changed-lines ratchet (closes #134)

Lands `gate-ds-conformance` **blocking** on `master`, plus a report-only pagination gate and an **enforcing** real-frontend-build gate. All jobs live in the single-owner `.github/workflows/harden-gate.yml`.

### The changed-lines ratchet (how this blocks NEW mess without a baseline)
`scripts/gate_ds_conformance.py` gains `--changed-only`:
- On **`pull_request`**: computes added/modified `(file,line)` pairs from `git diff --unified=0 origin/<base>...HEAD` (base from `GATE_BASE_REF`), parses the `@@ … +c,d @@` hunks, and **fails (exit 1)** if any of *those lines* introduce a raw design value (`#hex` / `rgb()` / `hsl()` / hard-coded `px` spacing-size-type / raw `font-family`). Pre-existing findings on untouched lines are ignored — so the ~178 existing violations do **not** block, and **no baseline file** is needed.
- On **`push` to master**: full scan **report-only** (`|| true`) + `--emit-issues` (opens idempotent `ds-extraction` issues). Advisory, never blocks the deploy-on-push.

Fallback: if the diff can't be computed (no base ref), it degrades to a full scan.

### False-positive reduction (hard-fail path)
Skips non-hand-authored feature files — `*.config.*`, `*.d.ts`, `packages/*/src/*` (contract-frozen generated stubs), `*.test.*`, `*/__tests__/*` — and, for the hex rule, ignores all-decimal matches (issue refs like `#117`, which are not CSS colors). The design-system package exclusion is preserved.

### Why this PR is green on the new gate
This PR touches only `scripts/`, `.github/`, `.claude/skills/`, `governance/`, `docs/` — **no UI files** — so the changed-lines ratchet reports 0 violations. Verified: `python scripts/gate_ds_conformance.py . --changed-only` → `no raw design values in changed lines. OK`.

### Also in this PR
- **`gate-pagination`** (report-only) — `scripts/gate_pagination.py` enforces the pagination standard (`governance/pagination-standard.md`). Ported net-new from #108 along with the `design-system-conformance` + `ui-frame-contract` skills and the pagination docs/allowlist.
- **`gate-frontend-build`** (ENFORCING, no `|| true`) — runs the **real** vite/PWA build (`root npm ci` → `frontend npm ci` → build `@fuzefront/chat-client`+`chat-ui` dist → `cd frontend && npm run build`), mirroring the `ci.yml` build job. Root `gate-build` is report-only and only builds the root package.json, which let an unbalanced brace in `frontend/src/index.css` break the prod build for 3 releases (hotfixed in 4428db9). This closes that gap.

### MANUAL STEP REQUIRED (human / repo admin, GitHub UI)
This token cannot edit branch rulesets. After merge, a repo admin must **add `gate-ds-conformance` to the `Protect default branch` ruleset's Required status checks** (Settings → Rules → Rulesets) so it actually blocks merges. Consider adding **`gate-frontend-build`** as a required check too. Until then the job runs but is not merge-blocking.

### Out of scope (not done here)
- Remediating the ~178 existing DS findings — `frontend-engineer` owns that (surfaced via full-scan/`ds-extraction` issues).
- Adding the check to the branch ruleset — needs the human UI/admin step above.
- The visual-regression / frames Playwright gate — follow-up (skill `ui-frame-contract` is landed here as the artifact contract).
