### PR TITLE
ci(post-prod): drop github reporter from post-prod e2e run

### DIFF
--- a/.github/workflows/post-prod-e2e.yml
+++ b/.github/workflows/post-prod-e2e.yml
@@ -49,7 +49,7 @@ jobs:
           # Falls back to the seeded admin creds inside the spec when unset.
           POST_PROD_EMAIL: ${{ secrets.POST_PROD_EMAIL }}
           POST_PROD_PASSWORD: ${{ secrets.POST_PROD_PASSWORD }}
-        run: cd frontend && npx playwright test --config playwright.post-prod.config.ts --reporter=github,list,html
+        run: cd frontend && npx playwright test --config playwright.post-prod.config.ts --reporter=list,html
 
       - name: Upload report
         if: always()


### PR DESCRIPTION
Removes the `github` Playwright reporter from the post-prod smoke run, leaving `list,html`.

⚠️ **This reverts `9266b20`** (_"ci: post-prod smoke — add github reporter so failures surface as annotations"_). With this change, post-prod E2E failures will **no longer surface as inline GitHub annotations** — only in the `list` console output and the uploaded HTML report. Merge only if that's intended.

Scope: single-line change to `.github/workflows/post-prod-e2e.yml`. Not related to the M2M provisioning work in #214.

🤖 Generated with [Claude Code](https://claude.com/claude-code)