### PR TITLE
fix(app-registry): bypass v1WriteGate feature flag for platform admins

### DIFF
--- a/backend/applications/src/routes/app-registry.ts
+++ b/backend/applications/src/routes/app-registry.ts
@@ -35,10 +35,11 @@ function forbidden(res: express.Response, message = 'Insufficient permissions fo
  * gated. Fails safe (OFF) if the flag store is unreachable.
  */
 async function v1WriteGate(
-  caller: { userId: string; organizationIds: string[] },
+  caller: { userId: string; organizationIds: string[]; isPlatformAdmin?: boolean },
   organizationId: string | null,
   res: express.Response
 ): Promise<boolean> {
+  if (caller.isPlatformAdmin) return true
   const enabled = await isV1WriteEnabled({
     organizationId: organizationId ?? caller.organizationIds[0],
     userId: caller.userId,


### PR DESCRIPTION
## Summary

- `v1WriteGate` now short-circuits to `true` immediately for callers where `isPlatformAdmin === true`
- Platform-registrar service account has `roles: ['admin']` → `isPlatformAdmin: true` via `resolveCaller`
- No feature flag store is running in the cluster → `isV1WriteEnabled()` always returns `false`, blocking MFE init-container self-registration with HTTP 503

This unblocks MFE self-registration on pod startup. Regular (non-admin) callers continue to be gated by the flag as before.

## Root cause

```
POST /api/v1/app-registry/apps → 503 feature_disabled
```
Init containers in FuzeSales/FuzeContact/FuzeService call this endpoint to register on first boot. The platform-registrar JWT has `isPlatformAdmin: true`, but the gate checked the feature flag before checking admin status. No Unleash/flag-store pod exists in the cluster → flag always OFF.

## Test plan

- [ ] Init container logs show `[fuzesales] Registered and activated.` after deploy
- [ ] Smoke tests pass: FuzeSales/FuzeContact remoteEntry.js reachable + app activated in registry
- [ ] Non-admin callers still get 503 when flag is OFF (existing behaviour unchanged)