### PR TITLE
fix(ds-propagate): auto-create labels before opening propagation issues

### DIFF
--- a/.github/workflows/ds-propagate.yml
+++ b/.github/workflows/ds-propagate.yml
@@ -55,6 +55,15 @@ jobs:
       contents: read
       issues: write
     steps:
+      - name: Ensure labels exist
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh label create "ds-propagation" --repo "$GITHUB_REPOSITORY" --color "0075ca" --description "Design system propagation task" --force
+          gh label create "frontend"       --repo "$GITHUB_REPOSITORY" --color "e4e669" --description "Frontend slice" --force
+          gh label create "mobile"         --repo "$GITHUB_REPOSITORY" --color "d93f0b" --description "Mobile slice" --force
+          gh label create "testing"        --repo "$GITHUB_REPOSITORY" --color "0e8a16" --description "Testing slice" --force
+
       - name: Create @claude frontend issue
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -95,6 +104,13 @@ jobs:
       contents: read
       issues: write
     steps:
+      - name: Ensure labels exist
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh label create "ds-propagation" --repo "$GITHUB_REPOSITORY" --color "0075ca" --description "Design system propagation task" --force
+          gh label create "mobile"         --repo "$GITHUB_REPOSITORY" --color "d93f0b" --description "Mobile slice" --force
+
       - name: Create @claude mobile issue
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -133,11 +149,19 @@ jobs:
   open-e2e-issue:
     name: Open UI-test propagation issue
     needs: [open-frontend-issue, open-mobile-issue]
+    if: always()
     runs-on: ubuntu-latest
     permissions:
       contents: read
       issues: write
     steps:
+      - name: Ensure labels exist
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh label create "ds-propagation" --repo "$GITHUB_REPOSITORY" --color "0075ca" --description "Design system propagation task" --force
+          gh label create "testing"        --repo "$GITHUB_REPOSITORY" --color "0e8a16" --description "Testing slice" --force
+
       - name: Create @claude e2e issue
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Problem

Run #2 failed with `could not add label: 'ds-propagation' not found` — the labels `ds-propagation`, `frontend`, `mobile`, `testing` didn't exist in the repo so `gh issue create --label` exited with code 1.

## Fix

Each job now runs `gh label create --force` (idempotent — creates if missing, no-ops if present) before opening its issue. Also adds `if: always()` to the e2e job so it still runs even if the first two jobs partially fail.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EsXcQutg2j6DicpRSEr8UN)_