### PR TITLE
fix(authentik): fix blueprint apply failures blocking prod login surface

### DIFF
--- a/deploy/helm/fuzefront/authentik/blueprints/flow-enrollment.yaml
+++ b/deploy/helm/fuzefront/authentik/blueprints/flow-enrollment.yaml
@@ -1,20 +1,16 @@
 # Authentik Blueprint — FuzeFront self-service enrollment flow
 #
 # Stages (in order):
-#   1. fuzefront-enroll-captcha     — reCAPTCHA (keys empty in dev → skipped)
-#   2. fuzefront-enroll-prompt      — email, username, password, password_repeat
-#   3. fuzefront-enroll-email-verify — send verification email + token challenge
-#   4. fuzefront-enroll-write       — create the user account
-#   5. fuzefront-enroll-login       — automatically log the new user in
+#   1. fuzefront-enroll-prompt  — email, username, password, password_repeat
+#   2. fuzefront-enroll-write   — create the user account (active immediately)
+#   3. fuzefront-enroll-login   — automatically log the new user in
 #
 # Password policy (12+ chars, upper/lower/digit/symbol) is applied as a
 # validation_policy on the prompt stage.
 #
-# The captcha stage requires real reCAPTCHA site/secret keys in production.
-# Set them via values authentik.blueprints.captchaPublicKey /
-# authentik.blueprints.captchaPrivateKey. In dev, empty keys cause the stage
-# to be effectively bypassed (Authentik skips captcha validation when keys
-# are blank).
+# NOTE: Captcha and email-verification stages are intentionally omitted until
+# prod SMTP is configured (authentik.smtp.* in values-prod.yaml). Without
+# SMTP, the email-verify stage stalls the flow. Re-add once SMTP is live.
 version: 1
 metadata:
   name: FuzeFront Enrollment Flow
@@ -35,18 +31,6 @@ entries:
       amount_symbols: 1
       password_field: password
       error_message: "Password must be at least 12 characters with uppercase, lowercase, digit and symbol."
-
-  # ── Captcha stage ────────────────────────────────────────────────────────────
-  - model: authentik_stages_captcha.captchastage
-    state: present
-    identifiers:
-      name: fuzefront-enroll-captcha
-    attrs:
-      name: fuzefront-enroll-captcha
-      # Blank keys in dev — replace with real reCAPTCHA v2/v3 keys in prod.
-      public_key: ""
-      private_key: ""
-      js_url: "https://www.recaptcha.net/recaptcha/api.js"
 
   # ── Prompt fields ─────────────────────────────────────────────────────────
   - model: authentik_stages_prompt.prompt
@@ -151,7 +135,7 @@ entries:
       name: fuzefront-enroll-write
     attrs:
       name: fuzefront-enroll-write
-      create_users_as_inactive: true  # account is inactive until email verified
+      create_users_as_inactive: false
       user_type: internal
 
   # ── User-login stage ─────────────────────────────────────────────────────────
@@ -181,7 +165,7 @@ entries:
     state: present
     identifiers:
       target: !Find [authentik_flows.flow, [slug, fuzefront-enrollment]]
-      stage: !Find [authentik_stages_captcha.captchastage, [name, fuzefront-enroll-captcha]]
+      stage: !Find [authentik_stages_prompt.promptstage, [name, fuzefront-enroll-prompt]]
     attrs:
       order: 10
       re_evaluate_policies: false
@@ -190,7 +174,7 @@ entries:
     state: present
     identifiers:
       target: !Find [authentik_flows.flow, [slug, fuzefront-enrollment]]
-      stage: !Find [authentik_stages_prompt.promptstage, [name, fuzefront-enroll-prompt]]
+      stage: !Find [authentik_stages_user_write.userwritestage, [name, fuzefront-enroll-write]]
     attrs:
       order: 20
       re_evaluate_policies: false
@@ -199,25 +183,7 @@ entries:
     state: present
     identifiers:
       target: !Find [authentik_flows.flow, [slug, fuzefront-enrollment]]
-      stage: !Find [authentik_stages_user_write.userwritestage, [name, fuzefront-enroll-write]]
-    attrs:
-      order: 30
-      re_evaluate_policies: false
-
-  - model: authentik_flows.flowstagebinding
-    state: present
-    identifiers:
-      target: !Find [authentik_flows.flow, [slug, fuzefront-enrollment]]
-      stage: !Find [authentik_stages_email.emailstage, [name, fuzefront-enroll-email-verify]]
-    attrs:
-      order: 40
-      re_evaluate_policies: false
-
-  - model: authentik_flows.flowstagebinding
-    state: present
-    identifiers:
-      target: !Find [authentik_flows.flow, [slug, fuzefront-enrollment]]
       stage: !Find [authentik_stages_user_login.userloginstage, [name, fuzefront-enroll-login]]
     attrs:
-      order: 50
+      order: 30
       re_evaluate_policies: false

--- a/deploy/helm/fuzefront/authentik/blueprints/source-google.yaml
+++ b/deploy/helm/fuzefront/authentik/blueprints/source-google.yaml
@@ -54,7 +54,7 @@ entries:
       consumer_key: !Env [GOOGLE_CLIENT_ID, ""]
       consumer_secret: !Env [GOOGLE_CLIENT_SECRET, ""]
       # Link on verified email — merges accounts instead of creating duplicates
-      user_matching_mode: link_by_email
+      user_matching_mode: email_link
       user_path_template: "goauthentik.io/sources/%(slug)s"
       # Show a "Sign in with Google" button on the login page
       authentication_flow: !Find [authentik_flows.flow, [slug, default-source-authentication]]


### PR DESCRIPTION
Root cause of all four blueprints silently failing post PR #224.

Bug 1 (flow-enrollment): CaptchaStage public_key/private_key must be non-empty (minLength:1 in Authentik 2024.12). Empty strings fail validation, rolling back the entire transactional blueprint — fuzefront-enrollment flow was never created, cascading to source-google.yaml failing its Find for that flow.
Fix: Remove captcha stage + binding. Also remove email-verify binding + set create_users_as_inactive: false (no prod SMTP yet; users stuck inactive otherwise).

Bug 2 (source-google): user_matching_mode 'link_by_email' is invalid in 2024.12; correct value is 'email_link'.
Fix: email_link.

After merge: Argo syncs chart, worker rolls, blueprints retry. enrollment+recovery apply on first run; source-google may need one automatic retry (~8 min via clear_failed_blueprints) since it races with enrollment/recovery creation.

Follow-up (separate PRs): prod SMTP for email-verify; reCAPTCHA keys to re-add captcha stage.