### PR TITLE
fix(security): fix prod password sign-in — OIDC state + HS256 alg

### DIFF
--- a/backend/security/src/services/oidc.ts
+++ b/backend/security/src/services/oidc.ts
@@ -88,7 +88,7 @@ class OIDCService {
       const tokenSet = await this.client.callback(
         this.config.redirectUri,
         { code, state },
-        { code_verifier: codeVerifier }
+        { code_verifier: codeVerifier, state }
       );
 
       console.log('✅ Received tokens from Authentik');

--- a/backend/security/src/services/oidc.ts
+++ b/backend/security/src/services/oidc.ts
@@ -38,6 +38,9 @@ class OIDCService {
         redirect_uris: [this.config.redirectUri],
         response_types: ['code'],
         grant_types: ['authorization_code'],
+        // Authentik signs ID tokens with HS256 (client-secret-based); without
+        // this override openid-client rejects them as "unexpected JWT alg".
+        id_token_signed_response_alg: 'HS256',
       });
 
       console.log('✅ OIDC client initialized successfully');

--- a/backend/security/tests/oidc-google-signin.test.ts
+++ b/backend/security/tests/oidc-google-signin.test.ts
@@ -230,7 +230,7 @@ describe('OIDCService.handleCallback()', () => {
     expect(mockClient.callback).toHaveBeenCalledWith(
       expect.any(String), // redirectUri
       { code: 'auth-code-xyz', state: 'state-abc' },
-      { code_verifier: 'verifier-123' }
+      { code_verifier: 'verifier-123', state: 'state-abc' }
     )
   })
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -133,6 +133,10 @@ export default defineConfig({
       // NetworkFirst so the shell always fetches fresh federation assets.
       globPatterns: ['**/*.{html,css,ico,png,svg,woff,woff2}'],
       workbox: {
+        // Exclude /api/* from the SPA navigation fallback so full-page navigations
+        // to backend redirect endpoints (e.g. /api/auth/oidc/signup → 302) are not
+        // intercepted by the SW and silently served as index.html instead.
+        navigateFallbackDenylist: [/^\/api\//],
         runtimeCaching: [
           {
             // API + WebSocket upgrade paths — never cache


### PR DESCRIPTION
## Summary

Three-commit fix to make native email/password sign-in work end-to-end on prod.

- **fix(pwa)**: exclude `/api/*` from service worker navigation fallback so the SW doesn't intercept backend redirects (e.g. `/api/auth/oidc/signup → 302`) and serve `index.html` instead.
- **fix(security): state in OIDC callback checks** — `fuzefront-security` was calling `client.callback()` without `state` in the checks object, causing `TypeError: checks.state argument is missing`. Matches the monolith's working implementation.
- **fix(security): id_token_signed_response_alg HS256** — Authentik signs ID tokens with HS256 (client-secret-based). Without `id_token_signed_response_alg: 'HS256'` in the client init, openid-client rejects tokens with `RPError: unexpected JWT alg received, expected RS256, got: HS256`. The monolith already has this override; this brings the security service into parity.

## Test plan

- [ ] `POST https://app.fuzefront.com/api/auth/oidc/password` with enrolled credentials → 200 + JWT
- [ ] User lands on dashboard after sign-in at `app.fuzefront.com/sign-in`
- [ ] Sign-up flow (T1) still works (regression check)