### PR TITLE
fix(sdlc): surface gh pr create failures instead of swallowing them

### DIFF
--- a/.github/workflows/claude-auto-pr.yml
+++ b/.github/workflows/claude-auto-pr.yml
@@ -57,7 +57,7 @@ jobs:
           # Only open a PR if the branch actually diverges from base.
           if git rev-list --count "origin/${BASE}..origin/${BRANCH}" | grep -qvE '^0$'; then
             gh pr create --base "$BASE" --head "$BRANCH" --fill --label "auto-merge" \
-              || echo "gh pr create failed (no diff or transient) — skipping."
+              || { echo "::error::gh pr create failed for $BRANCH — branch will persist with no PR until governance-nightly retries"; exit 1; }
           else
             echo "No commits on $BRANCH ahead of $BASE — no PR opened."
           fi


### PR DESCRIPTION
## Summary

- `claude-auto-pr.yml`: changes the silent `|| echo ... skipping` fallback on `gh pr create` to `exit 1` with a `::error::` annotation

## Why

Previously, if `gh pr create` failed (transient GitHub API error, rate limit, etc.) the workflow exited 0 — the branch was left with no PR and no visible signal anywhere. The only recovery path was the next `governance-nightly` run, which might also be credit-starved.

Now the workflow run goes **red**: the failure appears in the branch's commit status, shows up in the Actions UI, is retryable via "Re-run failed jobs", and would trigger any future failure-notification hooks. The `::error::` annotation pins the message to the workflow summary so the cause is immediately visible.

## Test plan

- [ ] Trigger a `claude/**` push and confirm `claude-auto-pr.yml` still opens PRs successfully
- [ ] This PR itself self-exercises the workflow: the `claude/auto-pr-fail-on-error` push should have triggered a non-draft PR + auto-merge label

🤖 Generated with Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01U7nAq7RMQAqe7HZd97B7my)_