### PR TITLE
fix(login): stop infinite render loop that floods /api/auth/method and freezes sign-in buttons

### DIFF
--- a/frontend/src/__tests__/LoginPage.google-signin.test.tsx
+++ b/frontend/src/__tests__/LoginPage.google-signin.test.tsx
@@ -156,6 +156,26 @@ describe('LoginPage — OIDC / Google Sign-In UI', () => {
     expect(screen.queryByText(/sign in with google/i)).not.toBeInTheDocument()
   })
 
+  // ── 1b: Regression — auth methods fetched ONCE, not in a render loop ─────
+
+  it('fetches auth methods exactly once (no re-render loop)', async () => {
+    vi.mocked(authAPI.getAuthMethods).mockResolvedValue(OIDC_METHODS)
+
+    render(<LoginPage />)
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/email/i)).toBeInTheDocument()
+    })
+    // Give any runaway effect a chance to re-fire before asserting.
+    await new Promise(r => setTimeout(r, 100))
+
+    // A single mount must produce a single /api/auth/method fetch. Before the
+    // useCurrentUser stabilization, an unstable setUser ref re-fired the
+    // page-load effect every render and flooded this endpoint (~2-3 req/s).
+    expect(authAPI.getAuthMethods).toHaveBeenCalledTimes(1)
+    expect(authAPI.handleOIDCCallback).toHaveBeenCalledTimes(1)
+  })
+
   // ── 2: Native credentials form + Google button when oidcConfigured is true
 
   it('renders the credentials form AND "Sign in with Google" (no Authentik redirect button) when oidcConfigured is true', async () => {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -92,6 +92,7 @@
   --success-color: #34d399;
   --warning-color: #f5a623;
   --error-color: #f26b7a;
+  --error-soft: rgba(242, 107, 122, 0.12); /* ds-conformance-allow: token definition */
   --shadow: rgba(0, 0, 0, 0.45);
   /* modal / dialog scrim — dims the shell behind overlays */
   --scrim: rgba(0, 0, 0, 0.55);
@@ -150,6 +151,7 @@
   --success-color: #10b981;
   --warning-color: #d98313;
   --error-color: #e0556b;
+  --error-soft: rgba(224, 85, 107, 0.1); /* ds-conformance-allow: token definition */
   --shadow: rgba(15, 23, 42, 0.12);
   --scrim: rgba(15, 23, 42, 0.32);
   --seam: linear-gradient(90deg, var(--accent-color) 0%, var(--accent-2) 100%);

--- a/frontend/src/lib/shared.tsx
+++ b/frontend/src/lib/shared.tsx
@@ -2,6 +2,8 @@ import React, {
   createContext,
   useContext,
   useState,
+  useCallback,
+  useMemo,
   ReactNode,
 } from 'react'
 import type { Organization } from '../services/api'
@@ -185,15 +187,25 @@ export function useAppContext() {
 
 export function useCurrentUser() {
   const { state, dispatch } = useAppContext()
-  return {
-    currentUser: state.user,
-    user: state.user,
-    isAuthenticated: !!state.user,
-    setCurrentUser: (user: User | null) =>
-      dispatch({ type: 'SET_USER', payload: user }),
-    setUser: (user: User | null) =>
-      dispatch({ type: 'SET_USER', payload: user }),
-  }
+  // Stable callback + memoized return: without this, every render produced a
+  // NEW setUser function, so any consumer with `useEffect(..., [setUser])`
+  // (e.g. LoginPage's page-load handler) re-fired on every render — an infinite
+  // loop that flooded /api/auth/method at ~2-3 req/s and made the page
+  // unresponsive. dispatch is stable, so these references are now stable too.
+  const setUser = useCallback(
+    (user: User | null) => dispatch({ type: 'SET_USER', payload: user }),
+    [dispatch]
+  )
+  return useMemo(
+    () => ({
+      currentUser: state.user,
+      user: state.user,
+      isAuthenticated: !!state.user,
+      setCurrentUser: setUser,
+      setUser,
+    }),
+    [state.user, setUser]
+  )
 }
 
 /**

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -58,7 +58,12 @@ function LoginPage() {
       setError('Authentication encountered an unexpected error. Please try again.')
       loadAuthMethods()
     })
-  }, [setUser])
+    // Runs ONCE on mount — this is a page-load handler (OIDC-callback exchange
+    // + auth-method fetch). Depending on setUser here previously re-fired the
+    // effect on every render and flooded /api/auth/method; setUser is now a
+    // stable ref, but a mount-only effect is the correct shape regardless.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   const loadAuthMethods = async () => {
     try {

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -295,7 +295,7 @@ function LoginPage() {
             padding: '10px',
             border: '1px solid var(--error-color)',
             borderRadius: '4px',
-            backgroundColor: 'rgba(255, 0, 0, 0.1)',
+            backgroundColor: 'var(--error-soft)',
           }}
         >
           <strong>Authentication Error:</strong>

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -62,7 +62,6 @@ function LoginPage() {
     // + auth-method fetch). Depending on setUser here previously re-fired the
     // effect on every render and flooded /api/auth/method; setUser is now a
     // stable ref, but a mount-only effect is the correct shape regardless.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   const loadAuthMethods = async () => {


### PR DESCRIPTION
## Symptom

On `/login` in prod: the page fires `GET /api/auth/method` continuously (~2-3 req/s), and the **Sign in with Google**, **Sign in with Authentik**, and **Create account** actions all do nothing.

## Root cause (single internal bug)

`useCurrentUser()` (`frontend/src/lib/shared.tsx`) returned a **new object literal with a new `setUser` function on every render**. `LoginPage`'s page-load `useEffect` declared `[setUser]` as its dependency, so:

render → new `setUser` identity → effect re-runs → `handleOIDCCallback()` + `loadAuthMethods()` → `setAuthMethods(...)` → **re-render** → new `setUser` → …

An infinite loop. It floods `/api/auth/method` (one fetch per cycle) **and** re-renders the component so fast that click handlers never take effect — which is why every sign-in button appears dead. This is a frontend bug, independent of Authentik/prod config.

## Fix

- **`useCurrentUser`** — wrap `setUser`/`setCurrentUser` in `useCallback` and memoize the returned object with `useMemo`. `dispatch` from `useReducer` is stable, so all consumers now get stable references. Root fix; prevents this class of loop app-wide.
- **`LoginPage`** — make the OIDC-callback + auth-method effect **mount-only** (`[]`). It's a page-load handler, not a reactive one.
- **Regression test** — asserts the login page fetches auth methods exactly once per mount.

Frontend unit tests 9/9, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R4AUD2d6aFpPT67pnLhQGk

---
_Generated by [Claude Code](https://claude.ai/code/session_01R4AUD2d6aFpPT67pnLhQGk)_