### PR TITLE
fix(release): scoped GitOps tag bump + fail loudly on rejected push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -203,14 +203,20 @@ jobs:
           # Bump ONLY the core-app image tags built by this workflow. A blanket
           # `tag:` sed would also stomp deliberately-pinned services and the
           # EXTERNAL images (authentik, unleash) whose tags are managed by hand.
+          # The tag: line must be the line IMMEDIATELY after the repository:
+          # line (true for every block in values-prod.yaml). Scoping `hot` to a
+          # single following line means a block that drops its tag: can never
+          # leak the bump onto a later, unrelated tag: (review finding).
           awk -v sha="$SHA" '
-            /repository: ghcr\.io\/izzywdev\/fuzefront-(backend|frontend|security-service|applications-service|clock-app)$/ { hot=1 }
-            hot && /^[[:space:]]*tag:/ {
-              match($0, /^[[:space:]]*/)
-              print substr($0, 1, RLENGTH) "tag: " sha
+            hot {
               hot=0
-              next
+              if ($0 ~ /^[[:space:]]*tag:/) {
+                match($0, /^[[:space:]]*/)
+                print substr($0, 1, RLENGTH) "tag: " sha
+                next
+              }
             }
+            /repository: ghcr\.io\/izzywdev\/fuzefront-(backend|frontend|security-service|applications-service|clock-app)$/ { hot=1 }
             { print }
           ' /tmp/vp-current.yaml > /tmp/vp-new.yaml
           if cmp -s /tmp/vp-current.yaml /tmp/vp-new.yaml; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -213,12 +213,23 @@ jobs:
               if ($0 ~ /^[[:space:]]*tag:/) {
                 match($0, /^[[:space:]]*/)
                 print substr($0, 1, RLENGTH) "tag: " sha
+                n++
                 next
               }
             }
             /repository: ghcr\.io\/izzywdev\/fuzefront-(backend|frontend|security-service|applications-service|clock-app)$/ { hot=1 }
             { print }
+            END { print n+0 > "/tmp/bump-count" }
           ' /tmp/vp-current.yaml > /tmp/vp-new.yaml
+          # Guard against silent no-ops: if the file layout drifts (quoted
+          # values, reordered keys, renamed registry path) the awk matches
+          # nothing and we would otherwise "succeed" while deploying stale
+          # tags (review finding). Exactly 5 core-app tags must be rewritten.
+          COUNT=$(cat /tmp/bump-count)
+          if [ "$COUNT" -ne 5 ]; then
+            echo "::error::expected 5 core-app tag rewrites in ${FILE}, got ${COUNT} — file layout changed; update the bump step"
+            exit 1
+          fi
           if cmp -s /tmp/vp-current.yaml /tmp/vp-new.yaml; then
             echo "values-prod.yaml already at ${SHA} — nothing to bump"
             exit 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -190,6 +190,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FILE: deploy/helm/fuzefront/values-prod.yaml
         run: |
+          set -euo pipefail
           SHA="${{ steps.tag.outputs.sha }}"
           # Read-modify-write against CURRENT master, not this job's (stale)
           # checkout: the builds above take minutes, and pairing fresh blob-SHA
@@ -199,14 +200,29 @@ jobs:
           RESP=$(gh api "repos/${GITHUB_REPOSITORY}/contents/${FILE}?ref=master")
           CUR_SHA=$(jq -r .sha <<<"$RESP")
           jq -r .content <<<"$RESP" | base64 -d > /tmp/vp-current.yaml
-          sed -E "s/^(\s*tag:).*/\1 ${SHA}/" /tmp/vp-current.yaml > /tmp/vp-new.yaml
+          # Bump ONLY the core-app image tags built by this workflow. A blanket
+          # `tag:` sed would also stomp deliberately-pinned services and the
+          # EXTERNAL images (authentik, unleash) whose tags are managed by hand.
+          awk -v sha="$SHA" '
+            /repository: ghcr\.io\/izzywdev\/fuzefront-(backend|frontend|security-service|applications-service|clock-app)$/ { hot=1 }
+            hot && /^[[:space:]]*tag:/ {
+              match($0, /^[[:space:]]*/)
+              print substr($0, 1, RLENGTH) "tag: " sha
+              hot=0
+              next
+            }
+            { print }
+          ' /tmp/vp-current.yaml > /tmp/vp-new.yaml
           if cmp -s /tmp/vp-current.yaml /tmp/vp-new.yaml; then
             echo "values-prod.yaml already at ${SHA} — nothing to bump"
             exit 0
           fi
-          gh api -X PUT "repos/${GITHUB_REPOSITORY}/contents/${FILE}" \
+          # No pipe here: a rejected PUT (e.g. ruleset denies the actor) must
+          # FAIL this step, not vanish into a downstream consumer's exit code.
+          NEW_COMMIT=$(gh api -X PUT "repos/${GITHUB_REPOSITORY}/contents/${FILE}" \
             -f message="release: fuzefront images ${SHA} [skip ci]" \
             -f branch=master \
             -f sha="${CUR_SHA}" \
             -f content="$(base64 -w0 /tmp/vp-new.yaml)" \
-            --jq '.commit.sha' | xargs -I{} echo "Bumped via API commit {} (server-signed)"
+            --jq '.commit.sha')
+          echo "Bumped via API commit ${NEW_COMMIT}"


### PR DESCRIPTION
## What

Repairs two defects in release.yml's "Bump image tags in values-prod.yaml (GitOps)" step, discovered while resurrecting prod deploys:

1. **Scoped tag bump.** The blanket `sed 's/^(\s*tag:).*/…/'` rewrote **every** `tag:` line in `values-prod.yaml` — including deliberately-pinned service tags (email/billing) and EXTERNAL images (`authentik`, `unleash`), which would have been stomped to the app image SHA on the next successful bump. Replaced with an awk pass that bumps only the five core-app images this workflow builds (backend, frontend, security-service, applications-service, clock-app), keyed off their `repository:` lines. Verified against the live file: exactly 5 lines change, output stays valid YAML.

2. **No more silent failure.** The previous step ended in `gh api PUT … | xargs echo`. Without pipefail, a rejected PUT (the master ruleset denies the `github-actions` actor) exited through xargs's status 0 — the step reported success while committing nothing (exactly what happened on the `965dd646` release). The PUT result is now captured with `$( )` under `set -euo pipefail`, so a rejected push fails the release run visibly.

## Context

- The master ruleset (`17974934`) requires PRs with no bypass for `github-actions` — the true cause of every failed release since Jul 7 (not `required_signatures`). A bypass-actor entry for the GitHub Actions integration is being added separately (repo settings); until it lands, this step will fail loudly instead of pretending to deploy.
- The `965dd6464a7a` images were bumped manually (`04270fd`) and are live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R4AUD2d6aFpPT67pnLhQGk

---
_Generated by [Claude Code](https://claude.ai/code/session_01R4AUD2d6aFpPT67pnLhQGk)_