### PR TITLE
fix(release): replace mawk-incompatible awk alternation with 5 literal patterns

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -217,7 +217,11 @@ jobs:
                 next
               }
             }
-            /repository: ghcr\.io\/izzywdev\/fuzefront-(backend|frontend|security-service|applications-service|clock-app)$/ { hot=1 }
+            /repository: ghcr\.io\/izzywdev\/fuzefront-backend$/ { hot=1 }
+            /repository: ghcr\.io\/izzywdev\/fuzefront-frontend$/ { hot=1 }
+            /repository: ghcr\.io\/izzywdev\/fuzefront-security-service$/ { hot=1 }
+            /repository: ghcr\.io\/izzywdev\/fuzefront-applications-service$/ { hot=1 }
+            /repository: ghcr\.io\/izzywdev\/fuzefront-clock-app$/ { hot=1 }
             { print }
             END { print n+0 > "/tmp/bump-count" }
           ' /tmp/vp-current.yaml > /tmp/vp-new.yaml


### PR DESCRIPTION
## Summary
- `mawk` (Ubuntu runner default) does not support ERE alternation (`|`) in `/regex/` patterns — only `gawk` does
- The single alternation pattern for 5 core-app image repos matched 0 lines, causing `"expected 5 core-app tag rewrites, got 0"` to fail on every release
- Replaced with 5 separate literal patterns (one per service), which work in both `mawk` and `gawk`
- The 5-rewrite count guard is unchanged

## Test plan
- [ ] Trigger a release and verify the "Bump image tags in values-prod.yaml" step rewrites all 5 tags and exits with count=5
- [ ] Confirm `values-prod.yaml` is updated via the GitHub Contents API commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)