### PR TITLE
fix(security): pass state in OIDC callback checks to fix password sign-in

### DIFF
--- a/backend/security/src/services/oidc.ts
+++ b/backend/security/src/services/oidc.ts
@@ -88,7 +88,7 @@ class OIDCService {
       const tokenSet = await this.client.callback(
         this.config.redirectUri,
         { code, state },
-        { code_verifier: codeVerifier }
+        { code_verifier: codeVerifier, state }
       );
 
       console.log('✅ Received tokens from Authentik');

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -133,6 +133,10 @@ export default defineConfig({
       // NetworkFirst so the shell always fetches fresh federation assets.
       globPatterns: ['**/*.{html,css,ico,png,svg,woff,woff2}'],
       workbox: {
+        // Exclude /api/* from the SPA navigation fallback so full-page navigations
+        // to backend redirect endpoints (e.g. /api/auth/oidc/signup → 302) are not
+        // intercepted by the SW and silently served as index.html instead.
+        navigateFallbackDenylist: [/^\/api\//],
         runtimeCaching: [
           {
             // API + WebSocket upgrade paths — never cache


### PR DESCRIPTION
## Root cause

POST /api/auth/oidc/password routed through fuzefront-security:3002 returned 500 Authentication failed while in-cluster worked.

Security service OIDCService.handleCallback called client.callback with { code_verifier: codeVerifier } as checks, missing state. openid-client throws 'checks.state argument is missing' when state was part of the auth request.

## Fix

Added state to checks in backend/security/src/services/oidc.ts:
{ code_verifier: codeVerifier, state }

Mirrors the working monolith backend/src/services/oidc.ts.