### PR TITLE
fix(authentik): flowstagebinding evaluate_on_plan + brand default conflict

### DIFF
--- a/deploy/helm/fuzefront/authentik/blueprints/brand-fuseseam.yaml
+++ b/deploy/helm/fuzefront/authentik/blueprints/brand-fuseseam.yaml
@@ -21,12 +21,20 @@ entries:
     identifiers:
       domain: "fuzefront.dev.local"
 
+  # Clear the built-in brand's default flag so our brand can claim it.
+  - model: authentik_brands.brand
+    state: present
+    identifiers:
+      domain: "authentik-default"
+    attrs:
+      default: false
+
   - model: authentik_brands.brand
     state: present
     identifiers:
       # Apex-suffix match covers auth.fuzefront.com (prod) and any other
-      # *.fuzefront.com host; default:true additionally covers dev hosts
-      # (fuzefront.dev.local) that don't suffix-match.
+      # *.fuzefront.com host; default:true is set after clearing the built-in
+      # brand above so only one brand is default at a time.
       domain: "fuzefront.com"
     attrs:
       name: "FuzeFront"

--- a/deploy/helm/fuzefront/authentik/blueprints/flow-enrollment.yaml
+++ b/deploy/helm/fuzefront/authentik/blueprints/flow-enrollment.yaml
@@ -168,6 +168,7 @@ entries:
       stage: !Find [authentik_stages_prompt.promptstage, [name, fuzefront-enroll-prompt]]
     attrs:
       order: 10
+      evaluate_on_plan: true
       re_evaluate_policies: false
 
   - model: authentik_flows.flowstagebinding
@@ -177,6 +178,7 @@ entries:
       stage: !Find [authentik_stages_user_write.userwritestage, [name, fuzefront-enroll-write]]
     attrs:
       order: 20
+      evaluate_on_plan: true
       re_evaluate_policies: false
 
   - model: authentik_flows.flowstagebinding
@@ -186,4 +188,5 @@ entries:
       stage: !Find [authentik_stages_user_login.userloginstage, [name, fuzefront-enroll-login]]
     attrs:
       order: 30
+      evaluate_on_plan: true
       re_evaluate_policies: false

--- a/deploy/helm/fuzefront/authentik/blueprints/flow-recovery.yaml
+++ b/deploy/helm/fuzefront/authentik/blueprints/flow-recovery.yaml
@@ -119,6 +119,8 @@ entries:
       stage: !Find [authentik_stages_identification.identificationstage, [name, fuzefront-recovery-identification]]
     attrs:
       order: 10
+      evaluate_on_plan: true
+      re_evaluate_policies: false
 
   - model: authentik_flows.flowstagebinding
     state: present
@@ -127,6 +129,8 @@ entries:
       stage: !Find [authentik_stages_email.emailstage, [name, fuzefront-recovery-email]]
     attrs:
       order: 20
+      evaluate_on_plan: true
+      re_evaluate_policies: false
 
   - model: authentik_flows.flowstagebinding
     state: present
@@ -135,6 +139,8 @@ entries:
       stage: !Find [authentik_stages_prompt.promptstage, [name, fuzefront-recovery-prompt]]
     attrs:
       order: 30
+      evaluate_on_plan: true
+      re_evaluate_policies: false
 
   - model: authentik_flows.flowstagebinding
     state: present
@@ -143,6 +149,8 @@ entries:
       stage: !Find [authentik_stages_user_write.userwritestage, [name, fuzefront-recovery-write]]
     attrs:
       order: 40
+      evaluate_on_plan: true
+      re_evaluate_policies: false
 
   - model: authentik_flows.flowstagebinding
     state: present
@@ -151,3 +159,5 @@ entries:
       stage: !Find [authentik_stages_user_login.userloginstage, [name, fuzefront-recovery-login]]
     attrs:
       order: 50
+      evaluate_on_plan: true
+      re_evaluate_policies: false


### PR DESCRIPTION
## Root causes

Two blueprint validation errors found via \`/api/v3/events/system_tasks/\` inspection that silently rolled back every enrollment/recovery blueprint apply since deploy:

### 1. FlowStageBinding validation (enrollment + recovery flows never created)

Authentik 2024.12 serializer requires **either** \`evaluate_on_plan\` **or** \`re_evaluate_policies\` to be true on every \`FlowStageBinding\`. Our bindings only set \`re_evaluate_policies: false\` without explicitly setting \`evaluate_on_plan: true\`, triggering:

> \`Entry invalid: non_field_errors: Either evaluation on plan or evaluation on run must be enabled\`

Since blueprints are fully transactional, this caused the entire enrollment blueprint to roll back — no flow, no stages, no password policy were ever created. Recovery also failed (depends on enrollment's password policy via \`!Find\`).

**Fix:** add \`evaluate_on_plan: true\` to all \`flowstagebinding\` entries in both files.

### 2. Brand default conflict (brand blueprint never applied)

The built-in \`authentik-default\` brand already has \`default: true\`. Setting the FuzeFront brand to \`default: true\` failed with:

> \`Entry invalid: {'default': ['Only a single brand can be set as default.']}\`

**Fix:** clear the built-in brand's \`default\` flag first, then set the FuzeFront brand as default.

## Effect when merged + Argo syncs

- \`fuzefront-enrollment\` flow will be created with 3 stages (prompt → write → login)
- \`fuzefront-recovery\` flow will be created with 5 stages
- \`enroll_url\` and \`recovery_url\` will appear in the flow executor probe
- FuzeFront fuse-seam brand will apply to all \`*.fuzefront.com\` auth pages

## Test plan
- [ ] Argo sync → confirm \`fuzefront-enrollment\` flow exists in Authentik DB
- [ ] Probe \`https://auth.fuzefront.com/api/v3/flows/executor/default-authentication-flow/\`: \`enroll_url\` and \`recovery_url\` present
- [ ] T1: browser sign-up at \`https://app.fuzefront.com/login\`