### PR TITLE
fix(permit): register product policies in the schema-sync CLI entry

### DIFF
--- a/backend/src/permit/sync-permit-schema.ts
+++ b/backend/src/permit/sync-permit-schema.ts
@@ -92,10 +92,18 @@ export async function syncPermitSchemaWithProducts(
 
 // CLI entry — only runs when executed directly (node dist/permit/sync-permit-schema.js).
 // Lazily importing the real client here keeps the module import-safe for tests.
+// Product policies (backend/src/permit/products/*) must be listed here — the
+// permit-schema-sync Job runs this entry, and a policy that isn't passed to
+// syncPermitSchemaWithProducts never reaches the Permit control plane.
 if (require.main === module) {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  /* eslint-disable @typescript-eslint/no-var-requires */
   const permit = require('../config/permit').default as PermitSchemaClient
-  syncPermitSchema(permit)
+  const products: ProductPolicy[] = [
+    require('./products/fuzemarket.policy').default,
+    require('./products/mendys-datasets.policy').default,
+  ]
+  /* eslint-enable @typescript-eslint/no-var-requires */
+  syncPermitSchemaWithProducts(permit, products)
     .then(() => {
       console.log('Permit schema sync complete')
       process.exit(0)


### PR DESCRIPTION
Follow-up to #228 / #222: the `permit-schema-sync` Job executes `node dist/permit/sync-permit-schema.js`, whose CLI entry synced only the base platform schema. The product policies under `backend/src/permit/products/` (fuzemarket, mendys-datasets) were never imported by anything, so the `mendys-datasets.*` resources/roles required by the datasets marketplace never reached the Permit control plane (verified via the Permit schema API — zero `mendys-datasets` keys in the environment).

This wires the CLI entry through `syncPermitSchemaWithProducts` with both product policies. Idempotent — the job is get-or-create/update and re-runs on every post-upgrade hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)