### PR TITLE
fix(ds-agent): enable show_full_output + API key guard for diagnosis

### DIFF
--- a/.github/workflows/ds-claude-agent.yml
+++ b/.github/workflows/ds-claude-agent.yml
@@ -29,9 +29,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Check API key presence
+        run: |
+          if [ -z "$ANTHROPIC_API_KEY" ]; then
+            echo "::error::ANTHROPIC_API_KEY secret is not set. Add it under Settings → Secrets → Actions."
+            exit 1
+          fi
+          echo "ANTHROPIC_API_KEY is present (${#ANTHROPIC_API_KEY} chars)"
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+
       - name: Run Claude Code Action
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: ${{ inputs.prompt }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          show_full_output: true


### PR DESCRIPTION
## Summary

The two `ds-claude-agent.yml` dispatch runs both completed in ~20 seconds with `is_error: true, total_cost_usd: 0` — Claude Code SDK exited before making any API calls. With `show_full_output: false` (the default), the actual error is hidden.

This PR adds two fixes to unblock diagnosis:

- **API key guard** — an explicit check step that fails fast with a clear error if `ANTHROPIC_API_KEY` is empty, rather than silently failing inside the action
- **`show_full_output: true`** — exposes Claude's full output in the job logs so the actual error is visible

## Changes

- `.github/workflows/ds-claude-agent.yml`: add `show_full_output: true` + pre-flight API key check step

## Next steps after merge

Re-dispatch `ds-claude-agent.yml` once and read the full log to determine root cause (bad key format, rate limit, model error, etc.), then fix and trigger full propagation.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EsXcQutg2j6DicpRSEr8UN)_