### PR TITLE
fix(authentik): add required invalidation_flow to mendys-datasets provider blueprint

### DIFF
--- a/deploy/helm/fuzefront/authentik/blueprints/provider-oidc-mendys-datasets.yaml
+++ b/deploy/helm/fuzefront/authentik/blueprints/provider-oidc-mendys-datasets.yaml
@@ -123,6 +123,12 @@ entries:
       # Reference the flow defined above. !Find resolves within the same
       # blueprint run — the flow entry is applied before this provider entry.
       authorization_flow: !Find [authentik_flows.flow, [slug, mendys-datasets-authorization-implicit-consent]]
+      # REQUIRED since authentik 2024.10 — provider creation fails validation
+      # without it ("invalidation_flow: This field is required"), which is why
+      # the first apply of this blueprint errored and created nothing. The
+      # default system flow ships with every install (default blueprint
+      # flow-default-provider-invalidation.yaml).
+      invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
 
   # ── Application ───────────────────────────────────────────────────────────────
   - model: authentik_core.application


### PR DESCRIPTION
The 15:02 UTC blueprint apply for `provider-oidc-mendys-datasets.yaml` reported task SUCCESS but the BlueprintInstance is in `error`: the OAuth2 provider entry fails serializer validation — **`invalidation_flow` is required** at provider creation since authentik 2024.10. Nothing was created (verified via the admin API: 0 providers matching Mendys, application `mendys-datasets` absent), so OIDC discovery 404s and the marketplace login 503s.

Fix: reference the stock `default-provider-invalidation-flow` via `!Find`. The blueprints ConfigMap change rolls the worker (checksum annotation), and file-change discovery re-applies the blueprint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)