### PR TITLE
feat(seeds): remove coupled MFE registrations; MFEs now self-register at startup

### DIFF
--- a/backend/src/seeds/register-platform-apps.ts
+++ b/backend/src/seeds/register-platform-apps.ts
@@ -1,96 +1,33 @@
 /**
- * One-time seed: registers FuzeSales, FuzeContact, FuzeService in the FuzeFront
- * app registry so they appear in the App selector menu.
+ * One-time seed: registers platform apps in the FuzeFront app registry
+ * so they appear in the App selector menu.
  *
  * Run: npx ts-node src/seeds/register-platform-apps.ts
  * Idempotent: skips apps that are already registered.
+ *
+ * FuzeSales, FuzeContact, and FuzeService self-register at pod startup
+ * via a Kubernetes init container in each app's own Helm chart.
+ * See docs/mfe-self-registration.md for the pattern.
  */
 import axios from 'axios'
 
 const API = process.env.FUZEFRONT_API_URL || 'http://localhost:3001'
 const TOKEN = process.env.SEED_API_TOKEN  // admin JWT or service token
 
-const APPS = [
-  {
-    slug: 'fuzesales',
-    manifest: {
-      manifestVersion: '1',
-      slug: 'fuzesales',
-      name: 'FuzeSales',
-      menuLabel: 'Sales',
-      description: 'CRM and sales pipeline management',
-      icon: { kind: 'emoji', value: '💼' },
-      mode: 'portal',
-      builtin: false,
-      integration: {
-        type: 'module-federation',
-        remoteEntry: process.env.FUZESALES_REMOTE_ENTRY || 'https://sales.fuzefront.com/remoteEntry.js',
-        scope: 'fuzesales',
-        module: './FuzeSalesApp',
-      },
-      chrome: { menu: 'host', topbar: 'host' },
-      routing: { path: '/app/fuzesales' },
-      visibility: 'organization',
-    },
-  },
-  {
-    slug: 'fuzecontact',
-    manifest: {
-      manifestVersion: '1',
-      slug: 'fuzecontact',
-      name: 'FuzeContact',
-      menuLabel: 'Contact',
-      description: 'Omnichannel contact and conversation management',
-      icon: { kind: 'emoji', value: '📞' },
-      mode: 'portal',
-      builtin: false,
-      integration: {
-        type: 'module-federation',
-        remoteEntry: process.env.FUZECONTACT_REMOTE_ENTRY || 'https://contact.fuzefront.com/remoteEntry.js',
-        scope: 'fuzecontact',
-        module: './FuzeContactApp',
-      },
-      chrome: { menu: 'host', topbar: 'host' },
-      routing: { path: '/app/fuzecontact' },
-      visibility: 'organization',
-    },
-  },
-  {
-    slug: 'fuzeservice',
-    manifest: {
-      manifestVersion: '1',
-      slug: 'fuzeservice',
-      name: 'FuzeService',
-      menuLabel: 'Service',
-      description: 'Helpdesk and customer service management',
-      icon: { kind: 'emoji', value: '🎧' },
-      mode: 'portal',
-      builtin: false,
-      integration: {
-        type: 'module-federation',
-        remoteEntry: process.env.FUZESERVICE_REMOTE_ENTRY || 'https://service.fuzefront.com/remoteEntry.js',
-        scope: 'fuzeservice',
-        module: './FuzeServiceApp',
-      },
-      chrome: { menu: 'host', topbar: 'host' },
-      routing: { path: '/app/fuzeservice' },
-      visibility: 'organization',
-    },
-  },
+const APPS: Array<{ slug: string; manifest: Record<string, unknown> }> = [
+  // Add platform-managed built-ins here.
+  // Product MFEs (FuzeSales, FuzeContact, FuzeService) self-register from their own repos.
 ]
 
 async function registerApp(app: typeof APPS[0]) {
   const headers = { Authorization: `Bearer ${TOKEN}`, 'Content-Type': 'application/json' }
   try {
-    // Check if already registered
     const check = await axios.get(`${API}/api/v1/app-registry/apps/${app.slug}`, { headers }).catch(() => null)
     if (check?.data?.slug === app.slug) {
       console.log(`[skip] ${app.slug} already registered`)
       return
     }
-    // Register
     await axios.post(`${API}/api/v1/app-registry/apps`, { slug: app.slug, manifest: app.manifest }, { headers })
-    // Activate
     await axios.post(`${API}/api/v1/app-registry/apps/${app.slug}/activate`, {}, { headers })
     console.log(`[ok] registered + activated ${app.slug}`)
   } catch (err: any) {

--- a/docs/mfe-self-registration.md
+++ b/docs/mfe-self-registration.md
@@ -1,0 +1,59 @@
+# MFE Self-Registration Pattern
+
+Each MFE self-registers with FuzeFront at pod startup via a Kubernetes init container.
+The registration manifest lives in the MFE's own repo — no FuzeFront coupling.
+
+## Why registration is a hard requirement
+
+The MFE depends on FuzeFront for AuthN, AuthZ, org/user context, billing, sockets,
+and more. An unregistered MFE cannot function. If registration fails, the pod must
+not start — it will CrashLoopBackOff until the issue is resolved.
+
+## How it works
+
+1. The MFE repo contains `registration/manifest.json` (AppManifest) and
+   `registration/register.sh` (idempotent startup script).
+2. The Helm chart runs the script as a Kubernetes init container (not optional).
+3. The script logic:
+   - `GET /api/v1/app-registry/apps/{slug}` → 200 + activated → done (skip)
+   - 200 + not activated → POST activate, then done
+   - 404 → POST register, POST activate, then done
+   - Any other result → exit 1 (hard stop — pod will not start)
+4. `FUZEFRONT_API_URL` and `FUZEFRONT_REGISTRATION_TOKEN` are required env vars,
+   injected from a Kubernetes Secret named `fuzefront-registration` (key: `token`).
+   Missing secret → pod fails at scheduling time (not optional).
+
+## AppManifest shape
+
+See `services/app-registry-service/openapi.yaml`. Key fields for an MF app:
+
+```json
+{
+  "manifestVersion": "1",
+  "slug": "fuzesales",
+  "name": "FuzeSales",
+  "menuLabel": "Sales",
+  "mode": "portal",
+  "integration": {
+    "type": "module-federation",
+    "remoteEntry": "https://fuzesales.prod.fuzefront.com/assets/remoteEntry.js",
+    "scope": "fuzesales",
+    "module": "./FuzeSalesApp"
+  },
+  "routing": { "path": "/app/fuzesales" },
+  "visibility": "organization"
+}
+```
+
+## Auth token
+
+`FUZEFRONT_REGISTRATION_TOKEN` is a Bearer JWT for a service account with `apps:register`
+scope. Same format as `SEED_API_TOKEN`. Create one service-level token and seal it
+into a `fuzefront-registration` SealedSecret in each MFE's namespace:
+
+```bash
+kubectl create secret generic fuzefront-registration \
+  --namespace=fuzesales \
+  --from-literal=token=<PLATFORM_REGISTRATION_TOKEN> \
+  --dry-run=client -o yaml | kubeseal > sealed-fuzefront-registration.yaml
+```


### PR DESCRIPTION
## Summary

- Removes the FuzeSales, FuzeContact, and FuzeService registration blocks from `backend/src/seeds/register-platform-apps.ts`
- Replaces them with a comment pointing to the new self-registration pattern
- Adds `docs/mfe-self-registration.md` documenting the init-container pattern, hard-stop rationale, AppManifest shape, and auth token requirements

## Why

FuzeSales, FuzeContact, and FuzeService now self-register via a Kubernetes init container in each app's own Helm chart. Keeping registrations coupled into FuzeFront's seed script creates an unnecessary dependency and a single point of failure. With self-registration, each MFE owns its own registration manifest (`registration/manifest.json`) and script (`registration/register.sh`), and the pod hard-stops (CrashLoopBackOff) if registration fails — which is the correct behavior since the MFE cannot function unregistered.

## Test plan

- [ ] Verify `backend/src/seeds/register-platform-apps.ts` contains only the comment block and no fuzesales/fuzecontact/fuzeservice entries
- [ ] Verify `docs/mfe-self-registration.md` exists and documents the pattern correctly
- [ ] Confirm no other backend seed logic was removed (imports, helpers, other app entries remain intact)
- [ ] MFE self-registration contract tests in each MFE repo validate the init-container behavior independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)