### PR TITLE
fix(unleash): seal real unleash-secrets values, unbreak fuzefront-sealed Argo app

### DIFF
--- a/deploy/contabo/sealed/unleash-secrets.yaml
+++ b/deploy/contabo/sealed/unleash-secrets.yaml
@@ -1,31 +1,23 @@
 # =============================================================================
 # unleash-secrets — per-service SealedSecret for the self-hosted Unleash server.
 #
-# !!! PLACEHOLDERS !!! The encryptedData blobs below are FAKE and will NOT decrypt.
-# They exist so the manifest is committed and discoverable; you MUST seal the REAL
-# values before flipping `unleash.enabled: true` (otherwise the bootstrap Job and
-# the Unleash pod stay pending / fail on the missing/garbage Secret keys).
+# The encryptedData blobs are REAL sealed values (sealed 2026-07-13 against the
+# prod controller cert from https://sealed-secrets.prod.fuzefront.com/v1/cert.pem,
+# replacing the fake AgPLACEHOLDER_* blobs that kept the fuzefront-sealed Argo app
+# Degraded with "illegal base64 data"). Re-seal any key with:
 #
-# Seal each key (offline, credential-free — FuzeInfra holds the decrypt key, we
-# fetch its published public cert) with:
-#
-#   deploy/scripts/seal-secret.sh UNLEASH_DB_PASSWORD   --scope fuzefront/unleash-secrets
-#   deploy/scripts/seal-secret.sh INIT_ADMIN_API_TOKENS --scope fuzefront/unleash-secrets
-#   deploy/scripts/seal-secret.sh UNLEASH_CLIENT_TOKEN  --scope fuzefront/unleash-secrets
+#   deploy/scripts/seal-secret.sh <KEY> --scope fuzefront/unleash-secrets
 #
 # Keys (all consumed by templates/unleash.yaml + unleash-db-bootstrap-job.yaml):
 #   UNLEASH_DB_PASSWORD   — password for the least-privilege unleash_svc Postgres
 #                           role (set by the bootstrap Job; used in DATABASE_URL).
-#   INIT_ADMIN_API_TOKENS — admin/bootstrap API token, format `*:*.<hex>`
-#                           (e.g. `*:*.unleash-insecure-admin-token` style hex).
+#   INIT_ADMIN_API_TOKENS — admin/bootstrap API token, format `*:*.<hex>`.
 #   UNLEASH_CLIENT_TOKEN  — the client/SDK token the @fuzefront/feature-flags
-#                           package uses, format `[project]:[env].<hex>` (e.g.
-#                           `default:production.<64-hex>`). Fed to the server as
-#                           INIT_CLIENT_API_TOKENS.
+#                           package uses, format `default:production.<hex>`. Fed to
+#                           the server as INIT_CLIENT_API_TOKENS.
 #
-# Then: git add this file && commit && push → Argo (FuzeInfra-operated) syncs it
-# and the in-cluster sealed-secrets controller decrypts it into the real Secret.
-# Plaintext NEVER touches git, chat, or shell history.
+# NOTE: kubeseal --merge-into rewrites this file and strips comments — restore
+# this header after re-sealing. Plaintext NEVER touches git, chat, or shell history.
 # =============================================================================
 ---
 apiVersion: bitnami.com/v1alpha1
@@ -35,9 +27,9 @@ metadata:
   namespace: fuzefront
 spec:
   encryptedData:
-    UNLEASH_DB_PASSWORD: AgPLACEHOLDER_seal_with_deploy_scripts_seal-secret.sh_UNLEASH_DB_PASSWORD
-    INIT_ADMIN_API_TOKENS: AgPLACEHOLDER_seal_with_deploy_scripts_seal-secret.sh_INIT_ADMIN_API_TOKENS
-    UNLEASH_CLIENT_TOKEN: AgPLACEHOLDER_seal_with_deploy_scripts_seal-secret.sh_UNLEASH_CLIENT_TOKEN
+    INIT_ADMIN_API_TOKENS: AgCwj4t26TFGiieeAaqT5/AccEgVz7HX9Fxh2JCnDfThFylIeutM7evvIPw3r0i4fH4s8x1GXeXwTh6y/2PAfwdkF2D9FP54QFK8uGa28ZnFIGipQLv66Vo9GUUrDCOIdYcdr5dHKz+SJnV++t4A06ja1/qtEhjHPNDtYajHRqM+k58fY7W1/4c1ph0bjxraNE6F9d6knZmrMGHx82yS7186H0iua1ogPuwO5dympJeGS6mC9FduwNQsbliShywPSmv7gTZe1guy2Mef/FMFYTyjtpdgtptEuS+7uUX81DoklcMny4a9sUt7q/9bcdo78yJj6TtRHVpfZs3jr9cUqr9Caugd1lcYXqGdODVOEW04bQKQ7Gt5SdBrKh43fGfCVye9abl5a3Gmi1mwxhKkZJ/WNtkfmSEhOBDeSBdDeWXxf3DcObKybc0f8Q0a0CmE+H62F72ekIzlECGxFf4f00oSxp6wkuBm5Y51rwaHirlNC9IUcR6tH1WisVMj4WSlestfiY5DU50valN0L8kLdB9tOCNBosHsui6Jn3D1R8PM+kQtdAzQh1cS7JTKOninYpqgdqjMGNz3+CWH1GxyDhE6Cnlb/K3csnPDTmGd0W0iBGbAA1yN8TpLACs7DhtvZDk/JWJ5bDiJmXfVvbJEIcMqogIDkG8vGM9Fd/zBR6JbfpJ1HXUJY/G+Nz4ShT0rueKVtn43aLEADDMWBZzBxLWv0Cwur/+RlV2Gbx4KTC7IVtkmokQSenUctXFK1QjW7UJXAssJ/yizQE5EdWG3Icm0M1i/CQ==
+    UNLEASH_CLIENT_TOKEN: AgAihW1oEfVVyIlur8PTzka/MG2r8qJj4m48OJmv+BCSQPnRVyqiyNHtVMGwYULodXRH2IHpTmCKI3rWW4e3bWk1gkMrOCj0v9DPMAWGQ3zgdHytwcyrk6KScGd9kvsANuBPNkQQI7Bx/2Gg+PIXUBw7eeHV6CGsNZQMozvX2PfSmURFqMcQqjTU5PyprGTjt2SWNkbUMSJDqr+wIcVgY34jnKtinZUzA8eCucYMp64G9uaZL2ArYY+W6tbV3jeYwlGPvfk5OkbjkSAobT7CldVXypvqfRWWuel/Qhyxle0KaGPG8WHvnJC3A2o+QRc+efp+p8G9FMGm7myO4e8BptoqFZnTcI9KGu/ml1IqUvSxJI7znJaxbcZ+h3uUNg4SgvDiL7rkLYmxhdCYONl+rnG0bh3mchNcsbzEmPt3AkvbTpPYCxQE4fpk3ycnKwx3E/8L2/dI2lkQ2xdZOV5W2NeCkXsHp8AYTqyJFjvjn+8kA9E+GA/AI12ZX29J49nbW2xfEa+Mmi6yoYD2sV7/Krq/nXSDh09SDCU+XRYVfEA+7cpUP7bTtT6QFqnrDkxkVbbzbjqiRXBIwL5GY24Jv2PjAeHZ6gOoSnySFO3IfdXzHSldzLZuHVh1YRzznMZF0xaLrBmdzQKFOabsNogfSXfIbttRtBkZ47wrITInCdWN0MtgRfw4uHHzQeGRHw5pEwR7spetPkk0RobMzCsK6+FB+98OtfIM3a43GFTZ8sCOo9ue+y+5J5e/eUSAR35+O/HQSSjOBEtiH3Qj9yX3Wt4OPIphnVGs0ReoZ2z0WCzGYSfebA==
+    UNLEASH_DB_PASSWORD: AgCWdg3DsKna2x5CMNt6IRuLTxKho1PbG5MFn8l2Xu6cxEh+PpS8z2BIdHFduvGg7wn87czzow17izJIvHSgX2v0ce6g1qXMEacP+esaX/51RFGay/ua+4aFshvZpvGnLggSw2xa0K5XQzbYCAa1aT4cn1S2uVFU4W99uJ6rLmzmSSkMGGgSWt5uwuogm/lhQk/oahNqy30y3hhpmde6wydrknhRa+5dFEJAzG5jNFwremTKnoWlOtnCqzlpuZN3+BFAsyw9cSTr505ZeLzY82yORZFhfIg2qSz4w3tg4RsIFIg0bi+TYe35P19JTXszsZGYihSQM0y0oCBol/XAOQTWFR+Yuv9ER+4JI34Dml85aXK1N2VXZJXeHeduTDTnYdxB3s7BF7v7KK5n+tCMZbXCrgiuqJekeqORhYeptaFAvcKl+0lMJbAJay75rvWMHFxuU4xZcuT8dRRlmXgKK4EkkIT0dmDGvQcP5PDJwzGSI5LhbNN+098dxDzGGQdroUGKYzVQ5l4yOTUocWrLay2DjsqvlqQETmr08m7SDQVcYrksjQ31AVhh2jUm9pXpFS6lhEsd53rSBde3pQuq0itzwNS3uawxwQRJgXj+kNUr8FQ4dODHNycuP+UfR7YnG3xif9FtyFDJQk0svoEfc+0XQ/s4AmjSfjMpITudUBg4P+UOR7UnIinNN83KkA76gPRh1EuiZDyWLgD7rCeZ4xHORTfFLt6m0ThkP1GiTOfCew9fWJxhHM21D2JLX+R5dTEvPS/shrSzN9Gxr2yoc5jb
   template:
     metadata:
       name: unleash-secrets

--- a/deploy/scripts/seal-secret.sh
+++ b/deploy/scripts/seal-secret.sh
@@ -33,7 +33,8 @@ NS="fuzefront"
 NAME="billing-secrets"
 # FuzeInfra publishes the sealed-secrets public cert here (single source of truth,
 # always current). Override via env if the URL differs.
-CERT_URL="${FUZEINFRA_SEALED_CERT_URL:-https://sealed-secrets.fuzeinfra.fuzefront.com/v1/cert.pem}"
+# (sealed-secrets.fuzeinfra.fuzefront.com no longer resolves; prod is canonical.)
+CERT_URL="${FUZEINFRA_SEALED_CERT_URL:-https://sealed-secrets.prod.fuzefront.com/v1/cert.pem}"
 
 CERT_OVERRIDE=""; INFILE=""; KEY=""; MANIFEST=""
 while [ $# -gt 0 ]; do


### PR DESCRIPTION
## Problem
`unleash-secrets` (ns `fuzefront`, synced by the **fuzefront-sealed** Argo app) has failed decryption since 2026-06-30:

> illegal base64 data at input byte 13 (INIT_ADMIN_API_TOKENS, UNLEASH_CLIENT_TOKEN, UNLEASH_DB_PASSWORD)

Root cause: the manifest shipped in #125 still contained the **fake `AgPLACEHOLDER_*` blobs** (byte 13 is the first `_`) — the real values were never sealed. The controller rejects them → SealedSecret `Synced=False` → app permanently **Degraded**. No `unleash-secrets` Secret ever materialized in-cluster.

## Fix
- Sealed **fresh, real values** for all three keys with `deploy/scripts/seal-secret.sh --scope fuzefront/unleash-secrets` (hidden temp files, plaintext never printed/committed). Fresh values are safe: nothing ever consumed the placeholders, `unleash.enabled` is still `false` in prod, and the DB bootstrap Job idempotently `CREATE/ALTER ROLE`s `unleash_svc`. Token formats per spec: `*:*.<hex>` / `default:production.<hex>`; DB password is hex-only (URL-safe in `DATABASE_URL`).
- Sealing cert fetched from https://sealed-secrets.prod.fuzefront.com/v1/cert.pem and **verified byte-identical** to `kubeseal --fetch-cert` from the live `kube-system/sealed-secrets-controller`.
- Restored the manifest doc header that `kubeseal --merge-into` strips.
- `seal-secret.sh`: default cert URL `sealed-secrets.fuzeinfra.fuzefront.com` no longer resolves (DNS gone) — repointed the default to the working prod URL.

## Out of scope
`unleash.enabled` stays `false` — flipping it is a deliberate human deploy-window action per `values-prod.yaml`; this PR just satisfies the secret prerequisite.

## Verification (post-merge, after Argo sync)
```
kubectl get sealedsecret unleash-secrets -n fuzefront -o jsonpath='{.status.conditions}'   # expect Synced=True
kubectl get secret unleash-secrets -n fuzefront                                            # expect 3 data keys
# fuzefront-sealed Application -> Healthy
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
