### PR TITLE
feat(auth): native email/password sign-in driven by Authentik (no redirect) + console cleanup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -203,14 +203,20 @@ jobs:
           # Bump ONLY the core-app image tags built by this workflow. A blanket
           # `tag:` sed would also stomp deliberately-pinned services and the
           # EXTERNAL images (authentik, unleash) whose tags are managed by hand.
+          # The tag: line must be the line IMMEDIATELY after the repository:
+          # line (true for every block in values-prod.yaml). Scoping `hot` to a
+          # single following line means a block that drops its tag: can never
+          # leak the bump onto a later, unrelated tag: (review finding).
           awk -v sha="$SHA" '
-            /repository: ghcr\.io\/izzywdev\/fuzefront-(backend|frontend|security-service|applications-service|clock-app)$/ { hot=1 }
-            hot && /^[[:space:]]*tag:/ {
-              match($0, /^[[:space:]]*/)
-              print substr($0, 1, RLENGTH) "tag: " sha
+            hot {
               hot=0
-              next
+              if ($0 ~ /^[[:space:]]*tag:/) {
+                match($0, /^[[:space:]]*/)
+                print substr($0, 1, RLENGTH) "tag: " sha
+                next
+              }
             }
+            /repository: ghcr\.io\/izzywdev\/fuzefront-(backend|frontend|security-service|applications-service|clock-app)$/ { hot=1 }
             { print }
           ' /tmp/vp-current.yaml > /tmp/vp-new.yaml
           if cmp -s /tmp/vp-current.yaml /tmp/vp-new.yaml; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -213,12 +213,23 @@ jobs:
               if ($0 ~ /^[[:space:]]*tag:/) {
                 match($0, /^[[:space:]]*/)
                 print substr($0, 1, RLENGTH) "tag: " sha
+                n++
                 next
               }
             }
             /repository: ghcr\.io\/izzywdev\/fuzefront-(backend|frontend|security-service|applications-service|clock-app)$/ { hot=1 }
             { print }
+            END { print n+0 > "/tmp/bump-count" }
           ' /tmp/vp-current.yaml > /tmp/vp-new.yaml
+          # Guard against silent no-ops: if the file layout drifts (quoted
+          # values, reordered keys, renamed registry path) the awk matches
+          # nothing and we would otherwise "succeed" while deploying stale
+          # tags (review finding). Exactly 5 core-app tags must be rewritten.
+          COUNT=$(cat /tmp/bump-count)
+          if [ "$COUNT" -ne 5 ]; then
+            echo "::error::expected 5 core-app tag rewrites in ${FILE}, got ${COUNT} — file layout changed; update the bump step"
+            exit 1
+          fi
           if cmp -s /tmp/vp-current.yaml /tmp/vp-new.yaml; then
             echo "values-prod.yaml already at ${SHA} — nothing to bump"
             exit 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -190,6 +190,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FILE: deploy/helm/fuzefront/values-prod.yaml
         run: |
+          set -euo pipefail
           SHA="${{ steps.tag.outputs.sha }}"
           # Read-modify-write against CURRENT master, not this job's (stale)
           # checkout: the builds above take minutes, and pairing fresh blob-SHA
@@ -199,14 +200,29 @@ jobs:
           RESP=$(gh api "repos/${GITHUB_REPOSITORY}/contents/${FILE}?ref=master")
           CUR_SHA=$(jq -r .sha <<<"$RESP")
           jq -r .content <<<"$RESP" | base64 -d > /tmp/vp-current.yaml
-          sed -E "s/^(\s*tag:).*/\1 ${SHA}/" /tmp/vp-current.yaml > /tmp/vp-new.yaml
+          # Bump ONLY the core-app image tags built by this workflow. A blanket
+          # `tag:` sed would also stomp deliberately-pinned services and the
+          # EXTERNAL images (authentik, unleash) whose tags are managed by hand.
+          awk -v sha="$SHA" '
+            /repository: ghcr\.io\/izzywdev\/fuzefront-(backend|frontend|security-service|applications-service|clock-app)$/ { hot=1 }
+            hot && /^[[:space:]]*tag:/ {
+              match($0, /^[[:space:]]*/)
+              print substr($0, 1, RLENGTH) "tag: " sha
+              hot=0
+              next
+            }
+            { print }
+          ' /tmp/vp-current.yaml > /tmp/vp-new.yaml
           if cmp -s /tmp/vp-current.yaml /tmp/vp-new.yaml; then
             echo "values-prod.yaml already at ${SHA} — nothing to bump"
             exit 0
           fi
-          gh api -X PUT "repos/${GITHUB_REPOSITORY}/contents/${FILE}" \
+          # No pipe here: a rejected PUT (e.g. ruleset denies the actor) must
+          # FAIL this step, not vanish into a downstream consumer's exit code.
+          NEW_COMMIT=$(gh api -X PUT "repos/${GITHUB_REPOSITORY}/contents/${FILE}" \
             -f message="release: fuzefront images ${SHA} [skip ci]" \
             -f branch=master \
             -f sha="${CUR_SHA}" \
             -f content="$(base64 -w0 /tmp/vp-new.yaml)" \
-            --jq '.commit.sha' | xargs -I{} echo "Bumped via API commit {} (server-signed)"
+            --jq '.commit.sha')
+          echo "Bumped via API commit ${NEW_COMMIT}"

--- a/backend/security/src/index.ts
+++ b/backend/security/src/index.ts
@@ -25,6 +25,10 @@ dotenv.config()
 
 const PORT = process.env.PORT || 3002
 const app = createExpressApp({ serviceName: 'security-service' })
+// Behind the k8s ingress every request otherwise carries the ingress IP —
+// trust the first proxy hop so req.ip (rate limiting, auth logs) reflects
+// the real client from X-Forwarded-For.
+app.set('trust proxy', 1)
 const httpServer = createServer(app)
 const startTime = Date.now()
 

--- a/backend/security/src/routes/auth.ts
+++ b/backend/security/src/routes/auth.ts
@@ -505,14 +505,14 @@ router.post('/oidc/password', passwordLoginRateLimiter, async (req, res) => {
       return res.status(401).json({ error: 'Invalid credentials' })
     }
     if (error instanceof UnsupportedFlowStageError) {
-      console.warn('⚠️ Unsupported Authentik flow stage', { requestId, message: error.message.replace(/[\r\n]+/g, ' ') })
+      console.warn('⚠️ Unsupported Authentik flow stage', JSON.stringify({ requestId, message: error.message.replace(/[\r\n]+/g, ' ') }))
       return res.status(503).json({
         error:
           'This account requires a browser sign-in flow (e.g. MFA). Use the SSO button instead.',
       })
     }
     if (error instanceof AuthentikUnavailableError) {
-      console.error('❌ Authentik unavailable', { requestId, message: error.message.replace(/[\r\n]+/g, ' ') })
+      console.error('❌ Authentik unavailable', JSON.stringify({ requestId, message: error.message.replace(/[\r\n]+/g, ' ') }))
       return res
         .status(503)
         .json({ error: 'Authentication service unavailable. Try again shortly.' })

--- a/backend/security/src/routes/auth.ts
+++ b/backend/security/src/routes/auth.ts
@@ -1,5 +1,6 @@
 import crypto from 'crypto'
 import express from 'express'
+import rateLimit from 'express-rate-limit'
 import bcrypt from 'bcryptjs'
 import jwt from 'jsonwebtoken'
 import { v4 as uuidv4 } from 'uuid'
@@ -406,29 +407,18 @@ router.get('/oidc/login', async (req, res) => {
 })
 
 
-// Fixed-window rate limit for the password endpoint (per replica): the
-// flow-executor login is a credential-stuffing surface, so cap attempts per
-// client-IP+account before we ever contact Authentik.
-const PW_WINDOW_MS = 5 * 60_000
-const PW_MAX_ATTEMPTS = 10
-const pwAttempts = new Map<string, { count: number; resetAt: number }>()
-setInterval(() => {
-  const now = Date.now()
-  for (const [k, v] of pwAttempts) {
-    if (v.resetAt < now) pwAttempts.delete(k)
-  }
-}, 60_000).unref()
-
-function passwordRateLimited(key: string): boolean {
-  const now = Date.now()
-  const cur = pwAttempts.get(key)
-  if (!cur || cur.resetAt < now) {
-    pwAttempts.set(key, { count: 1, resetAt: now + PW_WINDOW_MS })
-    return false
-  }
-  cur.count++
-  return cur.count > PW_MAX_ATTEMPTS
-}
+// Rate limit for the password endpoint: the flow-executor login is a
+// credential-stuffing surface, so cap FAILED attempts per client before we
+// ever contact Authentik (same express-rate-limit convention as
+// tokenAuthRateLimiter). Successful sign-ins are never throttled.
+const passwordLoginRateLimiter = rateLimit({
+  windowMs: 5 * 60_000,
+  limit: 10,
+  skipSuccessfulRequests: true,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { error: 'Too many sign-in attempts. Try again later.' },
+})
 
 /**
  * @swagger
@@ -464,7 +454,7 @@ function passwordRateLimited(key: string): boolean {
  *         description: OIDC not configured, Authentik unreachable, or the
  *           account requires a browser flow (MFA/consent)
  */
-router.post('/oidc/password', async (req, res) => {
+router.post('/oidc/password', passwordLoginRateLimiter, async (req, res) => {
   const requestId = uuidv4().substring(0, 8)
   const { email, password } = req.body || {}
 
@@ -477,12 +467,6 @@ router.post('/oidc/password', async (req, res) => {
 
   if (!email || !password) {
     return res.status(400).json({ error: 'Email and password required' })
-  }
-  const rlKey = `${req.ip}|${String(email).toLowerCase()}`
-  if (passwordRateLimited(rlKey)) {
-    return res
-      .status(429)
-      .json({ error: 'Too many sign-in attempts. Try again later.' })
   }
   if (!oidcService.isConfigured()) {
     return res.status(503).json({

--- a/backend/security/src/routes/auth.ts
+++ b/backend/security/src/routes/auth.ts
@@ -405,6 +405,31 @@ router.get('/oidc/login', async (req, res) => {
   }
 })
 
+
+// Fixed-window rate limit for the password endpoint (per replica): the
+// flow-executor login is a credential-stuffing surface, so cap attempts per
+// client-IP+account before we ever contact Authentik.
+const PW_WINDOW_MS = 5 * 60_000
+const PW_MAX_ATTEMPTS = 10
+const pwAttempts = new Map<string, { count: number; resetAt: number }>()
+setInterval(() => {
+  const now = Date.now()
+  for (const [k, v] of pwAttempts) {
+    if (v.resetAt < now) pwAttempts.delete(k)
+  }
+}, 60_000).unref()
+
+function passwordRateLimited(key: string): boolean {
+  const now = Date.now()
+  const cur = pwAttempts.get(key)
+  if (!cur || cur.resetAt < now) {
+    pwAttempts.set(key, { count: 1, resetAt: now + PW_WINDOW_MS })
+    return false
+  }
+  cur.count++
+  return cur.count > PW_MAX_ATTEMPTS
+}
+
 /**
  * @swagger
  * /api/auth/oidc/password:
@@ -453,6 +478,12 @@ router.post('/oidc/password', async (req, res) => {
   if (!email || !password) {
     return res.status(400).json({ error: 'Email and password required' })
   }
+  const rlKey = `${req.ip}|${String(email).toLowerCase()}`
+  if (passwordRateLimited(rlKey)) {
+    return res
+      .status(429)
+      .json({ error: 'Too many sign-in attempts. Try again later.' })
+  }
   if (!oidcService.isConfigured()) {
     return res.status(503).json({
       error:
@@ -466,9 +497,9 @@ router.post('/oidc/password', async (req, res) => {
     // Session + JWT minting — identical to the local login / OIDC callback.
     const sessionId = uuidv4()
     const expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000) // 24 hours
-    // nosemgrep: fuze-auth-self-minted-user-token — this IS FuzeFront's
-    // identity service; it is the issuer of platform tokens (same mint as
-    // /login and the OIDC callback), not a product self-minting.
+    // This IS FuzeFront's identity service — the issuer of platform tokens
+    // (same mint as /login and the OIDC callback), not a product self-minting.
+    // nosemgrep: fuze-auth-self-minted-user-token, semgrep.fuze-auth-self-minted-user-token
     const token = jwt.sign(
       { userId: user.id, sessionId },
       process.env.JWT_SECRET!,
@@ -482,7 +513,7 @@ router.post('/oidc/password', async (req, res) => {
 
     selfHealProvisioningOnLogin(user.id)
 
-    console.log('🎉 Authentik password login successful', { requestId, email: user.email })
+    console.log('🎉 Authentik password login successful', { requestId, userId: user.id })
     return res.json({ token, user, sessionId })
   } catch (error) {
     if (error instanceof InvalidCredentialsError) {
@@ -490,14 +521,14 @@ router.post('/oidc/password', async (req, res) => {
       return res.status(401).json({ error: 'Invalid credentials' })
     }
     if (error instanceof UnsupportedFlowStageError) {
-      console.warn('⚠️ Unsupported Authentik flow stage', { requestId, message: error.message })
+      console.warn('⚠️ Unsupported Authentik flow stage', { requestId, message: error.message.replace(/[\r\n]+/g, ' ') })
       return res.status(503).json({
         error:
           'This account requires a browser sign-in flow (e.g. MFA). Use the SSO button instead.',
       })
     }
     if (error instanceof AuthentikUnavailableError) {
-      console.error('❌ Authentik unavailable', { requestId, message: error.message })
+      console.error('❌ Authentik unavailable', { requestId, message: error.message.replace(/[\r\n]+/g, ' ') })
       return res
         .status(503)
         .json({ error: 'Authentication service unavailable. Try again shortly.' })

--- a/backend/security/src/routes/auth.ts
+++ b/backend/security/src/routes/auth.ts
@@ -369,7 +369,8 @@ router.get('/oidc/login', async (req, res) => {
   // Structured trace: enough to diagnose a broken handoff from pod logs alone
   // (misconfigured issuer/redirect/frontend-base, or an uninitialized client
   // whose discovery against Authentik failed at boot).
-  console.log(`🔐 [${requestId}] OIDC login request received`, {
+  console.log('🔐 OIDC login request received', {
+    requestId,
     referer: req.get('Referer'),
     configured: oidcService.isConfigured?.(),
     initialized: oidcService.isInitialized?.(),
@@ -442,7 +443,8 @@ router.post('/oidc/password', async (req, res) => {
   const requestId = uuidv4().substring(0, 8)
   const { email, password } = req.body || {}
 
-  console.log(`🔐 [${requestId}] Authentik password login request`, {
+  console.log('🔐 Authentik password login request', {
+    requestId,
     hasEmail: !!email,
     configured: oidcService.isConfigured?.(),
     initialized: oidcService.isInitialized?.(),
@@ -464,6 +466,9 @@ router.post('/oidc/password', async (req, res) => {
     // Session + JWT minting — identical to the local login / OIDC callback.
     const sessionId = uuidv4()
     const expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000) // 24 hours
+    // nosemgrep: fuze-auth-self-minted-user-token — this IS FuzeFront's
+    // identity service; it is the issuer of platform tokens (same mint as
+    // /login and the OIDC callback), not a product self-minting.
     const token = jwt.sign(
       { userId: user.id, sessionId },
       process.env.JWT_SECRET!,
@@ -477,27 +482,27 @@ router.post('/oidc/password', async (req, res) => {
 
     selfHealProvisioningOnLogin(user.id)
 
-    console.log(`🎉 [${requestId}] Authentik password login successful:`, user.email)
+    console.log('🎉 Authentik password login successful', { requestId, email: user.email })
     return res.json({ token, user, sessionId })
   } catch (error) {
     if (error instanceof InvalidCredentialsError) {
-      console.log(`❌ [${requestId}] Authentik rejected credentials`)
+      console.log('❌ Authentik rejected credentials', { requestId })
       return res.status(401).json({ error: 'Invalid credentials' })
     }
     if (error instanceof UnsupportedFlowStageError) {
-      console.warn(`⚠️ [${requestId}] ${error.message}`)
+      console.warn('⚠️ Unsupported Authentik flow stage', { requestId, message: error.message })
       return res.status(503).json({
         error:
           'This account requires a browser sign-in flow (e.g. MFA). Use the SSO button instead.',
       })
     }
     if (error instanceof AuthentikUnavailableError) {
-      console.error(`❌ [${requestId}] Authentik unavailable:`, error.message)
+      console.error('❌ Authentik unavailable', { requestId, message: error.message })
       return res
         .status(503)
         .json({ error: 'Authentication service unavailable. Try again shortly.' })
     }
-    console.error(`❌ [${requestId}] Authentik password login error:`, error)
+    console.error('❌ Authentik password login error', { requestId }, error)
     return res.status(500).json({ error: 'Authentication failed' })
   }
 })

--- a/backend/security/src/routes/auth.ts
+++ b/backend/security/src/routes/auth.ts
@@ -7,6 +7,12 @@ import { db } from '../config/database'
 import { authenticateToken } from '../middleware/auth'
 import { User } from '../types/shared'
 import { oidcService } from '../services/oidc'
+import {
+  authentikPasswordLogin,
+  InvalidCredentialsError,
+  AuthentikUnavailableError,
+  UnsupportedFlowStageError,
+} from '../services/authentikPassword'
 import { runInternalProvision } from '../services/organizationProvisioning'
 
 
@@ -360,7 +366,17 @@ router.post('/logout', authenticateToken, async (req: any, res) => {
  */
 router.get('/oidc/login', async (req, res) => {
   const requestId = uuidv4().substring(0, 8)
-  console.log(`🔐 [${requestId}] OIDC login request received`)
+  // Structured trace: enough to diagnose a broken handoff from pod logs alone
+  // (misconfigured issuer/redirect/frontend-base, or an uninitialized client
+  // whose discovery against Authentik failed at boot).
+  console.log(`🔐 [${requestId}] OIDC login request received`, {
+    referer: req.get('Referer'),
+    configured: oidcService.isConfigured?.(),
+    initialized: oidcService.isInitialized?.(),
+    issuerUrl: process.env.AUTHENTIK_ISSUER_URL,
+    redirectUri: process.env.AUTHENTIK_REDIRECT_URI,
+    frontendBase: FRONTEND_BASE,
+  })
 
   try {
     if (!oidcService.isConfigured()) {
@@ -385,6 +401,104 @@ router.get('/oidc/login', async (req, res) => {
   } catch (error) {
     console.error(`❌ [${requestId}] OIDC login error:`, error)
     res.status(500).json({ error: 'Failed to initiate OIDC login' })
+  }
+})
+
+/**
+ * @swagger
+ * /api/auth/oidc/password:
+ *   post:
+ *     summary: Password sign-in against Authentik (no redirect)
+ *     description: >
+ *       Authenticates email+password by driving Authentik's flow-executor API
+ *       server-side, then completes the OIDC code exchange with the resulting
+ *       Authentik session. Authentik remains the sole identity authority; the
+ *       response shape matches /api/auth/login so the frontend treats both
+ *       identically.
+ *     tags: [Authentication]
+ *     security: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [email, password]
+ *             properties:
+ *               email: { type: string }
+ *               password: { type: string }
+ *     responses:
+ *       200:
+ *         description: Authenticated — platform JWT + user
+ *       400:
+ *         description: Missing email or password
+ *       401:
+ *         description: Invalid credentials
+ *       503:
+ *         description: OIDC not configured, Authentik unreachable, or the
+ *           account requires a browser flow (MFA/consent)
+ */
+router.post('/oidc/password', async (req, res) => {
+  const requestId = uuidv4().substring(0, 8)
+  const { email, password } = req.body || {}
+
+  console.log(`🔐 [${requestId}] Authentik password login request`, {
+    hasEmail: !!email,
+    configured: oidcService.isConfigured?.(),
+    initialized: oidcService.isInitialized?.(),
+  })
+
+  if (!email || !password) {
+    return res.status(400).json({ error: 'Email and password required' })
+  }
+  if (!oidcService.isConfigured()) {
+    return res.status(503).json({
+      error:
+        'OIDC authentication not configured. Please set AUTHENTIK_CLIENT_ID and AUTHENTIK_CLIENT_SECRET.',
+    })
+  }
+
+  try {
+    const user = await authentikPasswordLogin(email, password)
+
+    // Session + JWT minting — identical to the local login / OIDC callback.
+    const sessionId = uuidv4()
+    const expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000) // 24 hours
+    const token = jwt.sign(
+      { userId: user.id, sessionId },
+      process.env.JWT_SECRET!,
+      { expiresIn: '24h' }
+    )
+    await db('sessions').insert({
+      id: sessionId,
+      user_id: user.id,
+      expires_at: expiresAt,
+    })
+
+    selfHealProvisioningOnLogin(user.id)
+
+    console.log(`🎉 [${requestId}] Authentik password login successful:`, user.email)
+    return res.json({ token, user, sessionId })
+  } catch (error) {
+    if (error instanceof InvalidCredentialsError) {
+      console.log(`❌ [${requestId}] Authentik rejected credentials`)
+      return res.status(401).json({ error: 'Invalid credentials' })
+    }
+    if (error instanceof UnsupportedFlowStageError) {
+      console.warn(`⚠️ [${requestId}] ${error.message}`)
+      return res.status(503).json({
+        error:
+          'This account requires a browser sign-in flow (e.g. MFA). Use the SSO button instead.',
+      })
+    }
+    if (error instanceof AuthentikUnavailableError) {
+      console.error(`❌ [${requestId}] Authentik unavailable:`, error.message)
+      return res
+        .status(503)
+        .json({ error: 'Authentication service unavailable. Try again shortly.' })
+    }
+    console.error(`❌ [${requestId}] Authentik password login error:`, error)
+    return res.status(500).json({ error: 'Authentication failed' })
   }
 })
 

--- a/backend/security/src/routes/auth.ts
+++ b/backend/security/src/routes/auth.ts
@@ -414,7 +414,10 @@ router.get('/oidc/login', async (req, res) => {
 const passwordLoginRateLimiter = rateLimit({
   windowMs: 5 * 60_000,
   limit: 10,
+  // Count ONLY rejected credentials (401) against the budget: 503s from an
+  // Authentik outage or an MFA-required account must not lock users out.
   skipSuccessfulRequests: true,
+  requestWasSuccessful: (_req, res) => res.statusCode !== 401,
   standardHeaders: true,
   legacyHeaders: false,
   message: { error: 'Too many sign-in attempts. Try again later.' },
@@ -476,6 +479,20 @@ router.post('/oidc/password', passwordLoginRateLimiter, async (req, res) => {
   }
 
   try {
+    // Lazy re-init mirrors the monolith and /oidc/login: Authentik may not
+    // have been ready when this replica booted — self-heal here instead of
+    // 503ing until an SSO request happens to re-initialize the client.
+    if (!oidcService.isInitialized()) {
+      try {
+        await oidcService.initialize()
+      } catch (initErr) {
+        console.error('❌ OIDC lazy init failed', JSON.stringify({ requestId, message: (initErr as Error).message?.replace(/[\r\n]+/g, ' ') }))
+        return res
+          .status(503)
+          .json({ error: 'Authentication service unavailable. Try again shortly.' })
+      }
+    }
+
     const user = await authentikPasswordLogin(email, password)
 
     // Session + JWT minting — identical to the local login / OIDC callback.

--- a/backend/security/src/services/authentikPassword.ts
+++ b/backend/security/src/services/authentikPassword.ts
@@ -156,7 +156,15 @@ async function flowRequest(
 
     const loc = res.headers.get('location')
     if ([301, 302, 303, 307, 308].includes(res.status) && loc) {
-      url = new URL(loc, url).toString()
+      const nextUrl = new URL(loc, url)
+      // The jar carries authentik_session/authentik_csrf — never present those
+      // cookies to any host other than Authentik itself.
+      if (nextUrl.origin !== new URL(base).origin) {
+        throw new AuthentikUnavailableError(
+          `Flow executor redirected off-origin to ${nextUrl.origin} — refusing to follow with session cookies`
+        )
+      }
+      url = nextUrl.toString()
       // 301/302/303 rewrite the retry as GET (Django semantics); 307/308
       // preserve the original method and body per HTTP spec.
       if (res.status !== 307 && res.status !== 308) {
@@ -288,7 +296,8 @@ export async function authentikPasswordLogin(
         `authorize returned HTTP ${res.status} without redirect (consent flow?)`
       )
     }
-    const resolved = new URL(next, location).toString()
+    const resolvedUrl = new URL(next, location)
+    const resolved = resolvedUrl.toString()
     if (resolved.startsWith(target)) {
       const u = new URL(resolved)
       code = u.searchParams.get('code')
@@ -298,6 +307,13 @@ export async function authentikPasswordLogin(
         throw new AuthentikUnavailableError(`Authorize error: ${err}`)
       }
       break
+    }
+    // Continue only within Authentik's own origin — the jar must not follow
+    // an arbitrary redirect elsewhere.
+    if (resolvedUrl.origin !== new URL(base).origin) {
+      throw new AuthentikUnavailableError(
+        `Authorize flow redirected off-origin to ${resolvedUrl.origin} — refusing to follow with session cookies`
+      )
     }
     location = resolved
   }

--- a/backend/security/src/services/authentikPassword.ts
+++ b/backend/security/src/services/authentikPassword.ts
@@ -125,7 +125,7 @@ async function flowRequest(
   let method: 'GET' | 'POST' = body ? 'POST' : 'GET'
   let payload: string | undefined = body ? JSON.stringify(body) : undefined
 
-  for (let hop = 0; hop < 4; hop++) {
+  for (let hop = 0; hop < 10; hop++) {
     const headers: Record<string, string> = {
       Accept: 'application/json',
       // Django CSRF validates Referer on secure requests.
@@ -265,7 +265,7 @@ export async function authentikPasswordLogin(
   let code: string | null = null
   let returnedState: string | null = null
 
-  for (let hop = 0; hop < 5; hop++) {
+  for (let hop = 0; hop < 10; hop++) {
     let res: Response
     try {
       res = await fetch(location, {

--- a/backend/security/src/services/authentikPassword.ts
+++ b/backend/security/src/services/authentikPassword.ts
@@ -145,12 +145,12 @@ async function flowRequest(
     )
   }
   jar.absorb(res)
-  if (res.status >= 500) {
-    throw new AuthentikUnavailableError(`Authentik flow executor HTTP ${res.status}`)
-  }
   if (!res.ok) {
+    // Surface Authentik's own error payload — a bare status is undebuggable
+    // from CI logs (e.g. 403 CSRF vs 404 unknown flow slug).
+    const bodySnippet = (await res.text().catch(() => '')).slice(0, 300)
     throw new AuthentikUnavailableError(
-      `Authentik flow executor unexpected HTTP ${res.status}`
+      `Authentik flow executor HTTP ${res.status} at ${url}: ${bodySnippet}`
     )
   }
   return (await res.json()) as FlowChallenge

--- a/backend/security/src/services/authentikPassword.ts
+++ b/backend/security/src/services/authentikPassword.ts
@@ -161,7 +161,14 @@ async function flowRequest(
       payload = undefined
       continue
     }
+    const contentTypeEarly = res.headers.get('content-type') || ''
     if (!res.ok) {
+      // A 4xx with a JSON body is a FLOW response (e.g. 400 carrying
+      // response_errors for rejected credentials) — return it so the caller
+      // maps it to 401, instead of mislabeling it a 503 outage.
+      if (res.status < 500 && contentTypeEarly.includes('json')) {
+        return (await res.json()) as FlowChallenge
+      }
       // Surface Authentik's own error payload — a bare status is undebuggable
       // from CI logs (e.g. 403 CSRF vs 404 unknown flow slug).
       const bodySnippet = (await res.text().catch(() => '')).slice(0, 300)
@@ -169,11 +176,10 @@ async function flowRequest(
         `Authentik flow executor HTTP ${res.status} at ${url}: ${bodySnippet}`
       )
     }
-    const contentType = res.headers.get('content-type') || ''
-    if (!contentType.includes('json')) {
+    if (!contentTypeEarly.includes('json')) {
       const bodySnippet = (await res.text().catch(() => '')).slice(0, 300)
       throw new AuthentikUnavailableError(
-        `Authentik flow executor returned non-JSON (${contentType}) at ${url}: ${bodySnippet}`
+        `Authentik flow executor returned non-JSON (${contentTypeEarly}) at ${url}: ${bodySnippet}`
       )
     }
     return (await res.json()) as FlowChallenge

--- a/backend/security/src/services/authentikPassword.ts
+++ b/backend/security/src/services/authentikPassword.ts
@@ -157,8 +157,12 @@ async function flowRequest(
     const loc = res.headers.get('location')
     if ([301, 302, 303, 307, 308].includes(res.status) && loc) {
       url = new URL(loc, url).toString()
-      method = 'GET'
-      payload = undefined
+      // 301/302/303 rewrite the retry as GET (Django semantics); 307/308
+      // preserve the original method and body per HTTP spec.
+      if (res.status !== 307 && res.status !== 308) {
+        method = 'GET'
+        payload = undefined
+      }
       continue
     }
     const contentTypeEarly = res.headers.get('content-type') || ''

--- a/backend/security/src/services/authentikPassword.ts
+++ b/backend/security/src/services/authentikPassword.ts
@@ -216,9 +216,7 @@ export async function authentikPasswordLogin(
 
   if (!authenticated) {
     const last = challenge.component || challenge.type || 'unknown'
-    if (last === 'xak-flow-redirect') {
-      authenticated = true
-    } else {
+    if (last !== 'xak-flow-redirect') {
       throw new UnsupportedFlowStageError(last)
     }
   }

--- a/backend/security/src/services/authentikPassword.ts
+++ b/backend/security/src/services/authentikPassword.ts
@@ -117,43 +117,68 @@ async function flowRequest(
   jar: CookieJar,
   body?: Record<string, unknown>
 ): Promise<FlowChallenge> {
-  const url = `${base}/api/v3/flows/executor/${slug}/?query=`
-  const headers: Record<string, string> = {
-    Accept: 'application/json',
-    // Django CSRF validates Referer on secure requests.
-    Referer: `${base}/`,
-  }
-  const cookie = jar.header()
-  if (cookie) headers['Cookie'] = cookie
-  if (body) {
-    headers['Content-Type'] = 'application/json'
-    const csrf = jar.get('authentik_csrf')
-    if (csrf) headers['X-CSRFToken'] = csrf
-  }
+  // Authentik commonly answers the first executor request with a 302 that
+  // establishes the session cookie (Location points back into the flow), so
+  // follow same-origin redirects manually, carrying the jar. Per Django 302
+  // semantics a redirected POST is retried as GET.
+  let url = `${base}/api/v3/flows/executor/${slug}/?query=`
+  let method: 'GET' | 'POST' = body ? 'POST' : 'GET'
+  let payload: string | undefined = body ? JSON.stringify(body) : undefined
 
-  let res: Response
-  try {
-    res = await fetch(url, {
-      method: body ? 'POST' : 'GET',
-      headers,
-      body: body ? JSON.stringify(body) : undefined,
-      redirect: 'manual',
-    })
-  } catch (err) {
-    throw new AuthentikUnavailableError(
-      `Authentik unreachable at ${base}: ${(err as Error).message}`
-    )
+  for (let hop = 0; hop < 4; hop++) {
+    const headers: Record<string, string> = {
+      Accept: 'application/json',
+      // Django CSRF validates Referer on secure requests.
+      Referer: `${base}/`,
+    }
+    const cookie = jar.header()
+    if (cookie) headers['Cookie'] = cookie
+    if (method === 'POST') {
+      headers['Content-Type'] = 'application/json'
+      const csrf = jar.get('authentik_csrf')
+      if (csrf) headers['X-CSRFToken'] = csrf
+    }
+
+    let res: Response
+    try {
+      res = await fetch(url, {
+        method,
+        headers,
+        body: payload,
+        redirect: 'manual',
+      })
+    } catch (err) {
+      throw new AuthentikUnavailableError(
+        `Authentik unreachable at ${base}: ${(err as Error).message}`
+      )
+    }
+    jar.absorb(res)
+
+    const loc = res.headers.get('location')
+    if ([301, 302, 303, 307, 308].includes(res.status) && loc) {
+      url = new URL(loc, url).toString()
+      method = 'GET'
+      payload = undefined
+      continue
+    }
+    if (!res.ok) {
+      // Surface Authentik's own error payload — a bare status is undebuggable
+      // from CI logs (e.g. 403 CSRF vs 404 unknown flow slug).
+      const bodySnippet = (await res.text().catch(() => '')).slice(0, 300)
+      throw new AuthentikUnavailableError(
+        `Authentik flow executor HTTP ${res.status} at ${url}: ${bodySnippet}`
+      )
+    }
+    const contentType = res.headers.get('content-type') || ''
+    if (!contentType.includes('json')) {
+      const bodySnippet = (await res.text().catch(() => '')).slice(0, 300)
+      throw new AuthentikUnavailableError(
+        `Authentik flow executor returned non-JSON (${contentType}) at ${url}: ${bodySnippet}`
+      )
+    }
+    return (await res.json()) as FlowChallenge
   }
-  jar.absorb(res)
-  if (!res.ok) {
-    // Surface Authentik's own error payload — a bare status is undebuggable
-    // from CI logs (e.g. 403 CSRF vs 404 unknown flow slug).
-    const bodySnippet = (await res.text().catch(() => '')).slice(0, 300)
-    throw new AuthentikUnavailableError(
-      `Authentik flow executor HTTP ${res.status} at ${url}: ${bodySnippet}`
-    )
-  }
-  return (await res.json()) as FlowChallenge
+  throw new AuthentikUnavailableError('Authentik flow executor redirect loop')
 }
 
 function challengeHasCredentialErrors(challenge: FlowChallenge): boolean {

--- a/backend/security/src/services/authentikPassword.ts
+++ b/backend/security/src/services/authentikPassword.ts
@@ -1,0 +1,280 @@
+/**
+ * Server-side Authentik password authentication — no browser redirect.
+ *
+ * The login page shows native email/password fields; this service drives
+ * Authentik's flow-executor JSON API with those credentials, then completes a
+ * standard OIDC authorization-code + PKCE exchange using the authenticated
+ * Authentik session. Authentik therefore remains the SOLE identity authority
+ * (same as the redirect flow), and everything downstream — user sync into the
+ * platform DB, session/JWT minting — reuses the existing OIDC machinery.
+ *
+ * Flow:
+ *   1. GET  /api/v3/flows/executor/<slug>/?query=      → identification stage
+ *   2. POST { component, uid_field: email [, password] }
+ *   3. POST { component, password }                     (separate password stage)
+ *   4. challenge "xak-flow-redirect"                    → Authentik session established
+ *   5. GET the OIDC authorize URL with the session cookies (implicit consent)
+ *      → 302 …/api/auth/oidc/callback?code=…&state=…
+ *   6. oidcService.handleCallback(code, state, codeVerifier) → synced User
+ *
+ * Only single-factor identification/password flows are supported. Users with
+ * MFA or other stages configured must use the browser (Google/SSO) path — we
+ * fail closed with a clear error rather than trying to drive arbitrary stages.
+ */
+import { generators } from 'openid-client'
+import { oidcService } from './oidc'
+import { User } from '../types/shared'
+
+export class InvalidCredentialsError extends Error {
+  constructor(message = 'Invalid credentials') {
+    super(message)
+    this.name = 'InvalidCredentialsError'
+  }
+}
+
+export class AuthentikUnavailableError extends Error {
+  constructor(message = 'Authentication service unavailable') {
+    super(message)
+    this.name = 'AuthentikUnavailableError'
+  }
+}
+
+export class UnsupportedFlowStageError extends Error {
+  constructor(stage: string) {
+    super(`Unsupported Authentik flow stage: ${stage} (only identification+password is supported server-side)`)
+    this.name = 'UnsupportedFlowStageError'
+  }
+}
+
+/** Minimal cookie jar for the short-lived per-login Authentik session. */
+class CookieJar {
+  private cookies = new Map<string, string>()
+
+  absorb(res: { headers: Headers }): void {
+    // Node >=18.14 exposes getSetCookie(); fall back to the single-value get()
+    // (sufficient in practice — Authentik sets one cookie per response hop).
+    const anyHeaders = res.headers as Headers & { getSetCookie?: () => string[] }
+    const setCookies: string[] =
+      typeof anyHeaders.getSetCookie === 'function'
+        ? anyHeaders.getSetCookie()
+        : ([res.headers.get('set-cookie')].filter(Boolean) as string[])
+    for (const sc of setCookies) {
+      const pair = sc.split(';')[0]
+      const eq = pair.indexOf('=')
+      if (eq <= 0) continue
+      const name = pair.slice(0, eq).trim()
+      const value = pair.slice(eq + 1).trim()
+      if (value === '' || /max-age=0|expires=thu, 01 jan 1970/i.test(sc)) {
+        this.cookies.delete(name)
+      } else {
+        this.cookies.set(name, value)
+      }
+    }
+  }
+
+  header(): string {
+    return [...this.cookies].map(([k, v]) => `${k}=${v}`).join('; ')
+  }
+
+  get(name: string): string | undefined {
+    return this.cookies.get(name)
+  }
+}
+
+function authentikBaseUrl(): string {
+  if (process.env.AUTHENTIK_BASE_URL) {
+    return process.env.AUTHENTIK_BASE_URL.replace(/\/$/, '')
+  }
+  const issuer =
+    process.env.AUTHENTIK_ISSUER_URL ||
+    'http://localhost:9000/application/o/fuzefront/'
+  return new URL(issuer).origin
+}
+
+function authFlowSlug(): string {
+  return process.env.AUTHENTIK_AUTH_FLOW_SLUG || 'default-authentication-flow'
+}
+
+function redirectUri(): string {
+  return (
+    process.env.AUTHENTIK_REDIRECT_URI ||
+    'http://fuzefront.dev.local/api/auth/oidc/callback'
+  )
+}
+
+interface FlowChallenge {
+  component?: string
+  type?: string
+  to?: string
+  password_fields?: boolean
+  response_errors?: Record<string, Array<{ string?: string; code?: string }>>
+  [key: string]: unknown
+}
+
+async function flowRequest(
+  base: string,
+  slug: string,
+  jar: CookieJar,
+  body?: Record<string, unknown>
+): Promise<FlowChallenge> {
+  const url = `${base}/api/v3/flows/executor/${slug}/?query=`
+  const headers: Record<string, string> = {
+    Accept: 'application/json',
+    // Django CSRF validates Referer on secure requests.
+    Referer: `${base}/`,
+  }
+  const cookie = jar.header()
+  if (cookie) headers['Cookie'] = cookie
+  if (body) {
+    headers['Content-Type'] = 'application/json'
+    const csrf = jar.get('authentik_csrf')
+    if (csrf) headers['X-CSRFToken'] = csrf
+  }
+
+  let res: Response
+  try {
+    res = await fetch(url, {
+      method: body ? 'POST' : 'GET',
+      headers,
+      body: body ? JSON.stringify(body) : undefined,
+      redirect: 'manual',
+    })
+  } catch (err) {
+    throw new AuthentikUnavailableError(
+      `Authentik unreachable at ${base}: ${(err as Error).message}`
+    )
+  }
+  jar.absorb(res)
+  if (res.status >= 500) {
+    throw new AuthentikUnavailableError(`Authentik flow executor HTTP ${res.status}`)
+  }
+  if (!res.ok) {
+    throw new AuthentikUnavailableError(
+      `Authentik flow executor unexpected HTTP ${res.status}`
+    )
+  }
+  return (await res.json()) as FlowChallenge
+}
+
+function challengeHasCredentialErrors(challenge: FlowChallenge): boolean {
+  const errs = challenge.response_errors
+  if (!errs) return false
+  return Object.keys(errs).length > 0
+}
+
+/**
+ * Authenticate email+password against Authentik and return the synced platform
+ * User. Throws InvalidCredentialsError / AuthentikUnavailableError /
+ * UnsupportedFlowStageError.
+ */
+export async function authentikPasswordLogin(
+  email: string,
+  password: string
+): Promise<User> {
+  if (!oidcService.isConfigured() || !oidcService.isInitialized()) {
+    throw new AuthentikUnavailableError('OIDC is not configured/initialized')
+  }
+
+  const base = authentikBaseUrl()
+  const slug = authFlowSlug()
+  const jar = new CookieJar()
+
+  // ── Drive the authentication flow ─────────────────────────────────────────
+  let challenge = await flowRequest(base, slug, jar)
+  const MAX_STEPS = 6
+  let authenticated = false
+
+  for (let step = 0; step < MAX_STEPS; step++) {
+    const component = challenge.component || challenge.type || ''
+
+    if (component === 'xak-flow-redirect') {
+      authenticated = true
+      break
+    }
+
+    if (component === 'ak-stage-identification') {
+      const body: Record<string, unknown> = {
+        component,
+        uid_field: email,
+      }
+      // Combined identification+password stage
+      if (challenge.password_fields) body.password = password
+      challenge = await flowRequest(base, slug, jar, body)
+    } else if (component === 'ak-stage-password') {
+      challenge = await flowRequest(base, slug, jar, { component, password })
+    } else if (component === 'ak-stage-access-denied') {
+      throw new InvalidCredentialsError()
+    } else {
+      // MFA, consent, prompts, … — not driveable server-side.
+      throw new UnsupportedFlowStageError(component || 'unknown')
+    }
+
+    if (challengeHasCredentialErrors(challenge)) {
+      throw new InvalidCredentialsError()
+    }
+  }
+
+  if (!authenticated) {
+    const last = challenge.component || challenge.type || 'unknown'
+    if (last === 'xak-flow-redirect') {
+      authenticated = true
+    } else {
+      throw new UnsupportedFlowStageError(last)
+    }
+  }
+
+  // ── Complete OIDC code+PKCE with the authenticated session ────────────────
+  const state = generators.state()
+  const { url: authorizeUrl, codeVerifier } = oidcService.generateAuthUrl(state)
+  const target = redirectUri()
+
+  let location = authorizeUrl
+  let code: string | null = null
+  let returnedState: string | null = null
+
+  for (let hop = 0; hop < 5; hop++) {
+    let res: Response
+    try {
+      res = await fetch(location, {
+        method: 'GET',
+        headers: { Cookie: jar.header(), Accept: 'application/json' },
+        redirect: 'manual',
+      })
+    } catch (err) {
+      throw new AuthentikUnavailableError(
+        `Authorize request failed: ${(err as Error).message}`
+      )
+    }
+    jar.absorb(res)
+
+    const next = res.headers.get('location')
+    if (!next) {
+      // 200 here means Authentik rendered a flow UI (consent / re-auth) —
+      // implicit consent is expected on the FuzeFront provider.
+      throw new UnsupportedFlowStageError(
+        `authorize returned HTTP ${res.status} without redirect (consent flow?)`
+      )
+    }
+    const resolved = new URL(next, location).toString()
+    if (resolved.startsWith(target)) {
+      const u = new URL(resolved)
+      code = u.searchParams.get('code')
+      returnedState = u.searchParams.get('state')
+      const err = u.searchParams.get('error')
+      if (err) {
+        throw new AuthentikUnavailableError(`Authorize error: ${err}`)
+      }
+      break
+    }
+    location = resolved
+  }
+
+  if (!code) {
+    throw new AuthentikUnavailableError(
+      'Authorize flow did not produce an authorization code'
+    )
+  }
+
+  // Token exchange + user sync — identical to the redirect callback path.
+  return oidcService.handleCallback(code, returnedState || state, codeVerifier)
+}

--- a/backend/security/tests/authentik-password-login.test.ts
+++ b/backend/security/tests/authentik-password-login.test.ts
@@ -45,6 +45,7 @@ function mkRes(opts: {
 }) {
   const headerMap = new Map<string, string>()
   if (opts.location) headerMap.set('location', opts.location)
+  if (opts.json !== undefined) headerMap.set('content-type', 'application/json')
   return {
     ok: (opts.status ?? 200) >= 200 && (opts.status ?? 200) < 300,
     status: opts.status ?? 200,
@@ -53,6 +54,7 @@ function mkRes(opts: {
       getSetCookie: () => opts.setCookies ?? [],
     },
     json: async () => opts.json ?? {},
+    text: async () => JSON.stringify(opts.json ?? ''),
   } as unknown as Response
 }
 
@@ -124,6 +126,42 @@ describe('authentikPasswordLogin()', () => {
     const [authorizeUrl, authorizeInit] = fetchMock.mock.calls[3]
     expect(authorizeUrl).toContain('/application/o/authorize/')
     expect(authorizeInit.headers.Cookie).toContain('authentik_session=sess-1')
+  })
+
+  it('follows the session-establishing 302 before the first challenge', async () => {
+    fetchMock
+      // initial GET -> 302 back into the flow, setting session + csrf cookies
+      .mockResolvedValueOnce(
+        mkRes({
+          status: 302,
+          location:
+            'http://auth.example.test/api/v3/flows/executor/default-authentication-flow/?query=',
+          setCookies: [
+            'authentik_session=pre-sess; Path=/',
+            'authentik_csrf=csrf-tok; Path=/',
+          ],
+        })
+      )
+      // redirected GET -> identification challenge
+      .mockResolvedValueOnce(
+        mkRes({ json: { component: 'ak-stage-identification' } })
+      )
+      .mockResolvedValueOnce(mkRes({ json: { component: 'ak-stage-password' } }))
+      .mockResolvedValueOnce(
+        mkRes({ json: { component: 'xak-flow-redirect', to: '/' } })
+      )
+      .mockResolvedValueOnce(
+        mkRes({ status: 302, location: `${REDIRECT_URI}?code=c3&state=st` })
+      )
+
+    const user = await authentikPasswordLogin('e2e@test.local', 'pw123')
+    expect(user.email).toBe('e2e@test.local')
+
+    // The identification POST happened AFTER the redirect hop, with cookies.
+    const [identUrl, identInit] = fetchMock.mock.calls[2]
+    expect(identUrl).toContain('/flows/executor/')
+    expect(identInit.headers.Cookie).toContain('authentik_session=pre-sess')
+    expect(identInit.headers['X-CSRFToken']).toBe('csrf-tok')
   })
 
   it('supports a combined identification+password stage (password_fields: true)', async () => {

--- a/backend/security/tests/authentik-password-login.test.ts
+++ b/backend/security/tests/authentik-password-login.test.ts
@@ -258,6 +258,22 @@ describe('authentikPasswordLogin()', () => {
     ).rejects.toBeInstanceOf(UnsupportedFlowStageError)
   })
 
+  it('refuses to follow an off-origin redirect with session cookies', async () => {
+    fetchMock.mockResolvedValueOnce(
+      mkRes({
+        status: 302,
+        location: 'http://evil.example.net/steal',
+        setCookies: ['authentik_session=sess; Path=/'],
+      })
+    )
+
+    await expect(
+      authentikPasswordLogin('e2e@test.local', 'pw')
+    ).rejects.toBeInstanceOf(AuthentikUnavailableError)
+    // No request was made to the off-origin host.
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
   it('throws AuthentikUnavailableError when Authentik is unreachable', async () => {
     fetchMock.mockRejectedValueOnce(new Error('ECONNREFUSED'))
 

--- a/backend/security/tests/authentik-password-login.test.ts
+++ b/backend/security/tests/authentik-password-login.test.ts
@@ -1,0 +1,232 @@
+/**
+ * Unit tests for the server-side Authentik password login
+ * (services/authentikPassword.ts).
+ *
+ * The flow-executor conversation and the authorize redirect are simulated by
+ * mocking global.fetch — no network. The OIDC pieces (authorize URL, token
+ * exchange/user sync) are mocked at the oidcService boundary, mirroring how
+ * the redirect flow's tests isolate openid-client.
+ */
+
+jest.mock('../src/services/oidc', () => ({
+  oidcService: {
+    isConfigured: jest.fn().mockReturnValue(true),
+    isInitialized: jest.fn().mockReturnValue(true),
+    generateAuthUrl: jest.fn().mockReturnValue({
+      url: 'http://auth.example.test/application/o/authorize/?client_id=x&state=st',
+      codeVerifier: 'test-code-verifier',
+    }),
+    handleCallback: jest.fn().mockResolvedValue({
+      id: 'user-1',
+      email: 'e2e@test.local',
+      firstName: 'E2E',
+      lastName: 'User',
+      roles: ['user'],
+    }),
+  },
+}))
+
+import {
+  authentikPasswordLogin,
+  InvalidCredentialsError,
+  AuthentikUnavailableError,
+  UnsupportedFlowStageError,
+} from '../src/services/authentikPassword'
+import { oidcService } from '../src/services/oidc'
+
+const REDIRECT_URI = 'http://fuzefront.test.local/api/auth/oidc/callback'
+
+/** Build a minimal fetch Response stand-in. */
+function mkRes(opts: {
+  status?: number
+  json?: unknown
+  setCookies?: string[]
+  location?: string
+}) {
+  const headerMap = new Map<string, string>()
+  if (opts.location) headerMap.set('location', opts.location)
+  return {
+    ok: (opts.status ?? 200) >= 200 && (opts.status ?? 200) < 300,
+    status: opts.status ?? 200,
+    headers: {
+      get: (name: string) => headerMap.get(name.toLowerCase()) ?? null,
+      getSetCookie: () => opts.setCookies ?? [],
+    },
+    json: async () => opts.json ?? {},
+  } as unknown as Response
+}
+
+describe('authentikPasswordLogin()', () => {
+  const savedEnv = { ...process.env }
+  let fetchMock: jest.Mock
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    process.env.AUTHENTIK_ISSUER_URL =
+      'http://auth.example.test/application/o/fuzefront/'
+    process.env.AUTHENTIK_REDIRECT_URI = REDIRECT_URI
+    delete process.env.AUTHENTIK_BASE_URL
+    delete process.env.AUTHENTIK_AUTH_FLOW_SLUG
+    ;(oidcService.isConfigured as jest.Mock).mockReturnValue(true)
+    ;(oidcService.isInitialized as jest.Mock).mockReturnValue(true)
+    fetchMock = jest.fn()
+    ;(global as any).fetch = fetchMock
+  })
+
+  afterAll(() => {
+    process.env = savedEnv
+  })
+
+  it('drives identification → password → redirect, then exchanges the authorize code', async () => {
+    fetchMock
+      // 1. GET flow → identification stage (+ CSRF cookie)
+      .mockResolvedValueOnce(
+        mkRes({
+          json: { component: 'ak-stage-identification', password_fields: false },
+          setCookies: ['authentik_csrf=csrf-tok; Path=/'],
+        })
+      )
+      // 2. POST identification → password stage
+      .mockResolvedValueOnce(mkRes({ json: { component: 'ak-stage-password' } }))
+      // 3. POST password → flow complete (+ session cookie)
+      .mockResolvedValueOnce(
+        mkRes({
+          json: { component: 'xak-flow-redirect', to: '/' },
+          setCookies: ['authentik_session=sess-1; Path=/; HttpOnly'],
+        })
+      )
+      // 4. GET authorize → 302 straight to our callback with the code
+      .mockResolvedValueOnce(
+        mkRes({
+          status: 302,
+          location: `${REDIRECT_URI}?code=the-code&state=st`,
+        })
+      )
+
+    const user = await authentikPasswordLogin('e2e@test.local', 'pw123')
+
+    expect(user.email).toBe('e2e@test.local')
+    expect(oidcService.handleCallback).toHaveBeenCalledWith(
+      'the-code',
+      'st',
+      'test-code-verifier'
+    )
+
+    // Identification POST carried the uid_field + CSRF header + cookie jar.
+    const [, identInit] = fetchMock.mock.calls[1]
+    expect(JSON.parse(identInit.body)).toMatchObject({
+      component: 'ak-stage-identification',
+      uid_field: 'e2e@test.local',
+    })
+    expect(identInit.headers['X-CSRFToken']).toBe('csrf-tok')
+
+    // Authorize GET presented the authenticated session cookie.
+    const [authorizeUrl, authorizeInit] = fetchMock.mock.calls[3]
+    expect(authorizeUrl).toContain('/application/o/authorize/')
+    expect(authorizeInit.headers.Cookie).toContain('authentik_session=sess-1')
+  })
+
+  it('supports a combined identification+password stage (password_fields: true)', async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        mkRes({
+          json: { component: 'ak-stage-identification', password_fields: true },
+        })
+      )
+      .mockResolvedValueOnce(
+        mkRes({ json: { component: 'xak-flow-redirect', to: '/' } })
+      )
+      .mockResolvedValueOnce(
+        mkRes({ status: 302, location: `${REDIRECT_URI}?code=c2&state=st` })
+      )
+
+    await authentikPasswordLogin('e2e@test.local', 'pw123')
+
+    const [, identInit] = fetchMock.mock.calls[1]
+    expect(JSON.parse(identInit.body)).toMatchObject({
+      uid_field: 'e2e@test.local',
+      password: 'pw123',
+    })
+  })
+
+  it('throws InvalidCredentialsError when the password stage reports response_errors', async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        mkRes({ json: { component: 'ak-stage-identification' } })
+      )
+      .mockResolvedValueOnce(mkRes({ json: { component: 'ak-stage-password' } }))
+      .mockResolvedValueOnce(
+        mkRes({
+          json: {
+            component: 'ak-stage-password',
+            response_errors: {
+              password: [{ string: 'Invalid password', code: 'invalid' }],
+            },
+          },
+        })
+      )
+
+    await expect(
+      authentikPasswordLogin('e2e@test.local', 'wrong')
+    ).rejects.toBeInstanceOf(InvalidCredentialsError)
+    expect(oidcService.handleCallback).not.toHaveBeenCalled()
+  })
+
+  it('throws InvalidCredentialsError on an access-denied stage', async () => {
+    fetchMock.mockResolvedValueOnce(
+      mkRes({ json: { component: 'ak-stage-access-denied' } })
+    )
+
+    await expect(
+      authentikPasswordLogin('nobody@test.local', 'pw')
+    ).rejects.toBeInstanceOf(InvalidCredentialsError)
+  })
+
+  it('fails closed on stages it cannot drive (e.g. MFA)', async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        mkRes({ json: { component: 'ak-stage-identification' } })
+      )
+      .mockResolvedValueOnce(
+        mkRes({ json: { component: 'ak-stage-authenticator-validate' } })
+      )
+
+    await expect(
+      authentikPasswordLogin('mfa@test.local', 'pw')
+    ).rejects.toBeInstanceOf(UnsupportedFlowStageError)
+  })
+
+  it('throws AuthentikUnavailableError when Authentik is unreachable', async () => {
+    fetchMock.mockRejectedValueOnce(new Error('ECONNREFUSED'))
+
+    await expect(
+      authentikPasswordLogin('e2e@test.local', 'pw')
+    ).rejects.toBeInstanceOf(AuthentikUnavailableError)
+  })
+
+  it('throws AuthentikUnavailableError when OIDC is not initialized', async () => {
+    ;(oidcService.isInitialized as jest.Mock).mockReturnValue(false)
+
+    await expect(
+      authentikPasswordLogin('e2e@test.local', 'pw')
+    ).rejects.toBeInstanceOf(AuthentikUnavailableError)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('fails when authorize renders a flow UI instead of redirecting (consent required)', async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        mkRes({ json: { component: 'ak-stage-identification' } })
+      )
+      .mockResolvedValueOnce(mkRes({ json: { component: 'ak-stage-password' } }))
+      .mockResolvedValueOnce(
+        mkRes({ json: { component: 'xak-flow-redirect', to: '/' } })
+      )
+      // authorize returns 200 HTML (no Location) — consent flow not implicit
+      .mockResolvedValueOnce(mkRes({ status: 200 }))
+
+    await expect(
+      authentikPasswordLogin('e2e@test.local', 'pw')
+    ).rejects.toBeInstanceOf(UnsupportedFlowStageError)
+  })
+})

--- a/backend/security/tests/authentik-password-login.test.ts
+++ b/backend/security/tests/authentik-password-login.test.ts
@@ -210,6 +210,30 @@ describe('authentikPasswordLogin()', () => {
     expect(oidcService.handleCallback).not.toHaveBeenCalled()
   })
 
+  it('maps a 4xx JSON flow response carrying response_errors to InvalidCredentialsError', async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        mkRes({ json: { component: 'ak-stage-identification' } })
+      )
+      .mockResolvedValueOnce(mkRes({ json: { component: 'ak-stage-password' } }))
+      // Authentik rejects the credentials with an HTTP 400 + JSON errors body
+      .mockResolvedValueOnce(
+        mkRes({
+          status: 400,
+          json: {
+            component: 'ak-stage-password',
+            response_errors: {
+              password: [{ string: 'Invalid password', code: 'invalid' }],
+            },
+          },
+        })
+      )
+
+    await expect(
+      authentikPasswordLogin('e2e@test.local', 'wrong')
+    ).rejects.toBeInstanceOf(InvalidCredentialsError)
+  })
+
   it('throws InvalidCredentialsError on an access-denied stage', async () => {
     fetchMock.mockResolvedValueOnce(
       mkRes({ json: { component: 'ak-stage-access-denied' } })

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -40,6 +40,10 @@ declare global {
 }
 
 const app = express()
+// Behind the k8s ingress every request otherwise carries the ingress IP —
+// trust the first proxy hop so req.ip (rate limiting, auth logs) reflects
+// the real client from X-Forwarded-For.
+app.set('trust proxy', 1)
 const httpServer = createServer(app)
 const PORT = process.env.PORT || 3001
 

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -1,5 +1,6 @@
 import crypto from 'crypto'
 import express from 'express'
+import rateLimit from 'express-rate-limit'
 import bcrypt from 'bcryptjs'
 import jwt from 'jsonwebtoken'
 import { v4 as uuidv4 } from 'uuid'
@@ -416,29 +417,18 @@ router.get('/oidc/login', async (req, res) => {
 })
 
 
-// Fixed-window rate limit for the password endpoint (per replica): the
-// flow-executor login is a credential-stuffing surface, so cap attempts per
-// client-IP+account before we ever contact Authentik.
-const PW_WINDOW_MS = 5 * 60_000
-const PW_MAX_ATTEMPTS = 10
-const pwAttempts = new Map<string, { count: number; resetAt: number }>()
-setInterval(() => {
-  const now = Date.now()
-  for (const [k, v] of pwAttempts) {
-    if (v.resetAt < now) pwAttempts.delete(k)
-  }
-}, 60_000).unref()
-
-function passwordRateLimited(key: string): boolean {
-  const now = Date.now()
-  const cur = pwAttempts.get(key)
-  if (!cur || cur.resetAt < now) {
-    pwAttempts.set(key, { count: 1, resetAt: now + PW_WINDOW_MS })
-    return false
-  }
-  cur.count++
-  return cur.count > PW_MAX_ATTEMPTS
-}
+// Rate limit for the password endpoint: the flow-executor login is a
+// credential-stuffing surface, so cap FAILED attempts per client before we
+// ever contact Authentik (same express-rate-limit convention as
+// tokenAuthRateLimiter). Successful sign-ins are never throttled.
+const passwordLoginRateLimiter = rateLimit({
+  windowMs: 5 * 60_000,
+  limit: 10,
+  skipSuccessfulRequests: true,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { error: 'Too many sign-in attempts. Try again later.' },
+})
 
 /**
  * @swagger
@@ -457,7 +447,7 @@ function passwordRateLimited(key: string): boolean {
  *       401: { description: Invalid credentials }
  *       503: { description: OIDC unavailable or browser flow required }
  */
-router.post('/oidc/password', async (req, res) => {
+router.post('/oidc/password', passwordLoginRateLimiter, async (req, res) => {
   const requestId = uuidv4().substring(0, 8)
   const { email, password } = req.body || {}
 
@@ -470,12 +460,6 @@ router.post('/oidc/password', async (req, res) => {
 
   if (!email || !password) {
     return res.status(400).json({ error: 'Email and password required' })
-  }
-  const rlKey = `${req.ip}|${String(email).toLowerCase()}`
-  if (passwordRateLimited(rlKey)) {
-    return res
-      .status(429)
-      .json({ error: 'Too many sign-in attempts. Try again later.' })
   }
   if (!oidcService.isConfigured()) {
     return res.status(503).json({

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -502,14 +502,14 @@ router.post('/oidc/password', passwordLoginRateLimiter, async (req, res) => {
       return res.status(401).json({ error: 'Invalid credentials' })
     }
     if (error instanceof UnsupportedFlowStageError) {
-      console.warn('⚠️ Unsupported Authentik flow stage', { requestId, message: error.message.replace(/[\r\n]+/g, ' ') })
+      console.warn('⚠️ Unsupported Authentik flow stage', JSON.stringify({ requestId, message: error.message.replace(/[\r\n]+/g, ' ') }))
       return res.status(503).json({
         error:
           'This account requires a browser sign-in flow (e.g. MFA). Use the SSO button instead.',
       })
     }
     if (error instanceof AuthentikUnavailableError) {
-      console.error('❌ Authentik unavailable', { requestId, message: error.message.replace(/[\r\n]+/g, ' ') })
+      console.error('❌ Authentik unavailable', JSON.stringify({ requestId, message: error.message.replace(/[\r\n]+/g, ' ') }))
       return res
         .status(503)
         .json({ error: 'Authentication service unavailable. Try again shortly.' })

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -415,6 +415,31 @@ router.get('/oidc/login', async (req, res) => {
   }
 })
 
+
+// Fixed-window rate limit for the password endpoint (per replica): the
+// flow-executor login is a credential-stuffing surface, so cap attempts per
+// client-IP+account before we ever contact Authentik.
+const PW_WINDOW_MS = 5 * 60_000
+const PW_MAX_ATTEMPTS = 10
+const pwAttempts = new Map<string, { count: number; resetAt: number }>()
+setInterval(() => {
+  const now = Date.now()
+  for (const [k, v] of pwAttempts) {
+    if (v.resetAt < now) pwAttempts.delete(k)
+  }
+}, 60_000).unref()
+
+function passwordRateLimited(key: string): boolean {
+  const now = Date.now()
+  const cur = pwAttempts.get(key)
+  if (!cur || cur.resetAt < now) {
+    pwAttempts.set(key, { count: 1, resetAt: now + PW_WINDOW_MS })
+    return false
+  }
+  cur.count++
+  return cur.count > PW_MAX_ATTEMPTS
+}
+
 /**
  * @swagger
  * /api/auth/oidc/password:
@@ -446,6 +471,12 @@ router.post('/oidc/password', async (req, res) => {
   if (!email || !password) {
     return res.status(400).json({ error: 'Email and password required' })
   }
+  const rlKey = `${req.ip}|${String(email).toLowerCase()}`
+  if (passwordRateLimited(rlKey)) {
+    return res
+      .status(429)
+      .json({ error: 'Too many sign-in attempts. Try again later.' })
+  }
   if (!oidcService.isConfigured()) {
     return res.status(503).json({
       error:
@@ -463,9 +494,9 @@ router.post('/oidc/password', async (req, res) => {
 
     const sessionId = uuidv4()
     const expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000) // 24 hours
-    // nosemgrep: fuze-auth-self-minted-user-token — this IS FuzeFront's identity
-    // service; it is the issuer of platform tokens (same mint as /login and the
-    // OIDC callback above), not a product self-minting.
+    // This IS FuzeFront's identity service — the issuer of platform tokens
+    // (same mint as /login and the OIDC callback), not a product self-minting.
+    // nosemgrep: fuze-auth-self-minted-user-token, semgrep.fuze-auth-self-minted-user-token
     const token = jwt.sign(
       { userId: user.id, sessionId },
       process.env.JWT_SECRET!,
@@ -479,7 +510,7 @@ router.post('/oidc/password', async (req, res) => {
 
     selfHealProvisioningOnLogin(user.id)
 
-    console.log('🎉 Authentik password login successful', { requestId, email: user.email })
+    console.log('🎉 Authentik password login successful', { requestId, userId: user.id })
     return res.json({ token, user, sessionId })
   } catch (error) {
     if (error instanceof InvalidCredentialsError) {
@@ -487,14 +518,14 @@ router.post('/oidc/password', async (req, res) => {
       return res.status(401).json({ error: 'Invalid credentials' })
     }
     if (error instanceof UnsupportedFlowStageError) {
-      console.warn('⚠️ Unsupported Authentik flow stage', { requestId, message: error.message })
+      console.warn('⚠️ Unsupported Authentik flow stage', { requestId, message: error.message.replace(/[\r\n]+/g, ' ') })
       return res.status(503).json({
         error:
           'This account requires a browser sign-in flow (e.g. MFA). Use the SSO button instead.',
       })
     }
     if (error instanceof AuthentikUnavailableError) {
-      console.error('❌ Authentik unavailable', { requestId, message: error.message })
+      console.error('❌ Authentik unavailable', { requestId, message: error.message.replace(/[\r\n]+/g, ' ') })
       return res
         .status(503)
         .json({ error: 'Authentication service unavailable. Try again shortly.' })

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -424,7 +424,10 @@ router.get('/oidc/login', async (req, res) => {
 const passwordLoginRateLimiter = rateLimit({
   windowMs: 5 * 60_000,
   limit: 10,
+  // Count ONLY rejected credentials (401) against the budget: 503s from an
+  // Authentik outage or an MFA-required account must not lock users out.
   skipSuccessfulRequests: true,
+  requestWasSuccessful: (_req, res) => res.statusCode !== 401,
   standardHeaders: true,
   legacyHeaders: false,
   message: { error: 'Too many sign-in attempts. Try again later.' },
@@ -471,7 +474,14 @@ router.post('/oidc/password', passwordLoginRateLimiter, async (req, res) => {
   try {
     // Lazy re-init mirrors /oidc/login: Authentik may not have been ready at boot.
     if (!oidcService.isInitialized()) {
-      await oidcService.initialize()
+      try {
+        await oidcService.initialize()
+      } catch (initErr) {
+        console.error('❌ OIDC lazy init failed', JSON.stringify({ requestId, message: (initErr as Error).message?.replace(/[\r\n]+/g, ' ') }))
+        return res
+          .status(503)
+          .json({ error: 'Authentication service unavailable. Try again shortly.' })
+      }
     }
 
     const user = await authentikPasswordLogin(email, password)

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -7,6 +7,12 @@ import { db } from '../config/database'
 import { authenticateToken } from '../middleware/auth'
 import { User } from '../types/shared'
 import { oidcService } from '../services/oidc'
+import {
+  authentikPasswordLogin,
+  InvalidCredentialsError,
+  AuthentikUnavailableError,
+  UnsupportedFlowStageError,
+} from '../services/authentikPassword'
 import { runInternalProvision } from '../services/organizationProvisioning'
 
 const FRONTEND_BASE = (process.env.FRONTEND_URL || 'http://fuzefront.dev.local').replace(/\/$/, '')
@@ -406,6 +412,95 @@ router.get('/oidc/login', async (req, res) => {
   } catch (error) {
     console.error(`❌ [${requestId}] OIDC login error:`, error)
     res.status(500).json({ error: 'Failed to initiate OIDC login' })
+  }
+})
+
+/**
+ * @swagger
+ * /api/auth/oidc/password:
+ *   post:
+ *     summary: Password sign-in against Authentik (no redirect)
+ *     description: >
+ *       Authenticates email+password by driving Authentik's flow-executor API
+ *       server-side, then completes the OIDC code exchange with the resulting
+ *       Authentik session. Response shape matches /api/auth/login.
+ *     tags: [Authentication]
+ *     security: []
+ *     responses:
+ *       200: { description: Authenticated }
+ *       400: { description: Missing email or password }
+ *       401: { description: Invalid credentials }
+ *       503: { description: OIDC unavailable or browser flow required }
+ */
+router.post('/oidc/password', async (req, res) => {
+  const requestId = uuidv4().substring(0, 8)
+  const { email, password } = req.body || {}
+
+  console.log('🔐 Authentik password login request', {
+    requestId,
+    hasEmail: !!email,
+    configured: oidcService.isConfigured?.(),
+    initialized: oidcService.isInitialized?.(),
+  })
+
+  if (!email || !password) {
+    return res.status(400).json({ error: 'Email and password required' })
+  }
+  if (!oidcService.isConfigured()) {
+    return res.status(503).json({
+      error:
+        'OIDC authentication not configured. Please set AUTHENTIK_CLIENT_ID and AUTHENTIK_CLIENT_SECRET.',
+    })
+  }
+
+  try {
+    // Lazy re-init mirrors /oidc/login: Authentik may not have been ready at boot.
+    if (!oidcService.isInitialized()) {
+      await oidcService.initialize()
+    }
+
+    const user = await authentikPasswordLogin(email, password)
+
+    const sessionId = uuidv4()
+    const expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000) // 24 hours
+    // nosemgrep: fuze-auth-self-minted-user-token — this IS FuzeFront's identity
+    // service; it is the issuer of platform tokens (same mint as /login and the
+    // OIDC callback above), not a product self-minting.
+    const token = jwt.sign(
+      { userId: user.id, sessionId },
+      process.env.JWT_SECRET!,
+      { expiresIn: '24h' }
+    )
+    await db('sessions').insert({
+      id: sessionId,
+      user_id: user.id,
+      expires_at: expiresAt,
+    })
+
+    selfHealProvisioningOnLogin(user.id)
+
+    console.log('🎉 Authentik password login successful', { requestId, email: user.email })
+    return res.json({ token, user, sessionId })
+  } catch (error) {
+    if (error instanceof InvalidCredentialsError) {
+      console.log('❌ Authentik rejected credentials', { requestId })
+      return res.status(401).json({ error: 'Invalid credentials' })
+    }
+    if (error instanceof UnsupportedFlowStageError) {
+      console.warn('⚠️ Unsupported Authentik flow stage', { requestId, message: error.message })
+      return res.status(503).json({
+        error:
+          'This account requires a browser sign-in flow (e.g. MFA). Use the SSO button instead.',
+      })
+    }
+    if (error instanceof AuthentikUnavailableError) {
+      console.error('❌ Authentik unavailable', { requestId, message: error.message })
+      return res
+        .status(503)
+        .json({ error: 'Authentication service unavailable. Try again shortly.' })
+    }
+    console.error('❌ Authentik password login error', { requestId }, error)
+    return res.status(500).json({ error: 'Authentication failed' })
   }
 })
 

--- a/backend/src/services/authentikPassword.ts
+++ b/backend/src/services/authentikPassword.ts
@@ -111,7 +111,7 @@ async function flowRequest(
   let method: 'GET' | 'POST' = body ? 'POST' : 'GET'
   let payload: string | undefined = body ? JSON.stringify(body) : undefined
 
-  for (let hop = 0; hop < 4; hop++) {
+  for (let hop = 0; hop < 10; hop++) {
     const headers: Record<string, string> = {
       Accept: 'application/json',
       // Django CSRF validates Referer on secure requests.
@@ -251,7 +251,7 @@ export async function authentikPasswordLogin(
   let code: string | null = null
   let returnedState: string | null = null
 
-  for (let hop = 0; hop < 5; hop++) {
+  for (let hop = 0; hop < 10; hop++) {
     let res: Response
     try {
       res = await fetch(location, {

--- a/backend/src/services/authentikPassword.ts
+++ b/backend/src/services/authentikPassword.ts
@@ -143,8 +143,12 @@ async function flowRequest(
     const loc = res.headers.get('location')
     if ([301, 302, 303, 307, 308].includes(res.status) && loc) {
       url = new URL(loc, url).toString()
-      method = 'GET'
-      payload = undefined
+      // 301/302/303 rewrite the retry as GET (Django semantics); 307/308
+      // preserve the original method and body per HTTP spec.
+      if (res.status !== 307 && res.status !== 308) {
+        method = 'GET'
+        payload = undefined
+      }
       continue
     }
     const contentTypeEarly = res.headers.get('content-type') || ''

--- a/backend/src/services/authentikPassword.ts
+++ b/backend/src/services/authentikPassword.ts
@@ -131,8 +131,11 @@ async function flowRequest(
   }
   jar.absorb(res)
   if (!res.ok) {
+    // Surface Authentik's own error payload — a bare status is undebuggable
+    // from CI logs (e.g. 403 CSRF vs 404 unknown flow slug).
+    const bodySnippet = (await res.text().catch(() => '')).slice(0, 300)
     throw new AuthentikUnavailableError(
-      `Authentik flow executor unexpected HTTP ${res.status}`
+      `Authentik flow executor HTTP ${res.status} at ${url}: ${bodySnippet}`
     )
   }
   return (await res.json()) as FlowChallenge

--- a/backend/src/services/authentikPassword.ts
+++ b/backend/src/services/authentikPassword.ts
@@ -103,42 +103,68 @@ async function flowRequest(
   jar: CookieJar,
   body?: Record<string, unknown>
 ): Promise<FlowChallenge> {
-  const url = `${base}/api/v3/flows/executor/${slug}/?query=`
-  const headers: Record<string, string> = {
-    Accept: 'application/json',
-    Referer: `${base}/`,
-  }
-  const cookie = jar.header()
-  if (cookie) headers['Cookie'] = cookie
-  if (body) {
-    headers['Content-Type'] = 'application/json'
-    const csrf = jar.get('authentik_csrf')
-    if (csrf) headers['X-CSRFToken'] = csrf
-  }
+  // Authentik commonly answers the first executor request with a 302 that
+  // establishes the session cookie (Location points back into the flow), so
+  // follow same-origin redirects manually, carrying the jar. Per Django 302
+  // semantics a redirected POST is retried as GET.
+  let url = `${base}/api/v3/flows/executor/${slug}/?query=`
+  let method: 'GET' | 'POST' = body ? 'POST' : 'GET'
+  let payload: string | undefined = body ? JSON.stringify(body) : undefined
 
-  let res: Response
-  try {
-    res = await fetch(url, {
-      method: body ? 'POST' : 'GET',
-      headers,
-      body: body ? JSON.stringify(body) : undefined,
-      redirect: 'manual',
-    })
-  } catch (err) {
-    throw new AuthentikUnavailableError(
-      `Authentik unreachable at ${base}: ${(err as Error).message}`
-    )
+  for (let hop = 0; hop < 4; hop++) {
+    const headers: Record<string, string> = {
+      Accept: 'application/json',
+      // Django CSRF validates Referer on secure requests.
+      Referer: `${base}/`,
+    }
+    const cookie = jar.header()
+    if (cookie) headers['Cookie'] = cookie
+    if (method === 'POST') {
+      headers['Content-Type'] = 'application/json'
+      const csrf = jar.get('authentik_csrf')
+      if (csrf) headers['X-CSRFToken'] = csrf
+    }
+
+    let res: Response
+    try {
+      res = await fetch(url, {
+        method,
+        headers,
+        body: payload,
+        redirect: 'manual',
+      })
+    } catch (err) {
+      throw new AuthentikUnavailableError(
+        `Authentik unreachable at ${base}: ${(err as Error).message}`
+      )
+    }
+    jar.absorb(res)
+
+    const loc = res.headers.get('location')
+    if ([301, 302, 303, 307, 308].includes(res.status) && loc) {
+      url = new URL(loc, url).toString()
+      method = 'GET'
+      payload = undefined
+      continue
+    }
+    if (!res.ok) {
+      // Surface Authentik's own error payload — a bare status is undebuggable
+      // from CI logs (e.g. 403 CSRF vs 404 unknown flow slug).
+      const bodySnippet = (await res.text().catch(() => '')).slice(0, 300)
+      throw new AuthentikUnavailableError(
+        `Authentik flow executor HTTP ${res.status} at ${url}: ${bodySnippet}`
+      )
+    }
+    const contentType = res.headers.get('content-type') || ''
+    if (!contentType.includes('json')) {
+      const bodySnippet = (await res.text().catch(() => '')).slice(0, 300)
+      throw new AuthentikUnavailableError(
+        `Authentik flow executor returned non-JSON (${contentType}) at ${url}: ${bodySnippet}`
+      )
+    }
+    return (await res.json()) as FlowChallenge
   }
-  jar.absorb(res)
-  if (!res.ok) {
-    // Surface Authentik's own error payload — a bare status is undebuggable
-    // from CI logs (e.g. 403 CSRF vs 404 unknown flow slug).
-    const bodySnippet = (await res.text().catch(() => '')).slice(0, 300)
-    throw new AuthentikUnavailableError(
-      `Authentik flow executor HTTP ${res.status} at ${url}: ${bodySnippet}`
-    )
-  }
-  return (await res.json()) as FlowChallenge
+  throw new AuthentikUnavailableError('Authentik flow executor redirect loop')
 }
 
 function challengeHasCredentialErrors(challenge: FlowChallenge): boolean {

--- a/backend/src/services/authentikPassword.ts
+++ b/backend/src/services/authentikPassword.ts
@@ -1,0 +1,259 @@
+/**
+ * Server-side Authentik password authentication — no browser redirect.
+ * Monolith-backend port of backend/security/src/services/authentikPassword.ts
+ * (the split security service is authoritative in prod; the monolith serves
+ * the docker-compose / e2e stacks). Behavior is identical; the only
+ * differences are this oidc service's signatures: generateAuthUrl(state)
+ * returns the URL string and stashes the PKCE verifier in the in-process map,
+ * and handleCallback(code, state) reads it back from there.
+ *
+ * See the security-service copy for the full flow documentation.
+ */
+import { generators } from 'openid-client'
+import { oidcService } from './oidc'
+import { User } from '../types/shared'
+
+export class InvalidCredentialsError extends Error {
+  constructor(message = 'Invalid credentials') {
+    super(message)
+    this.name = 'InvalidCredentialsError'
+  }
+}
+
+export class AuthentikUnavailableError extends Error {
+  constructor(message = 'Authentication service unavailable') {
+    super(message)
+    this.name = 'AuthentikUnavailableError'
+  }
+}
+
+export class UnsupportedFlowStageError extends Error {
+  constructor(stage: string) {
+    super(`Unsupported Authentik flow stage: ${stage} (only identification+password is supported server-side)`)
+    this.name = 'UnsupportedFlowStageError'
+  }
+}
+
+/** Minimal cookie jar for the short-lived per-login Authentik session. */
+class CookieJar {
+  private cookies = new Map<string, string>()
+
+  absorb(res: { headers: Headers }): void {
+    const anyHeaders = res.headers as Headers & { getSetCookie?: () => string[] }
+    const setCookies: string[] =
+      typeof anyHeaders.getSetCookie === 'function'
+        ? anyHeaders.getSetCookie()
+        : ([res.headers.get('set-cookie')].filter(Boolean) as string[])
+    for (const sc of setCookies) {
+      const pair = sc.split(';')[0]
+      const eq = pair.indexOf('=')
+      if (eq <= 0) continue
+      const name = pair.slice(0, eq).trim()
+      const value = pair.slice(eq + 1).trim()
+      if (value === '' || /max-age=0|expires=thu, 01 jan 1970/i.test(sc)) {
+        this.cookies.delete(name)
+      } else {
+        this.cookies.set(name, value)
+      }
+    }
+  }
+
+  header(): string {
+    return [...this.cookies].map(([k, v]) => `${k}=${v}`).join('; ')
+  }
+
+  get(name: string): string | undefined {
+    return this.cookies.get(name)
+  }
+}
+
+function authentikBaseUrl(): string {
+  if (process.env.AUTHENTIK_BASE_URL) {
+    return process.env.AUTHENTIK_BASE_URL.replace(/\/$/, '')
+  }
+  const issuer =
+    process.env.AUTHENTIK_ISSUER_URL ||
+    'http://localhost:9000/application/o/fuzefront/'
+  return new URL(issuer).origin
+}
+
+function authFlowSlug(): string {
+  return process.env.AUTHENTIK_AUTH_FLOW_SLUG || 'default-authentication-flow'
+}
+
+function redirectUri(): string {
+  return (
+    process.env.AUTHENTIK_REDIRECT_URI ||
+    'http://fuzefront.dev.local/api/auth/oidc/callback'
+  )
+}
+
+interface FlowChallenge {
+  component?: string
+  type?: string
+  to?: string
+  password_fields?: boolean
+  response_errors?: Record<string, Array<{ string?: string; code?: string }>>
+  [key: string]: unknown
+}
+
+async function flowRequest(
+  base: string,
+  slug: string,
+  jar: CookieJar,
+  body?: Record<string, unknown>
+): Promise<FlowChallenge> {
+  const url = `${base}/api/v3/flows/executor/${slug}/?query=`
+  const headers: Record<string, string> = {
+    Accept: 'application/json',
+    Referer: `${base}/`,
+  }
+  const cookie = jar.header()
+  if (cookie) headers['Cookie'] = cookie
+  if (body) {
+    headers['Content-Type'] = 'application/json'
+    const csrf = jar.get('authentik_csrf')
+    if (csrf) headers['X-CSRFToken'] = csrf
+  }
+
+  let res: Response
+  try {
+    res = await fetch(url, {
+      method: body ? 'POST' : 'GET',
+      headers,
+      body: body ? JSON.stringify(body) : undefined,
+      redirect: 'manual',
+    })
+  } catch (err) {
+    throw new AuthentikUnavailableError(
+      `Authentik unreachable at ${base}: ${(err as Error).message}`
+    )
+  }
+  jar.absorb(res)
+  if (!res.ok) {
+    throw new AuthentikUnavailableError(
+      `Authentik flow executor unexpected HTTP ${res.status}`
+    )
+  }
+  return (await res.json()) as FlowChallenge
+}
+
+function challengeHasCredentialErrors(challenge: FlowChallenge): boolean {
+  const errs = challenge.response_errors
+  if (!errs) return false
+  return Object.keys(errs).length > 0
+}
+
+/**
+ * Authenticate email+password against Authentik and return the synced platform
+ * User. Throws InvalidCredentialsError / AuthentikUnavailableError /
+ * UnsupportedFlowStageError.
+ */
+export async function authentikPasswordLogin(
+  email: string,
+  password: string
+): Promise<User> {
+  if (!oidcService.isConfigured() || !oidcService.isInitialized()) {
+    throw new AuthentikUnavailableError('OIDC is not configured/initialized')
+  }
+
+  const base = authentikBaseUrl()
+  const slug = authFlowSlug()
+  const jar = new CookieJar()
+
+  // ── Drive the authentication flow ─────────────────────────────────────────
+  let challenge = await flowRequest(base, slug, jar)
+  const MAX_STEPS = 6
+  let authenticated = false
+
+  for (let step = 0; step < MAX_STEPS; step++) {
+    const component = challenge.component || challenge.type || ''
+
+    if (component === 'xak-flow-redirect') {
+      authenticated = true
+      break
+    }
+
+    if (component === 'ak-stage-identification') {
+      const body: Record<string, unknown> = {
+        component,
+        uid_field: email,
+      }
+      if (challenge.password_fields) body.password = password
+      challenge = await flowRequest(base, slug, jar, body)
+    } else if (component === 'ak-stage-password') {
+      challenge = await flowRequest(base, slug, jar, { component, password })
+    } else if (component === 'ak-stage-access-denied') {
+      throw new InvalidCredentialsError()
+    } else {
+      throw new UnsupportedFlowStageError(component || 'unknown')
+    }
+
+    if (challengeHasCredentialErrors(challenge)) {
+      throw new InvalidCredentialsError()
+    }
+  }
+
+  if (!authenticated) {
+    const last = challenge.component || challenge.type || 'unknown'
+    if (last === 'xak-flow-redirect') {
+      authenticated = true
+    } else {
+      throw new UnsupportedFlowStageError(last)
+    }
+  }
+
+  // ── Complete OIDC code+PKCE with the authenticated session ────────────────
+  // The monolith's generateAuthUrl(state) stores the PKCE verifier in its
+  // in-process map keyed by state; handleCallback(code, state) reads it back.
+  const state = generators.state()
+  const authorizeUrl = oidcService.generateAuthUrl(state)
+  const target = redirectUri()
+
+  let location = authorizeUrl
+  let code: string | null = null
+  let returnedState: string | null = null
+
+  for (let hop = 0; hop < 5; hop++) {
+    let res: Response
+    try {
+      res = await fetch(location, {
+        method: 'GET',
+        headers: { Cookie: jar.header(), Accept: 'application/json' },
+        redirect: 'manual',
+      })
+    } catch (err) {
+      throw new AuthentikUnavailableError(
+        `Authorize request failed: ${(err as Error).message}`
+      )
+    }
+    jar.absorb(res)
+
+    const next = res.headers.get('location')
+    if (!next) {
+      throw new UnsupportedFlowStageError(
+        `authorize returned HTTP ${res.status} without redirect (consent flow?)`
+      )
+    }
+    const resolved = new URL(next, location).toString()
+    if (resolved.startsWith(target)) {
+      const u = new URL(resolved)
+      code = u.searchParams.get('code')
+      returnedState = u.searchParams.get('state')
+      const err = u.searchParams.get('error')
+      if (err) {
+        throw new AuthentikUnavailableError(`Authorize error: ${err}`)
+      }
+      break
+    }
+    location = resolved
+  }
+
+  if (!code) {
+    throw new AuthentikUnavailableError(
+      'Authorize flow did not produce an authorization code'
+    )
+  }
+
+  return oidcService.handleCallback(code, returnedState || state)
+}

--- a/backend/src/services/authentikPassword.ts
+++ b/backend/src/services/authentikPassword.ts
@@ -196,9 +196,7 @@ export async function authentikPasswordLogin(
 
   if (!authenticated) {
     const last = challenge.component || challenge.type || 'unknown'
-    if (last === 'xak-flow-redirect') {
-      authenticated = true
-    } else {
+    if (last !== 'xak-flow-redirect') {
       throw new UnsupportedFlowStageError(last)
     }
   }

--- a/backend/src/services/authentikPassword.ts
+++ b/backend/src/services/authentikPassword.ts
@@ -142,7 +142,15 @@ async function flowRequest(
 
     const loc = res.headers.get('location')
     if ([301, 302, 303, 307, 308].includes(res.status) && loc) {
-      url = new URL(loc, url).toString()
+      const nextUrl = new URL(loc, url)
+      // The jar carries authentik_session/authentik_csrf — never present those
+      // cookies to any host other than Authentik itself.
+      if (nextUrl.origin !== new URL(base).origin) {
+        throw new AuthentikUnavailableError(
+          `Flow executor redirected off-origin to ${nextUrl.origin} — refusing to follow with session cookies`
+        )
+      }
+      url = nextUrl.toString()
       // 301/302/303 rewrite the retry as GET (Django semantics); 307/308
       // preserve the original method and body per HTTP spec.
       if (res.status !== 307 && res.status !== 308) {
@@ -272,7 +280,8 @@ export async function authentikPasswordLogin(
         `authorize returned HTTP ${res.status} without redirect (consent flow?)`
       )
     }
-    const resolved = new URL(next, location).toString()
+    const resolvedUrl = new URL(next, location)
+    const resolved = resolvedUrl.toString()
     if (resolved.startsWith(target)) {
       const u = new URL(resolved)
       code = u.searchParams.get('code')
@@ -282,6 +291,13 @@ export async function authentikPasswordLogin(
         throw new AuthentikUnavailableError(`Authorize error: ${err}`)
       }
       break
+    }
+    // Continue only within Authentik's own origin — the jar must not follow
+    // an arbitrary redirect elsewhere.
+    if (resolvedUrl.origin !== new URL(base).origin) {
+      throw new AuthentikUnavailableError(
+        `Authorize flow redirected off-origin to ${resolvedUrl.origin} — refusing to follow with session cookies`
+      )
     }
     location = resolved
   }

--- a/backend/src/services/authentikPassword.ts
+++ b/backend/src/services/authentikPassword.ts
@@ -147,7 +147,14 @@ async function flowRequest(
       payload = undefined
       continue
     }
+    const contentTypeEarly = res.headers.get('content-type') || ''
     if (!res.ok) {
+      // A 4xx with a JSON body is a FLOW response (e.g. 400 carrying
+      // response_errors for rejected credentials) — return it so the caller
+      // maps it to 401, instead of mislabeling it a 503 outage.
+      if (res.status < 500 && contentTypeEarly.includes('json')) {
+        return (await res.json()) as FlowChallenge
+      }
       // Surface Authentik's own error payload — a bare status is undebuggable
       // from CI logs (e.g. 403 CSRF vs 404 unknown flow slug).
       const bodySnippet = (await res.text().catch(() => '')).slice(0, 300)
@@ -155,11 +162,10 @@ async function flowRequest(
         `Authentik flow executor HTTP ${res.status} at ${url}: ${bodySnippet}`
       )
     }
-    const contentType = res.headers.get('content-type') || ''
-    if (!contentType.includes('json')) {
+    if (!contentTypeEarly.includes('json')) {
       const bodySnippet = (await res.text().catch(() => '')).slice(0, 300)
       throw new AuthentikUnavailableError(
-        `Authentik flow executor returned non-JSON (${contentType}) at ${url}: ${bodySnippet}`
+        `Authentik flow executor returned non-JSON (${contentTypeEarly}) at ${url}: ${bodySnippet}`
       )
     }
     return (await res.json()) as FlowChallenge

--- a/frontend/e2e/post-prod/live-smoke.spec.ts
+++ b/frontend/e2e/post-prod/live-smoke.spec.ts
@@ -9,10 +9,10 @@ import { test, expect, type Page, type ConsoleMessage } from '@playwright/test'
  *   2. Core API health is up.
  *   3. The backend advertises OIDC as configured (/api/auth/method) — this is
  *      the flag that hides the local form, so it is asserted explicitly.
- *   4. /login offers ONLY SSO sign-in: "Sign in with Authentik" and
- *      "Sign in with Google" are visible, and the internal (local
- *      email/password) form is NOT rendered. Google auth is federated through
- *      Authentik, so both buttons start the same OIDC flow.
+ *   4. /login shows the NATIVE credentials form (email/password verified
+ *      against Authentik server-side — no redirect) plus a "Sign in with
+ *      Google" button (federated through Authentik). The old "Sign in with
+ *      Authentik" redirect button is gone.
  *   5. Clicking "Sign in with Google" hands off into the OIDC flow.
  *   6. The auth backend is routable.
  *   7. The dashboard renders for an authenticated user and Module-Federation
@@ -80,20 +80,22 @@ test.describe('FuzeFront live post-prod smoke', () => {
     expect(body.defaultMethod).toBe('oidc')
   })
 
-  test('4. /login offers ONLY Authentik + Google sign-in (no local form)', async ({ page }) => {
+  test('4. /login offers the native credentials form + Google (no Authentik redirect button)', async ({ page }) => {
     await page.goto('/login')
 
-    // SSO buttons are the only sign-in affordances.
-    await expect(
-      page.getByRole('button', { name: /sign in with authentik/i })
-    ).toBeVisible({ timeout: 20_000 })
+    // Native credentials form — the default UI. With oidcConfigured=true these
+    // fields are verified AGAINST AUTHENTIK server-side (no redirect).
+    await expect(page.locator('input[type="email"]')).toBeVisible({ timeout: 20_000 })
+    await expect(page.locator('input[type="password"]')).toBeVisible()
+    await expect(page.getByRole('button', { name: /^sign in$/i })).toBeVisible()
+
+    // Google is federated through Authentik and offered as a button.
     await expect(
       page.getByRole('button', { name: /sign in with google/i })
     ).toBeVisible()
 
-    // The internal (local email/password) sign-in must NOT be rendered.
-    await expect(page.locator('input[type="email"]')).toHaveCount(0)
-    await expect(page.locator('input[type="password"]')).toHaveCount(0)
+    // The old "Sign in with Authentik" redirect button is gone.
+    await expect(page.getByText(/sign in with authentik/i)).toHaveCount(0)
 
     // The demo-credentials disclosure is gone.
     await expect(page.getByText(/demo credentials/i)).toHaveCount(0)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -191,17 +191,16 @@ function AppContent() {
     return <AcceptInvitePage />
   }
 
-  console.log('AppContent - Authentication state:', {
-    isAuthenticated,
-    user: user?.email,
-  })
-
-  if (!isAuthenticated) {
-    console.log('User not authenticated, showing login page')
-    return <LoginPage />
+  if (import.meta.env.DEV) {
+    console.log('AppContent - Authentication state:', {
+      isAuthenticated,
+      user: user?.email,
+    })
   }
 
-  console.log('User authenticated, showing main app')
+  if (!isAuthenticated) {
+    return <LoginPage />
+  }
 
   // Standalone apps (mode = "standalone") render WITHOUT any portal chrome —
   // no side menu, no topbar — on their own surface (frame 04). Short-circuit

--- a/frontend/src/__tests__/LoginPage.google-signin.test.tsx
+++ b/frontend/src/__tests__/LoginPage.google-signin.test.tsx
@@ -122,6 +122,8 @@ describe('LoginPage — OIDC / Google Sign-In UI', () => {
     vi.spyOn(authAPI, 'handleOIDCCallback').mockResolvedValue({})
     vi.spyOn(authAPI, 'getAuthMethods')
     vi.spyOn(authAPI, 'loginWithOIDC').mockResolvedValue(undefined)
+    vi.spyOn(authAPI, 'loginWithAuthentikPassword')
+    vi.spyOn(authAPI, 'login')
     vi.spyOn(authAPI, 'getCurrentUser')
 
     // Suppress api.ts / component console noise so test output stays clean.
@@ -136,14 +138,14 @@ describe('LoginPage — OIDC / Google Sign-In UI', () => {
     vi.restoreAllMocks()
   })
 
-  // ── 1: OIDC buttons hidden / local form shown when oidcConfigured is false
+  // ── 1: No Google button, local-auth form fallback when oidcConfigured=false
 
-  it('does NOT render OIDC buttons but DOES render the local fallback form when oidcConfigured is false', async () => {
+  it('renders the credentials form but no Google button when oidcConfigured is false', async () => {
     vi.mocked(authAPI.getAuthMethods).mockResolvedValue(LOCAL_ONLY_METHODS)
 
     render(<LoginPage />)
 
-    // Wait for auth methods to have loaded (the local fallback form is the
+    // Wait for auth methods to have loaded (the credentials form is the
     // sentinel — it only renders once authMethods state is set).
     await waitFor(() => {
       expect(screen.getByLabelText(/email/i)).toBeInTheDocument()
@@ -154,42 +156,100 @@ describe('LoginPage — OIDC / Google Sign-In UI', () => {
     expect(screen.queryByText(/sign in with google/i)).not.toBeInTheDocument()
   })
 
-  // ── 2: OIDC buttons shown / local form hidden when oidcConfigured is true
+  // ── 2: Native credentials form + Google button when oidcConfigured is true
 
-  it('renders "Sign in with Authentik" and "Sign in with Google" buttons when oidcConfigured is true', async () => {
+  it('renders the credentials form AND "Sign in with Google" (no Authentik redirect button) when oidcConfigured is true', async () => {
     vi.mocked(authAPI.getAuthMethods).mockResolvedValue(OIDC_METHODS)
 
     render(<LoginPage />)
 
     await waitFor(() => {
       expect(
-        screen.getByRole('button', { name: /sign in with authentik/i })
+        screen.getByRole('button', { name: /sign in with google/i })
       ).toBeInTheDocument()
     })
-    expect(
-      screen.getByRole('button', { name: /sign in with google/i })
-    ).toBeInTheDocument()
+    // Default UI components for credentials — always present.
+    expect(screen.getByLabelText(/email/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/password/i)).toBeInTheDocument()
+    // The redirect button is gone — Authentik is driven server-side instead.
+    expect(screen.queryByText(/sign in with authentik/i)).not.toBeInTheDocument()
   })
 
-  it('does NOT render the local email/password form when oidcConfigured is true (Authentik-only sign-in)', async () => {
+  // ── 2a: Form submit verifies credentials AGAINST AUTHENTIK when configured
+
+  it('submitting the form calls loginWithAuthentikPassword (not local login) when oidcConfigured is true', async () => {
+    const mockUser = {
+      id: 'user-1',
+      email: 'someone@example.com',
+      firstName: 'Some',
+      lastName: 'One',
+      roles: ['user'],
+    }
+    const setUser = vi.fn()
+    ;(sharedMock.useCurrentUser as ReturnType<typeof vi.fn>).mockReturnValue(
+      makeUserCtx({ setUser })
+    )
     vi.mocked(authAPI.getAuthMethods).mockResolvedValue(OIDC_METHODS)
+    vi.mocked(authAPI.loginWithAuthentikPassword).mockResolvedValue({
+      token: 'jwt-authentik',
+      sessionId: 'sess-ak',
+      user: mockUser,
+    } as any)
 
     render(<LoginPage />)
 
     await waitFor(() => {
-      expect(
-        screen.getByRole('button', { name: /sign in with authentik/i })
-      ).toBeInTheDocument()
+      expect(screen.getByLabelText(/email/i)).toBeInTheDocument()
     })
 
-    // The internal (local) sign-in capability must be hidden: no email or
-    // password inputs, no local submit button.
-    expect(screen.queryByLabelText(/email/i)).not.toBeInTheDocument()
-    expect(screen.queryByLabelText(/password/i)).not.toBeInTheDocument()
-    expect(screen.queryByRole('button', { name: /^sign in$/i })).not.toBeInTheDocument()
+    fireEvent.change(screen.getByLabelText(/email/i), {
+      target: { value: 'someone@example.com' },
+    })
+    fireEvent.change(screen.getByLabelText(/password/i), {
+      target: { value: 'hunter22' },
+    })
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /^sign in$/i }))
+    })
+
+    expect(authAPI.loginWithAuthentikPassword).toHaveBeenCalledWith({
+      email: 'someone@example.com',
+      password: 'hunter22',
+    })
+    expect(authAPI.login).not.toHaveBeenCalled()
+    expect(setUser).toHaveBeenCalledWith(mockUser)
+    expect(locationStub.href).toBe('/dashboard')
   })
 
-  // ── 2b: Clicking the Google button starts the same Authentik OIDC flow ───
+  it('submitting the form calls the LOCAL login when oidcConfigured is false', async () => {
+    vi.mocked(authAPI.getAuthMethods).mockResolvedValue(LOCAL_ONLY_METHODS)
+    vi.mocked(authAPI.login).mockResolvedValue({
+      token: 'jwt-local',
+      sessionId: 'sess-local',
+      user: { id: 'u2', email: 'dev@local', firstName: 'D', lastName: 'V', roles: ['user'] },
+    } as any)
+
+    render(<LoginPage />)
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/email/i)).toBeInTheDocument()
+    })
+
+    fireEvent.change(screen.getByLabelText(/email/i), {
+      target: { value: 'dev@local' },
+    })
+    fireEvent.change(screen.getByLabelText(/password/i), {
+      target: { value: 'pw' },
+    })
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /^sign in$/i }))
+    })
+
+    expect(authAPI.login).toHaveBeenCalledTimes(1)
+    expect(authAPI.loginWithAuthentikPassword).not.toHaveBeenCalled()
+  })
+
+  // ── 2b: Clicking the Google button starts the Authentik OIDC redirect ────
 
   it('clicking "Sign in with Google" calls authAPI.loginWithOIDC (Google is federated via Authentik)', async () => {
     vi.mocked(authAPI.getAuthMethods).mockResolvedValue(OIDC_METHODS)
@@ -204,26 +264,6 @@ describe('LoginPage — OIDC / Google Sign-In UI', () => {
 
     await act(async () => {
       fireEvent.click(screen.getByRole('button', { name: /sign in with google/i }))
-    })
-
-    expect(authAPI.loginWithOIDC).toHaveBeenCalledTimes(1)
-  })
-
-  // ── 3: Clicking the OIDC button calls loginWithOIDC ─────────────────────
-
-  it('clicking "Sign in with Authentik" calls authAPI.loginWithOIDC', async () => {
-    vi.mocked(authAPI.getAuthMethods).mockResolvedValue(OIDC_METHODS)
-
-    render(<LoginPage />)
-
-    await waitFor(() => {
-      expect(
-        screen.getByRole('button', { name: /sign in with authentik/i })
-      ).toBeInTheDocument()
-    })
-
-    await act(async () => {
-      fireEvent.click(screen.getByRole('button', { name: /sign in with authentik/i }))
     })
 
     expect(authAPI.loginWithOIDC).toHaveBeenCalledTimes(1)
@@ -302,7 +342,7 @@ describe('LoginPage — OIDC / Google Sign-In UI', () => {
     // Wait for auth methods so the page is fully settled.
     await waitFor(() => {
       expect(
-        screen.getByRole('button', { name: /sign in with authentik/i })
+        screen.getByRole('button', { name: /sign in with google/i })
       ).toBeInTheDocument()
     })
 

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -76,8 +76,11 @@ function LoginPage() {
     }
   }
 
-  // Log environment information on component mount
+  // Log environment information on component mount (dev-only: this block also
+  // fired a /health probe and dumped env/localStorage details into the prod
+  // console on every login-page visit).
   useEffect(() => {
+    if (!import.meta.env.DEV) return
     console.log('🏠 LoginPage mounted - Environment Info:', {
       timestamp: new Date().toISOString(),
       currentURL: window.location.href,
@@ -124,38 +127,28 @@ function LoginPage() {
       })
   }, [])
 
-  const handleLocalLogin = async (e: React.FormEvent) => {
+  // Credentials form submit. When Authentik/OIDC is configured the credentials
+  // are verified AGAINST AUTHENTIK (server-side flow-executor — no redirect);
+  // the local users-table login is only the fallback for stacks without
+  // Authentik (local dev, CI ephemeral environments).
+  const handleCredentialsLogin = async (e: React.FormEvent) => {
     e.preventDefault()
-    console.log('🎯 Local login form submitted:', {
-      email,
-      passwordLength: password.length,
-      timestamp: new Date().toISOString(),
-    })
-
     setLoading(true)
     setError('')
 
     try {
-      console.log('🔄 Starting local login process...')
-      const { token, user } = await authAPI.login({ email, password })
-
-      console.log('🎉 Local login successful:', {
-        hasToken: !!token,
-        hasUser: !!user,
-        userEmail: user?.email,
-        userRoles: user?.roles,
-      })
+      const { token, user } = authMethods?.oidcConfigured
+        ? await authAPI.loginWithAuthentikPassword({ email, password })
+        : await authAPI.login({ email, password })
 
       if (token && user) {
-        console.log('👤 Setting user in context...')
         setUser(user)
-        console.log('🔄 Redirecting to dashboard...')
         window.location.href = '/dashboard'
       } else {
         throw new Error('Invalid response from server')
       }
     } catch (err: any) {
-      console.error('❌ Local login error:', err)
+      console.error('❌ Login error:', err)
       let errorMessage = err.response?.data?.error || err.message || 'Login failed'
 
       if (err.code === 'NETWORK_ERROR' || !err.response) {
@@ -307,74 +300,13 @@ function LoginPage() {
         </div>
       )}
 
-      {/* OIDC Authentication Options — the ONLY sign-in paths when Authentik is
-          configured. Google auth is federated through Authentik (the platform
-          never contacts Google directly), so both buttons start the same OIDC
-          flow; Authentik presents Google as an identity provider. */}
-      {authMethods?.oidcConfigured && (
-        <div style={{ marginBottom: '1rem' }}>
-          <button
-            type="button"
-            onClick={handleOIDCLogin}
-            disabled={loading}
-            style={{
-              width: '100%',
-              padding: '12px',
-              backgroundColor: 'var(--accent-color)',
-              color: 'white',
-              border: 'none',
-              borderRadius: '6px',
-              cursor: 'pointer',
-              fontSize: '16px',
-              fontWeight: 'bold',
-              marginBottom: '10px',
-            }}
-          >
-            {loading ? '🔄 Redirecting...' : '🔐 Sign in with Authentik'}
-          </button>
-          <button
-            type="button"
-            onClick={handleOIDCLogin}
-            disabled={loading}
-            aria-label="Sign in with Google"
-            style={{
-              width: '100%',
-              padding: '12px',
-              backgroundColor: 'var(--bg-primary)',
-              color: 'var(--text-primary)',
-              border: '1px solid var(--border-color)',
-              borderRadius: '6px',
-              cursor: 'pointer',
-              fontSize: '16px',
-              fontWeight: 'bold',
-              marginBottom: '10px',
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              gap: '10px',
-            }}
-          >
-            {/* Official Google "G" mark — see GOOGLE_BRAND above. */}
-            <svg width="18" height="18" viewBox="0 0 48 48" aria-hidden="true">
-              <path fill={GOOGLE_BRAND.red} d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z" />
-              <path fill={GOOGLE_BRAND.blue} d="M46.98 24.55c0-1.57-.15-3.09-.38-4.55H24v9.02h12.94c-.58 2.96-2.26 5.48-4.78 7.18l7.73 6c4.51-4.18 7.09-10.36 7.09-17.65z" />
-              <path fill={GOOGLE_BRAND.yellow} d="M10.53 28.59c-.48-1.45-.76-2.99-.76-4.59s.27-3.14.76-4.59l-7.98-6.19C.92 16.46 0 20.12 0 24c0 3.88.92 7.54 2.56 10.78l7.97-6.19z" />
-              <path fill={GOOGLE_BRAND.green} d="M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.16 2.3-6.26 0-11.57-4.22-13.47-9.91l-7.98 6.19C6.51 42.62 14.62 48 24 48z" />
-            </svg>
-            {loading ? 'Redirecting...' : 'Sign in with Google'}
-          </button>
-          <p style={{ textAlign: 'center', color: 'var(--text-tertiary)', fontSize: '14px' }}>
-            Single Sign-On via Authentik
-          </p>
-        </div>
-      )}
-
-      {/* Local (email/password) authentication is ONLY offered as a fallback
-          when Authentik/OIDC is not configured (local dev, CI ephemeral
-          stacks). In production Authentik is the sole identity authority, so
-          this form is intentionally hidden there. */}
-      {authMethods && !authMethods.oidcConfigured && (
-        <form onSubmit={handleLocalLogin}>
+      {/* Credentials form — the DEFAULT sign-in UI. When Authentik/OIDC is
+          configured, submitting verifies the credentials against AUTHENTIK
+          server-side (no redirect); Authentik stays the sole identity
+          authority. Without Authentik (local dev / CI stacks) the same form
+          falls back to the local users-table login. */}
+      {authMethods && (
+        <form onSubmit={handleCredentialsLogin}>
           <div className="form-group">
             <label htmlFor="email">Email</label>
             <input
@@ -401,6 +333,56 @@ function LoginPage() {
             {loading ? 'Signing in...' : 'Sign In'}
           </button>
         </form>
+      )}
+
+      {/* Google sign-in — federated through Authentik (the platform never
+          contacts Google directly), so the button starts the Authentik OIDC
+          redirect flow where Google is offered as the identity provider. */}
+      {authMethods?.oidcConfigured && (
+        <div style={{ marginTop: '1rem' }}>
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              margin: '16px 0',
+              color: 'var(--text-tertiary)',
+            }}
+          >
+            <hr style={{ flex: 1, border: 'none', borderTop: '1px solid var(--border-color)' }} />
+            <span style={{ padding: '0 15px', fontSize: '14px' }}>or</span>
+            <hr style={{ flex: 1, border: 'none', borderTop: '1px solid var(--border-color)' }} />
+          </div>
+          <button
+            type="button"
+            onClick={handleOIDCLogin}
+            disabled={loading}
+            aria-label="Sign in with Google"
+            style={{
+              width: '100%',
+              padding: '12px',
+              backgroundColor: 'var(--bg-primary)',
+              color: 'var(--text-primary)',
+              border: '1px solid var(--border-color)',
+              borderRadius: '6px',
+              cursor: 'pointer',
+              fontSize: '16px',
+              fontWeight: 'bold',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              gap: '10px',
+            }}
+          >
+            {/* Official Google "G" mark — see GOOGLE_BRAND above. */}
+            <svg width="18" height="18" viewBox="0 0 48 48" aria-hidden="true">
+              <path fill={GOOGLE_BRAND.red} d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z" />
+              <path fill={GOOGLE_BRAND.blue} d="M46.98 24.55c0-1.57-.15-3.09-.38-4.55H24v9.02h12.94c-.58 2.96-2.26 5.48-4.78 7.18l7.73 6c4.51-4.18 7.09-10.36 7.09-17.65z" />
+              <path fill={GOOGLE_BRAND.yellow} d="M10.53 28.59c-.48-1.45-.76-2.99-.76-4.59s.27-3.14.76-4.59l-7.98-6.19C.92 16.46 0 20.12 0 24c0 3.88.92 7.54 2.56 10.78l7.97-6.19z" />
+              <path fill={GOOGLE_BRAND.green} d="M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.16 2.3-6.26 0-11.57-4.22-13.47-9.91l-7.98 6.19C6.51 42.62 14.62 48 24 48z" />
+            </svg>
+            {loading ? 'Redirecting...' : 'Sign in with Google'}
+          </button>
+        </div>
       )}
 
       <div style={{ marginTop: '1rem' }}>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -10,32 +10,40 @@ const API_BASE_URL =
   (typeof window !== 'undefined' ? window.location.origin : 'http://localhost:3001')
 const API_URL = `${API_BASE_URL}/api`
 
-console.log('🔧 API Configuration:', {
-  API_BASE_URL,
-  VITE_API_URL: import.meta.env.VITE_API_URL,
-  NODE_ENV: import.meta.env.NODE_ENV,
-  MODE: import.meta.env.MODE,
-  timestamp: new Date().toISOString(),
-})
+// Verbose API diagnostics (config dump, per-request console groups, module-load
+// health probe) are DEV-ONLY: in production they flooded the console with a
+// multi-line group for every API call and fired an extra /api/health request
+// on each page load.
+const API_DEBUG = import.meta.env.DEV
 
-// Test API connectivity on module load
-console.log('🌐 Testing API connectivity...')
-fetch('/api/health')
-  .then(response => {
-    console.log('✅ API Health Check Success:', {
-      status: response.status,
-      statusText: response.statusText,
-      url: response.url,
-      headers: Object.fromEntries(response.headers.entries()),
-    })
+if (API_DEBUG) {
+  console.log('🔧 API Configuration:', {
+    API_BASE_URL,
+    VITE_API_URL: import.meta.env.VITE_API_URL,
+    NODE_ENV: import.meta.env.NODE_ENV,
+    MODE: import.meta.env.MODE,
+    timestamp: new Date().toISOString(),
   })
-  .catch(error => {
-    console.error('❌ API Health Check Failed:', {
-      error: error.message,
-      type: error.constructor.name,
-      stack: error.stack,
+
+  // Test API connectivity on module load
+  console.log('🌐 Testing API connectivity...')
+  fetch('/api/health')
+    .then(response => {
+      console.log('✅ API Health Check Success:', {
+        status: response.status,
+        statusText: response.statusText,
+        url: response.url,
+        headers: Object.fromEntries(response.headers.entries()),
+      })
     })
-  })
+    .catch(error => {
+      console.error('❌ API Health Check Failed:', {
+        error: error.message,
+        type: error.constructor.name,
+        stack: error.stack,
+      })
+    })
+}
 
 const api = axios.create({
   baseURL: API_URL,
@@ -52,31 +60,22 @@ api.interceptors.request.use(
     const requestId = Math.random().toString(36).substr(2, 9)
     ;(config as any).metadata = { startTime: Date.now(), requestId }
 
-    console.group(`🚀 API Request [${requestId}]`)
-    console.log('Request Details:', {
-      method: config.method?.toUpperCase(),
-      url: config.url,
-      baseURL: config.baseURL,
-      fullURL: `${config.baseURL}${config.url}`,
-      timeout: config.timeout,
-      hasToken: !!token,
-      tokenPreview: token ? `${token.substring(0, 20)}...` : 'none',
-      headers: config.headers,
-      data: config.data,
-      timestamp: new Date().toISOString(),
-    })
-    console.log('Browser Info:', {
-      userAgent: navigator.userAgent,
-      onLine: navigator.onLine,
-      connection: (navigator as any).connection
-        ? {
-            effectiveType: (navigator as any).connection.effectiveType,
-            downlink: (navigator as any).connection.downlink,
-            rtt: (navigator as any).connection.rtt,
-          }
-        : 'not available',
-    })
-    console.groupEnd()
+    if (API_DEBUG) {
+      console.group(`🚀 API Request [${requestId}]`)
+      console.log('Request Details:', {
+        method: config.method?.toUpperCase(),
+        url: config.url,
+        baseURL: config.baseURL,
+        fullURL: `${config.baseURL}${config.url}`,
+        timeout: config.timeout,
+        hasToken: !!token,
+        tokenPreview: token ? `${token.substring(0, 20)}...` : 'none',
+        headers: config.headers,
+        data: config.data,
+        timestamp: new Date().toISOString(),
+      })
+      console.groupEnd()
+    }
 
     if (token) {
       config.headers.Authorization = `Bearer ${token}`
@@ -96,25 +95,27 @@ api.interceptors.request.use(
 // Enhanced response logging with timing
 api.interceptors.response.use(
   response => {
-    const duration = (response.config as any).metadata
-      ? Date.now() - (response.config as any).metadata.startTime
-      : 0
-    const requestId = (response.config as any).metadata?.requestId || 'unknown'
+    if (API_DEBUG) {
+      const duration = (response.config as any).metadata
+        ? Date.now() - (response.config as any).metadata.startTime
+        : 0
+      const requestId = (response.config as any).metadata?.requestId || 'unknown'
 
-    console.group(`✅ API Response [${requestId}] - ${duration}ms`)
-    console.log('Response Details:', {
-      status: response.status,
-      statusText: response.statusText,
-      url: response.config.url,
-      method: response.config.method?.toUpperCase(),
-      duration: `${duration}ms`,
-      headers: response.headers,
-      dataKeys: response.data ? Object.keys(response.data) : 'no data',
-      dataSize: JSON.stringify(response.data || {}).length + ' bytes',
-      timestamp: new Date().toISOString(),
-    })
-    console.log('Response Data:', response.data)
-    console.groupEnd()
+      console.group(`✅ API Response [${requestId}] - ${duration}ms`)
+      console.log('Response Details:', {
+        status: response.status,
+        statusText: response.statusText,
+        url: response.config.url,
+        method: response.config.method?.toUpperCase(),
+        duration: `${duration}ms`,
+        headers: response.headers,
+        dataKeys: response.data ? Object.keys(response.data) : 'no data',
+        dataSize: JSON.stringify(response.data || {}).length + ' bytes',
+        timestamp: new Date().toISOString(),
+      })
+      console.log('Response Data:', response.data)
+      console.groupEnd()
+    }
 
     return response
   },
@@ -217,10 +218,30 @@ export const authAPI = {
     return response.data
   },
 
-  // OIDC authentication (redirects to Authentik)
+  // OIDC authentication (redirects to Authentik — used for Google/SSO and
+  // the sign-up/enrollment affordance)
   async loginWithOIDC(): Promise<void> {
     // This will redirect the browser to Authentik
     window.location.href = `${API_URL}/auth/oidc/login`
+  },
+
+  // Password sign-in against Authentik WITHOUT a redirect: the backend drives
+  // Authentik's flow-executor with these credentials and returns the same
+  // { token, user, sessionId } shape as local login.
+  async loginWithAuthentikPassword(
+    credentials: LoginCredentials
+  ): Promise<LoginResponse> {
+    const response = await api.post<LoginResponse>(
+      '/auth/oidc/password',
+      credentials
+    )
+    if (response.data?.token) {
+      localStorage.setItem('authToken', response.data.token)
+    }
+    if (response.data?.sessionId) {
+      localStorage.setItem('sessionId', response.data.sessionId)
+    }
+    return response.data
   },
 
   // Get current user (the backend wraps the payload as { user })

--- a/frontend/tests/oidc-plumbing.e2e.spec.ts
+++ b/frontend/tests/oidc-plumbing.e2e.spec.ts
@@ -108,8 +108,11 @@ test.describe('OIDC plumbing — full stack (local Authentik user)', () => {
     await page.goto(FRONTEND_URL)
     await expect(page).toHaveTitle(/FuzeFront|Sign in/i, { timeout: 15_000 })
 
-    // Step 2: OIDC button visible (backend is configured with Authentik)
-    const oidcButton = page.getByRole('button', { name: /sign in with authentik/i })
+    // Step 2: the redirect entry point is now the Google button (the dedicated
+    // "Sign in with Authentik" button was replaced by the native credentials
+    // form). This e2e Authentik has no Google source, so the button lands on
+    // Authentik's own identification flow — exactly what we want to drive.
+    const oidcButton = page.getByRole('button', { name: /sign in with google/i })
     await expect(oidcButton).toBeVisible({ timeout: 15_000 })
     await oidcButton.click()
 
@@ -135,6 +138,37 @@ test.describe('OIDC plumbing — full stack (local Authentik user)', () => {
     const payload = JSON.parse(Buffer.from(authToken!.split('.')[1], 'base64url').toString())
     expect(payload.sub).toBeTruthy()
     expect(payload.email).toBeTruthy()
+  })
+
+  // ── 3b. Native credentials form drives the Authentik-backed login ──────
+  test('native email/password form signs in via Authentik (no redirect) and lands on dashboard', async ({
+    page,
+  }) => {
+    test.setTimeout(120_000)
+
+    await page.goto(FRONTEND_URL)
+    const emailField = page.locator('input[type="email"]')
+    await expect(emailField).toBeVisible({ timeout: 15_000 })
+
+    await emailField.fill(E2E_USER_EMAIL)
+    await page.locator('input[type="password"]').fill(E2E_USER_PASSWORD)
+
+    const loginResp = page.waitForResponse(
+      r => r.url().includes('/api/auth/oidc/password'),
+      { timeout: 30_000 }
+    )
+    await page.getByRole('button', { name: /^sign in$/i }).click()
+    const resp = await loginResp
+    expect(
+      resp.status(),
+      `POST /api/auth/oidc/password -> ${resp.status()}`
+    ).toBe(200)
+
+    // The page never navigated to Authentik — the whole exchange was server-side.
+    await page.waitForURL(`${FRONTEND_URL}/dashboard`, { timeout: 30_000 })
+    const authToken = await page.evaluate(() => localStorage.getItem('authToken'))
+    expect(authToken).toBeTruthy()
+    expect(authToken!.split('.').length).toBe(3)
   })
 
   // ── 4. Error path: OIDC error redirected to frontend ───────────────────

--- a/frontend/tests/oidc-plumbing.e2e.spec.ts
+++ b/frontend/tests/oidc-plumbing.e2e.spec.ts
@@ -65,6 +65,34 @@ test.describe('OIDC plumbing — full stack (local Authentik user)', () => {
     expect(body.methods).toContain('oidc')
   })
 
+  // ── 2b. Server-side password sign-in (flow-executor, no redirect) ───────
+  // The native login form posts credentials to /api/auth/oidc/password; the
+  // backend drives Authentik's flow-executor with them and completes the OIDC
+  // code exchange server-side. This exercises that path against REAL Authentik.
+  test('password sign-in against Authentik (no redirect) returns a platform JWT', async ({
+    request,
+  }) => {
+    const resp = await request.post(`${BACKEND_URL}/api/auth/oidc/password`, {
+      data: { email: E2E_USER_EMAIL, password: E2E_USER_PASSWORD },
+    })
+    expect(
+      resp.status(),
+      `POST /api/auth/oidc/password -> ${resp.status()} (401 = Authentik rejected creds; 503 = flow-executor/authorize plumbing broken)`
+    ).toBe(200)
+    const body = await resp.json()
+    expect(body.token, 'platform JWT returned').toBeTruthy()
+    expect(body.token.split('.')).toHaveLength(3)
+    expect(body.sessionId).toBeTruthy()
+    expect(body.user?.email?.toLowerCase()).toBe(E2E_USER_EMAIL.toLowerCase())
+  })
+
+  test('password sign-in rejects a wrong password with 401', async ({ request }) => {
+    const resp = await request.post(`${BACKEND_URL}/api/auth/oidc/password`, {
+      data: { email: E2E_USER_EMAIL, password: 'definitely-wrong-password' },
+    })
+    expect(resp.status()).toBe(401)
+  })
+
   // ── 3. Full OIDC sign-in flow ───────────────────────────────────────────
   test('full OIDC sign-in flow with local user lands on dashboard with a real JWT', async ({
     page,

--- a/frontend/tests/oidc-plumbing.e2e.spec.ts
+++ b/frontend/tests/oidc-plumbing.e2e.spec.ts
@@ -77,7 +77,7 @@ test.describe('OIDC plumbing — full stack (local Authentik user)', () => {
     })
     expect(
       resp.status(),
-      `POST /api/auth/oidc/password -> ${resp.status()} (401 = Authentik rejected creds; 503 = flow-executor/authorize plumbing broken)`
+      `POST /api/auth/oidc/password -> ${resp.status()}: ${await resp.text().catch(() => '')}`
     ).toBe(200)
     const body = await resp.json()
     expect(body.token, 'platform JWT returned').toBeTruthy()
@@ -90,7 +90,10 @@ test.describe('OIDC plumbing — full stack (local Authentik user)', () => {
     const resp = await request.post(`${BACKEND_URL}/api/auth/oidc/password`, {
       data: { email: E2E_USER_EMAIL, password: 'definitely-wrong-password' },
     })
-    expect(resp.status()).toBe(401)
+    expect(
+      resp.status(),
+      `expected 401, got ${resp.status()}: ${await resp.text().catch(() => '')}`
+    ).toBe(401)
   })
 
   // ── 3. Full OIDC sign-in flow ───────────────────────────────────────────


### PR DESCRIPTION
## What

Product direction change per owner: the login page shows **default email/password UI components** as the primary sign-in — no redirect to Authentik's hosted page — while **Authentik remains the sole identity authority**. Google stays as a button (federated through Authentik).

### Backend
- New `backend/security/src/services/authentikPassword.ts`: drives Authentik's **flow-executor JSON API** server-side with the submitted credentials (identification + password stages; combined identification-with-password supported), then completes a standard OIDC authorization-code + PKCE exchange using the authenticated Authentik session and reuses `oidcService.handleCallback` for token exchange + user sync. Minimal per-login cookie jar; CSRF header from `authentik_csrf`; fails closed (`503`, "use the SSO button") on stages it can't drive (MFA/consent).
- New `POST /api/auth/oidc/password` → `{ token, user, sessionId }`, same shape as `/api/auth/login`; 401 on rejected credentials; 503 when OIDC is unconfigured/uninitialized or Authentik is unreachable.
- **Handoff tracing**: `/oidc/login` now logs issuer/redirectUri/frontendBase + client-init state so the reported "blinks but nothing happens" redirect failure is diagnosable from security-service pod logs.

### Frontend
- LoginPage: credentials form is always the primary UI. With `oidcConfigured`, submit posts to the new Authentik-backed endpoint; without it (local dev/CI stacks), the same form falls back to local users-table auth. "Sign in with Authentik" redirect button removed; "Sign in with Google" retained.
- **Console flood fix**: axios interceptors' per-request/response `console.group`s, the module-load config dump + extra `/api/health` probe, LoginPage's mount env dump, and AppContent auth-state logs are now DEV-only.

### Tests
- 8 new unit tests for the flow-executor service (happy path, combined stage, wrong password, access-denied, MFA fail-closed, unreachable, uninitialized, consent-flow detection) — all passing.
- LoginPage suite reworked to the new contract — 8/8 passing.
- `oidc-plumbing` e2e (runs against **real Authentik** in CI) gains two tests: password sign-in returns a platform JWT; wrong password → 401.
- Post-prod smoke test 4 updated: native form + Google button, no Authentik redirect button, no demo creds.

## Notes
- Users must exist **in Authentik** to sign in via the form in prod (Authentik is the authority). The platform-DB-only synthetic smoke account continues to use the API path (`/api/auth/login`), which is unchanged.
- The Authentik authentication flow must be single-factor identification+password with implicit consent on the FuzeFront provider (matches the e2e blueprint). Accounts with MFA get a clear error directing them to the SSO button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R4AUD2d6aFpPT67pnLhQGk

---
_Generated by [Claude Code](https://claude.ai/code/session_01R4AUD2d6aFpPT67pnLhQGk)_