### PR TITLE
feat(prod): seed synthetic smoke admin admin@fuzefront.com (phase 2/2)

### DIFF
--- a/deploy/helm/fuzefront/values-prod.yaml
+++ b/deploy/helm/fuzefront/values-prod.yaml
@@ -45,6 +45,10 @@ frontend:
 # the Phase 3 cutover. tag "" is rewritten by CI's release sed.
 securityService:
   enabled: true   # serves /api/auth (local auth + seeded users); OIDC falls back to local
+  # Synthetic account for post-prod e2e smoke (POST_PROD_EMAIL/POST_PROD_PASSWORD).
+  # Fresh address (absent in prod) so the idempotent seed-admin hook does a clean
+  # insert with the sealed FUZEFRONT_ADMIN_PASSWORD. See PR #213 (password reseal).
+  adminEmail: admin@fuzefront.com
   image:
     repository: ghcr.io/izzywdev/fuzefront-security-service
     tag: 965dd6464a7a


### PR DESCRIPTION
## Phase 2 of 2 — trigger the seed of the synthetic smoke account

Sets `securityService.adminEmail=admin@fuzefront.com`. On merge, the `fuzefront` umbrella-chart Argo sync runs the idempotent `seed-admin` post-upgrade hook, which inserts `admin@fuzefront.com` (confirmed absent in the prod `users` table) with the `FUZEFRONT_ADMIN_PASSWORD` re-sealed in #213 — already verified live in the Secret before this merge, so no stale-password race.

Rendered check: `helm template … security-seed-job.yaml` → `FUZEFRONT_ADMIN_EMAIL: "admin@fuzefront.com"` ✓

Follow-up (outside this PR): set `POST_PROD_EMAIL`/`POST_PROD_PASSWORD` repo secrets and run `post-prod-e2e.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)