### PR TITLE
feat(chat): multi-app scoped history, cursor pagination, widget resume + infinite scroll

### DIFF
--- a/.github/workflows/chat-packages-publish.yml
+++ b/.github/workflows/chat-packages-publish.yml
@@ -1,0 +1,86 @@
+# Publish the chat packages to GitHub Packages under the @izzywdev scope.
+#
+# GitHub Packages requires the npm scope to match the repository owner, so the
+# canonical @fuzefront/* names cannot publish until the org transfer completes
+# (see packages-publish.yml, which stays the long-term path and no-ops until
+# then). Consuming apps (e.g. MendysRobotics) need the chat packages TODAY, so
+# this workflow publishes the same builds under owner-scoped alias names:
+#
+#   @fuzefront/chat-client -> @izzywdev/fuzefront-chat-client
+#   @fuzefront/chat-ui     -> @izzywdev/fuzefront-chat-ui
+#
+# Consumers install via npm aliases so their imports keep the canonical names:
+#
+#   "@fuzefront/chat-client": "npm:@izzywdev/fuzefront-chat-client@^1.1.0",
+#   "@fuzefront/chat-ui":     "npm:@izzywdev/fuzefront-chat-ui@^1.1.0"
+#
+# Once the org transfer lands and packages-publish.yml activates, consumers
+# drop the alias and this workflow is deleted. Publishing is idempotent: a
+# version that already exists in the registry is skipped, not overwritten.
+name: Publish chat packages (alias scope)
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [master]
+    paths:
+      - 'packages/chat-client/**'
+      - 'packages/chat-ui/**'
+
+concurrency:
+  group: chat-packages-publish
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    if: github.repository_owner == 'izzywdev'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@izzywdev'
+
+      - name: Build chat-client
+        working-directory: packages/chat-client
+        run: |
+          npm install --workspaces=false --no-audit --no-fund
+          npm run build
+
+      - name: Build chat-ui
+        working-directory: packages/chat-ui
+        run: |
+          npm install --workspaces=false --no-audit --no-fund
+          npm run build
+
+      - name: Publish @izzywdev/fuzefront-chat-client
+        working-directory: packages/chat-client
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION=$(npm pkg get version | tr -d '"')
+          npm pkg set name=@izzywdev/fuzefront-chat-client
+          if npm view "@izzywdev/fuzefront-chat-client@${VERSION}" version --registry=https://npm.pkg.github.com >/dev/null 2>&1; then
+            echo "@izzywdev/fuzefront-chat-client@${VERSION} already published — skipping."
+          else
+            npm publish --registry=https://npm.pkg.github.com
+          fi
+
+      - name: Publish @izzywdev/fuzefront-chat-ui
+        working-directory: packages/chat-ui
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION=$(npm pkg get version | tr -d '"')
+          npm pkg set name=@izzywdev/fuzefront-chat-ui
+          if npm view "@izzywdev/fuzefront-chat-ui@${VERSION}" version --registry=https://npm.pkg.github.com >/dev/null 2>&1; then
+            echo "@izzywdev/fuzefront-chat-ui@${VERSION} already published — skipping."
+          else
+            npm publish --registry=https://npm.pkg.github.com
+          fi

--- a/.github/workflows/chat-packages-publish.yml
+++ b/.github/workflows/chat-packages-publish.yml
@@ -39,9 +39,9 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
           node-version: '20.x'
           registry-url: 'https://npm.pkg.github.com'

--- a/frontend/src/components/FuzeChatWidget.tsx
+++ b/frontend/src/components/FuzeChatWidget.tsx
@@ -39,6 +39,7 @@ export function FuzeChatWidget() {
     <ChatWidget
       client={client}
       orgId={activeOrganizationId}
+      appId="fuzefront"
       onError={message => window.__FUZEFRONT__?.notify?.({ level: 'error', message })}
     />
   )

--- a/packages/chat-client/package.json
+++ b/packages/chat-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fuzefront/chat-client",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "TypeScript SSE+HTTP client for FuzeFront chat-service",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",
@@ -27,8 +27,8 @@
     "@types/node": "18.19.0",
     "jest": "29.7.0",
     "ts-jest": "29.1.1",
-    "typescript": "5.1.6",
-    "tsup": "^8.0.2"
+    "tsup": "^8.0.2",
+    "typescript": "5.1.6"
   },
   "module": "dist/index.js",
   "exports": {

--- a/packages/chat-client/src/client.ts
+++ b/packages/chat-client/src/client.ts
@@ -22,6 +22,8 @@ import type {
   ChatStreamEvent,
   Conversation,
   ConversationWithMessages,
+  GetConversationOptions,
+  ListConversationsFilter,
 } from './types';
 
 export interface ChatServiceClientConfig {
@@ -120,19 +122,37 @@ export class ChatServiceClient {
   }
 
   /**
-   * List all conversations for the authenticated user / org.
+   * List conversations for the authenticated user, most-recently-updated
+   * first, optionally narrowed to one app/org tenant.
    * Throws on non-2xx (including 401).
    */
-  async listConversations(): Promise<Conversation[]> {
-    return this.fetchJson<Conversation[]>('GET', '/chat/conversations');
+  async listConversations(filter: ListConversationsFilter = {}): Promise<Conversation[]> {
+    const params = new URLSearchParams();
+    if (filter.appId) params.set('appId', filter.appId);
+    if (filter.orgId) params.set('orgId', filter.orgId);
+    const qs = params.toString();
+    return this.fetchJson<Conversation[]>('GET', `/chat/conversations${qs ? `?${qs}` : ''}`);
   }
 
   /**
-   * Fetch a single conversation with its full message history.
+   * Fetch a conversation with one keyset-paginated page of its history.
+   * Without a cursor the newest page is returned; `before` pages towards
+   * older messages (infinite scroll up), `after` towards newer.
    * Throws on non-2xx (including 401).
    */
-  async getConversation(id: string): Promise<ConversationWithMessages> {
-    return this.fetchJson<ConversationWithMessages>('GET', `/chat/conversations/${id}`);
+  async getConversation(
+    id: string,
+    options: GetConversationOptions = {},
+  ): Promise<ConversationWithMessages> {
+    const params = new URLSearchParams();
+    if (options.before) params.set('before', options.before);
+    if (options.after) params.set('after', options.after);
+    if (options.limit !== undefined) params.set('limit', String(options.limit));
+    const qs = params.toString();
+    return this.fetchJson<ConversationWithMessages>(
+      'GET',
+      `/chat/conversations/${id}${qs ? `?${qs}` : ''}`,
+    );
   }
 
   /**

--- a/packages/chat-client/src/types.ts
+++ b/packages/chat-client/src/types.ts
@@ -13,6 +13,12 @@ export interface ChatStreamRequest {
   messages: ChatMessage[];
   conversationId?: string;
   orgId: string;
+  /**
+   * Consuming application ('fuzefront', 'mendys', ...). Scopes the
+   * conversation to (userId, appId[, orgId]). Ignored when the JWT already
+   * carries an appId claim; the server defaults to 'fuzefront'.
+   */
+  appId?: string;
 }
 
 /** A source document returned by the RAG pipeline. */
@@ -27,6 +33,7 @@ export interface RagSource {
  * Each variant carries a discriminant `type` field.
  */
 export type ChatStreamEvent =
+  | { type: 'conversation'; conversationId: string }
   | { type: 'text_delta'; delta: string }
   | {
       type: 'tool_pending';
@@ -45,8 +52,27 @@ export type ChatStreamEvent =
 export interface Conversation {
   id: string;
   title: string | null;
+  /** Consuming application the conversation belongs to. */
+  appId: string;
+  orgId: string | null;
   createdAt: string;
   updatedAt: string;
+}
+
+/** Optional tenant filters for listConversations. */
+export interface ListConversationsFilter {
+  appId?: string;
+  orgId?: string;
+}
+
+/** Cursor options for getConversation's message page. */
+export interface GetConversationOptions {
+  /** Page towards messages older than this message id (scroll up). */
+  before?: string;
+  /** Page towards messages newer than this message id (scroll down). */
+  after?: string;
+  /** Page size (server default 50, max 200). */
+  limit?: number;
 }
 
 /** A single message stored in a conversation. */
@@ -57,7 +83,14 @@ export interface ConversationMessage {
   createdAt: string;
 }
 
-/** Full conversation including stored message history. */
+/**
+ * A conversation plus one keyset-paginated page of its history.
+ * `messages` is oldest-first; without a cursor it is the NEWEST page.
+ */
 export interface ConversationWithMessages extends Conversation {
   messages: ConversationMessage[];
+  /** Older messages exist before the first message of this page. */
+  hasMoreBefore: boolean;
+  /** Newer messages exist after the last message of this page. */
+  hasMoreAfter: boolean;
 }

--- a/packages/chat-client/tests/client.test.ts
+++ b/packages/chat-client/tests/client.test.ts
@@ -175,6 +175,40 @@ describe('ChatServiceClient.streamChat', () => {
     expect((init.headers as Record<string, string>)['Authorization']).toBeUndefined();
   });
 
+  it('includes appId in the request body when provided', async () => {
+    const sseText = sseEvent({ type: 'done' });
+    mockFetch.mockResolvedValueOnce(makeSseResponse(sseText));
+
+    const client = new ChatServiceClient({
+      baseUrl: 'http://localhost:3000',
+      getToken: () => 'token',
+    });
+
+    for await (const _ of client.streamChat({ messages: [], orgId: 'org1', appId: 'mendys' })) {
+      // drain
+    }
+
+    const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(init.body as string).appId).toBe('mendys');
+  });
+
+  it('yields the conversation announcement event', async () => {
+    const sseText =
+      sseEvent({ type: 'conversation', conversationId: 'conv-1' }) + sseEvent({ type: 'done' });
+    mockFetch.mockResolvedValueOnce(makeSseResponse(sseText));
+
+    const client = new ChatServiceClient({
+      baseUrl: 'http://localhost:3000',
+      getToken: () => 'token',
+    });
+
+    const events: ChatStreamEvent[] = [];
+    for await (const evt of client.streamChat({ messages: [], orgId: 'org1' })) {
+      events.push(evt);
+    }
+    expect(events[0]).toEqual({ type: 'conversation', conversationId: 'conv-1' });
+  });
+
   it('includes conversationId in the request body when provided', async () => {
     const sseText = sseEvent({ type: 'done' });
     mockFetch.mockResolvedValueOnce(makeSseResponse(sseText));
@@ -255,6 +289,20 @@ describe('ChatServiceClient.listConversations', () => {
     expect((init.headers as Record<string, string>)['Authorization']).toBe('Bearer tok');
   });
 
+  it('narrows by appId/orgId query params when a filter is given', async () => {
+    mockFetch.mockResolvedValueOnce(makeJsonResponse([]));
+
+    const client = new ChatServiceClient({
+      baseUrl: 'http://localhost:3000',
+      getToken: () => 'tok',
+    });
+
+    await client.listConversations({ appId: 'mendys', orgId: 'org-9' });
+
+    const [url] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('http://localhost:3000/chat/conversations?appId=mendys&orgId=org-9');
+  });
+
   it('throws on 401', async () => {
     mockFetch.mockResolvedValueOnce(new Response('Unauthorized', { status: 401 }));
 
@@ -292,6 +340,25 @@ describe('ChatServiceClient.getConversation', () => {
     expect(result).toEqual(mockData);
     const [url] = mockFetch.mock.calls[0] as [string, RequestInit];
     expect(url).toBe('http://localhost:3000/chat/conversations/conv1');
+  });
+
+  it('forwards before/after/limit cursors as query params', async () => {
+    mockFetch.mockImplementation(async () =>
+      makeJsonResponse({ id: 'conv1', messages: [], hasMoreBefore: false, hasMoreAfter: false }),
+    );
+
+    const client = new ChatServiceClient({
+      baseUrl: 'http://localhost:3000',
+      getToken: () => 'tok',
+    });
+
+    await client.getConversation('conv1', { before: 'm10', limit: 25 });
+    let [url] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('http://localhost:3000/chat/conversations/conv1?before=m10&limit=25');
+
+    await client.getConversation('conv1', { after: 'm20' });
+    [url] = mockFetch.mock.calls[1] as [string, RequestInit];
+    expect(url).toBe('http://localhost:3000/chat/conversations/conv1?after=m20');
   });
 
   it('throws on 401', async () => {

--- a/packages/chat-ui/package.json
+++ b/packages/chat-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fuzefront/chat-ui",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Design-system-first React chat UI for the FuzeFront chat-service (SSE streaming, RAG citations, agent confirmation prompts).",
   "license": "MIT",
   "type": "module",
@@ -38,7 +38,7 @@
     "test:watch": "vitest"
   },
   "peerDependencies": {
-    "@fuzefront/chat-client": "^1.0.0",
+    "@fuzefront/chat-client": "^1.1.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0"
   },

--- a/packages/chat-ui/src/components/ChatPanel.tsx
+++ b/packages/chat-ui/src/components/ChatPanel.tsx
@@ -11,6 +11,14 @@ export interface ChatPanelProps {
   onCancel: (confirmationId: string) => void;
   onFeedback: (messageId: string, rating: 'positive' | 'negative') => void;
   onClose?: () => void;
+  /** True while the initial history page is loading (composer disabled). */
+  loadingHistory?: boolean;
+  /** Older history exists — enables scroll-up paging in the list. */
+  hasMoreBefore?: boolean;
+  /** Newer history exists — enables scroll-down paging in the list. */
+  hasMoreAfter?: boolean;
+  onLoadOlder?: () => void;
+  onLoadNewer?: () => void;
 }
 
 /**
@@ -27,6 +35,11 @@ export function ChatPanel({
   onCancel,
   onFeedback,
   onClose,
+  loadingHistory = false,
+  hasMoreBefore = false,
+  hasMoreAfter = false,
+  onLoadOlder,
+  onLoadNewer,
 }: ChatPanelProps) {
   const { strings, dir } = useChatI18n();
 
@@ -57,9 +70,14 @@ export function ChatPanel({
         onApprove={onApprove}
         onCancel={onCancel}
         onFeedback={onFeedback}
+        loadingHistory={loadingHistory}
+        hasMoreBefore={hasMoreBefore}
+        hasMoreAfter={hasMoreAfter}
+        onLoadOlder={onLoadOlder}
+        onLoadNewer={onLoadNewer}
       />
 
-      <Composer disabled={streaming} onSend={onSend} />
+      <Composer disabled={streaming || loadingHistory} onSend={onSend} />
     </aside>
   );
 }

--- a/packages/chat-ui/src/components/ChatPanel.tsx
+++ b/packages/chat-ui/src/components/ChatPanel.tsx
@@ -19,6 +19,8 @@ export interface ChatPanelProps {
   hasMoreAfter?: boolean;
   onLoadOlder?: () => void;
   onLoadNewer?: () => void;
+  /** Increments per locally-sent user message; forces scroll-to-bottom. */
+  sendSignal?: number;
 }
 
 /**
@@ -40,6 +42,7 @@ export function ChatPanel({
   hasMoreAfter = false,
   onLoadOlder,
   onLoadNewer,
+  sendSignal,
 }: ChatPanelProps) {
   const { strings, dir } = useChatI18n();
 
@@ -75,6 +78,7 @@ export function ChatPanel({
         hasMoreAfter={hasMoreAfter}
         onLoadOlder={onLoadOlder}
         onLoadNewer={onLoadNewer}
+        sendSignal={sendSignal}
       />
 
       <Composer disabled={streaming || loadingHistory} onSend={onSend} />

--- a/packages/chat-ui/src/components/ChatWidget.tsx
+++ b/packages/chat-ui/src/components/ChatWidget.tsx
@@ -9,8 +9,20 @@ export interface ChatWidgetProps {
   client: ChatServiceClient;
   /** Tenant the conversation belongs to. */
   orgId: string;
+  /**
+   * Consuming application ('fuzefront', 'mendys', ...). Scopes stored history
+   * to (user, org, app) so each app resumes only its own thread.
+   */
+  appId?: string;
   /** Resume an existing conversation. */
   conversationId?: string;
+  /**
+   * Load persisted history when the panel opens (WhatsApp-style resume of the
+   * scope's most recent conversation). Default true.
+   */
+  resume?: boolean;
+  /** History page size for the initial load and each infinite-scroll page. */
+  pageSize?: number;
   /** Start open. Default false (launcher-driven). */
   defaultOpen?: boolean;
   /** Text direction; forwarded to i18n + the drawer root. Default 'ltr'. */
@@ -25,7 +37,10 @@ export interface ChatWidgetProps {
 export function ChatWidget({
   client,
   orgId,
+  appId,
   conversationId,
+  resume = true,
+  pageSize,
   defaultOpen = false,
   dir = 'ltr',
   strings,
@@ -36,7 +51,10 @@ export function ChatWidget({
       <ChatWidgetInner
         client={client}
         orgId={orgId}
+        appId={appId}
         conversationId={conversationId}
+        resume={resume}
+        pageSize={pageSize}
         defaultOpen={defaultOpen}
         onError={onError}
       />
@@ -47,13 +65,19 @@ export function ChatWidget({
 function ChatWidgetInner({
   client,
   orgId,
+  appId,
   conversationId,
+  resume,
+  pageSize,
   defaultOpen,
   onError,
-}: Pick<ChatWidgetProps, 'client' | 'orgId' | 'conversationId' | 'defaultOpen' | 'onError'>) {
+}: Pick<
+  ChatWidgetProps,
+  'client' | 'orgId' | 'appId' | 'conversationId' | 'resume' | 'pageSize' | 'defaultOpen' | 'onError'
+>) {
   const [open, setOpen] = useState(Boolean(defaultOpen));
   const { strings, dir } = useChatI18n();
-  const chat = useChat({ client, orgId, conversationId, onError });
+  const chat = useChat({ client, orgId, appId, conversationId, resume, pageSize, onError });
 
   if (!open) {
     return (
@@ -73,6 +97,11 @@ function ChatWidgetInner({
     <ChatPanel
       messages={chat.messages}
       streaming={chat.streaming}
+      loadingHistory={chat.loadingHistory}
+      hasMoreBefore={chat.hasMoreBefore}
+      hasMoreAfter={chat.hasMoreAfter}
+      onLoadOlder={chat.loadOlder}
+      onLoadNewer={chat.loadNewer}
       onSend={chat.send}
       onApprove={chat.confirm}
       onCancel={chat.cancel}

--- a/packages/chat-ui/src/components/ChatWidget.tsx
+++ b/packages/chat-ui/src/components/ChatWidget.tsx
@@ -102,6 +102,7 @@ function ChatWidgetInner({
       hasMoreAfter={chat.hasMoreAfter}
       onLoadOlder={chat.loadOlder}
       onLoadNewer={chat.loadNewer}
+      sendSignal={chat.sendCount}
       onSend={chat.send}
       onApprove={chat.confirm}
       onCancel={chat.cancel}

--- a/packages/chat-ui/src/components/MessageList.tsx
+++ b/packages/chat-ui/src/components/MessageList.tsx
@@ -47,9 +47,14 @@ export function MessageList({
 
   // Whether the user is pinned to the bottom (auto-scroll allowed).
   const nearBottomRef = useRef(true);
-  // Prepend anchoring: remember the scroll height when an older page was
-  // requested so the viewport can be offset by exactly the prepended height.
+  // Prepend anchoring: when an older page is requested, remember the current
+  // first message ELEMENT and its offsetTop. After the prepend, that same node
+  // has moved down by exactly the prepended height — immune to content being
+  // appended at the bottom (e.g. a streaming delta) while the page is in
+  // flight, which would corrupt a scrollHeight-based delta.
   const awaitingPrependRef = useRef(false);
+  const anchorElRef = useRef<HTMLElement | null>(null);
+  const anchorOffsetRef = useRef(0);
   const prependScrollHeightRef = useRef(0);
   const prevFirstIdRef = useRef<string | undefined>(undefined);
 
@@ -66,6 +71,9 @@ export function MessageList({
       !awaitingPrependRef.current
     ) {
       awaitingPrependRef.current = true;
+      const anchor = el.querySelector<HTMLElement>('.ffc-msg');
+      anchorElRef.current = anchor;
+      anchorOffsetRef.current = anchor?.offsetTop ?? 0;
       prependScrollHeightRef.current = el.scrollHeight;
       onLoadOlder();
     }
@@ -76,13 +84,20 @@ export function MessageList({
   };
 
   // Keep the viewport anchored when an older page is prepended: offset the
-  // scroll position by however much taller the list just became.
+  // scroll position by how far the previously-first message moved down.
   useLayoutEffect(() => {
     const el = listRef.current;
     const firstId = messages[0]?.id;
     if (el && awaitingPrependRef.current && firstId !== prevFirstIdRef.current) {
-      el.scrollTop += el.scrollHeight - prependScrollHeightRef.current;
+      const anchor = anchorElRef.current;
+      if (anchor && el.contains(anchor)) {
+        el.scrollTop += anchor.offsetTop - anchorOffsetRef.current;
+      } else {
+        // Anchor node gone (remount) — fall back to the total-height delta.
+        el.scrollTop += el.scrollHeight - prependScrollHeightRef.current;
+      }
       awaitingPrependRef.current = false;
+      anchorElRef.current = null;
     }
     prevFirstIdRef.current = firstId;
   }, [messages]);

--- a/packages/chat-ui/src/components/MessageList.tsx
+++ b/packages/chat-ui/src/components/MessageList.tsx
@@ -1,29 +1,118 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useLayoutEffect, useRef } from 'react';
 import { useChatI18n } from '../i18n';
 import type { UiMessage } from '../hooks/types';
 import { MessageItem } from './MessageItem';
+
+/** Distance (px) from an edge that counts as "at" that edge. */
+const EDGE_THRESHOLD = 48;
 
 export interface MessageListProps {
   messages: UiMessage[];
   onApprove: (confirmationId: string) => void;
   onCancel: (confirmationId: string) => void;
   onFeedback: (messageId: string, rating: 'positive' | 'negative') => void;
+  /** True while the initial history page is loading. */
+  loadingHistory?: boolean;
+  /** Older history exists above the window — scroll-up paging enabled. */
+  hasMoreBefore?: boolean;
+  /** Newer history exists below the window — scroll-down paging enabled. */
+  hasMoreAfter?: boolean;
+  /** Load one page of older messages (called near the top edge). */
+  onLoadOlder?: () => void;
+  /** Load one page of newer messages (called near the bottom edge). */
+  onLoadNewer?: () => void;
 }
 
-/** Scrollable, auto-scrolling, live-region message list. */
-export function MessageList({ messages, onApprove, onCancel, onFeedback }: MessageListProps) {
+/**
+ * Scrollable, live-region message list with WhatsApp-style history paging:
+ * scrolling near the top loads older messages (keeping the viewport anchored
+ * on the previously-visible message), scrolling near the bottom loads newer
+ * ones. Auto-scroll to new content only happens while the user is already at
+ * the bottom, so reading old history is never yanked away.
+ */
+export function MessageList({
+  messages,
+  onApprove,
+  onCancel,
+  onFeedback,
+  loadingHistory = false,
+  hasMoreBefore = false,
+  hasMoreAfter = false,
+  onLoadOlder,
+  onLoadNewer,
+}: MessageListProps) {
   const { strings } = useChatI18n();
+  const listRef = useRef<HTMLDivElement>(null);
   const endRef = useRef<HTMLDivElement>(null);
 
-  // Auto-scroll on new content (including streaming deltas).
+  // Whether the user is pinned to the bottom (auto-scroll allowed).
+  const nearBottomRef = useRef(true);
+  // Prepend anchoring: remember the scroll height when an older page was
+  // requested so the viewport can be offset by exactly the prepended height.
+  const awaitingPrependRef = useRef(false);
+  const prependScrollHeightRef = useRef(0);
+  const prevFirstIdRef = useRef<string | undefined>(undefined);
+
+  const handleScroll = () => {
+    const el = listRef.current;
+    if (!el) return;
+    const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
+    nearBottomRef.current = distanceFromBottom <= EDGE_THRESHOLD;
+
+    if (
+      el.scrollTop <= EDGE_THRESHOLD &&
+      hasMoreBefore &&
+      onLoadOlder &&
+      !awaitingPrependRef.current
+    ) {
+      awaitingPrependRef.current = true;
+      prependScrollHeightRef.current = el.scrollHeight;
+      onLoadOlder();
+    }
+
+    if (distanceFromBottom <= EDGE_THRESHOLD && hasMoreAfter && onLoadNewer) {
+      onLoadNewer();
+    }
+  };
+
+  // Keep the viewport anchored when an older page is prepended: offset the
+  // scroll position by however much taller the list just became.
+  useLayoutEffect(() => {
+    const el = listRef.current;
+    const firstId = messages[0]?.id;
+    if (el && awaitingPrependRef.current && firstId !== prevFirstIdRef.current) {
+      el.scrollTop += el.scrollHeight - prependScrollHeightRef.current;
+      awaitingPrependRef.current = false;
+    }
+    prevFirstIdRef.current = firstId;
+  }, [messages]);
+
+  // Auto-scroll on new content (including streaming deltas) — but only while
+  // the user is already at the bottom.
   const tail = messages[messages.length - 1];
   useEffect(() => {
-    endRef.current?.scrollIntoView({ block: 'end' });
+    if (nearBottomRef.current) {
+      endRef.current?.scrollIntoView({ block: 'end' });
+    }
   }, [messages.length, tail?.content]);
 
   return (
-    <div className="ffc-list" role="log" aria-live="polite" aria-busy={tail?.streaming || undefined}>
-      {messages.length === 0 ? (
+    <div
+      ref={listRef}
+      className="ffc-list"
+      role="log"
+      aria-live="polite"
+      aria-busy={loadingHistory || tail?.streaming || undefined}
+      onScroll={handleScroll}
+    >
+      {hasMoreBefore ? (
+        <p className="ffc-history-more" aria-hidden="true">
+          {strings.historyLoading}
+        </p>
+      ) : null}
+      {loadingHistory ? (
+        <p className="ffc-empty">{strings.historyLoading}</p>
+      ) : messages.length === 0 ? (
         <p className="ffc-empty">{strings.emptyState}</p>
       ) : (
         messages.map((m) => (

--- a/packages/chat-ui/src/components/MessageList.tsx
+++ b/packages/chat-ui/src/components/MessageList.tsx
@@ -21,6 +21,12 @@ export interface MessageListProps {
   onLoadOlder?: () => void | Promise<void>;
   /** Load one page of newer messages (called near the bottom edge). */
   onLoadNewer?: () => void | Promise<void>;
+  /**
+   * Increments on each locally-sent user message (ChatModel.sendCount).
+   * Forces a scroll to the bottom on the user's own send even when they had
+   * scrolled up into history.
+   */
+  sendSignal?: number;
 }
 
 /**
@@ -40,6 +46,7 @@ export function MessageList({
   hasMoreAfter = false,
   onLoadOlder,
   onLoadNewer,
+  sendSignal = 0,
 }: MessageListProps) {
   const { strings } = useChatI18n();
   const listRef = useRef<HTMLDivElement>(null);
@@ -108,6 +115,15 @@ export function MessageList({
     }
     prevFirstIdRef.current = firstId;
   }, [messages]);
+
+  // The user's own send always snaps to the bottom (and re-pins auto-scroll),
+  // even if they had scrolled up into history before composing.
+  useEffect(() => {
+    if (sendSignal > 0) {
+      nearBottomRef.current = true;
+      endRef.current?.scrollIntoView({ block: 'end' });
+    }
+  }, [sendSignal]);
 
   // Auto-scroll on new content (including streaming deltas) — but only while
   // the user is already at the bottom.

--- a/packages/chat-ui/src/components/MessageList.tsx
+++ b/packages/chat-ui/src/components/MessageList.tsx
@@ -18,9 +18,9 @@ export interface MessageListProps {
   /** Newer history exists below the window — scroll-down paging enabled. */
   hasMoreAfter?: boolean;
   /** Load one page of older messages (called near the top edge). */
-  onLoadOlder?: () => void;
+  onLoadOlder?: () => void | Promise<void>;
   /** Load one page of newer messages (called near the bottom edge). */
-  onLoadNewer?: () => void;
+  onLoadNewer?: () => void | Promise<void>;
 }
 
 /**
@@ -75,7 +75,14 @@ export function MessageList({
       anchorElRef.current = anchor;
       anchorOffsetRef.current = anchor?.offsetTop ?? 0;
       prependScrollHeightRef.current = el.scrollHeight;
-      onLoadOlder();
+      Promise.resolve(onLoadOlder()).finally(() => {
+        // If the page never prepended (request failed / came back empty) the
+        // layout effect below never clears the guard — re-arm paging once the
+        // commit (and its anchoring pass) has had a chance to run.
+        setTimeout(() => {
+          awaitingPrependRef.current = false;
+        }, 0);
+      });
     }
 
     if (distanceFromBottom <= EDGE_THRESHOLD && hasMoreAfter && onLoadNewer) {

--- a/packages/chat-ui/src/hooks/chatReducer.ts
+++ b/packages/chat-ui/src/hooks/chatReducer.ts
@@ -31,6 +31,12 @@ export interface ChatModel {
   hasMoreAfter: boolean;
   /** The active server conversation id, once known (prop, hydrate, or stream). */
   conversationId?: string;
+  /**
+   * Monotonic count of locally-sent user messages. UI uses it to force-scroll
+   * to the bottom on the user's OWN send even when they had scrolled up into
+   * history (streamed deltas alone never yank a reader away from history).
+   */
+  sendCount: number;
 }
 
 export type ChatAction =
@@ -59,6 +65,7 @@ export const initialModel: ChatModel = {
   hasMoreBefore: false,
   hasMoreAfter: false,
   conversationId: undefined,
+  sendCount: 0,
 };
 
 /** Update the last assistant message in place via the given transform. */
@@ -93,6 +100,7 @@ export function chatReducer(state: ChatModel, action: ChatAction): ChatModel {
     case 'user_message':
       return {
         ...state,
+        sendCount: state.sendCount + 1,
         messages: [
           ...state.messages,
           { id: action.id, role: 'user', content: action.content, streaming: false },

--- a/packages/chat-ui/src/hooks/chatReducer.ts
+++ b/packages/chat-ui/src/hooks/chatReducer.ts
@@ -3,6 +3,7 @@
  * Kept side-effect-free so it can be unit-tested without React.
  *
  * Event handling (matches @fuzefront/chat-client's ChatStreamEvent):
+ *   conversation -> record the server-resolved conversation id (thread resume)
  *   text_delta   -> append delta to the current streaming assistant message
  *   rag_sources  -> attach citations to the current assistant message
  *   tool_pending -> add a pending confirmation card to the current message
@@ -10,6 +11,10 @@
  *   tool_denied  -> mark the relevant confirmation denied
  *   error        -> set error on the current assistant message
  *   done         -> mark the current assistant message no longer streaming
+ *
+ * History actions (hydrate / infinite scroll) merge server-loaded pages into
+ * the same message list: hydrate_done seeds the newest page, history_prepend
+ * adds an older page above (scroll up), history_append a newer page below.
  */
 import type { ChatStreamEvent } from '@fuzefront/chat-client';
 import type { PendingConfirmation, UiMessage } from './types';
@@ -18,6 +23,14 @@ export interface ChatModel {
   messages: UiMessage[];
   /** True while a turn is streaming. */
   streaming: boolean;
+  /** True while the initial history page is loading (composer disabled). */
+  loadingHistory: boolean;
+  /** Older messages exist above the loaded window (enables scroll-up paging). */
+  hasMoreBefore: boolean;
+  /** Newer messages exist below the loaded window (enables scroll-down paging). */
+  hasMoreAfter: boolean;
+  /** The active server conversation id, once known (prop, hydrate, or stream). */
+  conversationId?: string;
 }
 
 export type ChatAction =
@@ -27,9 +40,26 @@ export type ChatAction =
   | { kind: 'set_feedback'; id: string; feedback: 'positive' | 'negative' }
   | { kind: 'confirm_running'; confirmationId: string }
   | { kind: 'confirm_resolved'; confirmationId: string; status: 'approved' | 'denied'; summary?: string }
+  | { kind: 'hydrate_start' }
+  | {
+      kind: 'hydrate_done';
+      messages: UiMessage[];
+      conversationId?: string;
+      hasMoreBefore: boolean;
+      hasMoreAfter: boolean;
+    }
+  | { kind: 'history_prepend'; messages: UiMessage[]; hasMoreBefore: boolean }
+  | { kind: 'history_append'; messages: UiMessage[]; hasMoreAfter: boolean }
   | { kind: 'reset' };
 
-export const initialModel: ChatModel = { messages: [], streaming: false };
+export const initialModel: ChatModel = {
+  messages: [],
+  streaming: false,
+  loadingHistory: false,
+  hasMoreBefore: false,
+  hasMoreAfter: false,
+  conversationId: undefined,
+};
 
 /** Update the last assistant message in place via the given transform. */
 function mapLastAssistant(
@@ -110,6 +140,34 @@ export function chatReducer(state: ChatModel, action: ChatAction): ChatModel {
         })),
       };
 
+    case 'hydrate_start':
+      return { ...state, loadingHistory: true };
+
+    case 'hydrate_done':
+      return {
+        ...state,
+        loadingHistory: false,
+        conversationId: action.conversationId ?? state.conversationId,
+        hasMoreBefore: action.hasMoreBefore,
+        hasMoreAfter: action.hasMoreAfter,
+        // Anything already streamed locally stays below the hydrated history.
+        messages: [...action.messages, ...state.messages],
+      };
+
+    case 'history_prepend':
+      return {
+        ...state,
+        hasMoreBefore: action.hasMoreBefore,
+        messages: [...action.messages, ...state.messages],
+      };
+
+    case 'history_append':
+      return {
+        ...state,
+        hasMoreAfter: action.hasMoreAfter,
+        messages: [...state.messages, ...action.messages],
+      };
+
     case 'stream_event':
       return applyStreamEvent(state, action.event);
 
@@ -120,6 +178,9 @@ export function chatReducer(state: ChatModel, action: ChatAction): ChatModel {
 
 function applyStreamEvent(state: ChatModel, event: ChatStreamEvent): ChatModel {
   switch (event.type) {
+    case 'conversation':
+      return { ...state, conversationId: event.conversationId };
+
     case 'text_delta':
       return {
         ...state,

--- a/packages/chat-ui/src/hooks/useChat.ts
+++ b/packages/chat-ui/src/hooks/useChat.ts
@@ -1,13 +1,21 @@
 /**
  * useChat — drives a streaming conversation against a ChatServiceClient.
  *
- * Owns: the reduced message model, send/confirm/cancel/feedback actions, and the
- * for-await consumption of the SSE event union. The client's streamChat never
+ * Owns: the reduced message model, send/confirm/cancel/feedback actions, the
+ * for-await consumption of the SSE event union, and the persisted-history
+ * lifecycle — hydrating the most recent conversation for the caller's
+ * (user, org, app) scope on mount, and paging older/newer messages with
+ * cursors for bidirectional infinite scroll. The client's streamChat never
  * throws (it yields a terminal `error` event), so the loop here is plain.
  */
-import { useCallback, useReducer, useRef } from 'react';
-import type { ChatMessage, ChatServiceClient } from '@fuzefront/chat-client';
+import { useCallback, useEffect, useReducer, useRef } from 'react';
+import type {
+  ChatMessage,
+  ChatServiceClient,
+  ConversationMessage,
+} from '@fuzefront/chat-client';
 import { chatReducer, initialModel, type ChatModel } from './chatReducer';
+import type { UiMessage } from './types';
 
 let idCounter = 0;
 /** Monotonic id generator (crypto.randomUUID when available, else a counter). */
@@ -19,10 +27,49 @@ function nextId(prefix: string): string {
   return `${prefix}-${idCounter}`;
 }
 
+/** Extract plain text from stored message content ({type:'text',text} or raw string). */
+function contentText(content: unknown): string {
+  if (typeof content === 'string') return content;
+  if (content && typeof content === 'object' && 'text' in content) {
+    const text = (content as { text?: unknown }).text;
+    if (typeof text === 'string') return text;
+  }
+  return content == null ? '' : JSON.stringify(content);
+}
+
+/** Map a stored server message to the UI model (tool messages are not rendered). */
+function toUiMessages(stored: ConversationMessage[]): UiMessage[] {
+  return stored
+    .filter((m): m is ConversationMessage & { role: 'user' | 'assistant' } => m.role !== 'tool')
+    .map((m) => ({
+      id: m.id,
+      role: m.role,
+      content: contentText(m.content),
+      streaming: false,
+    }));
+}
+
+/** Map stored messages to the LLM request payload shape. */
+function toChatMessages(stored: ConversationMessage[]): ChatMessage[] {
+  return stored
+    .filter((m): m is ConversationMessage & { role: 'user' | 'assistant' } => m.role !== 'tool')
+    .map((m) => ({ role: m.role, content: contentText(m.content) }));
+}
+
 export interface UseChatOptions {
   client: ChatServiceClient;
   orgId: string;
+  /** Consuming application ('fuzefront', 'mendys', ...) scoping the history. */
+  appId?: string;
   conversationId?: string;
+  /**
+   * Load persisted history on mount. Without an explicit conversationId the
+   * caller's most recent conversation for (user, org, app) is resumed —
+   * WhatsApp-style. Default true.
+   */
+  resume?: boolean;
+  /** History page size for hydrate/loadOlder/loadNewer. Default 50. */
+  pageSize?: number;
   /** Called when a turn errors (in addition to the error surfacing in state). */
   onError?: (message: string) => void;
 }
@@ -32,15 +79,81 @@ export interface UseChatResult extends ChatModel {
   confirm(confirmationId: string): Promise<void>;
   cancel(confirmationId: string): void;
   feedback(messageId: string, rating: 'positive' | 'negative'): Promise<void>;
+  /** Page one screen of older history above the loaded window (scroll up). */
+  loadOlder(): Promise<void>;
+  /** Page one screen of newer history below the loaded window (scroll down). */
+  loadNewer(): Promise<void>;
   reset(): void;
 }
 
 export function useChat(options: UseChatOptions): UseChatResult {
-  const { client, orgId, conversationId, onError } = options;
+  const { client, orgId, appId, conversationId, resume = true, pageSize = 50, onError } = options;
   const [model, dispatch] = useReducer(chatReducer, initialModel);
 
   // Keep the running history for the request payload without re-creating `send`.
   const historyRef = useRef<ChatMessage[]>([]);
+  // The active thread; seeded by the prop / hydration, updated by the server's
+  // `conversation` announcement so follow-up sends reuse the same thread.
+  const conversationIdRef = useRef<string | undefined>(conversationId);
+  // Cursor edges of the server-loaded window (server message ids).
+  const oldestLoadedIdRef = useRef<string | undefined>(undefined);
+  const newestLoadedIdRef = useRef<string | undefined>(undefined);
+  // In-flight guards so scroll handlers can fire repeatedly without stacking requests.
+  const loadingOlderRef = useRef(false);
+  const loadingNewerRef = useRef(false);
+  // Keep the latest onError without retriggering the hydration effect.
+  const onErrorRef = useRef(onError);
+  onErrorRef.current = onError;
+
+  // Hydrate persisted history on mount / scope change.
+  useEffect(() => {
+    conversationIdRef.current = conversationId;
+    oldestLoadedIdRef.current = undefined;
+    newestLoadedIdRef.current = undefined;
+    if (!resume && !conversationId) return;
+
+    let cancelled = false;
+    (async () => {
+      dispatch({ kind: 'hydrate_start' });
+      try {
+        let targetId = conversationId;
+        if (!targetId) {
+          // Most recent conversation for this (user, org, app) scope.
+          const conversations = await client.listConversations({ appId, orgId });
+          targetId = conversations[0]?.id;
+        }
+        if (!targetId) {
+          if (!cancelled) {
+            dispatch({ kind: 'hydrate_done', messages: [], hasMoreBefore: false, hasMoreAfter: false });
+          }
+          return;
+        }
+        const page = await client.getConversation(targetId, { limit: pageSize });
+        if (cancelled) return;
+
+        conversationIdRef.current = targetId;
+        oldestLoadedIdRef.current = page.messages[0]?.id;
+        newestLoadedIdRef.current = page.messages[page.messages.length - 1]?.id;
+        historyRef.current = toChatMessages(page.messages);
+
+        dispatch({
+          kind: 'hydrate_done',
+          conversationId: targetId,
+          messages: toUiMessages(page.messages),
+          hasMoreBefore: page.hasMoreBefore,
+          hasMoreAfter: page.hasMoreAfter,
+        });
+      } catch (err) {
+        if (cancelled) return;
+        onErrorRef.current?.(err instanceof Error ? err.message : String(err));
+        dispatch({ kind: 'hydrate_done', messages: [], hasMoreBefore: false, hasMoreAfter: false });
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [client, orgId, appId, conversationId, resume, pageSize]);
 
   const send = useCallback(
     async (text: string) => {
@@ -56,8 +169,10 @@ export function useChat(options: UseChatOptions): UseChatResult {
       for await (const event of client.streamChat({
         messages: historyRef.current,
         orgId,
-        conversationId,
+        appId,
+        conversationId: conversationIdRef.current,
       })) {
+        if (event.type === 'conversation') conversationIdRef.current = event.conversationId;
         if (event.type === 'text_delta') assistantText += event.delta;
         if (event.type === 'error') onError?.(event.message);
         dispatch({ kind: 'stream_event', event });
@@ -69,8 +184,50 @@ export function useChat(options: UseChatOptions): UseChatResult {
         { role: 'assistant', content: assistantText },
       ];
     },
-    [client, orgId, conversationId, onError],
+    [client, orgId, appId, onError],
   );
+
+  const loadOlder = useCallback(async () => {
+    const targetId = conversationIdRef.current;
+    const cursor = oldestLoadedIdRef.current;
+    if (!targetId || !cursor || loadingOlderRef.current) return;
+    loadingOlderRef.current = true;
+    try {
+      const page = await client.getConversation(targetId, { before: cursor, limit: pageSize });
+      if (page.messages.length > 0) oldestLoadedIdRef.current = page.messages[0].id;
+      dispatch({
+        kind: 'history_prepend',
+        messages: toUiMessages(page.messages),
+        hasMoreBefore: page.hasMoreBefore,
+      });
+    } catch (err) {
+      onErrorRef.current?.(err instanceof Error ? err.message : String(err));
+    } finally {
+      loadingOlderRef.current = false;
+    }
+  }, [client, pageSize]);
+
+  const loadNewer = useCallback(async () => {
+    const targetId = conversationIdRef.current;
+    const cursor = newestLoadedIdRef.current;
+    if (!targetId || !cursor || loadingNewerRef.current) return;
+    loadingNewerRef.current = true;
+    try {
+      const page = await client.getConversation(targetId, { after: cursor, limit: pageSize });
+      if (page.messages.length > 0) {
+        newestLoadedIdRef.current = page.messages[page.messages.length - 1].id;
+      }
+      dispatch({
+        kind: 'history_append',
+        messages: toUiMessages(page.messages),
+        hasMoreAfter: page.hasMoreAfter,
+      });
+    } catch (err) {
+      onErrorRef.current?.(err instanceof Error ? err.message : String(err));
+    } finally {
+      loadingNewerRef.current = false;
+    }
+  }, [client, pageSize]);
 
   const confirm = useCallback(
     async (confirmationId: string) => {
@@ -105,8 +262,11 @@ export function useChat(options: UseChatOptions): UseChatResult {
 
   const reset = useCallback(() => {
     historyRef.current = [];
+    conversationIdRef.current = undefined;
+    oldestLoadedIdRef.current = undefined;
+    newestLoadedIdRef.current = undefined;
     dispatch({ kind: 'reset' });
   }, []);
 
-  return { ...model, send, confirm, cancel, feedback, reset };
+  return { ...model, send, confirm, cancel, feedback, loadOlder, loadNewer, reset };
 }

--- a/packages/chat-ui/src/hooks/useChat.ts
+++ b/packages/chat-ui/src/hooks/useChat.ts
@@ -105,11 +105,16 @@ export function useChat(options: UseChatOptions): UseChatResult {
   const onErrorRef = useRef(onError);
   onErrorRef.current = onError;
 
-  // Hydrate persisted history on mount / scope change.
+  // Hydrate persisted history on mount / scope change. A scope change
+  // (client/org/app/conversation) always starts from a clean slate — the
+  // previous scope's messages must neither stay rendered nor leak into the
+  // next streamChat payload via historyRef.
   useEffect(() => {
     conversationIdRef.current = conversationId;
     oldestLoadedIdRef.current = undefined;
     newestLoadedIdRef.current = undefined;
+    historyRef.current = [];
+    dispatch({ kind: 'reset' });
     if (!resume && !conversationId) return;
 
     let cancelled = false;

--- a/packages/chat-ui/src/i18n/index.ts
+++ b/packages/chat-ui/src/i18n/index.ts
@@ -36,6 +36,7 @@ export interface ChatStrings {
   feedbackNegative: string;
   errorPrefix: string;
   emptyState: string;
+  historyLoading: string;
   assistantRole: string;
   userRole: string;
 }
@@ -60,6 +61,7 @@ const EN: ChatStrings = {
   feedbackNegative: 'Bad response',
   errorPrefix: 'Something went wrong',
   emptyState: 'Ask a question to get started.',
+  historyLoading: 'Loading earlier messages…',
   assistantRole: 'Assistant',
   userRole: 'You',
 };

--- a/packages/chat-ui/src/styles/chat-ui.css
+++ b/packages/chat-ui/src/styles/chat-ui.css
@@ -116,6 +116,15 @@
   text-align: center;
 }
 
+/* Scroll-up paging indicator pinned above the oldest loaded message. */
+.ffc-history-more {
+  margin: 0;
+  padding-block: var(--space-2);
+  color: var(--text-tertiary);
+  font-size: var(--text-sm);
+  text-align: center;
+}
+
 .ffc-msg {
   display: flex;
   flex-direction: column;

--- a/packages/chat-ui/tests/fakeClient.ts
+++ b/packages/chat-ui/tests/fakeClient.ts
@@ -2,28 +2,50 @@ import type {
   ChatServiceClient,
   ChatStreamEvent,
   ChatStreamRequest,
+  Conversation,
+  ConversationWithMessages,
+  GetConversationOptions,
+  ListConversationsFilter,
 } from '@fuzefront/chat-client';
 
 /**
  * A minimal stand-in for ChatServiceClient that replays a scripted event list
- * for streamChat and records confirm/feedback calls. Implements only the methods
- * the UI uses, cast to the client type for the hook's signature.
+ * for streamChat, records confirm/feedback calls, and serves scripted
+ * conversation history for the hydrate/infinite-scroll paths. Implements only
+ * the methods the UI uses, cast to the client type for the hook's signature.
  */
 export interface FakeClient {
   client: ChatServiceClient;
   confirmCalls: string[];
   feedbackCalls: Array<{ messageId: string; rating: 'positive' | 'negative' }>;
+  listCalls: ListConversationsFilter[];
+  getCalls: Array<{ id: string; options?: GetConversationOptions }>;
+  streamRequests: ChatStreamRequest[];
+}
+
+export interface FakeClientOptions {
+  confirmThrows?: boolean;
+  feedbackThrows?: boolean;
+  /** Scripted result for listConversations (default []). */
+  conversations?: Conversation[];
+  /** Scripted results for getConversation, consumed in call order. */
+  pages?: ConversationWithMessages[];
 }
 
 export function makeFakeClient(
   events: ChatStreamEvent[],
-  opts: { confirmThrows?: boolean; feedbackThrows?: boolean } = {},
+  opts: FakeClientOptions = {},
 ): FakeClient {
   const confirmCalls: string[] = [];
   const feedbackCalls: Array<{ messageId: string; rating: 'positive' | 'negative' }> = [];
+  const listCalls: ListConversationsFilter[] = [];
+  const getCalls: Array<{ id: string; options?: GetConversationOptions }> = [];
+  const streamRequests: ChatStreamRequest[] = [];
+  const pages = [...(opts.pages ?? [])];
 
   const client = {
-    async *streamChat(_req: ChatStreamRequest): AsyncIterable<ChatStreamEvent> {
+    async *streamChat(req: ChatStreamRequest): AsyncIterable<ChatStreamEvent> {
+      streamRequests.push(req);
       for (const ev of events) {
         // microtask boundary so React can flush between deltas
         await Promise.resolve();
@@ -38,13 +60,27 @@ export function makeFakeClient(
       feedbackCalls.push({ messageId, rating });
       if (opts.feedbackThrows) throw new Error('feedback failed');
     },
-    async listConversations() {
-      return [];
+    async listConversations(filter: ListConversationsFilter = {}) {
+      listCalls.push(filter);
+      return opts.conversations ?? [];
     },
-    async getConversation(id: string) {
-      return { id, title: null, createdAt: '', updatedAt: '', messages: [] };
+    async getConversation(id: string, options?: GetConversationOptions) {
+      getCalls.push({ id, options });
+      const page = pages.shift();
+      if (page) return page;
+      return {
+        id,
+        title: null,
+        appId: 'fuzefront',
+        orgId: null,
+        createdAt: '',
+        updatedAt: '',
+        messages: [],
+        hasMoreBefore: false,
+        hasMoreAfter: false,
+      };
     },
   } as unknown as ChatServiceClient;
 
-  return { client, confirmCalls, feedbackCalls };
+  return { client, confirmCalls, feedbackCalls, listCalls, getCalls, streamRequests };
 }

--- a/packages/chat-ui/tests/useChat.test.tsx
+++ b/packages/chat-ui/tests/useChat.test.tsx
@@ -1,7 +1,34 @@
 import { describe, it, expect } from 'vitest';
 import { renderHook, act, waitFor } from '@testing-library/react';
+import type { ConversationWithMessages } from '@fuzefront/chat-client';
 import { useChat } from '../src/hooks/useChat';
 import { makeFakeClient } from './fakeClient';
+
+const CONV = {
+  id: 'conv-1',
+  title: null,
+  appId: 'mendys',
+  orgId: 'org1',
+  createdAt: '2026-01-01',
+  updatedAt: '2026-01-02',
+};
+
+function page(
+  ids: string[],
+  { hasMoreBefore = false, hasMoreAfter = false } = {},
+): ConversationWithMessages {
+  return {
+    ...CONV,
+    messages: ids.map((id, i) => ({
+      id,
+      role: i % 2 === 0 ? ('user' as const) : ('assistant' as const),
+      content: { type: 'text', text: `text-${id}` },
+      createdAt: `2026-01-0${i + 1}`,
+    })),
+    hasMoreBefore,
+    hasMoreAfter,
+  };
+}
 
 describe('useChat', () => {
   it('streams a turn: user message, accumulated assistant text, done', async () => {
@@ -11,7 +38,7 @@ describe('useChat', () => {
       { type: 'text_delta', delta: 'lo' },
       { type: 'done' },
     ]);
-    const { result } = renderHook(() => useChat({ client, orgId: 'org1' }));
+    const { result } = renderHook(() => useChat({ client, orgId: 'org1', resume: false }));
 
     await act(async () => {
       await result.current.send('hi there');
@@ -25,7 +52,7 @@ describe('useChat', () => {
 
   it('ignores empty sends', async () => {
     const { client } = makeFakeClient([{ type: 'done' }]);
-    const { result } = renderHook(() => useChat({ client, orgId: 'org1' }));
+    const { result } = renderHook(() => useChat({ client, orgId: 'org1', resume: false }));
     await act(async () => {
       await result.current.send('   ');
     });
@@ -37,7 +64,7 @@ describe('useChat', () => {
       { type: 'tool_pending', confirmationId: 'c1', toolName: 'create_org', args: {}, description: 'd' },
       { type: 'done' },
     ]);
-    const { result } = renderHook(() => useChat({ client, orgId: 'org1' }));
+    const { result } = renderHook(() => useChat({ client, orgId: 'org1', resume: false }));
     await act(async () => {
       await result.current.send('make an org');
     });
@@ -59,7 +86,7 @@ describe('useChat', () => {
       { confirmThrows: true },
     );
     const { result } = renderHook(() =>
-      useChat({ client, orgId: 'org1', onError: (m) => (captured = m) }),
+      useChat({ client, orgId: 'org1', resume: false, onError: (m) => (captured = m) }),
     );
     await act(async () => {
       await result.current.send('x');
@@ -76,7 +103,7 @@ describe('useChat', () => {
       { type: 'text_delta', delta: 'hey' },
       { type: 'done' },
     ]);
-    const { result } = renderHook(() => useChat({ client, orgId: 'org1' }));
+    const { result } = renderHook(() => useChat({ client, orgId: 'org1', resume: false }));
     await act(async () => {
       await result.current.send('hi');
     });
@@ -92,12 +119,120 @@ describe('useChat', () => {
     let captured = '';
     const { client } = makeFakeClient([{ type: 'error', message: 'stream failed' }]);
     const { result } = renderHook(() =>
-      useChat({ client, orgId: 'org1', onError: (m) => (captured = m) }),
+      useChat({ client, orgId: 'org1', resume: false, onError: (m) => (captured = m) }),
     );
     await act(async () => {
       await result.current.send('hi');
     });
     expect(captured).toBe('stream failed');
     expect(result.current.messages[1].error).toBe('stream failed');
+  });
+
+  it('adopts the server-announced conversation id for follow-up sends', async () => {
+    const { client, streamRequests } = makeFakeClient([
+      { type: 'conversation', conversationId: 'conv-9' },
+      { type: 'text_delta', delta: 'ok' },
+      { type: 'done' },
+    ]);
+    const { result } = renderHook(() => useChat({ client, orgId: 'org1', resume: false }));
+    await act(async () => {
+      await result.current.send('first');
+    });
+    expect(result.current.conversationId).toBe('conv-9');
+    await act(async () => {
+      await result.current.send('second');
+    });
+    expect(streamRequests[0].conversationId).toBeUndefined();
+    expect(streamRequests[1].conversationId).toBe('conv-9');
+  });
+
+  it('hydrates the most recent conversation for the (org, app) scope on mount', async () => {
+    const { client, listCalls, getCalls, streamRequests } = makeFakeClient(
+      [{ type: 'text_delta', delta: 'ok' }, { type: 'done' }],
+      {
+        conversations: [CONV],
+        pages: [page(['m1', 'm2'], { hasMoreBefore: true })],
+      },
+    );
+    const { result } = renderHook(() =>
+      useChat({ client, orgId: 'org1', appId: 'mendys', pageSize: 2 }),
+    );
+
+    await waitFor(() => expect(result.current.loadingHistory).toBe(false));
+    expect(listCalls[0]).toEqual({ appId: 'mendys', orgId: 'org1' });
+    expect(getCalls[0]).toEqual({ id: 'conv-1', options: { limit: 2 } });
+    expect(result.current.conversationId).toBe('conv-1');
+    expect(result.current.messages.map((m) => m.content)).toEqual(['text-m1', 'text-m2']);
+    expect(result.current.hasMoreBefore).toBe(true);
+
+    // A follow-up send continues the resumed thread with the loaded context.
+    await act(async () => {
+      await result.current.send('and then?');
+    });
+    expect(streamRequests[0].conversationId).toBe('conv-1');
+    expect(streamRequests[0].appId).toBe('mendys');
+    expect(streamRequests[0].messages.map((m) => m.content)).toEqual([
+      'text-m1',
+      'text-m2',
+      'and then?',
+    ]);
+  });
+
+  it('starts empty when the scope has no conversations yet', async () => {
+    const { client } = makeFakeClient([{ type: 'done' }], { conversations: [] });
+    const { result } = renderHook(() => useChat({ client, orgId: 'org1', appId: 'mendys' }));
+    await waitFor(() => expect(result.current.loadingHistory).toBe(false));
+    expect(result.current.messages).toHaveLength(0);
+    expect(result.current.hasMoreBefore).toBe(false);
+  });
+
+  it('loadOlder pages backwards with a before-cursor and prepends', async () => {
+    const { client, getCalls } = makeFakeClient([{ type: 'done' }], {
+      conversations: [CONV],
+      pages: [
+        page(['m3', 'm4'], { hasMoreBefore: true }),
+        { ...page(['m1', 'm2']), hasMoreBefore: false, hasMoreAfter: true },
+      ],
+    });
+    const { result } = renderHook(() =>
+      useChat({ client, orgId: 'org1', appId: 'mendys', pageSize: 2 }),
+    );
+    await waitFor(() => expect(result.current.hasMoreBefore).toBe(true));
+
+    await act(async () => {
+      await result.current.loadOlder();
+    });
+
+    expect(getCalls[1]).toEqual({ id: 'conv-1', options: { before: 'm3', limit: 2 } });
+    expect(result.current.messages.map((m) => m.id)).toEqual(['m1', 'm2', 'm3', 'm4']);
+    expect(result.current.hasMoreBefore).toBe(false);
+
+    // Cursor moved to the new oldest edge for the next page.
+    await act(async () => {
+      await result.current.loadOlder();
+    });
+    expect(getCalls[2]).toEqual({ id: 'conv-1', options: { before: 'm1', limit: 2 } });
+  });
+
+  it('loadNewer pages forwards with an after-cursor and appends', async () => {
+    const { client, getCalls } = makeFakeClient([{ type: 'done' }], {
+      conversations: [CONV],
+      pages: [
+        page(['m1', 'm2'], { hasMoreAfter: true }),
+        page(['m3', 'm4'], { hasMoreAfter: false }),
+      ],
+    });
+    const { result } = renderHook(() =>
+      useChat({ client, orgId: 'org1', appId: 'mendys', pageSize: 2 }),
+    );
+    await waitFor(() => expect(result.current.hasMoreAfter).toBe(true));
+
+    await act(async () => {
+      await result.current.loadNewer();
+    });
+
+    expect(getCalls[1]).toEqual({ id: 'conv-1', options: { after: 'm2', limit: 2 } });
+    expect(result.current.messages.map((m) => m.id)).toEqual(['m1', 'm2', 'm3', 'm4']);
+    expect(result.current.hasMoreAfter).toBe(false);
   });
 });

--- a/packages/chat-ui/tests/useChat.test.tsx
+++ b/packages/chat-ui/tests/useChat.test.tsx
@@ -214,6 +214,36 @@ describe('useChat', () => {
     expect(getCalls[2]).toEqual({ id: 'conv-1', options: { before: 'm1', limit: 2 } });
   });
 
+  it('re-hydrating on a scope change replaces the previous scope entirely', async () => {
+    const { client, streamRequests } = makeFakeClient(
+      [{ type: 'text_delta', delta: 'ok' }, { type: 'done' }],
+      {
+        conversations: [CONV],
+        pages: [page(['m1', 'm2']), page(['m3', 'm4'])],
+      },
+    );
+    const { result, rerender } = renderHook(
+      ({ orgId }) => useChat({ client, orgId, appId: 'mendys', pageSize: 2 }),
+      { initialProps: { orgId: 'org1' } },
+    );
+    await waitFor(() => expect(result.current.messages).toHaveLength(2));
+
+    rerender({ orgId: 'org2' });
+    await waitFor(() =>
+      expect(result.current.messages.map((m) => m.id)).toEqual(['m3', 'm4']),
+    );
+
+    // The old scope's history must not leak into the next request payload.
+    await act(async () => {
+      await result.current.send('hello');
+    });
+    expect(streamRequests[0].messages.map((m) => m.content)).toEqual([
+      'text-m3',
+      'text-m4',
+      'hello',
+    ]);
+  });
+
   it('loadNewer pages forwards with an after-cursor and appends', async () => {
     const { client, getCalls } = makeFakeClient([{ type: 'done' }], {
       conversations: [CONV],

--- a/services/chat-service/openapi.yaml
+++ b/services/chat-service/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: FuzeFront Chat Service API
-  version: 1.0.0
+  version: 1.1.0
   description: >-
     HTTP + SSE API for the FuzeFront **chat-service** — an org/tenant-scoped AI
     chat microservice that wraps Anthropic (via the platform LiteLLM gateway),
@@ -18,16 +18,28 @@ info:
     browser talks to this service on a same-origin API base.
 
     ### Auth & isolation
-    Every `/chat/*` route requires a valid Authentik-issued JWT (`Authorization:
-    Bearer <token>`). `userId`/`orgId` are derived from the JWT, never from the
-    request body, and every read/write is scoped to the caller (BOLA-safe):
-    fetching another user's conversation by id returns `404`.
+    Every `/chat/*` route requires a valid JWT (`Authorization: Bearer <token>`)
+    signed with the service's `JWT_SECRET` (Authentik-issued for the FuzeFront
+    shell; consuming apps mint their own via a backend that shares the secret).
+    `userId`/`orgId` are derived from the JWT, never from the request body, and
+    every read/write is scoped to the caller (BOLA-safe): fetching another
+    user's conversation by id returns `404`.
+
+    ### Multi-app tenancy
+    Every conversation belongs to `(userId, appId[, orgId])` where `appId`
+    names the consuming application (`fuzefront`, `mendys`, ...). `appId` is
+    taken from the JWT `appId` claim when present, else from the request
+    (`appId` body field / query param), defaulting to `fuzefront`. It selects a
+    partition of the caller's OWN data — user isolation still comes solely from
+    the JWT `userId`.
 
     ### Streaming surface (SSE)
     `POST /chat/stream` returns `text/event-stream`; each `data:` line is one
     JSON `ChatStreamEvent` (the discriminated union in `ChatStreamEvent`). The
     event shape is intentionally AG-UI-compatible so the `@fuzefront/chat-ui`
-    renderer can consume it without translation.
+    renderer can consume it without translation. The first event of every
+    stream is `{ "type": "conversation", "conversationId": ... }` announcing
+    the resolved thread so clients can reuse and resume it.
 
     ### Async surface (events)
     The service emits a Kafka usage event after each turn for metered billing:
@@ -118,7 +130,20 @@ paths:
       summary: List the caller's conversations
       description: >-
         Conversations owned by the authenticated user, most-recently-updated
-        first. Mirrors `routes/chat.ts` -> `GET /chat/conversations`.
+        first, optionally narrowed to one app/org tenant. When the JWT carries
+        an `appId` claim it overrides the query param. Mirrors
+        `routes/chat.ts` -> `GET /chat/conversations`.
+      parameters:
+        - name: appId
+          in: query
+          required: false
+          description: Only conversations of this consuming app.
+          schema: { type: string }
+        - name: orgId
+          in: query
+          required: false
+          description: Only conversations of this organization.
+          schema: { type: string }
       responses:
         '200':
           description: The caller's conversations.
@@ -140,10 +165,12 @@ paths:
         not `403`, so ids are not enumerable. Mirrors `routes/chat.ts` ->
         `GET /chat/conversations/:id`.
 
-        **Planned (issue #120, `gate-pagination`):** the `before`/`limit` query
-        params below page the message history newest-first for the continuous
-        single-thread model. Marked `x-status: planned` until the backend +
-        independent contract tests land.
+        Message history is keyset-paginated on `(created_at, id)` for
+        bidirectional infinite scroll (issue #120, `gate-pagination`): without
+        a cursor the **newest** `limit` messages are returned; `before` pages
+        towards older messages, `after` towards newer. Messages are always
+        returned oldest-first within the page. `before` and `after` are
+        mutually exclusive (`400`); an unknown cursor id returns `400`.
       parameters:
         - name: id
           in: path
@@ -152,21 +179,26 @@ paths:
         - name: before
           in: query
           required: false
-          description: 'Planned: return messages created before this message id (cursor).'
+          description: Return messages created before this message id (cursor).
           schema: { type: string, format: uuid }
-          x-status: planned
+        - name: after
+          in: query
+          required: false
+          description: Return messages created after this message id (cursor).
+          schema: { type: string, format: uuid }
         - name: limit
           in: query
           required: false
-          description: 'Planned: max messages to return (default 50, max 200).'
+          description: 'Max messages to return (default 50, max 200).'
           schema: { type: integer, minimum: 1, maximum: 200, default: 50 }
-          x-status: planned
       responses:
         '200':
-          description: The conversation and its messages.
+          description: The conversation and one page of its messages.
           content:
             application/json:
               schema: { $ref: '#/components/schemas/ConversationWithMessages' }
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '404':
@@ -287,12 +319,19 @@ components:
         orgId:
           type: string
           description: Tenant scope. Cross-checked against the JWT org claim.
+        appId:
+          type: string
+          description: >-
+            Consuming application ('fuzefront', 'mendys', ...). Ignored when
+            the JWT carries an `appId` claim; defaults to `fuzefront`.
         conversationId:
           type: string
           format: uuid
           description: >-
-            Optional. Omit to use the caller's continuous thread (issue #120
-            target model). Currently a new conversation is created when omitted.
+            Optional. Reuse an existing conversation (must be owned by the
+            caller, else an `error` event is streamed). Omit to create a new
+            conversation; its id is announced by the stream's first event
+            (`EventConversation`).
 
     RagSource:
       type: object
@@ -305,6 +344,7 @@ components:
 
     ChatStreamEvent:
       oneOf:
+        - $ref: '#/components/schemas/EventConversation'
         - $ref: '#/components/schemas/EventTextDelta'
         - $ref: '#/components/schemas/EventToolPending'
         - $ref: '#/components/schemas/EventToolResult'
@@ -315,6 +355,13 @@ components:
       discriminator:
         propertyName: type
 
+    EventConversation:
+      type: object
+      description: First event of every stream — the resolved conversation id.
+      required: [type, conversationId]
+      properties:
+        type: { type: string, const: conversation }
+        conversationId: { type: string, format: uuid }
     EventTextDelta:
       type: object
       required: [type, delta]
@@ -367,10 +414,12 @@ components:
 
     Conversation:
       type: object
-      required: [id, title, createdAt, updatedAt]
+      required: [id, title, appId, orgId, createdAt, updatedAt]
       properties:
         id: { type: string, format: uuid }
         title: { type: string, nullable: true }
+        appId: { type: string }
+        orgId: { type: string, nullable: true }
         createdAt: { type: string, format: date-time }
         updatedAt: { type: string, format: date-time }
 
@@ -393,11 +442,18 @@ components:
       allOf:
         - $ref: '#/components/schemas/Conversation'
         - type: object
-          required: [messages]
+          required: [messages, hasMoreBefore, hasMoreAfter]
           properties:
             messages:
+              description: One page of messages, oldest-first.
               type: array
               items: { $ref: '#/components/schemas/ConversationMessage' }
+            hasMoreBefore:
+              type: boolean
+              description: Older messages exist before the first message of this page.
+            hasMoreAfter:
+              type: boolean
+              description: Newer messages exist after the last message of this page.
 
 security:
   - bearerAuth: []

--- a/services/chat-service/package.json
+++ b/services/chat-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fuzefront/chat-service",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "AI chat microservice for FuzeFront — RAG, agent loop, streaming",
   "private": true,
   "main": "dist/index.js",
@@ -16,14 +16,14 @@
   "dependencies": {
     "@fuzefront/shared": "file:../../shared",
     "express": "4.19.2",
+    "express-rate-limit": "^7.2.0",
+    "ioredis": "^5.3.2",
     "jsonwebtoken": "^9.0.2",
     "kafkajs": "2.2.4",
     "knex": "^3.1.0",
     "pg": "^8.11.5",
-    "zod": "3.22.4",
-    "express-rate-limit": "^7.2.0",
     "rate-limit-redis": "^4.2.0",
-    "ioredis": "^5.3.2"
+    "zod": "3.22.4"
   },
   "devDependencies": {
     "@types/express": "4.17.21",

--- a/services/chat-service/src/db/migrations/002_multi_app_scope_and_pagination.ts
+++ b/services/chat-service/src/db/migrations/002_multi_app_scope_and_pagination.ts
@@ -1,0 +1,69 @@
+import { Knex } from 'knex';
+
+// Migration 002 — multi-app chat scope + history pagination support.
+//
+// chat-service serves the whole Fuze family: consuming apps (fuzefront shell,
+// mendys, ...) bring their own subject identifiers, so chat identity can no
+// longer be foreign-keyed to the backend-owned users/organizations tables in
+// fuzefront_platform. Identity columns become opaque TEXT (existing UUIDs cast
+// losslessly) and every conversation gains an `app_id` tenant column.
+//
+// Also adds the two indexes cursor pagination relies on:
+//   - chat_conversations (user_id, app_id, org_id, updated_at DESC) for the
+//     scoped "most recent conversation" lookup, and
+//   - chat_messages (conversation_id, created_at, id) for keyset paging.
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(
+    `ALTER TABLE chat_conversations DROP CONSTRAINT IF EXISTS chat_conversations_user_id_fkey`,
+  );
+  await knex.raw(
+    `ALTER TABLE chat_conversations DROP CONSTRAINT IF EXISTS chat_conversations_org_id_fkey`,
+  );
+  await knex.raw(`ALTER TABLE chat_conversations ALTER COLUMN user_id TYPE TEXT`);
+  await knex.raw(`ALTER TABLE chat_conversations ALTER COLUMN org_id TYPE TEXT`);
+  await knex.raw(
+    `ALTER TABLE chat_conversations ADD COLUMN IF NOT EXISTS app_id TEXT NOT NULL DEFAULT 'fuzefront'`,
+  );
+
+  await knex.raw(`ALTER TABLE chat_audit_log ALTER COLUMN user_id TYPE TEXT`);
+  await knex.raw(`ALTER TABLE chat_audit_log ALTER COLUMN org_id TYPE TEXT`);
+  await knex.raw(`ALTER TABLE chat_feedback ALTER COLUMN user_id TYPE TEXT`);
+
+  await knex.raw(
+    `CREATE INDEX IF NOT EXISTS idx_chat_conversations_scope
+       ON chat_conversations (user_id, app_id, org_id, updated_at DESC)`,
+  );
+  await knex.raw(
+    `CREATE INDEX IF NOT EXISTS idx_chat_messages_conv_created
+       ON chat_messages (conversation_id, created_at, id)`,
+  );
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(`DROP INDEX IF EXISTS idx_chat_messages_conv_created`);
+  await knex.raw(`DROP INDEX IF EXISTS idx_chat_conversations_scope`);
+
+  await knex.raw(`ALTER TABLE chat_conversations DROP COLUMN IF EXISTS app_id`);
+
+  // Reverting TEXT -> UUID only succeeds while every stored id is a UUID
+  // (i.e. before any external app has written non-UUID subjects).
+  await knex.raw(
+    `ALTER TABLE chat_conversations ALTER COLUMN user_id TYPE UUID USING user_id::uuid`,
+  );
+  await knex.raw(
+    `ALTER TABLE chat_conversations ALTER COLUMN org_id TYPE UUID USING org_id::uuid`,
+  );
+  await knex.raw(`ALTER TABLE chat_audit_log ALTER COLUMN user_id TYPE UUID USING user_id::uuid`);
+  await knex.raw(`ALTER TABLE chat_audit_log ALTER COLUMN org_id TYPE UUID USING org_id::uuid`);
+  await knex.raw(`ALTER TABLE chat_feedback ALTER COLUMN user_id TYPE UUID USING user_id::uuid`);
+
+  await knex.raw(
+    `ALTER TABLE chat_conversations
+       ADD CONSTRAINT chat_conversations_user_id_fkey FOREIGN KEY (user_id) REFERENCES users(id)`,
+  );
+  await knex.raw(
+    `ALTER TABLE chat_conversations
+       ADD CONSTRAINT chat_conversations_org_id_fkey FOREIGN KEY (org_id) REFERENCES organizations(id)`,
+  );
+}

--- a/services/chat-service/src/db/repositories/conversations.ts
+++ b/services/chat-service/src/db/repositories/conversations.ts
@@ -3,12 +3,18 @@
 // Every read and write is scoped by `userId` derived from the JWT — NEVER from a
 // request-body field. findById additionally scopes by user_id so a user cannot
 // fetch another user's conversation by guessing its id (§10d data isolation).
+//
+// Conversations are additionally scoped by `app_id` (the consuming application:
+// 'fuzefront', 'mendys', ...) and optionally `org_id`, so each app sees only its
+// own history for the same subject (migration 002).
 
 import type { Knex } from 'knex';
 
 export interface ConversationRow {
   id: string;
   title: string | null;
+  app_id: string;
+  org_id: string | null;
   created_at: string;
   updated_at: string;
 }
@@ -16,22 +22,33 @@ export interface ConversationRow {
 export interface Conversation {
   id: string;
   title: string | null;
+  appId: string;
+  orgId: string | null;
   createdAt: string;
   updatedAt: string;
 }
 
 export interface CreateConversationInput {
   userId: string;
+  appId: string;
   orgId?: string | null;
   title?: string | null;
 }
 
+export interface ListConversationsFilter {
+  appId?: string;
+  orgId?: string;
+}
+
 const TABLE = 'chat_conversations';
+const COLUMNS = ['id', 'title', 'app_id', 'org_id', 'created_at', 'updated_at'];
 
 function toConversation(row: ConversationRow): Conversation {
   return {
     id: row.id,
     title: row.title,
+    appId: row.app_id,
+    orgId: row.org_id,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };
@@ -40,11 +57,15 @@ function toConversation(row: ConversationRow): Conversation {
 export class ConversationsRepository {
   constructor(private readonly knex: Knex) {}
 
-  /** List the authenticated user's conversations, most-recently-updated first. */
-  async list(userId: string): Promise<Conversation[]> {
-    const rows: ConversationRow[] = await this.knex(TABLE)
-      .where({ user_id: userId })
-      .orderBy('updated_at', 'desc');
+  /**
+   * List the authenticated user's conversations, most-recently-updated first,
+   * optionally narrowed to one app / org tenant.
+   */
+  async list(userId: string, filter: ListConversationsFilter = {}): Promise<Conversation[]> {
+    const query = this.knex(TABLE).where({ user_id: userId });
+    if (filter.appId) query.andWhere({ app_id: filter.appId });
+    if (filter.orgId) query.andWhere({ org_id: filter.orgId });
+    const rows: ConversationRow[] = await query.orderBy('updated_at', 'desc').select(COLUMNS);
     return rows.map(toConversation);
   }
 
@@ -52,19 +73,20 @@ export class ConversationsRepository {
   async findById(id: string, userId: string): Promise<Conversation | null> {
     const row: ConversationRow | undefined = await this.knex(TABLE)
       .where({ id, user_id: userId })
-      .first();
+      .first(COLUMNS);
     return row ? toConversation(row) : null;
   }
 
-  /** Create a new conversation owned by `userId`. */
+  /** Create a new conversation owned by `userId` within an app (+ optional org). */
   async create(input: CreateConversationInput): Promise<Conversation> {
     const [row]: ConversationRow[] = await this.knex(TABLE)
       .insert({
         user_id: input.userId,
+        app_id: input.appId,
         org_id: input.orgId ?? null,
         title: input.title ?? null,
       })
-      .returning(['id', 'title', 'created_at', 'updated_at']);
+      .returning(COLUMNS);
     return toConversation(row);
   }
 

--- a/services/chat-service/src/db/repositories/messages.ts
+++ b/services/chat-service/src/db/repositories/messages.ts
@@ -4,6 +4,10 @@
 // chat_conversations and filtering on conversations.user_id. Reads therefore
 // can only ever return messages from conversations the authenticated user owns.
 // `content` is stored as JSON (the column is JSONB) and parsed back on read.
+//
+// History reads are keyset-paginated on the (created_at, id) tuple — `id` breaks
+// ties for messages sharing a timestamp — backed by the
+// idx_chat_messages_conv_created index (migration 002). Cursors are message ids.
 
 import type { Knex } from 'knex';
 
@@ -23,6 +27,32 @@ export interface StoredMessage {
   createdAt: string;
 }
 
+export interface ListMessagesPageOptions {
+  /** Return messages strictly older than this message id (scroll up). */
+  before?: string;
+  /** Return messages strictly newer than this message id (scroll down). */
+  after?: string;
+  /** Page size (validated by the route). */
+  limit: number;
+}
+
+export interface MessagesPage {
+  /** Page content in chronological (oldest-first) order. */
+  messages: StoredMessage[];
+  /** Older messages exist before the first message of this page. */
+  hasMoreBefore: boolean;
+  /** Newer messages exist after the last message of this page. */
+  hasMoreAfter: boolean;
+}
+
+/** Thrown when a before/after cursor does not identify a message in the conversation. */
+export class CursorNotFoundError extends Error {
+  constructor(cursor: string) {
+    super(`Cursor message not found in conversation: ${cursor}`);
+    this.name = 'CursorNotFoundError';
+  }
+}
+
 const TABLE = 'chat_messages';
 const CONVERSATIONS = 'chat_conversations';
 
@@ -33,6 +63,15 @@ function parseContent(raw: unknown): unknown {
   } catch {
     return raw;
   }
+}
+
+function toStored(r: any): StoredMessage {
+  return {
+    id: r.id,
+    role: r.role,
+    content: parseContent(r.content),
+    createdAt: r.created_at,
+  };
 }
 
 export class MessagesRepository {
@@ -56,23 +95,91 @@ export class MessagesRepository {
    * enforced by joining chat_conversations and filtering by user_id.
    */
   async listForConversation(conversationId: string, userId: string): Promise<StoredMessage[]> {
-    const rows = await this.knex(TABLE)
+    const rows = await this.ownedQuery(conversationId, userId)
+      .orderBy(`${TABLE}.created_at`, 'asc')
+      .select(...this.columns());
+    return rows.map(toStored);
+  }
+
+  /**
+   * One page of a conversation's history, keyset-paginated for bidirectional
+   * infinite scroll. Without a cursor the newest `limit` messages are returned
+   * (the WhatsApp-style "open at the bottom" page); `before`/`after` page from
+   * a message id towards older/newer messages respectively.
+   */
+  async listPage(
+    conversationId: string,
+    userId: string,
+    opts: ListMessagesPageOptions,
+  ): Promise<MessagesPage> {
+    const { before, after, limit } = opts;
+
+    const cursorId = before ?? after;
+    let anchor: { created_at: string } | undefined;
+    if (cursorId) {
+      anchor = await this.knex(TABLE)
+        .where({ id: cursorId, conversation_id: conversationId })
+        .first(['created_at']);
+      if (!anchor) throw new CursorNotFoundError(cursorId);
+    }
+
+    // Fetch limit+1 rows to learn whether more exist past the page boundary.
+    const query = this.ownedQuery(conversationId, userId).limit(limit + 1);
+
+    if (before && anchor) {
+      query
+        .whereRaw(`(${TABLE}.created_at, ${TABLE}.id) < (?, ?)`, [anchor.created_at, before])
+        .orderBy([
+          { column: `${TABLE}.created_at`, order: 'desc' },
+          { column: `${TABLE}.id`, order: 'desc' },
+        ]);
+    } else if (after && anchor) {
+      query
+        .whereRaw(`(${TABLE}.created_at, ${TABLE}.id) > (?, ?)`, [anchor.created_at, after])
+        .orderBy([
+          { column: `${TABLE}.created_at`, order: 'asc' },
+          { column: `${TABLE}.id`, order: 'asc' },
+        ]);
+    } else {
+      // Tail page: newest `limit` messages.
+      query.orderBy([
+        { column: `${TABLE}.created_at`, order: 'desc' },
+        { column: `${TABLE}.id`, order: 'desc' },
+      ]);
+    }
+
+    const rows = await query.select(...this.columns());
+    const overflow = rows.length > limit;
+    const page = overflow ? rows.slice(0, limit) : rows;
+
+    // Descending fetches (tail + before) come back newest-first; restore
+    // chronological order for the response.
+    const descending = !after;
+    const messages = (descending ? [...page].reverse() : page).map(toStored);
+
+    if (before) {
+      // The anchor (and anything after it) sits beyond the page's newest edge.
+      return { messages, hasMoreBefore: overflow, hasMoreAfter: true };
+    }
+    if (after) {
+      return { messages, hasMoreBefore: true, hasMoreAfter: overflow };
+    }
+    return { messages, hasMoreBefore: overflow, hasMoreAfter: false };
+  }
+
+  private ownedQuery(conversationId: string, userId: string) {
+    return this.knex(TABLE)
       .join(CONVERSATIONS, `${CONVERSATIONS}.id`, `${TABLE}.conversation_id`)
       .where(`${TABLE}.conversation_id`, conversationId)
-      .where(`${CONVERSATIONS}.user_id`, userId)
-      .orderBy(`${TABLE}.created_at`, 'asc')
-      .select(
-        `${TABLE}.id as id`,
-        `${TABLE}.role as role`,
-        `${TABLE}.content as content`,
-        `${TABLE}.created_at as created_at`,
-      );
+      .where(`${CONVERSATIONS}.user_id`, userId);
+  }
 
-    return rows.map((r: any) => ({
-      id: r.id,
-      role: r.role,
-      content: parseContent(r.content),
-      createdAt: r.created_at,
-    }));
+  private columns(): string[] {
+    return [
+      `${TABLE}.id as id`,
+      `${TABLE}.role as role`,
+      `${TABLE}.content as content`,
+      `${TABLE}.created_at as created_at`,
+    ];
   }
 }

--- a/services/chat-service/src/middleware/auth.ts
+++ b/services/chat-service/src/middleware/auth.ts
@@ -21,6 +21,7 @@ declare global {
     interface Request {
       userId?: string;
       orgId?: string;
+      appId?: string;
     }
   }
 }
@@ -28,6 +29,8 @@ declare global {
 interface JwtClaims {
   userId: string;
   orgId?: string;
+  /** Consuming application ('fuzefront', 'mendys', ...). Optional for older tokens. */
+  appId?: string;
   [key: string]: unknown;
 }
 
@@ -51,6 +54,7 @@ export function authenticateToken(req: Request, res: Response, next: NextFunctio
     const decoded = jwt.verify(token, secret) as JwtClaims;
     req.userId = decoded.userId;
     req.orgId = decoded.orgId;
+    req.appId = decoded.appId;
     next();
   } catch {
     res.status(401).json({ error: 'Invalid token.' });

--- a/services/chat-service/src/routes/chat.ts
+++ b/services/chat-service/src/routes/chat.ts
@@ -129,7 +129,11 @@ export function createChatRouter(deps: ChatRouterDeps): Router {
         {
           emit: (event) => {
             if (event.type === 'text_delta') assistantText += event.delta;
-            write(event);
+            // Hold back the agent's terminal `done`: persistence/billing below
+            // may still fail, and the stream must end with exactly one terminal
+            // event (`done`, or `error`+`done` from the catch) — never an error
+            // AFTER a `done` the client already treated as success.
+            if (event.type !== 'done') write(event);
           },
           onUsage: (u) => {
             usage = u;
@@ -157,6 +161,8 @@ export function createChatRouter(deps: ChatRouterDeps): Router {
           totalTokens: usage.totalTokens,
         });
       }
+
+      write({ type: 'done' });
     } catch (err) {
       const message = err instanceof Error ? err.message : 'stream failed';
       write({ type: 'error', message });

--- a/services/chat-service/src/routes/chat.ts
+++ b/services/chat-service/src/routes/chat.ts
@@ -1,17 +1,23 @@
 // chat.ts — chat-service HTTP routes (plan §6a/§6f).
 //
 // Routes (matching @fuzefront/chat-client's contract):
-//   POST /chat/stream            — SSE: rag_sources -> text_delta... -> done.
+//   POST /chat/stream            — SSE: conversation -> rag_sources -> text_delta... -> done.
 //                                  Persists user + assistant messages, emits
 //                                  billing.llm.usage, scoped to JWT userId/orgId.
-//   GET  /chat/conversations     — list the caller's conversations.
-//   GET  /chat/conversations/:id — one conversation + messages (owner-scoped).
+//   GET  /chat/conversations     — list the caller's conversations (appId/orgId filters).
+//   GET  /chat/conversations/:id — one conversation + a keyset-paginated page of
+//                                  messages (before/after/limit; owner-scoped).
 //   POST /chat/feedback          — {messageId, rating} thumbs up/down.
 //   POST /chat/confirm/:id       — release a pending (mutating) tool.
 //
 // Auth + rate-limit middleware are applied by the caller (createChatRouter wires
 // auth; index.ts adds the limiters) — see app.ts. Every read/write is scoped by
 // req.userId / req.orgId from the JWT, never from the request body (§10d).
+//
+// Tenancy: each conversation belongs to (user_id, app_id[, org_id]). appId names
+// the consuming application ('fuzefront', 'mendys', ...) and is taken from the
+// JWT claim when present, else the request (it selects a partition of the
+// caller's OWN data, so it is not a privilege boundary the way userId is).
 //
 // The SSE wire format is the chat-client event union (each `data:` line is one
 // JSON ChatStreamEvent), a deliberate deviation from the plan's §6f AI-SDK
@@ -22,7 +28,7 @@ import { authenticateToken } from '../middleware/auth';
 import type { AgentEvent, AgentTurnInput, AgentCallbacks } from '../agent/loop';
 import type { TokenUsage } from '../llm/litellm';
 import type { Conversation, ConversationsRepository } from '../db/repositories/conversations';
-import type { MessagesRepository } from '../db/repositories/messages';
+import { CursorNotFoundError, type MessagesRepository } from '../db/repositories/messages';
 import type { FeedbackRepository, FeedbackRating } from '../db/repositories/feedback';
 import type { ConfirmationStore } from '../agent/confirmation';
 import type { BillingEmitter } from '../billing/emitter';
@@ -31,13 +37,29 @@ export interface ChatRouterDeps {
   /** Runs one agent turn, emitting events + reporting usage. */
   runAgentTurn(input: AgentTurnInput, cb: AgentCallbacks): Promise<void>;
   conversations: Pick<ConversationsRepository, 'list' | 'findById' | 'create' | 'touch'>;
-  messages: Pick<MessagesRepository, 'append' | 'listForConversation'>;
+  messages: Pick<MessagesRepository, 'append' | 'listPage'>;
   feedback: Pick<FeedbackRepository, 'submit'>;
   confirmations: Pick<ConfirmationStore, 'confirm'>;
   billing: Pick<BillingEmitter, 'emitUsage'>;
 }
 
 const VALID_RATINGS: FeedbackRating[] = ['positive', 'negative'];
+
+/** App tenant used when neither the JWT nor the request names one. */
+export const DEFAULT_APP_ID = 'fuzefront';
+
+/** History page-size bounds (openapi.yaml). */
+const DEFAULT_PAGE_LIMIT = 50;
+const MAX_PAGE_LIMIT = 200;
+
+/** SSE event announcing the resolved conversation id (first event of a stream). */
+type ConversationEvent = { type: 'conversation'; conversationId: string };
+
+function resolveAppId(req: Request, requested?: unknown): string {
+  if (req.appId) return req.appId;
+  if (typeof requested === 'string' && requested.trim()) return requested.trim();
+  return DEFAULT_APP_ID;
+}
 
 export function createChatRouter(deps: ChatRouterDeps): Router {
   const router = Router();
@@ -49,6 +71,7 @@ export function createChatRouter(deps: ChatRouterDeps): Router {
   router.post('/stream', async (req: Request, res: Response) => {
     const userId = req.userId as string;
     const orgId = (req.body?.orgId as string) || (req.orgId as string) || '';
+    const appId = resolveAppId(req, req.body?.appId);
     const messages: Array<{ role: 'user' | 'assistant'; content: string }> = Array.isArray(
       req.body?.messages,
     )
@@ -63,17 +86,30 @@ export function createChatRouter(deps: ChatRouterDeps): Router {
       'X-Accel-Buffering': 'no',
     });
 
-    const write = (event: AgentEvent) => {
+    const write = (event: AgentEvent | ConversationEvent) => {
       res.write(`data: ${JSON.stringify(event)}\n\n`);
     };
 
     // Resolve / create the conversation (owner-scoped).
     let conversationId: string | undefined = req.body?.conversationId;
     try {
-      if (!conversationId) {
-        const created = await deps.conversations.create({ userId, orgId, title: null });
+      if (conversationId) {
+        // A supplied id must belong to the caller — otherwise anyone could
+        // append into (and bill against) another user's conversation.
+        const owned = await deps.conversations.findById(conversationId, userId);
+        if (!owned) {
+          write({ type: 'error', message: 'Conversation not found.' });
+          write({ type: 'done' });
+          return;
+        }
+      } else {
+        const created = await deps.conversations.create({ userId, orgId, appId, title: null });
         conversationId = created.id;
       }
+
+      // Tell the client which conversation this turn belongs to, so it can
+      // reuse the thread on the next send and resume it on reopen.
+      write({ type: 'conversation', conversationId });
 
       // Persist the latest user message.
       const lastUser = [...messages].reverse().find((m) => m.role === 'user');
@@ -130,24 +166,55 @@ export function createChatRouter(deps: ChatRouterDeps): Router {
     }
   });
 
-  // GET /chat/conversations — list caller's conversations.
+  // GET /chat/conversations — list caller's conversations (optionally filtered
+  // to one app/org tenant via ?appId=&orgId=).
   router.get('/conversations', async (req: Request, res: Response) => {
     const userId = req.userId as string;
-    const conversations: Conversation[] = await deps.conversations.list(userId);
+    const appId =
+      req.appId || (typeof req.query.appId === 'string' ? req.query.appId : undefined);
+    const orgId = typeof req.query.orgId === 'string' ? req.query.orgId : undefined;
+    const conversations: Conversation[] = await deps.conversations.list(userId, {
+      appId,
+      orgId,
+    });
     res.json(conversations);
   });
 
-  // GET /chat/conversations/:id — one conversation + messages (owner-scoped).
+  // GET /chat/conversations/:id — one conversation + a page of messages
+  // (owner-scoped). ?before=<messageId> pages towards older messages,
+  // ?after=<messageId> towards newer; without a cursor the newest page is
+  // returned. ?limit= caps the page size (default 50, max 200).
   router.get('/conversations/:id', async (req: Request, res: Response) => {
     const userId = req.userId as string;
     const id = req.params.id;
+
+    const before = typeof req.query.before === 'string' ? req.query.before : undefined;
+    const after = typeof req.query.after === 'string' ? req.query.after : undefined;
+    if (before && after) {
+      res.status(400).json({ error: 'before and after are mutually exclusive.' });
+      return;
+    }
+    const rawLimit = Number.parseInt(String(req.query.limit ?? ''), 10);
+    const limit = Number.isFinite(rawLimit)
+      ? Math.min(Math.max(rawLimit, 1), MAX_PAGE_LIMIT)
+      : DEFAULT_PAGE_LIMIT;
+
     const conversation = await deps.conversations.findById(id, userId);
     if (!conversation) {
       res.status(404).json({ error: 'Conversation not found.' });
       return;
     }
-    const messages = await deps.messages.listForConversation(id, userId);
-    res.json({ ...conversation, messages });
+
+    try {
+      const page = await deps.messages.listPage(id, userId, { before, after, limit });
+      res.json({ ...conversation, ...page });
+    } catch (err) {
+      if (err instanceof CursorNotFoundError) {
+        res.status(400).json({ error: 'Unknown cursor message id.' });
+        return;
+      }
+      throw err;
+    }
   });
 
   // POST /chat/feedback — {messageId, rating}.

--- a/services/chat-service/tests/db/migration.test.ts
+++ b/services/chat-service/tests/db/migration.test.ts
@@ -8,6 +8,7 @@
 // This test is intentionally non-blocking: CI runs without Postgres.
 
 import * as migration from '../../src/db/migrations/001_create_chat_tables';
+import * as migration002 from '../../src/db/migrations/002_multi_app_scope_and_pagination';
 
 const CHAT_TABLES = ['chat_conversations', 'chat_messages', 'chat_audit_log', 'chat_feedback'];
 
@@ -18,6 +19,13 @@ describe('001_create_chat_tables migration module', () => {
 
   it('exports a down() function', () => {
     expect(typeof migration.down).toBe('function');
+  });
+});
+
+describe('002_multi_app_scope_and_pagination migration module', () => {
+  it('exports up() and down() functions', () => {
+    expect(typeof migration002.up).toBe('function');
+    expect(typeof migration002.down).toBe('function');
   });
 });
 

--- a/services/chat-service/tests/db/repositories/conversations.test.ts
+++ b/services/chat-service/tests/db/repositories/conversations.test.ts
@@ -1,5 +1,6 @@
 // conversations.test.ts — conversation repo scopes every read/write by userId
-// (never by request body) — §10d. Knex is mocked with a chainable stub.
+// (never by request body) — §10d — plus the app/org tenant filters (migration
+// 002). Knex is mocked with a chainable stub.
 
 import { ConversationsRepository } from '../../../src/db/repositories/conversations';
 
@@ -10,7 +11,12 @@ function makeKnex() {
       state.wheres.push(cond);
       return qb;
     }),
+    andWhere: jest.fn((cond: any) => {
+      state.wheres.push(cond);
+      return qb;
+    }),
     orderBy: jest.fn(() => qb),
+    select: jest.fn(() => Promise.resolve(state.selectResult ?? [])),
     first: jest.fn(() => Promise.resolve(state.firstResult)),
     insert: jest.fn((row: any) => {
       state.inserted = row;
@@ -21,10 +27,7 @@ function makeKnex() {
       state.updated = row;
       return Promise.resolve(1);
     }),
-    then: undefined,
   };
-  // Make qb awaitable for select() chains used as a promise.
-  qb.then = (resolve: any) => resolve(state.selectResult ?? []);
   const knex: any = jest.fn((table: string) => {
     state.table = table;
     return qb;
@@ -37,31 +40,59 @@ describe('ConversationsRepository', () => {
   it('list filters by userId and orders by updated_at desc', async () => {
     const { knex, qb, state } = makeKnex();
     state.selectResult = [
-      { id: 'c1', title: 'T', created_at: '2026-01-01', updated_at: '2026-01-02' },
+      {
+        id: 'c1',
+        title: 'T',
+        app_id: 'fuzefront',
+        org_id: 'org-1',
+        created_at: '2026-01-01',
+        updated_at: '2026-01-02',
+      },
     ];
     const repo = new ConversationsRepository(knex);
     const result = await repo.list('user-1');
     expect(knex).toHaveBeenCalledWith('chat_conversations');
     expect(qb.where).toHaveBeenCalledWith({ user_id: 'user-1' });
     expect(qb.orderBy).toHaveBeenCalledWith('updated_at', 'desc');
-    expect(result[0]).toMatchObject({ id: 'c1', title: 'T' });
+    expect(result[0]).toMatchObject({ id: 'c1', title: 'T', appId: 'fuzefront', orgId: 'org-1' });
+  });
+
+  it('list narrows by appId and orgId when a filter is given', async () => {
+    const { knex, qb, state } = makeKnex();
+    state.selectResult = [];
+    const repo = new ConversationsRepository(knex);
+    await repo.list('user-1', { appId: 'mendys', orgId: 'org-9' });
+    expect(qb.where).toHaveBeenCalledWith({ user_id: 'user-1' });
+    expect(qb.andWhere).toHaveBeenCalledWith({ app_id: 'mendys' });
+    expect(qb.andWhere).toHaveBeenCalledWith({ org_id: 'org-9' });
   });
 
   it('findById scopes by BOTH id and userId so users cannot read others conversations', async () => {
     const { knex, qb, state } = makeKnex();
-    state.firstResult = { id: 'c1', user_id: 'user-1', title: 'T' };
+    state.firstResult = { id: 'c1', user_id: 'user-1', title: 'T', app_id: 'fuzefront' };
     const repo = new ConversationsRepository(knex);
     await repo.findById('c1', 'user-1');
     expect(qb.where).toHaveBeenCalledWith({ id: 'c1', user_id: 'user-1' });
   });
 
-  it('create inserts user_id from the argument and returns the new row', async () => {
+  it('create inserts user_id + app_id from the argument and returns the new row', async () => {
     const { knex, state } = makeKnex();
-    state.returningResult = [{ id: 'c-new', title: 'Hi', user_id: 'user-1' }];
+    state.returningResult = [{ id: 'c-new', title: 'Hi', app_id: 'mendys', org_id: 'org-1' }];
     const repo = new ConversationsRepository(knex);
-    const created = await repo.create({ userId: 'user-1', orgId: 'org-1', title: 'Hi' });
-    expect(state.inserted).toMatchObject({ user_id: 'user-1', org_id: 'org-1', title: 'Hi' });
+    const created = await repo.create({
+      userId: 'user-1',
+      appId: 'mendys',
+      orgId: 'org-1',
+      title: 'Hi',
+    });
+    expect(state.inserted).toMatchObject({
+      user_id: 'user-1',
+      app_id: 'mendys',
+      org_id: 'org-1',
+      title: 'Hi',
+    });
     expect(created.id).toBe('c-new');
+    expect(created.appId).toBe('mendys');
   });
 
   it('touch updates updated_at scoped by id + userId', async () => {

--- a/services/chat-service/tests/db/repositories/messages.test.ts
+++ b/services/chat-service/tests/db/repositories/messages.test.ts
@@ -1,7 +1,8 @@
 // messages.test.ts — messages repo joins ownership through chat_conversations so
-// reads are scoped to the authenticated user (§10d). Knex mocked.
+// reads are scoped to the authenticated user (§10d), and pages history on the
+// (created_at, id) keyset for bidirectional infinite scroll. Knex mocked.
 
-import { MessagesRepository } from '../../../src/db/repositories/messages';
+import { CursorNotFoundError, MessagesRepository } from '../../../src/db/repositories/messages';
 
 function makeKnex() {
   const state: any = {};
@@ -13,11 +14,24 @@ function makeKnex() {
     returning: jest.fn(() => Promise.resolve(state.returningResult)),
     join: jest.fn(() => qb),
     where: jest.fn(() => qb),
+    whereRaw: jest.fn((sql: string, bindings: unknown[]) => {
+      state.whereRaw = { sql, bindings };
+      return qb;
+    }),
     orderBy: jest.fn(() => qb),
+    limit: jest.fn((n: number) => {
+      state.limit = n;
+      return qb;
+    }),
+    first: jest.fn(() => Promise.resolve(state.anchorResult)),
     select: jest.fn(() => Promise.resolve(state.selectResult ?? [])),
   };
   const knex: any = jest.fn(() => qb);
   return { knex, qb, state };
+}
+
+function row(id: string, at: string, text = 'x') {
+  return { id, role: 'user', content: JSON.stringify({ type: 'text', text }), created_at: at };
 }
 
 describe('MessagesRepository', () => {
@@ -41,9 +55,7 @@ describe('MessagesRepository', () => {
 
   it('listForConversation joins conversations and filters by user_id', async () => {
     const { knex, qb, state } = makeKnex();
-    state.selectResult = [
-      { id: 'm1', role: 'user', content: JSON.stringify({ type: 'text', text: 'q' }), created_at: 't' },
-    ];
+    state.selectResult = [row('m1', 't', 'q')];
     const repo = new MessagesRepository(knex);
     const msgs = await repo.listForConversation('c1', 'user-1');
     // ownership enforced via join + where on conversations.user_id
@@ -62,5 +74,71 @@ describe('MessagesRepository', () => {
     const repo = new MessagesRepository(knex);
     const msgs = await repo.listForConversation('c1', 'user-1');
     expect(msgs[0].content).toEqual({ type: 'text', text: 'hello' });
+  });
+
+  describe('listPage', () => {
+    it('tail page (no cursor): newest limit messages, chronological, overflow -> hasMoreBefore', async () => {
+      const { knex, qb, state } = makeKnex();
+      // DESC fetch of limit+1 = 3 rows
+      state.selectResult = [row('m3', '3'), row('m2', '2'), row('m1', '1')];
+      const repo = new MessagesRepository(knex);
+      const page = await repo.listPage('c1', 'user-1', { limit: 2 });
+
+      expect(state.limit).toBe(3); // limit + 1 overflow probe
+      expect(page.messages.map((m) => m.id)).toEqual(['m2', 'm3']); // oldest-first
+      expect(page.hasMoreBefore).toBe(true);
+      expect(page.hasMoreAfter).toBe(false);
+      // ownership join still applies to paged reads
+      expect(qb.join).toHaveBeenCalled();
+      expect(JSON.stringify(qb.where.mock.calls.flat())).toContain('user-1');
+    });
+
+    it('tail page without overflow reports no more history', async () => {
+      const { knex, state } = makeKnex();
+      state.selectResult = [row('m2', '2'), row('m1', '1')];
+      const repo = new MessagesRepository(knex);
+      const page = await repo.listPage('c1', 'user-1', { limit: 5 });
+      expect(page.messages.map((m) => m.id)).toEqual(['m1', 'm2']);
+      expect(page.hasMoreBefore).toBe(false);
+      expect(page.hasMoreAfter).toBe(false);
+    });
+
+    it('before cursor pages towards older messages on the (created_at, id) keyset', async () => {
+      const { knex, state } = makeKnex();
+      state.anchorResult = { created_at: '5' };
+      state.selectResult = [row('m4', '4'), row('m3', '3'), row('m2', '2')]; // overflow at limit 2
+      const repo = new MessagesRepository(knex);
+      const page = await repo.listPage('c1', 'user-1', { before: 'm5', limit: 2 });
+
+      expect(state.whereRaw.sql).toContain('<');
+      expect(state.whereRaw.bindings).toEqual(['5', 'm5']);
+      expect(page.messages.map((m) => m.id)).toEqual(['m3', 'm4']);
+      expect(page.hasMoreBefore).toBe(true);
+      // the anchor itself sits after the page
+      expect(page.hasMoreAfter).toBe(true);
+    });
+
+    it('after cursor pages towards newer messages', async () => {
+      const { knex, state } = makeKnex();
+      state.anchorResult = { created_at: '1' };
+      state.selectResult = [row('m2', '2'), row('m3', '3')]; // no overflow at limit 2
+      const repo = new MessagesRepository(knex);
+      const page = await repo.listPage('c1', 'user-1', { after: 'm1', limit: 2 });
+
+      expect(state.whereRaw.sql).toContain('>');
+      expect(state.whereRaw.bindings).toEqual(['1', 'm1']);
+      expect(page.messages.map((m) => m.id)).toEqual(['m2', 'm3']);
+      expect(page.hasMoreBefore).toBe(true);
+      expect(page.hasMoreAfter).toBe(false);
+    });
+
+    it('throws CursorNotFoundError for a cursor outside the conversation', async () => {
+      const { knex, state } = makeKnex();
+      state.anchorResult = undefined;
+      const repo = new MessagesRepository(knex);
+      await expect(repo.listPage('c1', 'user-1', { before: 'ghost', limit: 2 })).rejects.toThrow(
+        CursorNotFoundError,
+      );
+    });
   });
 });

--- a/services/chat-service/tests/routes/chat.test.ts
+++ b/services/chat-service/tests/routes/chat.test.ts
@@ -5,6 +5,7 @@ import express from 'express';
 import request from 'supertest';
 import jwt from 'jsonwebtoken';
 import { createChatRouter } from '../../src/routes/chat';
+import { CursorNotFoundError } from '../../src/db/repositories/messages';
 
 const JWT_SECRET = 'test-secret';
 const USER_ID = '11111111-1111-1111-1111-111111111111';
@@ -13,6 +14,15 @@ const ORG_ID = '22222222-2222-2222-2222-222222222222';
 function token(claims: Record<string, unknown> = {}) {
   return jwt.sign({ userId: USER_ID, orgId: ORG_ID, ...claims }, JWT_SECRET);
 }
+
+const CONVERSATION = {
+  id: 'c1',
+  title: 'T',
+  appId: 'fuzefront',
+  orgId: ORG_ID,
+  createdAt: 'a',
+  updatedAt: 'b',
+};
 
 function buildApp(overrides: any = {}) {
   process.env.JWT_SECRET = JWT_SECRET;
@@ -25,18 +35,18 @@ function buildApp(overrides: any = {}) {
       cb.emit({ type: 'done' });
     }),
     conversations: {
-      list: jest.fn().mockResolvedValue([
-        { id: 'c1', title: 'T', createdAt: 'a', updatedAt: 'b' },
-      ]),
-      findById: jest.fn().mockResolvedValue({ id: 'c1', title: 'T', createdAt: 'a', updatedAt: 'b' }),
-      create: jest.fn().mockResolvedValue({ id: 'c-new', title: null, createdAt: 'a', updatedAt: 'b' }),
+      list: jest.fn().mockResolvedValue([CONVERSATION]),
+      findById: jest.fn().mockResolvedValue(CONVERSATION),
+      create: jest.fn().mockResolvedValue({ ...CONVERSATION, id: 'c-new', title: null }),
       touch: jest.fn().mockResolvedValue(undefined),
     },
     messages: {
       append: jest.fn().mockResolvedValue({ id: 'm1' }),
-      listForConversation: jest.fn().mockResolvedValue([
-        { id: 'm1', role: 'user', content: { type: 'text', text: 'hi' }, createdAt: 't' },
-      ]),
+      listPage: jest.fn().mockResolvedValue({
+        messages: [{ id: 'm1', role: 'user', content: { type: 'text', text: 'hi' }, createdAt: 't' }],
+        hasMoreBefore: false,
+        hasMoreAfter: false,
+      }),
     },
     feedback: { submit: jest.fn().mockResolvedValue(undefined) },
     confirmations: {
@@ -77,15 +87,68 @@ describe('POST /chat/stream', () => {
     );
   });
 
-  it('creates a conversation when none is supplied', async () => {
+  it('creates a conversation when none is supplied and announces its id first', async () => {
     const { app, deps } = buildApp();
-    await request(app)
+    const res = await request(app)
       .post('/chat/stream')
       .set('Authorization', `Bearer ${token()}`)
       .send({ messages: [{ role: 'user', content: 'hi' }], orgId: ORG_ID });
     expect(deps.conversations.create).toHaveBeenCalledWith(
-      expect.objectContaining({ userId: USER_ID, orgId: ORG_ID }),
+      expect.objectContaining({ userId: USER_ID, orgId: ORG_ID, appId: 'fuzefront' }),
     );
+    const firstEvent = res.text.split('\n\n')[0];
+    expect(firstEvent).toContain('"type":"conversation"');
+    expect(firstEvent).toContain('"conversationId":"c-new"');
+  });
+
+  it('scopes the new conversation to the appId from the request body', async () => {
+    const { app, deps } = buildApp();
+    await request(app)
+      .post('/chat/stream')
+      .set('Authorization', `Bearer ${token()}`)
+      .send({ messages: [{ role: 'user', content: 'hi' }], orgId: ORG_ID, appId: 'mendys' });
+    expect(deps.conversations.create).toHaveBeenCalledWith(
+      expect.objectContaining({ appId: 'mendys' }),
+    );
+  });
+
+  it('prefers the JWT appId claim over the request body', async () => {
+    const { app, deps } = buildApp();
+    await request(app)
+      .post('/chat/stream')
+      .set('Authorization', `Bearer ${token({ appId: 'mendys' })}`)
+      .send({ messages: [{ role: 'user', content: 'hi' }], orgId: ORG_ID, appId: 'spoofed' });
+    expect(deps.conversations.create).toHaveBeenCalledWith(
+      expect.objectContaining({ appId: 'mendys' }),
+    );
+  });
+
+  it('reuses a supplied conversation only after verifying ownership', async () => {
+    const { app, deps } = buildApp();
+    await request(app)
+      .post('/chat/stream')
+      .set('Authorization', `Bearer ${token()}`)
+      .send({ messages: [{ role: 'user', content: 'hi' }], orgId: ORG_ID, conversationId: 'c1' });
+    expect(deps.conversations.findById).toHaveBeenCalledWith('c1', USER_ID);
+    expect(deps.conversations.create).not.toHaveBeenCalled();
+  });
+
+  it('streams an error (not a foreign write) for a conversation the caller does not own', async () => {
+    const { app, deps } = buildApp({
+      conversations: {
+        findById: jest.fn().mockResolvedValue(null),
+        list: jest.fn(),
+        create: jest.fn(),
+        touch: jest.fn(),
+      },
+    });
+    const res = await request(app)
+      .post('/chat/stream')
+      .set('Authorization', `Bearer ${token()}`)
+      .send({ messages: [{ role: 'user', content: 'hi' }], orgId: ORG_ID, conversationId: 'cx' });
+    expect(res.text).toContain('"type":"error"');
+    expect(deps.messages.append).not.toHaveBeenCalled();
+    expect(deps.runAgentTurn).not.toHaveBeenCalled();
   });
 });
 
@@ -96,8 +159,35 @@ describe('GET /chat/conversations', () => {
       .get('/chat/conversations')
       .set('Authorization', `Bearer ${token()}`)
       .expect(200);
-    expect(deps.conversations.list).toHaveBeenCalledWith(USER_ID);
+    expect(deps.conversations.list).toHaveBeenCalledWith(USER_ID, {
+      appId: undefined,
+      orgId: undefined,
+    });
     expect(res.body[0].id).toBe('c1');
+  });
+
+  it('narrows by appId/orgId query params', async () => {
+    const { app, deps } = buildApp();
+    await request(app)
+      .get('/chat/conversations?appId=mendys&orgId=org-9')
+      .set('Authorization', `Bearer ${token()}`)
+      .expect(200);
+    expect(deps.conversations.list).toHaveBeenCalledWith(USER_ID, {
+      appId: 'mendys',
+      orgId: 'org-9',
+    });
+  });
+
+  it('the JWT appId claim wins over the query param', async () => {
+    const { app, deps } = buildApp();
+    await request(app)
+      .get('/chat/conversations?appId=spoofed')
+      .set('Authorization', `Bearer ${token({ appId: 'mendys' })}`)
+      .expect(200);
+    expect(deps.conversations.list).toHaveBeenCalledWith(
+      USER_ID,
+      expect.objectContaining({ appId: 'mendys' }),
+    );
   });
 
   it('401 without a token', async () => {
@@ -107,16 +197,56 @@ describe('GET /chat/conversations', () => {
 });
 
 describe('GET /chat/conversations/:id', () => {
-  it('returns the conversation with messages, scoped to the user', async () => {
+  it('returns the conversation with the newest message page by default', async () => {
     const { app, deps } = buildApp();
     const res = await request(app)
       .get('/chat/conversations/c1')
       .set('Authorization', `Bearer ${token()}`)
       .expect(200);
     expect(deps.conversations.findById).toHaveBeenCalledWith('c1', USER_ID);
-    expect(deps.messages.listForConversation).toHaveBeenCalledWith('c1', USER_ID);
+    expect(deps.messages.listPage).toHaveBeenCalledWith('c1', USER_ID, {
+      before: undefined,
+      after: undefined,
+      limit: 50,
+    });
     expect(res.body.id).toBe('c1');
     expect(res.body.messages).toHaveLength(1);
+    expect(res.body.hasMoreBefore).toBe(false);
+    expect(res.body.hasMoreAfter).toBe(false);
+  });
+
+  it('forwards before/limit cursors and clamps limit to 200', async () => {
+    const { app, deps } = buildApp();
+    await request(app)
+      .get('/chat/conversations/c1?before=m9&limit=999')
+      .set('Authorization', `Bearer ${token()}`)
+      .expect(200);
+    expect(deps.messages.listPage).toHaveBeenCalledWith('c1', USER_ID, {
+      before: 'm9',
+      after: undefined,
+      limit: 200,
+    });
+  });
+
+  it('400 when before and after are combined', async () => {
+    const { app } = buildApp();
+    await request(app)
+      .get('/chat/conversations/c1?before=m1&after=m2')
+      .set('Authorization', `Bearer ${token()}`)
+      .expect(400);
+  });
+
+  it('400 on an unknown cursor id', async () => {
+    const { app } = buildApp({
+      messages: {
+        append: jest.fn(),
+        listPage: jest.fn().mockRejectedValue(new CursorNotFoundError('ghost')),
+      },
+    });
+    await request(app)
+      .get('/chat/conversations/c1?before=ghost')
+      .set('Authorization', `Bearer ${token()}`)
+      .expect(400);
   });
 
   it('404 when the conversation is not owned by the user', async () => {


### PR DESCRIPTION
## 📋 Description

Makes the chat stack consumable by any Fuze-family app (first consumer: MendysRobotics) with WhatsApp-style persistent history:

- **Multi-app tenancy** — conversations are now scoped to `(userId, appId[, orgId])`. Migration `002` adds `app_id` to `chat_conversations`, converts `user_id`/`org_id` to opaque `TEXT` (dropping the FKs into FuzeFront's own `users`/`organizations` tables) so consuming apps bring their own subject ids, and adds the keyset-pagination indexes.
- **Cursor pagination (issue #120, `gate-pagination`)** — `GET /chat/conversations/:id` now really implements `before`/`after`/`limit` keyset paging on `(created_at, id)`; the response carries `hasMoreBefore`/`hasMoreAfter`. `GET /chat/conversations` filters by `appId`/`orgId`.
- **Thread continuity fix** — the stream now announces the resolved conversation id as its first SSE event (`{type:'conversation'}`). Previously the server never returned the created id, so **every turn silently created a new conversation row** and resume was impossible. A supplied `conversationId` is also now ownership-checked before appending (closes a write-side BOLA: any caller could append into another user's conversation).
- **`@fuzefront/chat-client` 1.1.0** — `appId` on `streamChat`, tenant filters on `listConversations`, cursor options + `hasMore*` on `getConversation`.
- **`@fuzefront/chat-ui` 1.1.0** — `useChat` hydrates the scope's most recent conversation on mount (`resume`, default on), follows the server conversation id across turns, and exposes `loadOlder`/`loadNewer`; `MessageList` gets bidirectional infinite scroll with prepend scroll anchoring (auto-scroll only while pinned to the bottom); `ChatWidget` gains `appId`/`resume`/`pageSize` props.
- **Publish path for consumers** — new `chat-packages-publish.yml` publishes the packages under owner-scoped alias names (`@izzywdev/fuzefront-chat-client`, `@izzywdev/fuzefront-chat-ui`) to GitHub Packages, since the canonical `@fuzefront` scope is blocked until the org transfer (existing `packages-publish.yml` remains the long-term path). Consumers install via npm aliases so imports keep the canonical names.
- Shell `FuzeChatWidget` passes `appId="fuzefront"`.

Companion PR in **izzywdev/MendysRobotics** (same branch name) embeds the widget in the Mendys portal.

## 🔄 Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🐛 Bug fix (stream never returned the conversation id; unverified conversationId writes)
- [x] 🧪 Test addition or improvement

## 🧪 Testing

- [x] Unit tests — chat-service: 23 suites / 122 tests pass; chat-client: 26 tests pass; chat-ui: 33 tests pass (new coverage for app scoping, cursor paging, ownership check, hydration, loadOlder/loadNewer, conversation-id adoption)
- [x] Manual testing — `tsc --noEmit` clean on chat-service and chat-ui; tsup builds of both packages succeed

**Test Configuration:**

- Node.js version: 22.x
- npm version: 10.x
- OS: Linux

### Test Instructions

```bash
cd services/chat-service && npm install && npx jest
cd packages/chat-client && npm install --workspaces=false && npx jest && npm run build
cd packages/chat-ui && npm install --workspaces=false && npm test && npm run build
```

## 🔧 Implementation Details

### Changes Made

- **Frontend Changes:**
  - `packages/chat-ui`: history hydration + bidirectional infinite scroll (reducer actions `hydrate_*`, `history_prepend/append`; scroll anchoring in `MessageList`; composer disabled while hydrating)
  - `frontend/src/components/FuzeChatWidget.tsx`: `appId="fuzefront"`
- **Backend Changes:**
  - `services/chat-service`: migration 002, repo `listPage` (keyset, limit+1 overflow probe), route pagination + appId resolution (JWT claim > request > `fuzefront` default), conversation announcement event, ownership check on supplied conversationId, `openapi.yaml` v1.1.0
- **SDK Changes:**
  - `packages/chat-client` 1.1.0 (types + client methods, backward compatible)

### Code Quality

- [x] Code follows the project's coding standards
- [x] Self-review of code completed
- [x] Code is commented, particularly in hard-to-understand areas
- [x] No console.log or debugging statements left in code

### Documentation

- [x] API documentation updated (`services/chat-service/openapi.yaml`)

## 🚨 Breaking Changes

None for existing callers:

1. **What breaks:** `GET /chat/conversations/:id` now returns the newest 50 messages by default instead of the full history (per the previously-planned contract). No in-repo caller consumed the unpaginated form (the shell never loaded history).
2. **Migration path:** pass `limit`/`before` to page; response gains `hasMoreBefore`/`hasMoreAfter`.
3. **Deprecation timeline:** n/a — migration 002's `down()` restores the UUID/FK schema while all stored ids are UUIDs.

## 📋 Checklist

### Pre-submission

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

### Code Quality

- [x] Code follows conventional commit format
- [x] TypeScript strict mode passes
- [x] No security vulnerabilities introduced (ownership check added; appId is a data partition of the caller's own rows, not a privilege boundary — user isolation stays on the JWT `userId`)

## 🔗 Related Issues and PRs

- Related to #120 (`gate-pagination` — implements the planned `before`/`limit` params, plus `after`)
- Companion: izzywdev/MendysRobotics `claude/floating-chat-widget-embed-ygpfqy`

## 📝 Additional Notes

### Deployment Notes

- [x] Requires database migration (knex migration 002 — additive + type widening, no data rewrite)
- [x] Requires configuration changes for consumers only: a consuming app's token minter must share the chat-service `JWT_SECRET` and set the `appId` claim

### Future Work

- Publish `@fuzefront/*` canonically once the org transfer lands, then drop `chat-packages-publish.yml` and consumer aliases
- Org-membership validation of the `orgId` claim (existing TODO in auth middleware)
- `chat_conversations.org_id` read-filtering by org for org-switching UIs

## 🔄 Backwards Compatibility

- [x] Fully backwards compatible (older tokens without `appId` default to `fuzefront`; unknown SSE event types are ignored by existing reducers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TEfTCWN2usb8W8xXfbkM1f

---
_Generated by [Claude Code](https://claude.ai/code/session_01TEfTCWN2usb8W8xXfbkM1f)_