### PR TITLE
fix(ds-propagate): rewrite propagation workflow to use @claude issues

### DIFF
--- a/.github/workflows/ds-propagate.yml
+++ b/.github/workflows/ds-propagate.yml
@@ -1,23 +1,20 @@
 name: Design System Propagation
 
-# When a push to master touches design-system/**, spawn Claude Code cloud
-# agents to propagate the updated DS to the frontend, mobile frontend, and
-# UI testing layers. Each agent opens its own PR so diffs are reviewable.
+# When a push to master touches design-system/**, open three GitHub Issues
+# with @claude in the body. The existing claude.yml workflow picks them up
+# and runs the appropriate agent for each propagation slice.
 #
-# Requires repo secret: ANTHROPIC_API_KEY.
-# Requires the Claude Code on the web environment to be configured in the
-# izzywdev org (see https://code.claude.com/docs/en/claude-code-on-the-web).
+# Requires: GITHUB_TOKEN (automatic), ANTHROPIC_API_KEY (for claude.yml).
 on:
   push:
     branches: [master]
     paths:
       - 'design-system/**'
 
-  # Allow manual trigger with a custom commit SHA / message override
   workflow_dispatch:
     inputs:
       reason:
-        description: 'Reason for manual trigger (shown in agent prompts)'
+        description: 'Reason for manual trigger'
         required: false
         default: 'Manual DS propagation run'
 
@@ -28,6 +25,8 @@ jobs:
     outputs:
       summary: ${{ steps.summarise.outputs.summary }}
       changed_files: ${{ steps.summarise.outputs.changed_files }}
+      new_components: ${{ steps.summarise.outputs.new_components }}
+      new_tokens: ${{ steps.summarise.outputs.new_tokens }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -38,120 +37,135 @@ jobs:
         run: |
           CHANGED=$(git diff --name-only HEAD~1 HEAD -- 'design-system/**' | head -80 | tr '\n' ',')
           echo "changed_files=$CHANGED" >> "$GITHUB_OUTPUT"
-          # Build a short human-readable summary for the agent prompts
           NEW_COMPONENTS=$(git diff --name-only HEAD~1 HEAD -- 'design-system/components/**/*.jsx' | \
             sed 's|design-system/components/||;s|\.jsx||' | tr '\n' ', ')
           NEW_TOKENS=$(git diff --name-only HEAD~1 HEAD -- 'design-system/tokens/**' | \
             sed 's|design-system/tokens/||' | tr '\n' ', ')
-          SUMMARY="DS update on $(git log -1 --format='%s'). New/changed components: ${NEW_COMPONENTS:-none}. Changed token files: ${NEW_TOKENS:-none}."
+          COMMIT_MSG=$(git log -1 --format='%s')
+          echo "new_components=${NEW_COMPONENTS:-none}" >> "$GITHUB_OUTPUT"
+          echo "new_tokens=${NEW_TOKENS:-none}" >> "$GITHUB_OUTPUT"
+          SUMMARY="DS update — ${COMMIT_MSG}. Components: ${NEW_COMPONENTS:-none}. Token files: ${NEW_TOKENS:-none}."
           echo "summary=$SUMMARY" >> "$GITHUB_OUTPUT"
 
-  propagate-frontend:
-    name: Propagate DS → frontend
+  open-frontend-issue:
+    name: Open frontend propagation issue
     needs: detect-changes
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
       issues: write
-      id-token: write
-      actions: read
     steps:
-      - uses: actions/checkout@v4
+      - name: Create @claude frontend issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SUMMARY: ${{ needs.detect-changes.outputs.summary }}
+          CHANGED: ${{ needs.detect-changes.outputs.changed_files }}
+          RUN: ${{ github.run_number }}
+        run: |
+          gh issue create \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "DS propagation run #${RUN} — frontend" \
+            --label "ds-propagation,frontend" \
+            --body "$(cat <<EOF
+          @claude You are acting as **frontend-engineer**.
 
-      - name: Run Claude — frontend-engineer
-        uses: anthropics/claude-code-action@v1
-        with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          agent_type: frontend-engineer
-          prompt: |
-            The @fuzefront/design-system package has just been updated on master.
+          The \`@fuzefront/design-system\` package was just updated on master (run #${RUN}).
 
-            Change summary: ${{ needs.detect-changes.outputs.summary }}
-            Changed files: ${{ needs.detect-changes.outputs.changed_files }}
+          **Change summary:** ${SUMMARY}
+          **Changed files:** ${CHANGED}
 
-            Your task (SCOPE DONE when complete):
-            1. Read the changed design-system files listed above.
-            2. Update all files under `frontend/` that consume the changed tokens or
-               components — import the new mobile primitives (BottomNav, BottomSheet,
-               Drawer) wherever appropriate in the shell layout, apply any new spacing
-               tokens, and remove any raw-value one-offs that now have a token.
-            3. Make sure the responsive shell uses BottomNav on xs/sm (<768px) instead
-               of or alongside the side panel.
-            4. Commit on branch `ds-propagate/frontend-{{github.run_number}}`, push, open a draft PR.
-            5. Report SCOPE DONE (verified) or OUT OF SCOPE — NOT DONE for each item.
+          **Your task (report SCOPE DONE when complete):**
+          1. Read the changed design-system files listed above.
+          2. Update all files under \`frontend/\` that consume the changed tokens or
+             components — import the new mobile primitives (BottomNav, BottomSheet,
+             Drawer) wherever appropriate in the shell layout, apply any new spacing
+             tokens, and remove any raw-value one-offs that now have a token.
+          3. Make sure the responsive shell uses BottomNav on xs/sm (<768px) instead
+             of or alongside the side panel.
+          4. Commit on branch \`ds-propagate/frontend-${RUN}\`, push, open a draft PR.
+          5. Report SCOPE DONE (verified) or OUT OF SCOPE — NOT DONE for each item.
+          EOF
+          )"
 
-  propagate-mobile:
-    name: Propagate DS → mobile frontend
+  open-mobile-issue:
+    name: Open mobile propagation issue
     needs: detect-changes
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
       issues: write
-      id-token: write
-      actions: read
     steps:
-      - uses: actions/checkout@v4
+      - name: Create @claude mobile issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SUMMARY: ${{ needs.detect-changes.outputs.summary }}
+          CHANGED: ${{ needs.detect-changes.outputs.changed_files }}
+          RUN: ${{ github.run_number }}
+        run: |
+          gh issue create \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "DS propagation run #${RUN} — mobile" \
+            --label "ds-propagation,mobile" \
+            --body "$(cat <<EOF
+          @claude You are acting as **mobile-frontend-engineer**.
 
-      - name: Run Claude — mobile-frontend-engineer
-        uses: anthropics/claude-code-action@v1
-        with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          agent_type: mobile-frontend-engineer
-          prompt: |
-            The @fuzefront/design-system package has just been updated on master.
+          The \`@fuzefront/design-system\` package was just updated on master (run #${RUN}).
 
-            Change summary: ${{ needs.detect-changes.outputs.summary }}
-            Changed files: ${{ needs.detect-changes.outputs.changed_files }}
+          **Change summary:** ${SUMMARY}
+          **Changed files:** ${CHANGED}
 
-            Your task (SCOPE DONE when complete):
-            1. Read the new mobile DS primitives: BottomNav, BottomSheet, Drawer
-               (design-system/components/mobile/) and the updated spacing tokens
-               (design-system/tokens/spacing.css — especially --bottom-nav-height,
-               --drawer-width, --sheet-max-h, --touch-target, safe-area vars).
-            2. Wire BottomNav into the Android TWA shell and any responsive shell
-               layouts under `frontend/` that target xs/sm breakpoints.
-            3. Apply the new touch-target, safe-area, and motion tokens wherever
-               touch interactions or slide animations exist.
-            4. Ensure PWA manifest / viewport meta are consistent with the new
-               --top-bar-height-mobile token (52px).
-            5. Commit on branch `ds-propagate/mobile-{{github.run_number}}`, push, open a draft PR.
-            6. Report SCOPE DONE (verified) or OUT OF SCOPE — NOT DONE for each item.
+          **Your task (report SCOPE DONE when complete):**
+          1. Read the new mobile DS primitives: BottomNav, BottomSheet, Drawer
+             (\`design-system/components/mobile/\`) and the updated spacing tokens
+             (\`design-system/tokens/spacing.css\` — especially --bottom-nav-height,
+             --drawer-width, --sheet-max-h, --touch-target, safe-area vars).
+          2. Wire BottomNav into the Android TWA shell and any responsive shell
+             layouts under \`frontend/\` that target xs/sm breakpoints.
+          3. Apply the new touch-target, safe-area, and motion tokens wherever
+             touch interactions or slide animations exist.
+          4. Ensure PWA manifest / viewport meta are consistent with the new
+             --top-bar-height-mobile token (52px).
+          5. Commit on branch \`ds-propagate/mobile-${RUN}\`, push, open a draft PR.
+          6. Report SCOPE DONE (verified) or OUT OF SCOPE — NOT DONE for each item.
+          EOF
+          )"
 
-  ui-tests:
-    name: Verify DS propagation — UI tests
-    needs: [propagate-frontend, propagate-mobile]
-    if: always()
+  open-e2e-issue:
+    name: Open UI-test propagation issue
+    needs: [open-frontend-issue, open-mobile-issue]
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
       issues: write
-      id-token: write
-      actions: read
     steps:
-      - uses: actions/checkout@v4
+      - name: Create @claude e2e issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SUMMARY: ${{ needs.detect-changes.outputs.summary }}
+          RUN: ${{ github.run_number }}
+        run: |
+          gh issue create \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "DS propagation run #${RUN} — UI tests" \
+            --label "ds-propagation,testing" \
+            --body "$(cat <<EOF
+          @claude You are acting as **frontend-test-engineer**.
 
-      - name: Run Claude — frontend-test-engineer
-        uses: anthropics/claude-code-action@v1
-        with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          agent_type: frontend-test-engineer
-          prompt: |
-            The @fuzefront/design-system has been updated (mobile components + spacing
-            tokens) and the frontend/mobile propagation agents have run (jobs above).
+          The \`@fuzefront/design-system\` has been updated (mobile components + spacing
+          tokens) and the frontend/mobile propagation issues for run #${RUN} have been opened.
 
-            Change summary: ${{ needs.detect-changes.outputs.summary }}
+          **Change summary:** ${SUMMARY}
 
-            Your task (SCOPE DONE when complete):
-            1. Write or update Playwright tests that exercise the new mobile DS primitives:
-               - BottomNav renders at xs viewport (375px wide) and tab selection works.
-               - Drawer opens/closes, focus-traps, Escape closes it.
-               - BottomSheet renders, Escape closes it, backdrop tap closes it.
-            2. Verify token coverage: spot-check that --bottom-nav-height, --touch-target,
-               and --sheet-max-h are actually applied (use CSS computed style assertions).
-            3. Run the existing e2e suite and confirm no regressions in TopBar, Modal,
-               SidePanel at md+ viewport.
-            4. Commit test updates on branch `ds-propagate/e2e-{{github.run_number}}`, push, open a draft PR.
-            5. Report SCOPE DONE (verified) or OUT OF SCOPE — NOT DONE for each item.
+          **Your task (report SCOPE DONE when complete):**
+          1. Write or update Playwright tests for the new mobile DS primitives:
+             - BottomNav renders at xs viewport (375px wide) and tab selection works.
+             - Drawer opens/closes, focus-traps, Escape closes it.
+             - BottomSheet renders, Escape closes it, backdrop tap closes it.
+          2. Verify token coverage: spot-check that --bottom-nav-height, --touch-target,
+             and --sheet-max-h are actually applied (CSS computed style assertions).
+          3. Run the existing e2e suite and confirm no regressions in TopBar, Modal,
+             SidePanel at md+ viewport.
+          4. Commit on branch \`ds-propagate/e2e-${RUN}\`, push, open a draft PR.
+          5. Report SCOPE DONE (verified) or OUT OF SCOPE — NOT DONE for each item.
+          EOF
+          )"


### PR DESCRIPTION
## Summary

Fixes the failed propagation run — two bugs in the original workflow:

1. **`claude-code-action@v1` does not support `push` events** — it only handles `issue_comment`, `pull_request_review_comment`, `issues`, and `pull_request_review`. Running it on `push` always fails with `Unsupported event type: push`.
2. **`agent_type` is not a valid input** for `claude-code-action@v1` — flagged as an unknown input warning.

## Fix

Instead of calling `claude-code-action` directly in the `push` workflow, each propagation job now opens a **GitHub Issue** with `@claude` in the body and the full agent prompt. The existing `claude.yml` workflow (`issues: [opened]`) picks these up automatically and runs Claude — exactly the same path as a human typing `@claude` in an issue.

The three issues opened per DS push are:
- `DS propagation run #N — frontend` → `frontend-engineer` prompt
- `DS propagation run #N — mobile` → `mobile-frontend-engineer` prompt  
- `DS propagation run #N — UI tests` → `frontend-test-engineer` prompt (opens after the first two)

## Test plan

- [ ] Merge to master
- [ ] Confirm three issues are opened in the repo with `ds-propagation` label
- [ ] Confirm `claude.yml` fires on each and Claude opens draft PRs on `ds-propagate/frontend-N`, `ds-propagate/mobile-N`, `ds-propagate/e2e-N`


---
_Generated by [Claude Code](https://claude.ai/code/session_01EsXcQutg2j6DicpRSEr8UN)_