### PR TITLE
feat(registry): register FuzeMarket as MF remote in app-registry seed

### DIFF
--- a/services/app-registry-service/seed/fuzemarket.manifest.json
+++ b/services/app-registry-service/seed/fuzemarket.manifest.json
@@ -1,0 +1,25 @@
+{
+  "manifestVersion": "1",
+  "slug": "fuzemarket",
+  "name": "FuzeMarket",
+  "menuLabel": "FuzeMarket",
+  "description": "Marketing & SEO control dashboard for Velogear Premium (Shopify store velogearpremium.com). Keyword strategy, content pipeline, analytics, competitor tracking, and AI-powered SEO recommendations.",
+  "icon": { "kind": "emoji", "value": "🛍️" },
+  "mode": "portal",
+  "builtin": false,
+  "integration": {
+    "type": "module-federation",
+    "remoteEntry": "https://fuzemarket.fuze.internal/dist/remoteEntry.js",
+    "scope": "fuzemarket",
+    "module": "./App"
+  },
+  "chrome": {
+    "menu": "host",
+    "topbar": "host"
+  },
+  "routing": {
+    "path": "/fuzemarket"
+  },
+  "visibility": "private",
+  "roles": ["admin", "owner"]
+}


### PR DESCRIPTION
## Summary

- Adds `services/app-registry-service/seed/fuzemarket.manifest.json` so FuzeFront's app-registry service seeds FuzeMarket on startup and the host shell can discover + dynamically load it.
- Follows the same manifest shape as `clock.manifest.json` (the canonical example).

## Manifest config

| Field | Value |
|---|---|
| `integration.type` | `module-federation` |
| `integration.scope` | `fuzemarket` |
| `integration.module` | `./App` |
| `integration.remoteEntry` | `https://fuzemarket.fuze.internal/dist/remoteEntry.js` |
| `routing.path` | `/fuzemarket` |
| `visibility` | `private` (admin/owner roles) |

## Companion PR

FuzeMarket: `izzywdev/FuzeMarket` — `claude/fuzemarketproduction-onboarding-4mkpjw` switches the federation build from webpack to Vite + React (ESM format, host-compatible).

## What's still needed after merge

- Helm/k8s Service + Ingress for `fuzemarket.fuze.internal` (devops stream)
- Authentik SSO migration replacing FuzeMarket's own scrypt-KDF auth (tracked as FuzeFront #117)

## Test plan

- [ ] `docker-compose up` → `GET /api/apps` includes the `fuzemarket` entry
- [ ] FuzeFront host navigates to `/fuzemarket` → FuzeMarket iframe renders inside the shell
- [ ] `dist/remoteEntry.js` loads from `https://fuzemarket.fuze.internal/dist/remoteEntry.js`

🤖 Generated with Claude Code

https://claude.ai/code/session_01GH8pydy1CM4U1i3CxQsBFb

---
_Generated by [Claude Code](https://claude.ai/code/session_01GH8pydy1CM4U1i3CxQsBFb)_