### PR TITLE
feat(billing): vendor-neutral, DB-backed invoices + payment-provider abstraction

### DIFF
--- a/.github/workflows/billing-service-tests.yml
+++ b/.github/workflows/billing-service-tests.yml
@@ -49,10 +49,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Use Node.js 22.x
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '22.x'
 

--- a/.github/workflows/billing-service-tests.yml
+++ b/.github/workflows/billing-service-tests.yml
@@ -1,11 +1,12 @@
 name: Billing Service Tests
 
-# Runs the billing-service test suites in CI. Crucially this provisions a real
-# Postgres so the DB-backed INTEGRATION tests (migration 003 + PgInvoiceRepository:
-# store -> read -> keyset-paginate, idempotent upsert) actually EXECUTE against a
-# real database instead of self-skipping. Without a reachable DATABASE_URL the
-# integration + db suites skip (see tests/integration/*.integration.test.ts and
-# tests/db.test.ts), which is what happened before this workflow existed.
+# Runs the billing-service DB-backed test suites in CI. Crucially this provisions
+# a real Postgres so the invoice INTEGRATION tests (migration 003 +
+# PgInvoiceRepository: store -> read -> keyset-paginate, idempotent upsert) actually
+# EXECUTE against a real database instead of self-skipping. Without a reachable
+# DATABASE_URL the integration suite skips (tests/integration/*.integration.test.ts),
+# which is what happened before this workflow existed. The no-DB acceptance suite
+# (tests/acceptance) runs alongside.
 #
 # billing-service is a standalone package (NOT part of the root npm workspace /
 # lerna set), so deps are installed inside the service dir, mirroring its
@@ -63,7 +64,7 @@ jobs:
         # needed — jest maps @fuzefront/shared to the TS source via moduleNameMapper.
         run: npm install --ignore-scripts
 
-      - name: Run DB integration + acceptance + db suites (real Postgres)
+      - name: Run invoice DB integration + acceptance suites (real Postgres)
         working-directory: services/billing-service
         env:
           # Presence of DATABASE_URL is what flips the gated suites from

--- a/.github/workflows/billing-service-tests.yml
+++ b/.github/workflows/billing-service-tests.yml
@@ -1,0 +1,75 @@
+name: Billing Service Tests
+
+# Runs the billing-service test suites in CI. Crucially this provisions a real
+# Postgres so the DB-backed INTEGRATION tests (migration 003 + PgInvoiceRepository:
+# store -> read -> keyset-paginate, idempotent upsert) actually EXECUTE against a
+# real database instead of self-skipping. Without a reachable DATABASE_URL the
+# integration + db suites skip (see tests/integration/*.integration.test.ts and
+# tests/db.test.ts), which is what happened before this workflow existed.
+#
+# billing-service is a standalone package (NOT part of the root npm workspace /
+# lerna set), so deps are installed inside the service dir, mirroring its
+# Dockerfile.
+
+on:
+  push:
+    branches: [main, master, develop]
+    paths:
+      - 'services/billing-service/**'
+      - '.github/workflows/billing-service-tests.yml'
+  pull_request:
+    branches: [main, master, develop]
+  workflow_dispatch:
+
+jobs:
+  db-integration:
+    name: Billing service DB integration + acceptance
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    # Stateless Postgres service container. Same image/creds convention as
+    # backend-tests.yml. The DB name matches docker-compose.test.yml so the
+    # integration test's DATABASE_URL points at a pre-created database (the
+    # least-privilege migrations never CREATE DATABASE; the test creates the
+    # billing SCHEMA up-front as the superuser, then runs the real migrations).
+    services:
+      postgres:
+        image: postgres:15-alpine
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_USER: postgres
+          POSTGRES_DB: fuzefront_platform_test
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Use Node.js 22.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.x'
+
+      - name: Install billing-service dependencies
+        working-directory: services/billing-service
+        # Matches the service Dockerfile (`npm install --ignore-scripts`): this
+        # package is standalone (not a workspace member), and no shared build is
+        # needed — jest maps @fuzefront/shared to the TS source via moduleNameMapper.
+        run: npm install --ignore-scripts
+
+      - name: Run DB integration + acceptance + db suites (real Postgres)
+        working-directory: services/billing-service
+        env:
+          # Presence of DATABASE_URL is what flips the gated suites from
+          # describe.skip -> describe (they run for real against the service DB).
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432/fuzefront_platform_test
+          NODE_ENV: test
+        run: |
+          echo "Running DB-backed integration + acceptance suites against real Postgres..."
+          npx jest tests/integration tests/acceptance --runInBand --verbose

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -362,7 +362,11 @@ jobs:
       - name: Lint specs (Spectral) + smoke the Prism mock
         if: steps.discover.outputs.found == 'true'
         run: |
-          npm install -g @stoplight/spectral-cli @stoplight/prism-cli
+          # Pin the CLIs: unpinned installs pull a spectral-cli whose transitive
+          # @asyncapi/specs ships an ESM index that crashes on CJS require
+          # ("module is not defined in ES module scope") before any lint runs.
+          # 6.11.1 predates that break and lints OpenAPI 3.1 fine.
+          npm install -g @stoplight/spectral-cli@6.11.1 @stoplight/prism-cli@5.8.1
           echo "${{ steps.discover.outputs.specs }}" | while read -r spec; do
             [ -z "$spec" ] && continue
             echo "=== $spec ==="

--- a/backend/src/routes/billing.ts
+++ b/backend/src/routes/billing.ts
@@ -410,8 +410,13 @@ async function forward(
   } catch (err) {
     const ax = err as AxiosError
     // Connection refused / DNS / timeout — the service is unreachable.
+    // Pass the request-derived parts as console arguments (not interpolated into
+    // the format string) so externally-controlled values can't shape the log
+    // record — clears CodeQL js/tainted-format-string + js/log-injection.
     console.error(
-      `[billing-proxy] upstream error for ${req.method} ${options.path}:`,
+      '[billing-proxy] upstream error for %s %s:',
+      req.method,
+      options.path,
       ax.code || ax.message
     )
     res

--- a/backend/src/routes/billing.ts
+++ b/backend/src/routes/billing.ts
@@ -283,7 +283,7 @@ async function forward(
      * X-Billing-* headers so the service can re-verify. When
      * `injectEntityToBody` is true it ALSO overrides the body's
      * entityType/entityId (for routes whose upstream schema carries the entity
-     * selector — create / setup-intent). The :stripeSubscriptionId routes use
+     * selector — create / setup-intent). The :subscriptionId routes use
      * an upstream schema with `additionalProperties: false` and NO entity
      * selector, so for those the entity travels via headers only.
      */
@@ -334,7 +334,7 @@ async function forward(
     delete sanitized.entityId
     delete sanitized.organizationId
     // Re-add the SERVER-DERIVED entity only for routes whose upstream schema
-    // accepts it (create / setup-intent). For :stripeSubscriptionId routes the
+    // accepts it (create / setup-intent). For :subscriptionId routes the
     // upstream schema forbids extra props, so the entity goes via headers only.
     if (options.authorizedEntity && options.injectEntityToBody) {
       sanitized.entityType = options.authorizedEntity.entityType
@@ -433,7 +433,7 @@ router.get('/plans', (req, res) =>
 // level authorization against the target entity before forwarding.
 //
 // Mutations require 'manage' on the target org; reads require 'read'. For the
-// :stripeSubscriptionId routes the caller must declare the owning entity
+// :subscriptionId routes the caller must declare the owning entity
 // (entityType + entityId / organizationId) so the proxy can authorize them on
 // it; the proxy forwards the trusted (authorized) entity downstream as
 // X-Billing-* headers and the billing-service re-verifies the subscription
@@ -465,7 +465,7 @@ router.post(
 // { subscription: <view> | null }. Absence is 200 {subscription:null}, never a
 // 404 — the UI treats null as "no current subscription".
 //
-// MUST be registered BEFORE GET /subscriptions/:stripeSubscriptionId so the
+// MUST be registered BEFORE GET /subscriptions/:subscriptionId so the
 // param route does not shadow this collection route.
 router.get(
   '/subscriptions',
@@ -483,13 +483,13 @@ router.get(
 )
 
 router.get(
-  '/subscriptions/:stripeSubscriptionId',
+  '/subscriptions/:subscriptionId',
   authenticateToken,
   async (req: BillingRequest, res) => {
     const entity = await authorizeBillingEntity(req, res, 'read')
     if (!entity) return
     return forward(req, res, {
-      path: `/subscriptions/${encodeURIComponent(req.params.stripeSubscriptionId)}`,
+      path: `/subscriptions/${encodeURIComponent(req.params.subscriptionId)}`,
       internalAuth: true,
       authorizedEntity: entity,
       actorUserId: req.user!.id,
@@ -498,13 +498,13 @@ router.get(
 )
 
 router.patch(
-  '/subscriptions/:stripeSubscriptionId',
+  '/subscriptions/:subscriptionId',
   authenticateToken,
   async (req: BillingRequest, res) => {
     const entity = await authorizeBillingEntity(req, res, 'manage')
     if (!entity) return
     return forward(req, res, {
-      path: `/subscriptions/${encodeURIComponent(req.params.stripeSubscriptionId)}`,
+      path: `/subscriptions/${encodeURIComponent(req.params.subscriptionId)}`,
       internalAuth: true,
       authorizedEntity: entity,
       actorUserId: req.user!.id,
@@ -513,13 +513,13 @@ router.patch(
 )
 
 router.delete(
-  '/subscriptions/:stripeSubscriptionId',
+  '/subscriptions/:subscriptionId',
   authenticateToken,
   async (req: BillingRequest, res) => {
     const entity = await authorizeBillingEntity(req, res, 'manage')
     if (!entity) return
     return forward(req, res, {
-      path: `/subscriptions/${encodeURIComponent(req.params.stripeSubscriptionId)}`,
+      path: `/subscriptions/${encodeURIComponent(req.params.subscriptionId)}`,
       internalAuth: true,
       authorizedEntity: entity,
       actorUserId: req.user!.id,

--- a/backend/src/routes/billing.ts
+++ b/backend/src/routes/billing.ts
@@ -410,13 +410,14 @@ async function forward(
   } catch (err) {
     const ax = err as AxiosError
     // Connection refused / DNS / timeout — the service is unreachable.
-    // Pass the request-derived parts as console arguments (not interpolated into
-    // the format string) so externally-controlled values can't shape the log
-    // record — clears CodeQL js/tainted-format-string + js/log-injection.
+    // Sanitize the request-derived parts (strip CR/LF + other control chars)
+    // before logging so externally-controlled values cannot forge log records
+    // — clears CodeQL js/log-injection + js/tainted-format-string.
+    const stripControl = (v: string) => String(v).replace(/[\u0000-\u001f\u007f]/g, '')
     console.error(
       '[billing-proxy] upstream error for %s %s:',
-      req.method,
-      options.path,
+      stripControl(req.method),
+      stripControl(options.path),
       ax.code || ax.message
     )
     res

--- a/backend/src/routes/billing.ts
+++ b/backend/src/routes/billing.ts
@@ -410,15 +410,16 @@ async function forward(
   } catch (err) {
     const ax = err as AxiosError
     // Connection refused / DNS / timeout — the service is unreachable.
-    // Sanitize the request-derived parts (strip CR/LF + other control chars)
-    // before logging so externally-controlled values cannot forge log records
-    // — clears CodeQL js/log-injection + js/tainted-format-string.
-    const stripControl = (v: string) => String(v).replace(/[\u0000-\u001f\u007f]/g, '')
+    // Collapse CR/LF from every dynamic value before logging so externally
+    // controlled input can't inject/forge log records. eslint no-control-regex
+    // safe, and the newline replace is the barrier CodeQL js/log-injection
+    // recognizes; the constant format string covers js/tainted-format-string.
+    const oneLine = (v: unknown) => String(v).replace(/[\r\n]+/g, ' ')
     console.error(
-      '[billing-proxy] upstream error for %s %s:',
-      stripControl(req.method),
-      stripControl(options.path),
-      ax.code || ax.message
+      '[billing-proxy] upstream error for %s %s: %s',
+      oneLine(req.method),
+      oneLine(options.path),
+      oneLine(ax.code || ax.message)
     )
     res
       .status(502)

--- a/backend/tests/billing-proxy.test.ts
+++ b/backend/tests/billing-proxy.test.ts
@@ -118,7 +118,7 @@ describe('billing proxy', () => {
   })
 
   it('GET subscription forwards the path param', async () => {
-    okUpstream({ subscription: { stripeSubscriptionId: 'sub_123' } })
+    okUpstream({ subscription: { subscriptionId: 'sub_123' } })
 
     const res = await request(app)
       .get('/api/v1/billing/subscriptions/sub_123')
@@ -133,7 +133,7 @@ describe('billing proxy', () => {
   })
 
   it('PATCH subscription forwards body + path', async () => {
-    okUpstream({ subscription: { stripeSubscriptionId: 'sub_123' } })
+    okUpstream({ subscription: { subscriptionId: 'sub_123' } })
 
     const res = await request(app)
       .patch('/api/v1/billing/subscriptions/sub_123')
@@ -338,7 +338,7 @@ describe('billing proxy', () => {
 
       it('PATCH /subscriptions/:id forwards (manage) without polluting the body schema', async () => {
         mockCheckOrgPermission.mockResolvedValue(true)
-        okUpstream({ subscription: { stripeSubscriptionId: 'sub_123' } })
+        okUpstream({ subscription: { subscriptionId: 'sub_123' } })
 
         const res = await request(app)
           .patch('/api/v1/billing/subscriptions/sub_123')
@@ -358,7 +358,7 @@ describe('billing proxy', () => {
 
       it('GET /subscriptions/:id requires only read permission', async () => {
         mockCheckOrgPermission.mockResolvedValue(true)
-        okUpstream({ subscription: { stripeSubscriptionId: 'sub_123' } })
+        okUpstream({ subscription: { subscriptionId: 'sub_123' } })
 
         const res = await request(app)
           .get('/api/v1/billing/subscriptions/sub_123')
@@ -428,7 +428,7 @@ describe('billing proxy', () => {
 
     describe('query param allow-list (no verbatim pass-through)', () => {
       it('drops unknown query params and forwards only the allow-list', async () => {
-        okUpstream({ subscription: { stripeSubscriptionId: 'sub_123' } })
+        okUpstream({ subscription: { subscriptionId: 'sub_123' } })
 
         await request(app)
           .get('/api/v1/billing/subscriptions/sub_123')

--- a/billing-client/src/client.ts
+++ b/billing-client/src/client.ts
@@ -7,6 +7,7 @@ import {
   CreateSubscriptionRequest,
   CreateSubscriptionResponse,
   EntityType,
+  InvoiceListResponse,
   PaymentCheckoutRequest,
   PaymentCheckoutResponse,
   Plan,
@@ -96,6 +97,31 @@ export class BillingClient {
       { headers: actorHeaders(actor) },
     );
     return res.data.payment;
+  }
+
+  /**
+   * List the authorized entity's invoices (GET /invoices), newest first, served
+   * from the local invoice store. Pagination is opaque-cursor based: pass the
+   * previous response's `nextCursor` as `cursor`. Actor/entity context is added
+   * by the host-backend billing proxy.
+   */
+  async listInvoices(opts: { limit?: number; cursor?: string } = {}): Promise<InvoiceListResponse> {
+    const res = await this.http.get<InvoiceListResponse>('/invoices', {
+      params: {
+        ...(opts.limit != null ? { limit: opts.limit } : {}),
+        ...(opts.cursor ? { cursor: opts.cursor } : {}),
+      },
+    });
+    return res.data;
+  }
+
+  /**
+   * Force a provider→store resync of the authorized entity's invoices
+   * (POST /invoices/sync) and return how many were upserted. Idempotent.
+   */
+  async syncInvoices(): Promise<{ synced: number }> {
+    const res = await this.http.post<{ synced: number }>('/invoices/sync', {});
+    return res.data;
   }
 
   async addCredits(

--- a/billing-client/src/client.ts
+++ b/billing-client/src/client.ts
@@ -19,7 +19,7 @@ const API_BASE = '/api/v1/billing';
 /**
  * Typed client over the billing-service REST API. Consumed by `backend` (and
  * other internal services) to read entitlements and drive checkout. Card data
- * never flows through here — only Stripe ids and client secrets.
+ * never flows through here — only provider ids and client secrets.
  */
 export class BillingClient {
   private readonly http: AxiosInstance;
@@ -37,9 +37,9 @@ export class BillingClient {
     return res.data.plans;
   }
 
-  async getSubscription(stripeSubscriptionId: string): Promise<BillingSubscription> {
+  async getSubscription(subscriptionId: string): Promise<BillingSubscription> {
     const res = await this.http.get<{ subscription: BillingSubscription }>(
-      `/subscriptions/${encodeURIComponent(stripeSubscriptionId)}`,
+      `/subscriptions/${encodeURIComponent(subscriptionId)}`,
     );
     return res.data.subscription;
   }
@@ -50,19 +50,19 @@ export class BillingClient {
   }
 
   async updateSubscription(
-    stripeSubscriptionId: string,
+    subscriptionId: string,
     req: UpdateSubscriptionRequest,
   ): Promise<BillingSubscription> {
     const res = await this.http.patch<{ subscription: BillingSubscription }>(
-      `/subscriptions/${encodeURIComponent(stripeSubscriptionId)}`,
+      `/subscriptions/${encodeURIComponent(subscriptionId)}`,
       req,
     );
     return res.data.subscription;
   }
 
-  async cancelSubscription(stripeSubscriptionId: string): Promise<BillingSubscription> {
+  async cancelSubscription(subscriptionId: string): Promise<BillingSubscription> {
     const res = await this.http.delete<{ subscription: BillingSubscription }>(
-      `/subscriptions/${encodeURIComponent(stripeSubscriptionId)}`,
+      `/subscriptions/${encodeURIComponent(subscriptionId)}`,
     );
     return res.data.subscription;
   }

--- a/billing-client/src/contract.ts
+++ b/billing-client/src/contract.ts
@@ -12,8 +12,10 @@
  */
 import type { components } from './schema';
 import type {
+  BillingInvoice,
   BillingPayment,
   BillingSubscription,
+  InvoiceListResponse,
   Plan,
   CreateSubscriptionRequest,
   CreateSubscriptionResponse,
@@ -45,6 +47,8 @@ type _PaymentRes = Exact<PaymentCheckoutResponse, Schemas['PaymentCheckoutRespon
 type _PaymentLine = Exact<PaymentLineItem, Schemas['PaymentLineItem']>;
 type _PaymentStatus = Exact<PaymentStatus, Schemas['PaymentStatus']>;
 type _Payment = Exact<BillingPayment, Schemas['BillingPayment']>;
+type _Invoice = Exact<BillingInvoice, Schemas['BillingInvoice']>;
+type _InvoiceList = Exact<InvoiceListResponse, Schemas['InvoiceListResponse']>;
 
 // Reference the aliases so `noUnusedLocals`-style lints don't strip them.
 export type ContractAlignment = {
@@ -59,4 +63,6 @@ export type ContractAlignment = {
   paymentLineItem: _PaymentLine;
   paymentStatus: _PaymentStatus;
   payment: _Payment;
+  invoice: _Invoice;
+  invoiceList: _InvoiceList;
 };

--- a/billing-client/src/index.ts
+++ b/billing-client/src/index.ts
@@ -5,8 +5,10 @@ export type { ContractAlignment } from './contract';
 export type {
   BillingActorContext,
   BillingClientConfig,
+  BillingInvoice,
   BillingPayment,
   BillingSubscription,
+  InvoiceListResponse,
   Plan,
   PlanTier,
   PaymentCheckoutRequest,

--- a/billing-client/src/schema.ts
+++ b/billing-client/src/schema.ts
@@ -197,15 +197,37 @@ export interface paths {
         };
         /**
          * List the authorized entity's invoices
-         * @description Returns the Stripe invoice history for the proxy-authorized entity (user or organization), most-recent first, as a stable contract subset of the Stripe Invoice. Read-only. Mirrors `GET /invoices`.
+         * @description Returns the invoice history for the proxy-authorized entity (user or organization), most-recent first. Served from the local invoice store, synced from the payment provider. Read-only.
          *
          *     Authorization: behind the internal-token guard; the entity is the SERVER-DERIVED actor context the proxy injects (`X-Billing-Actor-User-Id`, `X-Billing-Entity-Type`, `X-Billing-Entity-Id`; short aliases `X-FF-Actor-Id` / `X-FF-Org-Id`). Identity is never taken from the query string. An entity that has never had billing returns `{ invoices: [], nextCursor: null }` (200, not an error).
          *
-         *     Pagination is opaque-cursor based: pass the previous response's `nextCursor` (a Stripe invoice id) as `cursor` to fetch the next page. `nextCursor` is null on the last page.
+         *     Pagination is opaque-cursor based: pass the previous response's `nextCursor` as `cursor` to fetch the next page. `nextCursor` is null on the last page.
          */
         get: operations["listInvoices"];
         put?: never;
         post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/invoices/sync": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Force a provider→store resync of the authorized entity's invoices
+         * @description Forces a resync of the proxy-authorized entity's invoices from the payment provider into the local invoice store, then returns the number of invoices upserted. Idempotent — safe to call repeatedly.
+         *
+         *     Authorization is identical to `GET /invoices`: behind the internal-token guard, with the entity taken from the SERVER-DERIVED actor context the proxy injects (`X-Billing-Actor-User-Id`, `X-Billing-Entity-Type`, `X-Billing-Entity-Id`). An entity that has never had billing returns `{ synced: 0 }` (200, not an error).
+         */
+        post: operations["syncInvoices"];
         delete?: never;
         options?: never;
         head?: never;
@@ -500,13 +522,16 @@ export interface components {
             updatedAt: string;
         };
         BillingInvoice: {
-            /** @description Stripe invoice id (`in_...`). */
+            /**
+             * Format: uuid
+             * @description FuzeFront invoice id (opaque, stable). A FuzeFront UUID, not a provider id.
+             */
             id: string;
             /** @description Human-facing invoice number; null for drafts without one. */
             number: string | null;
             /**
              * Format: date-time
-             * @description ISO-8601 timestamp derived from the Stripe `created` unix seconds.
+             * @description ISO-8601 issue timestamp.
              */
             created: string;
             /** @description Amount due in the currency's minor unit (cents). */
@@ -519,22 +544,22 @@ export interface components {
              */
             currency: string;
             /**
-             * @description Stripe invoice status.
-             * @example paid
-             * @example open
-             * @example void
+             * @description Neutral invoice status: draft|open|paid|void|uncollectible.
              * @example draft
+             * @example open
+             * @example paid
+             * @example void
              * @example uncollectible
              */
             status: string;
-            /** @description Stripe-hosted invoice page url (null when unavailable). */
+            /** @description Provider-hosted document URL, opaque to consumers; null when unavailable. */
             hostedInvoiceUrl: string | null;
-            /** @description Url to the invoice PDF (null when unavailable). */
+            /** @description Provider-hosted document URL, opaque to consumers; null when unavailable. */
             invoicePdf: string | null;
         };
         InvoiceListResponse: {
             invoices: components["schemas"]["BillingInvoice"][];
-            /** @description Opaque cursor (Stripe invoice id) for the next page; null when there are no further pages. */
+            /** @description Opaque cursor for the next page; null on the last page. */
             nextCursor: string | null;
         };
         PortalSessionRequest: {
@@ -957,7 +982,7 @@ export interface operations {
             query?: {
                 /** @description Page size, clamped server-side to 1..100. Defaults to 20. */
                 limit?: number;
-                /** @description Opaque pagination cursor (a Stripe invoice id) passed to Stripe's `starting_after`. Use the previous response's `nextCursor`. */
+                /** @description Opaque cursor (previous `nextCursor`). Use the previous response's `nextCursor` to fetch the next page. */
                 cursor?: string;
             };
             header: {
@@ -983,6 +1008,38 @@ export interface operations {
                 };
             };
             400: components["responses"]["ValidationError"];
+            401: components["responses"]["Unauthorized"];
+            502: components["responses"]["StripeError"];
+        };
+    };
+    syncInvoices: {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Authenticated actor (the platform user id) — set by the host proxy AFTER it authenticates + authorizes the caller. Short alias: `X-FF-Actor-Id`. */
+                "X-Billing-Actor-User-Id": components["parameters"]["ActorUserIdHeader"];
+                /** @description Server-derived authorized entity type (`user`|`organization`) set by the proxy. When the `X-FF-Org-Id` alias is used this is implied to be `organization`. */
+                "X-Billing-Entity-Type": components["parameters"]["EntityTypeHeader"];
+                /** @description Server-derived authorized entity id set by the proxy. The service re-verifies the request target matches this. Short alias: `X-FF-Org-Id`. */
+                "X-Billing-Entity-Id": components["parameters"]["EntityIdHeader"];
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The resync completed; reports how many invoices were upserted. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @description Number of invoices upserted into the local store. */
+                        synced: number;
+                    };
+                };
+            };
             401: components["responses"]["Unauthorized"];
             502: components["responses"]["StripeError"];
         };

--- a/billing-client/src/schema.ts
+++ b/billing-client/src/schema.ts
@@ -35,7 +35,7 @@ export interface paths {
         put?: never;
         /**
          * Create or upgrade a subscription
-         * @description Creates a Stripe subscription for the entity (creating the Stripe customer if needed) and mirrors it locally. Returns a `clientSecret` when Stripe needs SCA/3DS confirmation on the client. Mirrors `POST /subscriptions`.
+         * @description Creates a provider subscription for the entity (creating the provider customer if needed) and mirrors it locally. Returns a `clientSecret` when the provider needs SCA/3DS confirmation on the client. Mirrors `POST /subscriptions`.
          */
         post: operations["createSubscription"];
         delete?: never;
@@ -44,26 +44,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/subscriptions/{stripeSubscriptionId}": {
+    "/subscriptions/{subscriptionId}": {
         parameters: {
             query?: never;
             header?: never;
             path: {
-                /** @description The Stripe subscription id (e.g. `sub_...`). */
-                stripeSubscriptionId: components["parameters"]["StripeSubscriptionId"];
+                /** @description The provider subscription id (e.g. `sub_...`). */
+                subscriptionId: components["parameters"]["SubscriptionId"];
             };
             cookie?: never;
         };
         /**
          * Get the local mirror of a subscription
-         * @description Returns the locally-mirrored subscription by Stripe subscription id, or 404 if no mirror exists. Mirrors `GET /subscriptions/:id`.
+         * @description Returns the locally-mirrored subscription by provider subscription id, or 404 if no mirror exists. Mirrors `GET /subscriptions/:id`.
          */
         get: operations["getSubscription"];
         put?: never;
         post?: never;
         /**
          * Cancel at period end (soft cancel)
-         * @description Sets `cancel_at_period_end=true`; Stripe keeps the subscription active until the period boundary. Mirrors `DELETE /subscriptions/:id`.
+         * @description Sets `cancel_at_period_end=true`; the provider keeps the subscription active until the period boundary. Mirrors `DELETE /subscriptions/:id`.
          */
         delete: operations["cancelSubscription"];
         options?: never;
@@ -86,7 +86,7 @@ export interface paths {
         put?: never;
         /**
          * Create a SetupIntent to collect a payment method
-         * @description Creates a Stripe SetupIntent (usage `off_session`) so the client can collect a payment method without an immediate charge (e.g. add a card during a no-card trial). Returns the `clientSecret` for the Stripe Payment Element. Mirrors `POST /setup-intent`.
+         * @description Creates a provider SetupIntent (usage `off_session`) so the client can collect a payment method without an immediate charge (e.g. add a card during a no-card trial). Returns the `clientSecret` for the provider Payment Element. Mirrors `POST /setup-intent`.
          */
         post: operations["createSetupIntent"];
         delete?: never;
@@ -105,10 +105,10 @@ export interface paths {
         get?: never;
         put?: never;
         /**
-         * Create a hosted Stripe Checkout Session (subscription mode)
-         * @description Creates a hosted Stripe Checkout Session in `subscription` mode for the given organization and plan, and returns the Stripe-hosted `url` to redirect the customer to. Stripe collects the card on its hosted page; on completion Stripe fires `checkout.session.completed`, which activates the local subscription mirror. We use HOSTED Checkout (not in-app Elements) so no raw card data touches our surface. Mirrors `POST /checkout`.
+         * Create a hosted Checkout Session (subscription mode)
+         * @description Creates a hosted Checkout Session in `subscription` mode for the given organization and plan, and returns the provider-hosted `url` to redirect the customer to. the provider collects the card on its hosted page; on completion the provider fires `checkout.session.completed`, which activates the local subscription mirror. We use HOSTED Checkout (not in-app Elements) so no raw card data touches our surface. Mirrors `POST /checkout`.
          *
-         *     Authorization (money path): the host proxy authenticates the platform JWT, authorizes the caller against the target organization, and forwards the SERVER-DERIVED actor + entity as trusted headers (`X-Billing-Actor-User-Id`, `X-Billing-Entity-Type`, `X-Billing-Entity-Id`; short aliases `X-FF-Actor-Id` / `X-FF-Org-Id`). The service RE-VERIFIES that `organizationId` matches the authorized entity before creating any Stripe object (rejects with 403 otherwise), and validates `planId` against the active plan catalogue (rejects unknown/inactive plans with 400). `planId: "basic"` resolves to the live $9/mo price.
+         *     Authorization (money path): the host proxy authenticates the platform JWT, authorizes the caller against the target organization, and forwards the SERVER-DERIVED actor + entity as trusted headers (`X-Billing-Actor-User-Id`, `X-Billing-Entity-Type`, `X-Billing-Entity-Id`; short aliases `X-FF-Actor-Id` / `X-FF-Org-Id`). The service RE-VERIFIES that `organizationId` matches the authorized entity before creating any provider object (rejects with 403 otherwise), and validates `planId` against the active plan catalogue (rejects unknown/inactive plans with 400). `planId: "basic"` resolves to the live $9/mo price.
          */
         post: operations["createCheckoutSession"];
         delete?: never;
@@ -127,12 +127,12 @@ export interface paths {
         get?: never;
         put?: never;
         /**
-         * Create a hosted Stripe Checkout Session (one-time payment mode)
-         * @description Creates a hosted Stripe Checkout Session in `payment` mode for an allowlisted consumer product (e.g. `mendys-datasets`) and returns the Stripe-hosted `url` to redirect the buyer to. The caller supplies the priced line items (name + unit amount in cents + quantity); the service builds Stripe `price_data` from them — no Stripe price catalogue entry is required. On completion Stripe fires `checkout.session.completed` (mode `payment`), which upserts the local `billing.payments` mirror and emits `billing.payment.completed` on Kafka. Failure/expiry are mirrored via `payment_intent.payment_failed` / `checkout.session.expired`. Mirrors `POST /payments/checkout`.
+         * Create a hosted Checkout Session (one-time payment mode)
+         * @description Creates a hosted Checkout Session in `payment` mode for an allowlisted consumer product (e.g. `mendys-datasets`) and returns the provider-hosted `url` to redirect the buyer to. The caller supplies the priced line items (name + unit amount in cents + quantity); the service builds provider `price_data` from them — no provider price catalogue entry is required. On completion the provider fires `checkout.session.completed` (mode `payment`), which upserts the local `billing.payments` mirror and emits `billing.payment.completed` on Kafka. Failure/expiry are mirrored via `payment_intent.payment_failed` / `checkout.session.expired`. Mirrors `POST /payments/checkout`.
          *
-         *     Authorization (money path): identical to `/checkout` — the host proxy authenticates the platform JWT, authorizes the caller against the target entity, and forwards the SERVER-DERIVED actor + entity as trusted headers (`X-Billing-Actor-User-Id`, `X-Billing-Entity-Type`, `X-Billing-Entity-Id`; aliases `X-FF-Actor-Id` / `X-FF-Org-Id`). The service RE-VERIFIES that the body's `entityType`/`entityId` match the authorized entity before creating any Stripe object (mismatch → 403). `productKey` must be in the server-side allowlist (`BILLING_PRODUCT_KEYS`), `currency` in the configured allowlist (default `usd`, `eur`), and each line amount plus the order total are bounded server-side (`BILLING_PAYMENT_MAX_TOTAL_CENTS`, default 5,000,000 cents) — violations → 400.
+         *     Authorization (money path): identical to `/checkout` — the host proxy authenticates the platform JWT, authorizes the caller against the target entity, and forwards the SERVER-DERIVED actor + entity as trusted headers (`X-Billing-Actor-User-Id`, `X-Billing-Entity-Type`, `X-Billing-Entity-Id`; aliases `X-FF-Actor-Id` / `X-FF-Org-Id`). The service RE-VERIFIES that the body's `entityType`/`entityId` match the authorized entity before creating any provider object (mismatch → 403). `productKey` must be in the server-side allowlist (`BILLING_PRODUCT_KEYS`), `currency` in the configured allowlist (default `usd`, `eur`), and each line amount plus the order total are bounded server-side (`BILLING_PAYMENT_MAX_TOTAL_CENTS`, default 5,000,000 cents) — violations → 400.
          *
-         *     Idempotency: retries with IDENTICAL parameters dedupe to one Stripe session (param-fingerprint idempotency key, same scheme as `/checkout`); any changed parameter yields a fresh session.
+         *     Idempotency: retries with IDENTICAL parameters dedupe to one provider session (param-fingerprint idempotency key, same scheme as `/checkout`); any changed parameter yields a fresh session.
          */
         post: operations["createPaymentCheckoutSession"];
         delete?: never;
@@ -146,14 +146,14 @@ export interface paths {
             query?: never;
             header?: never;
             path: {
-                /** @description The Stripe Checkout Session id (`cs_...`). */
+                /** @description The hosted Checkout Session id (`cs_...`). */
                 sessionId: string;
             };
             cookie?: never;
         };
         /**
          * Get the local payment mirror for a Checkout Session
-         * @description Returns the `billing.payments` mirror row for a payment-mode Checkout Session — the reconciliation-polling surface for consumer services that missed (or cannot receive) the `billing.payment.completed` event. `status` is `pending` until a webhook lands, then `paid` / `failed` / `expired`. 404 when the session is unknown. When the local row is missing but the session exists in Stripe AND its `productKey` metadata is allowlisted, the service falls back to live Stripe, re-mirrors the row, and returns it (singleton resource — pagination exempt).
+         * @description Returns the `billing.payments` mirror row for a payment-mode Checkout Session — the reconciliation-polling surface for consumer services that missed (or cannot receive) the `billing.payment.completed` event. `status` is `pending` until a webhook lands, then `paid` / `failed` / `expired`. 404 when the session is unknown. When the local row is missing but the session exists at the provider AND its `productKey` metadata is allowlisted, the service falls back to the live provider, re-mirrors the row, and returns it (singleton resource — pagination exempt).
          *
          *     Authorization: same model as `/payments/checkout`; the proxy-authorized entity must OWN the session (mismatch → 403).
          */
@@ -177,7 +177,7 @@ export interface paths {
         put?: never;
         /**
          * Add a one-time customer balance adjustment (admin only)
-         * @description Adds a one-time customer balance adjustment (credit) via a Stripe customer balance transaction. A positive `amount` (in cents, bounded) credits the customer (reduces what they owe). Mirrors `POST /credits`.
+         * @description Adds a one-time customer balance adjustment (credit) via a provider customer balance transaction. A positive `amount` (in cents, bounded) credits the customer (reduces what they owe). Mirrors `POST /credits`.
          *
          *     ADMIN-ONLY: in addition to the internal token, the host proxy must supply `X-Billing-Actor-Is-Admin: true` (it sets this only for callers it has authorized as platform admins). Without it the service responds 403. `amount` must be a positive integer and is capped server-side.
          */
@@ -244,8 +244,8 @@ export interface paths {
         get?: never;
         put?: never;
         /**
-         * Create a Stripe Customer Portal session
-         * @description Creates a Stripe Customer Portal session for the proxy-authorized entity and returns the Stripe-hosted `url` to redirect the customer to, where they can manage their subscription and payment methods. Mirrors `POST /portal`.
+         * Create a Customer Portal session
+         * @description Creates a Customer Portal session for the proxy-authorized entity and returns the provider-hosted `url` to redirect the customer to, where they can manage their subscription and payment methods. Mirrors `POST /portal`.
          *
          *     Authorization: behind the internal-token guard; the entity is the SERVER-DERIVED actor context the proxy injects (the entity is NEVER taken from the request body). An entity that has never had a billing customer cannot open a portal -> 409.
          */
@@ -256,7 +256,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/webhooks/stripe": {
+    "/webhooks/{provider}": {
         parameters: {
             query?: never;
             header?: never;
@@ -266,10 +266,10 @@ export interface paths {
         get?: never;
         put?: never;
         /**
-         * Stripe webhook receiver
-         * @description Receives Stripe events. The body MUST be the raw signed bytes (`application/json` consumed via `express.raw`) so signature verification works. Public (no internal token) — authenticity is established by the `Stripe-Signature` header. Idempotent: duplicate deliveries of the same event id return 200 without re-processing. Mirrors `POST /webhooks/stripe`.
+         * Provider webhook receiver
+         * @description Provider webhook receiver; authenticity verified by the provider signature. Receives events from the configured payment provider (selected by the `provider` path slug). The body MUST be the raw signed bytes (`application/json` consumed via `express.raw`) so signature verification works. Public (no internal token) — authenticity is established by the provider signature header. Idempotent: duplicate deliveries of the same event id return 200 without re-processing.
          */
-        post: operations["receiveStripeWebhook"];
+        post: operations["receiveProviderWebhook"];
         delete?: never;
         options?: never;
         head?: never;
@@ -285,7 +285,7 @@ export interface paths {
         };
         /**
          * Liveness / readiness probe
-         * @description Always available, even in degraded mode (no DB / no Stripe key). NOTE: mounted at the service root (`/health`), NOT under `/api/v1/billing` -- call it on the bare server origin.
+         * @description Always available, even in degraded mode (no DB / no provider key). NOTE: mounted at the service root (`/health`), NOT under `/api/v1/billing` -- call it on the bare server origin.
          */
         get: operations["getHealth"];
         put?: never;
@@ -306,7 +306,7 @@ export interface components {
          */
         EntityType: "user" | "organization";
         /**
-         * @description Plan tier name resolved from the Stripe price (free / starter / pro / enterprise, or any custom tier). Open string by design.
+         * @description Plan tier name resolved from the provider price (free / starter / pro / enterprise, or any custom tier). Open string by design.
          * @example free
          * @example starter
          * @example pro
@@ -314,7 +314,7 @@ export interface components {
          */
         PlanTier: string;
         /**
-         * @description Mirrors Stripe subscription status values. Open string by design.
+         * @description Mirrors provider subscription status values. Open string by design.
          * @example trialing
          * @example active
          * @example past_due
@@ -343,8 +343,8 @@ export interface components {
              * @description Local billing.customers primary key.
              */
             customerId: string;
-            stripeSubscriptionId: string;
-            stripePriceId: string;
+            subscriptionId: string;
+            priceId: string;
             planTier: components["schemas"]["PlanTier"];
             status: components["schemas"]["SubscriptionStatus"];
             seatQuantity: number;
@@ -361,12 +361,12 @@ export interface components {
             canceledAt: string | null;
         };
         Plan: {
-            stripePriceId: string;
-            stripeProductId: string;
+            priceId: string;
+            productId: string;
             tierName: components["schemas"]["PlanTier"];
             displayName: string;
             /**
-             * @description Billing cadence (`month` / `year`, or any Stripe interval).
+             * @description Billing cadence (`month` / `year`, or any provider interval).
              * @example month
              * @example year
              */
@@ -389,17 +389,17 @@ export interface components {
             /** Format: uuid */
             entityId: string;
             priceId: string;
-            /** @description Start a no-card trial (Stripe trial_period_days). */
+            /** @description Start a no-card trial (provider trial_period_days). */
             trial?: boolean;
             trialPeriodDays?: number;
             /** @description Seat quantity for per-seat plans. Defaults to 1. */
             seatQuantity?: number;
-            /** @description Existing Stripe PaymentMethod to attach (omit for no-card trials). */
+            /** @description Existing provider payment method to attach (omit for no-card trials). */
             paymentMethodId?: string;
         };
         CreateSubscriptionResponse: {
             subscription: components["schemas"]["BillingSubscription"];
-            /** @description Set when Stripe needs SCA/3DS confirmation on the client. */
+            /** @description Set when the provider needs SCA/3DS confirmation on the client. */
             clientSecret?: string;
             /** @description True when the client must confirm a PaymentIntent/SetupIntent. */
             requiresAction: boolean;
@@ -419,7 +419,7 @@ export interface components {
             note?: string;
         };
         CheckoutSessionRequest: {
-            /** @description Logical plan id (e.g. `basic`), a tier name, or a Stripe price id present in the active catalogue. Validated against active plans; `basic` resolves to the live $9/mo price. */
+            /** @description Logical plan id (e.g. `basic`), a tier name, or a provider price id present in the active catalogue. Validated against active plans; `basic` resolves to the live $9/mo price. */
             planId: string;
             /**
              * Format: uuid
@@ -428,19 +428,19 @@ export interface components {
             organizationId: string;
             /**
              * Format: uri
-             * @description Where Stripe redirects after a completed checkout.
+             * @description Where the provider redirects after a completed checkout.
              */
             successUrl: string;
             /**
              * Format: uri
-             * @description Where Stripe redirects if the customer cancels.
+             * @description Where the provider redirects if the customer cancels.
              */
             cancelUrl: string;
         };
         CheckoutSessionResponse: {
-            /** @description Stripe-hosted Checkout URL to redirect the customer to. */
+            /** @description provider-hosted Checkout URL to redirect the customer to. */
             url: string | null;
-            /** @description The Stripe Checkout Session id (`cs_...`). */
+            /** @description The hosted Checkout Session id (`cs_...`). */
             sessionId: string;
         };
         /**
@@ -449,7 +449,7 @@ export interface components {
          */
         PaymentStatus: "pending" | "paid" | "failed" | "expired";
         PaymentLineItem: {
-            /** @description Line-item display name shown on the Stripe-hosted page. */
+            /** @description Line-item display name shown on the provider-hosted page. */
             name: string;
             /** @description Optional line-item description shown under the name. */
             description?: string;
@@ -478,19 +478,19 @@ export interface components {
             lineItems: components["schemas"]["PaymentLineItem"][];
             /**
              * Format: uri
-             * @description Where Stripe redirects after a completed payment.
+             * @description Where the provider redirects after a completed payment.
              */
             successUrl: string;
             /**
              * Format: uri
-             * @description Where Stripe redirects if the buyer cancels.
+             * @description Where the provider redirects if the buyer cancels.
              */
             cancelUrl: string;
         };
         PaymentCheckoutResponse: {
-            /** @description The Stripe Checkout Session id (`cs_...`). */
+            /** @description The hosted Checkout Session id (`cs_...`). */
             sessionId: string;
-            /** @description Stripe-hosted Checkout URL to redirect the buyer to. */
+            /** @description provider-hosted Checkout URL to redirect the buyer to. */
             url: string | null;
         };
         BillingPayment: {
@@ -499,10 +499,10 @@ export interface components {
              * @description Local billing.payments primary key.
              */
             id: string;
-            /** @description Stripe Checkout Session id (`cs_...`). */
-            stripeSessionId: string;
-            /** @description Stripe PaymentIntent id (`pi_...`); null until Stripe creates the intent (typically when the buyer reaches the payment page). */
-            stripePaymentIntentId: string | null;
+            /** @description hosted Checkout Session id (`cs_...`). */
+            sessionId: string;
+            /** @description provider PaymentIntent id (`pi_...`); null until the provider creates the intent (typically when the buyer reaches the payment page). */
+            paymentIntentId: string | null;
             productKey: string;
             externalOrderId: string;
             entityType: components["schemas"]["EntityType"];
@@ -565,19 +565,19 @@ export interface components {
         PortalSessionRequest: {
             /**
              * Format: uri
-             * @description Where Stripe returns the customer after they leave the portal.
+             * @description Where the provider returns the customer after they leave the portal.
              */
             returnUrl: string;
         };
         PortalSessionResponse: {
-            /** @description Stripe-hosted Customer Portal url to redirect the customer to. */
+            /** @description provider-hosted Customer Portal url to redirect the customer to. */
             url: string;
         };
         Error: {
             error: string;
         };
-        StripeErrorBody: {
-            /** @example stripe error */
+        ProviderErrorBody: {
+            /** @example provider error */
             error: string;
             message?: string;
         };
@@ -625,13 +625,13 @@ export interface components {
                 "application/json": components["schemas"]["ValidationErrorBody"];
             };
         };
-        /** @description Upstream Stripe error (bad gateway). */
-        StripeError: {
+        /** @description Upstream provider error (bad gateway). */
+        ProviderError: {
             headers: {
                 [name: string]: unknown;
             };
             content: {
-                "application/json": components["schemas"]["StripeErrorBody"];
+                "application/json": components["schemas"]["ProviderErrorBody"];
             };
         };
         /** @description Unexpected server error. */
@@ -645,8 +645,8 @@ export interface components {
         };
     };
     parameters: {
-        /** @description The Stripe subscription id (e.g. `sub_...`). */
-        StripeSubscriptionId: string;
+        /** @description The provider subscription id (e.g. `sub_...`). */
+        SubscriptionId: string;
         /** @description Authenticated actor (the platform user id) — set by the host proxy AFTER it authenticates + authorizes the caller. Short alias: `X-FF-Actor-Id`. */
         ActorUserIdHeader: string;
         /** @description Server-derived authorized entity type (`user`|`organization`) set by the proxy. When the `X-FF-Org-Id` alias is used this is implied to be `organization`. */
@@ -707,7 +707,7 @@ export interface operations {
             };
             400: components["responses"]["ValidationError"];
             401: components["responses"]["Unauthorized"];
-            502: components["responses"]["StripeError"];
+            502: components["responses"]["ProviderError"];
         };
     };
     getSubscription: {
@@ -715,8 +715,8 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                /** @description The Stripe subscription id (e.g. `sub_...`). */
-                stripeSubscriptionId: components["parameters"]["StripeSubscriptionId"];
+                /** @description The provider subscription id (e.g. `sub_...`). */
+                subscriptionId: components["parameters"]["SubscriptionId"];
             };
             cookie?: never;
         };
@@ -742,8 +742,8 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                /** @description The Stripe subscription id (e.g. `sub_...`). */
-                stripeSubscriptionId: components["parameters"]["StripeSubscriptionId"];
+                /** @description The provider subscription id (e.g. `sub_...`). */
+                subscriptionId: components["parameters"]["SubscriptionId"];
             };
             cookie?: never;
         };
@@ -761,7 +761,7 @@ export interface operations {
                 };
             };
             401: components["responses"]["Unauthorized"];
-            502: components["responses"]["StripeError"];
+            502: components["responses"]["ProviderError"];
         };
     };
     updateSubscription: {
@@ -769,8 +769,8 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                /** @description The Stripe subscription id (e.g. `sub_...`). */
-                stripeSubscriptionId: components["parameters"]["StripeSubscriptionId"];
+                /** @description The provider subscription id (e.g. `sub_...`). */
+                subscriptionId: components["parameters"]["SubscriptionId"];
             };
             cookie?: never;
         };
@@ -793,7 +793,7 @@ export interface operations {
             };
             400: components["responses"]["ValidationError"];
             401: components["responses"]["Unauthorized"];
-            502: components["responses"]["StripeError"];
+            502: components["responses"]["ProviderError"];
         };
     };
     createSetupIntent: {
@@ -816,14 +816,14 @@ export interface operations {
                 };
                 content: {
                     "application/json": {
-                        /** @description Stripe SetupIntent client secret for the Payment Element. */
+                        /** @description provider SetupIntent client secret for the Payment Element. */
                         clientSecret: string;
                     };
                 };
             };
             400: components["responses"]["ValidationError"];
             401: components["responses"]["Unauthorized"];
-            502: components["responses"]["StripeError"];
+            502: components["responses"]["ProviderError"];
         };
     };
     createCheckoutSession: {
@@ -858,7 +858,7 @@ export interface operations {
             400: components["responses"]["ValidationError"];
             401: components["responses"]["Unauthorized"];
             403: components["responses"]["Forbidden"];
-            502: components["responses"]["StripeError"];
+            502: components["responses"]["ProviderError"];
         };
     };
     createPaymentCheckoutSession: {
@@ -899,10 +899,10 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["StripeErrorBody"];
+                    "application/json": components["schemas"]["ProviderErrorBody"];
                 };
             };
-            502: components["responses"]["StripeError"];
+            502: components["responses"]["ProviderError"];
         };
     };
     getPaymentSession: {
@@ -917,7 +917,7 @@ export interface operations {
                 "X-Billing-Entity-Id": components["parameters"]["EntityIdHeader"];
             };
             path: {
-                /** @description The Stripe Checkout Session id (`cs_...`). */
+                /** @description The hosted Checkout Session id (`cs_...`). */
                 sessionId: string;
             };
             cookie?: never;
@@ -938,7 +938,7 @@ export interface operations {
             401: components["responses"]["Unauthorized"];
             403: components["responses"]["Forbidden"];
             404: components["responses"]["NotFound"];
-            502: components["responses"]["StripeError"];
+            502: components["responses"]["ProviderError"];
         };
     };
     addCredits: {
@@ -964,7 +964,7 @@ export interface operations {
                 };
                 content: {
                     "application/json": {
-                        /** @description Stripe customer balance transaction id. */
+                        /** @description payment-provider customer balance transaction id. */
                         id: string;
                         /** @description Resulting customer balance in cents (negative = credit). */
                         endingBalance: number;
@@ -974,7 +974,7 @@ export interface operations {
             400: components["responses"]["ValidationError"];
             401: components["responses"]["Unauthorized"];
             403: components["responses"]["Forbidden"];
-            502: components["responses"]["StripeError"];
+            502: components["responses"]["ProviderError"];
         };
     };
     listInvoices: {
@@ -1009,7 +1009,7 @@ export interface operations {
             };
             400: components["responses"]["ValidationError"];
             401: components["responses"]["Unauthorized"];
-            502: components["responses"]["StripeError"];
+            502: components["responses"]["ProviderError"];
         };
     };
     syncInvoices: {
@@ -1041,7 +1041,7 @@ export interface operations {
                 };
             };
             401: components["responses"]["Unauthorized"];
-            502: components["responses"]["StripeError"];
+            502: components["responses"]["ProviderError"];
         };
     };
     createPortalSession: {
@@ -1088,17 +1088,20 @@ export interface operations {
                     };
                 };
             };
-            502: components["responses"]["StripeError"];
+            502: components["responses"]["ProviderError"];
         };
     };
-    receiveStripeWebhook: {
+    receiveProviderWebhook: {
         parameters: {
             query?: never;
             header: {
-                /** @description Stripe webhook signature header used to verify the payload. */
-                "Stripe-Signature": string;
+                /** @description Provider webhook signature header used to verify the payload authenticity. */
+                "X-Provider-Signature": string;
             };
-            path?: never;
+            path: {
+                /** @description Payment-provider slug identifying which provider sent the webhook (e.g. the configured payment provider). Selects the signature verifier + event decoder. */
+                provider: string;
+            };
             cookie?: never;
         };
         requestBody: {

--- a/billing-client/src/types.ts
+++ b/billing-client/src/types.ts
@@ -15,8 +15,8 @@ export type SubscriptionStatus =
 export interface BillingSubscription {
   id: string;
   customerId: string;
-  stripeSubscriptionId: string;
-  stripePriceId: string;
+  subscriptionId: string;
+  priceId: string;
   planTier: PlanTier;
   status: SubscriptionStatus;
   seatQuantity: number;
@@ -29,8 +29,8 @@ export interface BillingSubscription {
 }
 
 export interface Plan {
-  stripePriceId: string;
-  stripeProductId: string;
+  priceId: string;
+  productId: string;
   tierName: PlanTier;
   displayName: string;
   billingInterval: 'month' | 'year' | string;
@@ -72,7 +72,7 @@ export interface UpdateSubscriptionRequest {
 export type PaymentStatus = 'pending' | 'paid' | 'failed' | 'expired';
 
 export interface PaymentLineItem {
-  /** Line-item display name shown on the Stripe-hosted page. */
+  /** Line-item display name shown on the provider-hosted page. */
   name: string;
   /** Optional line-item description shown under the name. */
   description?: string;
@@ -98,9 +98,9 @@ export interface PaymentCheckoutRequest {
 }
 
 export interface PaymentCheckoutResponse {
-  /** The Stripe Checkout Session id (`cs_...`). */
+  /** The hosted Checkout Session id (`cs_...`). */
   sessionId: string;
-  /** Stripe-hosted Checkout URL to redirect the buyer to. */
+  /** Provider-hosted Checkout URL to redirect the buyer to. */
   url: string | null;
 }
 
@@ -140,8 +140,8 @@ export interface InvoiceListResponse {
 /** Local billing.payments mirror of a one-time payment-mode Checkout Session. */
 export interface BillingPayment {
   id: string;
-  stripeSessionId: string;
-  stripePaymentIntentId: string | null;
+  sessionId: string;
+  paymentIntentId: string | null;
   productKey: string;
   externalOrderId: string;
   entityType: EntityType;

--- a/billing-client/src/types.ts
+++ b/billing-client/src/types.ts
@@ -104,6 +104,39 @@ export interface PaymentCheckoutResponse {
   url: string | null;
 }
 
+/**
+ * A single invoice in the authorized entity's history. Vendor-neutral: `id` is
+ * OUR opaque FuzeFront UUID (never a provider id); `created` is the ISO-8601
+ * issue timestamp; amountDue/amountPaid are cents; currency is lowercased.
+ */
+export interface BillingInvoice {
+  /** FuzeFront invoice id (opaque, stable UUID). */
+  id: string;
+  /** Human-facing invoice number; null for drafts without one. */
+  number: string | null;
+  /** ISO-8601 issue timestamp. */
+  created: string;
+  /** Amount due in the currency's minor unit (cents). */
+  amountDue: number;
+  /** Amount paid in the currency's minor unit (cents). */
+  amountPaid: number;
+  /** ISO 4217 currency code, lowercased. */
+  currency: string;
+  /** Neutral status: draft|open|paid|void|uncollectible. */
+  status: string;
+  /** Provider-hosted document URL, opaque to consumers; null when unavailable. */
+  hostedInvoiceUrl: string | null;
+  /** Provider-hosted document URL, opaque to consumers; null when unavailable. */
+  invoicePdf: string | null;
+}
+
+/** A page of invoices with an opaque keyset cursor (null on the last page). */
+export interface InvoiceListResponse {
+  invoices: BillingInvoice[];
+  /** Opaque cursor for the next page; null on the last page. */
+  nextCursor: string | null;
+}
+
 /** Local billing.payments mirror of a one-time payment-mode Checkout Session. */
 export interface BillingPayment {
   id: string;

--- a/billing-client/tests/client.test.ts
+++ b/billing-client/tests/client.test.ts
@@ -125,6 +125,33 @@ describe('BillingClient', () => {
     expect(out).toEqual({ stripeSessionId: 'cs 1', status: 'paid' });
   });
 
+  it('listInvoices GETs /invoices with limit + cursor query params', async () => {
+    verbs.get.mockResolvedValue({
+      data: { invoices: [{ id: 'uuid-1' }], nextCursor: 'opaque-cursor' },
+    });
+    const c = new BillingClient({ baseUrl: 'http://b', internalToken: 't' });
+    const out = await c.listInvoices({ limit: 50, cursor: 'prev-cursor' });
+    expect(verbs.get).toHaveBeenCalledWith('/invoices', {
+      params: { limit: 50, cursor: 'prev-cursor' },
+    });
+    expect(out).toEqual({ invoices: [{ id: 'uuid-1' }], nextCursor: 'opaque-cursor' });
+  });
+
+  it('listInvoices omits absent params (no limit/cursor)', async () => {
+    verbs.get.mockResolvedValue({ data: { invoices: [], nextCursor: null } });
+    const c = new BillingClient({ baseUrl: 'http://b', internalToken: 't' });
+    await c.listInvoices();
+    expect(verbs.get).toHaveBeenCalledWith('/invoices', { params: {} });
+  });
+
+  it('syncInvoices POSTs /invoices/sync and returns {synced}', async () => {
+    verbs.post.mockResolvedValue({ data: { synced: 3 } });
+    const c = new BillingClient({ baseUrl: 'http://b', internalToken: 't' });
+    const out = await c.syncInvoices();
+    expect(verbs.post).toHaveBeenCalledWith('/invoices/sync', {});
+    expect(out).toEqual({ synced: 3 });
+  });
+
   it('createSetupIntent POSTs entity + returns clientSecret', async () => {
     verbs.post.mockResolvedValue({ data: { clientSecret: 'seti_secret' } });
     const c = new BillingClient({ baseUrl: 'http://b', internalToken: 't' });

--- a/billing-client/tests/client.test.ts
+++ b/billing-client/tests/client.test.ts
@@ -107,7 +107,7 @@ describe('BillingClient', () => {
 
   it('getPaymentSession GETs the encoded id with actor headers and unwraps {payment}', async () => {
     verbs.get.mockResolvedValue({
-      data: { payment: { stripeSessionId: 'cs 1', status: 'paid' } },
+      data: { payment: { sessionId: 'cs 1', status: 'paid' } },
     });
     const c = new BillingClient({ baseUrl: 'http://b', internalToken: 't' });
     const out = await c.getPaymentSession('cs 1', {
@@ -122,7 +122,7 @@ describe('BillingClient', () => {
         'X-Billing-Entity-Id': 'org-1',
       },
     });
-    expect(out).toEqual({ stripeSessionId: 'cs 1', status: 'paid' });
+    expect(out).toEqual({ sessionId: 'cs 1', status: 'paid' });
   });
 
   it('listInvoices GETs /invoices with limit + cursor query params', async () => {

--- a/deploy/PENDING-WORKFLOW-CHANGES-payment-service.md
+++ b/deploy/PENDING-WORKFLOW-CHANGES-payment-service.md
@@ -1,0 +1,101 @@
+# Pending workflow changes — payment-service in the release image matrix
+
+The bot that opened this PR **cannot edit `.github/workflows/`** (no `workflows`
+permission — the push is rejected), and workflow files are outside this slice's
+allowed paths. The deploy/CI slice for the vendor-neutral **payment-service**
+gateway needs ONE workflow change a human (or an admin/App identity) must apply:
+add the **payment-service** image to the `release.yml` build matrix + its path
+trigger, so its container is built + pushed to GHCR and the prod tag is bumped by
+GitOps.
+
+Everything else in the slice (Helm template + values + Argo umbrella wiring +
+SealedSecret scaffold + observability alerts + docker-compose) is already in this
+PR and does NOT depend on a workflow edit. The service is `enabled: false` in
+`values-prod.yaml`, so nothing renders (zero freeze surface) until go-live.
+
+---
+
+## Change 1 — `release.yml`: trigger on `services/payment-service/` changes
+
+In `.github/workflows/release.yml`, add `services/payment-service/**` to the
+`on.push.paths` list:
+
+```diff
+   push:
+     branches: [master]
+     paths:
+       - 'services/billing-service/**'
++      - 'services/payment-service/**'
+       - 'clock-app/**'
+       - 'deploy/helm/fuzefront/**'
+       - '.github/workflows/release.yml'
+```
+
+## Change 2 — `release.yml`: build & push the payment-service image
+
+Add a build step alongside the other services (e.g. right after the
+"Build and push billing-service" step, BEFORE the "Bump image tags" step).
+
+NOTE the **context**: payment-service is SELF-CONTAINED (no `@fuzefront/shared`
+dependency — its `Dockerfile` does `COPY package.json` + `COPY src/`), so its
+build context is `services/payment-service` (NOT the repo root the workspace
+services use), and the `file:` is `services/payment-service/Dockerfile`.
+`continue-on-error: true` matches the other ancillary services — a payment build
+failure must never block the core backend+frontend deploy.
+
+```diff
+       - name: Build and push billing-service
+         continue-on-error: true
+         uses: docker/build-push-action@v5
+         with:
+           context: .
+           file: services/billing-service/Dockerfile
+           push: true
+           tags: |
+             ghcr.io/izzywdev/fuzefront-billing-service:${{ steps.tag.outputs.sha }}
+             ghcr.io/izzywdev/fuzefront-billing-service:latest
+           cache-from: type=gha
+           cache-to: type=gha,mode=max
++
++      - name: Build and push payment-service (vendor-neutral payment gateway)
++        # Self-contained Dockerfile => context is services/payment-service
++        # (not repo root). Non-fatal like the other ancillary builds.
++        continue-on-error: true
++        uses: docker/build-push-action@v5
++        with:
++          context: services/payment-service
++          file: services/payment-service/Dockerfile
++          push: true
++          tags: |
++            ghcr.io/izzywdev/fuzefront-payment-service:${{ steps.tag.outputs.sha }}
++            ghcr.io/izzywdev/fuzefront-payment-service:latest
++          cache-from: type=gha
++          cache-to: type=gha,mode=max
+```
+
+## Tag bump — NO change needed
+
+The existing "Bump image tags in values-prod.yaml (GitOps)" step already rewrites
+**every** `tag:` line:
+
+```bash
+sed -i -E "s/^(\s*tag:).*/\1 ${SHA}/" deploy/helm/fuzefront/values-prod.yaml
+```
+
+`paymentService.image.tag: ""` was added to `values-prod.yaml` in this PR, so the
+existing sed bumps it to the built SHA automatically — no extra bump step. Because
+`paymentService.enabled: false`, the bumped tag is inert until go-live.
+
+---
+
+## Go-live (a later, deliberate step — NOT this PR)
+
+1. Apply Changes 1 + 2 to `.github/workflows/release.yml` and merge in the deploy
+   window (`master` is deploy-on-push; commits to `master` must be signed).
+2. Seal the real `STRIPE_SECRET_KEY` + `PAYMENT_INTERNAL_TOKEN` into
+   `payment-secrets` (`deploy/scripts/seal-secret.sh <KEY> --scope
+   fuzefront/payment-secrets`; scaffold placeholder in
+   `deploy/contabo/sealed/payment-secrets.yaml`).
+3. Flip `paymentService.enabled: true` in `values-prod.yaml` in a deploy window.
+   Argo rolls out the gateway; the neutral Payment Provider API returns 501 for
+   the still-unwired calls until the money path is absorbed from billing-service.

--- a/deploy/contabo/sealed/payment-secrets.yaml
+++ b/deploy/contabo/sealed/payment-secrets.yaml
@@ -1,0 +1,37 @@
+# payment-service per-service SealedSecret — SCAFFOLD.
+#
+# The payment-service gateway is a SCAFFOLD (not the live money path yet) and is
+# DISABLED in values-prod (paymentService.enabled: false), and BOTH keys below are
+# `optional: true` in the Deployment (templates/payment-service.yaml). So the
+# gateway runs in degraded mode (serves /health only) even before this Secret
+# holds real values — nothing is gated on it today.
+#
+# encryptedData is intentionally EMPTY: valid kubeseal ciphertext is
+# cluster-specific and can only be produced against the live sealed-secrets public
+# cert, which the repo owner fetches at seal time. DO NOT hand-write ciphertext.
+#
+# TO POPULATE (repo owner, per key — plaintext never touches git/chat/CI logs):
+#   deploy/scripts/seal-secret.sh STRIPE_SECRET_KEY       --scope fuzefront/payment-secrets
+#   deploy/scripts/seal-secret.sh PAYMENT_INTERNAL_TOKEN  --scope fuzefront/payment-secrets
+# That merges each sealed value into this file's spec.encryptedData in place.
+# Then: git add + commit + push; Argo (FuzeInfra-operated) syncs it and the
+# in-cluster controller decrypts it into the real `payment-secrets` Secret.
+#
+# GO-LIVE for the gateway (a later, deliberate step): seal the two keys here, add
+# the release.yml image build (deploy/PENDING-WORKFLOW-CHANGES-payment-service.md),
+# then flip paymentService.enabled: true in values-prod in a deploy window.
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: payment-secrets
+  namespace: fuzefront
+spec:
+  encryptedData: {}
+    # STRIPE_SECRET_KEY: <sealed — run seal-secret.sh>
+    # PAYMENT_INTERNAL_TOKEN: <sealed — run seal-secret.sh>
+  template:
+    metadata:
+      name: payment-secrets
+      namespace: fuzefront
+    type: Opaque

--- a/deploy/helm/fuzefront/alerts/payment-alerts.yaml
+++ b/deploy/helm/fuzefront/alerts/payment-alerts.yaml
@@ -1,0 +1,61 @@
+# Prometheus alert rules for the FuzeFront payment-service (vendor-neutral payment
+# gateway). Shipped as a ConfigMap labeled prometheus_rule: "1" (glob alerts/*.yaml
+# in observability.yaml) so the FuzeInfra Prometheus discovers + loads it. Plain
+# rule-group file (NOT a PrometheusRule CRD) — FuzeInfra runs vanilla Prometheus.
+#
+# These are payment-DOMAIN signals on top of the generic fuzefront.* alerts
+# (crash-loop / not-ready / 5xx / latency / target-down already cover the payment
+# pod since its service label matches fuzefront.*). The metric names below are the
+# EXPECTED payment-service emissions (prom-client) — the service does not emit them
+# yet (it is a SCAFFOLD), so these rules stay INERT until it does; shipping them
+# early is harmless. devops owns the alert wiring; the implementer owns the metric
+# names — reconcile the names at integration when the gateway grows a /metrics
+# endpoint (and add a dedicated Grafana dashboard then; a dashboard now would be
+# inert with no series to plot).
+groups:
+  - name: fuzefront.payment.rules
+    rules:
+      # Vendor (provider) API error ratio — checkout/customers/invoices calls.
+      # Elevated errors degrade every downstream payment flow routed through the
+      # gateway.
+      - alert: PaymentProviderApiErrorRate
+        expr: |
+          100 * sum(rate(payment_provider_api_errors_total{namespace="fuzefront"}[5m]))
+          / clamp_min(sum(rate(payment_provider_api_requests_total{namespace="fuzefront"}[5m])), 1) > 5
+        for: 10m
+        labels:
+          severity: warning
+          team: fuzefront
+          service: fuzefront-payment-service
+        annotations:
+          summary: "Elevated payment-provider API error rate from payment-service"
+          description: ">5% of vendor API calls routed through the payment gateway are erroring over 10m."
+
+      # Webhook processing failures — payment correctness signal. A spike means
+      # payment/subscription state may diverge from the vendor.
+      - alert: PaymentWebhookFailures
+        expr: |
+          increase(payment_webhook_failed_total{namespace="fuzefront"}[10m]) > 0
+        for: 5m
+        labels:
+          severity: critical
+          team: fuzefront
+          service: fuzefront-payment-service
+        annotations:
+          summary: "payment-service is failing to process provider webhooks"
+          description: "payment_webhook_failed_total increased over 10m — payment state may drift from the vendor."
+
+      # Gateway target down: the payment pod is unreachable by Prometheus while
+      # the service is enabled. (Generic target-down also covers this; kept
+      # explicit so the payment on-call context is attached.)
+      - alert: PaymentServiceTargetDown
+        expr: |
+          up{job=~".*", service="fuzefront-payment-service", namespace="fuzefront"} == 0
+        for: 10m
+        labels:
+          severity: warning
+          team: fuzefront
+          service: fuzefront-payment-service
+        annotations:
+          summary: "payment-service scrape target is down"
+          description: "Prometheus cannot scrape the payment-service pod for >10m while it is enabled."

--- a/deploy/helm/fuzefront/templates/payment-service.yaml
+++ b/deploy/helm/fuzefront/templates/payment-service.yaml
@@ -1,0 +1,96 @@
+{{- if .Values.paymentService.enabled }}
+# payment-service — the vendor-neutral payment GATEWAY (SCAFFOLD; not yet the
+# live money path). Absorbs ALL vendor (Stripe) interaction and exposes a neutral
+# Payment Provider API to billing-service + other consumers. No DB, no Kafka in
+# this scaffold — a stateless gateway. Synced by the UMBRELLA `fuzefront` Argo
+# Application (hybrid-Argo: same rule as billing/unleash — a second Argo app on
+# this chart path would DOUBLE-CLAIM the Deployment; a dedicated Argo Application
+# is only correct once payment-service is extracted into its OWN chart, tracked
+# follow-up). Isolation the hybrid model wants is still satisfied: it has its OWN
+# per-service `payment-secrets` SealedSecret, so a pending/crashing payment pod
+# cannot take down other services or read their secrets.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fuzefront-payment-service
+  labels:
+    {{- include "fuzefront.labels" . | nindent 4 }}
+    app.kubernetes.io/component: payment-service
+spec:
+  replicas: {{ .Values.paymentService.replicas }}
+  selector:
+    matchLabels:
+      app: fuzefront-payment-service
+  template:
+    metadata:
+      labels:
+        app: fuzefront-payment-service
+        {{- include "fuzefront.labels" . | nindent 8 }}
+      annotations:
+        {{- include "fuzefront.metricsAnnotations" (dict "port" .Values.paymentService.port "root" .) | nindent 8 }}
+    spec:
+      {{- include "fuzefront.scheduling" (dict "svc" .Values.paymentService "root" .) | nindent 6 }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: payment-service
+          image: "{{ .Values.paymentService.image.repository }}:{{ .Values.paymentService.image.tag }}"
+          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          ports:
+            - containerPort: {{ .Values.paymentService.port }}
+          env:
+            - name: NODE_ENV
+              value: "production"
+            - name: PORT
+              value: {{ .Values.paymentService.port | quote }}
+            # The active vendor adapter (the swap knob). Default 'stripe'.
+            - name: PAYMENT_PROVIDER
+              value: {{ .Values.paymentService.provider | quote }}
+            # Vendor secret + internal token come from the per-service
+            # payment-secrets SealedSecret. In this SCAFFOLD the keys may be
+            # placeholders — without a real STRIPE_SECRET_KEY the gateway boots in
+            # degraded mode (serves /health only, no live vendor calls), so the
+            # pod stays healthy and is safe to run before the money path lands.
+            - name: STRIPE_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.paymentService.secretName | default "payment-secrets" }}
+                  key: STRIPE_SECRET_KEY
+                  optional: true
+            - name: PAYMENT_INTERNAL_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.paymentService.secretName | default "payment-secrets" }}
+                  key: PAYMENT_INTERNAL_TOKEN
+                  optional: true
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: {{ .Values.paymentService.port }}
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: {{ .Values.paymentService.port }}
+            initialDelaySeconds: 30
+            periodSeconds: 15
+          resources:
+            {{- toYaml .Values.paymentService.resources | nindent 12 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: fuzefront-payment-service
+  labels:
+    {{- include "fuzefront.labels" . | nindent 4 }}
+spec:
+  selector:
+    app: fuzefront-payment-service
+  ports:
+    - port: {{ .Values.paymentService.port }}
+      targetPort: {{ .Values.paymentService.port }}
+{{- end }}

--- a/deploy/helm/fuzefront/values-prod.yaml
+++ b/deploy/helm/fuzefront/values-prod.yaml
@@ -146,6 +146,37 @@ billingService:
                 operator: In
                 values: ["fuzefront-node-2"]
 
+# payment-service — vendor-neutral payment GATEWAY (SCAFFOLD; not yet the live
+# money path). Synced by the UMBRELLA `fuzefront` Argo Application (gated by
+# paymentService.enabled), NOT a separate Application — its templates live in this
+# umbrella chart, so a second Argo app on the same chart path would DOUBLE-CLAIM
+# the Deployment (same hybrid-Argo rule that keeps billing/unleash in the
+# umbrella). A dedicated Argo app is only correct once payment-service is extracted
+# into its own chart (tracked follow-up). Isolation the hybrid model wants is still
+# satisfied: it has its OWN per-service `payment-secrets` SealedSecret.
+paymentService:
+  # First-light: DISABLED. While false the Deployment does NOT render, so the
+  # gateway adds ZERO freeze surface to the umbrella sync (no InvalidImageName even
+  # though its release image build step is still pending — see
+  # deploy/PENDING-WORKFLOW-CHANGES-payment-service.md). GO-LIVE for the gateway is
+  # a deliberate later step: add the release.yml build, flip this to true, seal the
+  # real STRIPE_SECRET_KEY / PAYMENT_INTERNAL_TOKEN. It is a SCAFFOLD, not the
+  # money path — billing-service remains the live path until the migration.
+  enabled: false
+  image:
+    repository: ghcr.io/izzywdev/fuzefront-payment-service
+    tag: ""  # CI's release sed writes the real image SHA here (once the build lands)
+  # Steer onto node-2 (keep it off the DB-heavy node-1, like billing/chat/litellm).
+  affinity:
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          preference:
+            matchExpressions:
+              - key: kubernetes.io/hostname
+                operator: In
+                values: ["fuzefront-node-2"]
+
 permit:
   enabled: true
 

--- a/deploy/helm/fuzefront/values.yaml
+++ b/deploy/helm/fuzefront/values.yaml
@@ -412,6 +412,35 @@ billingService:
   affinity: {}
   tolerations: []
 
+# payment-service — vendor-neutral payment GATEWAY (SCAFFOLD; not the live money
+# path yet). Stateless: no DB, no Kafka. Runnable with zero secrets — without a
+# real STRIPE_SECRET_KEY it serves /health only (degraded mode). Its templates
+# live in this umbrella chart, so it is synced by the umbrella `fuzefront` Argo
+# Application (hybrid-Argo — same rule as billingService/unleash). Disabled by
+# default; flip `enabled` + seal payment-secrets to bring it up.
+paymentService:
+  enabled: false
+  image:
+    repository: fuzefront/payment-service
+    tag: local
+  # 3007: billing-service is 3006. Keep unique across the service port map.
+  port: 3007
+  replicas: 1
+  # Active vendor adapter. Swapping the vendor = adding a sibling adapter and
+  # changing this. Default 'stripe'.
+  provider: stripe
+  # Per-service secret (payment-only keys: STRIPE_SECRET_KEY,
+  # PAYMENT_INTERNAL_TOKEN). Placeholders committed in
+  # deploy/contabo/sealed/payment-secrets.yaml; both keys are `optional: true` in
+  # the Deployment so the scaffold pod runs even before real values are sealed.
+  secretName: payment-secrets
+  resources:
+    requests: { cpu: 50m,  memory: 128Mi }
+    limits:   { cpu: 500m, memory: 256Mi }
+  nodeSelector: {}
+  affinity: {}
+  tolerations: []
+
 litellm:
   enabled: false
   image:

--- a/design/frames/billing-invoices/01-invoice-history.html
+++ b/design/frames/billing-invoices/01-invoice-history.html
@@ -1,0 +1,117 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Billing — Invoice history</title>
+<link rel="stylesheet" href="tokens.css" />
+</head>
+<body>
+<div class="shell" data-frame="01-invoice-history">
+  <div class="topbar">
+    <div class="wordmark"><span class="fuse">Fuze</span>Front</div>
+    <div class="spacer"></div>
+    <div class="launch-btn" aria-hidden="true">▦</div>
+    <div class="avatar">IZ</div>
+  </div>
+  <div class="body">
+    <nav class="side">
+      <div class="section-label">Organization</div>
+      <a class="nav-item"><span class="ico">📊</span> Overview</a>
+      <a class="nav-item"><span class="ico">👥</span> Members</a>
+      <a class="nav-item active" data-nav="billing"><span class="ico">🧾</span> Billing</a>
+      <a class="nav-item"><span class="ico">⚙️</span> Settings</a>
+    </nav>
+    <main class="content">
+      <h1 class="page-title">Billing</h1>
+      <p class="page-sub">Acme Corp · Pro plan · renews Aug 1, 2026</p>
+
+      <section class="ffb-invoices" data-panel="invoice-history" aria-label="Invoice history">
+        <div class="ffb-invoices__seam"></div>
+        <div class="ffb-invoices__head">
+          <h2 class="ffb-invoices__title">Invoices</h2>
+          <span class="ffb-invoices__count" data-invoice-count="4">4 shown</span>
+        </div>
+        <div class="ffb-invoices__list" data-invoice-list>
+
+          <div class="ffb-invoice-row" data-invoice="FF-2026-0042" data-status="paid">
+            <div class="ffb-invoice-row__main">
+              <div class="ffb-invoice-row__top">
+                <span class="ffb-invoice-row__num">FF-2026-0042</span>
+                <span class="ffb-invoice-row__date">· Jul 1, 2026</span>
+              </div>
+            </div>
+            <div class="ffb-invoice-row__side">
+              <span class="ffb-pill ffb-pill--paid"><span class="ffb-pill__dot"></span>Paid</span>
+              <span class="ffb-invoice-row__amount">$49.00</span>
+              <a class="ffb-dl" href="#" data-download="pdf" aria-label="Download invoice FF-2026-0042 PDF">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3v12m0 0l4-4m-4 4l-4-4M4 21h16"/></svg>PDF</a>
+            </div>
+          </div>
+
+          <div class="ffb-invoice-row" data-invoice="FF-2026-0031" data-status="paid">
+            <div class="ffb-invoice-row__main">
+              <div class="ffb-invoice-row__top">
+                <span class="ffb-invoice-row__num">FF-2026-0031</span>
+                <span class="ffb-invoice-row__date">· Jun 1, 2026</span>
+              </div>
+            </div>
+            <div class="ffb-invoice-row__side">
+              <span class="ffb-pill ffb-pill--paid"><span class="ffb-pill__dot"></span>Paid</span>
+              <span class="ffb-invoice-row__amount">$49.00</span>
+              <a class="ffb-dl" href="#" data-download="pdf" aria-label="Download invoice FF-2026-0031 PDF">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3v12m0 0l4-4m-4 4l-4-4M4 21h16"/></svg>PDF</a>
+            </div>
+          </div>
+
+          <div class="ffb-invoice-row" data-invoice="FF-2026-0025" data-status="open">
+            <div class="ffb-invoice-row__main">
+              <div class="ffb-invoice-row__top">
+                <span class="ffb-invoice-row__num">FF-2026-0025</span>
+                <span class="ffb-invoice-row__date">· May 1, 2026</span>
+              </div>
+            </div>
+            <div class="ffb-invoice-row__side">
+              <span class="ffb-pill ffb-pill--open"><span class="ffb-pill__dot"></span>Open</span>
+              <span class="ffb-invoice-row__amount">$49.00</span>
+              <a class="ffb-dl" href="#" data-download="hosted" aria-label="View invoice FF-2026-0025">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 3v5h5M8 13h8M8 17h5M6 3h9l5 5v11a1 1 0 01-1 1H6a1 1 0 01-1-1V4a1 1 0 011-1z"/></svg>View</a>
+            </div>
+          </div>
+
+          <div class="ffb-invoice-row" data-invoice="FF-2026-0018" data-status="void">
+            <div class="ffb-invoice-row__main">
+              <div class="ffb-invoice-row__top">
+                <span class="ffb-invoice-row__num">FF-2026-0018</span>
+                <span class="ffb-invoice-row__date">· Apr 1, 2026</span>
+              </div>
+            </div>
+            <div class="ffb-invoice-row__side">
+              <span class="ffb-pill ffb-pill--void"><span class="ffb-pill__dot"></span>Void</span>
+              <span class="ffb-invoice-row__amount">$0.00</span>
+              <a class="ffb-dl" href="#" data-download="pdf" aria-label="Download invoice FF-2026-0018 PDF">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3v12m0 0l4-4m-4 4l-4-4M4 21h16"/></svg>PDF</a>
+            </div>
+          </div>
+
+        </div>
+        <div class="ffb-invoices__foot">
+          <button class="btn btn-ghost" data-action="load-more">Load more</button>
+        </div>
+      </section>
+
+      <p class="ffb-note" style="margin-top: var(--space-4); max-width: 620px;">
+        Invoice ids, status and amounts are served from FuzeFront's own store (synced from the
+        payment provider). The download link is a provider-hosted document, opaque to the app —
+        no vendor name is ever exposed to the UI.
+      </p>
+    </main>
+  </div>
+</div>
+
+<div class="frame-nav">
+  <span class="caption">Frame (a) · <b>Invoice history</b> — populated list</span>
+  <a href="02-states.html" class="btn btn-primary">Next: states →</a>
+</div>
+</body>
+</html>

--- a/design/frames/billing-invoices/02-states.html
+++ b/design/frames/billing-invoices/02-states.html
@@ -1,0 +1,108 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Billing — Invoice history states</title>
+<link rel="stylesheet" href="tokens.css" />
+<style>
+  .states-grid { display: grid; gap: var(--space-6); grid-template-columns: 1fr;
+    max-width: 720px; }
+  @media (min-width: 720px){ .states-grid { grid-template-columns: 1fr 1fr; } }
+  .state-label { font-family: var(--font-mono); font-size: var(--text-2xs);
+    letter-spacing: var(--tracking-wide); text-transform: uppercase;
+    color: var(--text-tertiary); margin: 0 0 var(--space-2); }
+</style>
+</head>
+<body>
+<div class="shell" data-frame="02-states">
+  <div class="topbar">
+    <div class="wordmark"><span class="fuse">Fuze</span>Front</div>
+    <div class="spacer"></div>
+    <div class="launch-btn" aria-hidden="true">▦</div>
+    <div class="avatar">IZ</div>
+  </div>
+  <div class="body">
+    <nav class="side">
+      <div class="section-label">Organization</div>
+      <a class="nav-item"><span class="ico">📊</span> Overview</a>
+      <a class="nav-item"><span class="ico">👥</span> Members</a>
+      <a class="nav-item active" data-nav="billing"><span class="ico">🧾</span> Billing</a>
+      <a class="nav-item"><span class="ico">⚙️</span> Settings</a>
+    </nav>
+    <main class="content">
+      <h1 class="page-title">Invoices — states</h1>
+      <p class="page-sub">Loading, empty and error states for the InvoiceHistoryPanel.</p>
+
+      <div class="states-grid">
+        <div>
+          <p class="state-label">Loading (skeleton)</p>
+          <section class="ffb-invoices" data-panel="invoice-history" data-state="loading">
+            <div class="ffb-invoices__seam"></div>
+            <div class="ffb-invoices__head"><h2 class="ffb-invoices__title">Invoices</h2></div>
+            <div class="ffb-invoices__list">
+              <div class="ffb-invoice-row"><div class="ffb-invoice-row__main"><div class="ffb-skel" style="width:58%"></div><div class="ffb-skel" style="width:34%;margin-top:6px"></div></div><div class="ffb-skel" style="width:54px;height:20px"></div></div>
+              <div class="ffb-invoice-row"><div class="ffb-invoice-row__main"><div class="ffb-skel" style="width:50%"></div><div class="ffb-skel" style="width:30%;margin-top:6px"></div></div><div class="ffb-skel" style="width:54px;height:20px"></div></div>
+              <div class="ffb-invoice-row"><div class="ffb-invoice-row__main"><div class="ffb-skel" style="width:54%"></div><div class="ffb-skel" style="width:28%;margin-top:6px"></div></div><div class="ffb-skel" style="width:54px;height:20px"></div></div>
+            </div>
+          </section>
+        </div>
+
+        <div>
+          <p class="state-label">Empty</p>
+          <section class="ffb-invoices" data-panel="invoice-history" data-state="empty">
+            <div class="ffb-invoices__seam"></div>
+            <div class="ffb-invoices__head"><h2 class="ffb-invoices__title">Invoices</h2></div>
+            <div class="ffb-empty" data-empty>
+              <svg class="ffb-empty__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M14 3v5h5M6 3h9l5 5v11a1 1 0 01-1 1H6a1 1 0 01-1-1V4a1 1 0 011-1z"/><path d="M9 13h6M9 17h4"/></svg>
+              <p style="margin:0 0 var(--space-1);color:var(--text-primary);font-weight:var(--weight-medium)">No invoices yet</p>
+              <p class="ffb-note" style="margin:0">Invoices appear here after your first billed period.</p>
+            </div>
+          </section>
+        </div>
+
+        <div>
+          <p class="state-label">Error</p>
+          <section class="ffb-invoices" data-panel="invoice-history" data-state="error">
+            <div class="ffb-invoices__seam"></div>
+            <div class="ffb-invoices__head"><h2 class="ffb-invoices__title">Invoices</h2></div>
+            <div class="ffb-empty" data-error>
+              <svg class="ffb-empty__icon" style="color:var(--error-color)" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M12 8v5M12 16h.01"/></svg>
+              <p style="margin:0 0 var(--space-1);color:var(--text-primary);font-weight:var(--weight-medium)">Couldn't load invoices</p>
+              <p class="ffb-note" style="margin:0 0 var(--space-3)">Something went wrong on our end.</p>
+              <button class="btn btn-ghost" data-action="retry">Try again</button>
+            </div>
+          </section>
+        </div>
+
+        <div>
+          <p class="state-label">Uncollectible (status variant)</p>
+          <section class="ffb-invoices" data-panel="invoice-history">
+            <div class="ffb-invoices__seam"></div>
+            <div class="ffb-invoices__head"><h2 class="ffb-invoices__title">Invoices</h2></div>
+            <div class="ffb-invoices__list">
+              <div class="ffb-invoice-row" data-invoice="FF-2026-0009" data-status="uncollectible">
+                <div class="ffb-invoice-row__main"><div class="ffb-invoice-row__top">
+                  <span class="ffb-invoice-row__num">FF-2026-0009</span>
+                  <span class="ffb-invoice-row__date">· Mar 1, 2026</span></div></div>
+                <div class="ffb-invoice-row__side">
+                  <span class="ffb-pill ffb-pill--uncollectible"><span class="ffb-pill__dot"></span>Uncollectible</span>
+                  <span class="ffb-invoice-row__amount">$49.00</span>
+                  <a class="ffb-dl" href="#" data-download="hosted" aria-label="View invoice FF-2026-0009">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 3v5h5M8 13h8M8 17h5M6 3h9l5 5v11a1 1 0 01-1 1H6a1 1 0 01-1-1V4a1 1 0 011-1z"/></svg>View</a>
+                </div>
+              </div>
+            </div>
+          </section>
+        </div>
+      </div>
+    </main>
+  </div>
+</div>
+
+<div class="frame-nav">
+  <span class="caption">Frame (b) · <b>States</b> — loading / empty / error / status variants</span>
+  <a href="01-invoice-history.html" class="btn btn-ghost">← Back to list</a>
+</div>
+</body>
+</html>

--- a/design/frames/billing-invoices/index.html
+++ b/design/frames/billing-invoices/index.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Billing Invoices — Approval Frames</title>
+<link rel="stylesheet" href="tokens.css" />
+<style>
+  .wrap { max-width: 880px; margin: 0 auto; padding: var(--space-12) var(--space-8) var(--space-16); }
+  .eyebrow { font-family: var(--font-mono); font-size: var(--text-2xs); letter-spacing: var(--tracking-wide);
+    text-transform: uppercase; color: var(--cyan-400); margin-bottom: var(--space-3); }
+  h1 { font-family: var(--font-display); font-size: var(--text-2xl); letter-spacing: var(--tracking-display); margin: 0 0 var(--space-2); }
+  .lead { color: var(--text-secondary); margin: 0; max-width: 64ch; }
+  .grid { display: grid; grid-template-columns: 1fr 1fr; gap: var(--space-5); margin-top: var(--space-8); }
+  @media (max-width: 640px){ .grid { grid-template-columns: 1fr; } }
+  .frame-link { display: block; text-decoration: none; color: inherit; background: var(--bg-tertiary);
+    border: 1px solid var(--border-color); border-radius: var(--radius-lg); padding: var(--space-6);
+    position: relative; overflow: hidden; transition: transform var(--duration-base) var(--ease-standard); }
+  .frame-link:hover { transform: translateY(-2px); box-shadow: var(--shadow-md); border-color: var(--border-strong); }
+  .frame-link .seam { position: absolute; top: 0; left: 0; right: 0; height: 2px; background: var(--seam); opacity: 0; transition: opacity var(--duration-base); }
+  .frame-link:hover .seam { opacity: 1; }
+  .frame-link .step { font-family: var(--font-mono); font-size: var(--text-2xs); color: var(--text-tertiary); letter-spacing: var(--tracking-wide); }
+  .frame-link h3 { margin: var(--space-2) 0; font-size: var(--text-lg); }
+  .frame-link p { margin: 0; color: var(--text-tertiary); font-size: var(--text-sm); }
+  .meta { margin-top: var(--space-10); font-size: var(--text-sm); color: var(--text-tertiary); }
+  .meta code { font-family: var(--font-mono); color: var(--text-secondary); }
+  .pending { display: inline-flex; align-items: center; gap: 6px; font-family: var(--font-mono);
+    font-size: var(--text-2xs); padding: 2px 8px; border-radius: var(--radius-pill);
+    color: var(--warning-color); border: 1px solid rgba(245,185,80,0.4); text-transform: uppercase;
+    letter-spacing: var(--tracking-wide); margin-top: var(--space-4); }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <div class="eyebrow">Contract-freeze · UX approval</div>
+  <h1>Billing — Invoice history · Approval Frames</h1>
+  <p class="lead">These frames demonstrate the <b>InvoiceHistoryPanel</b> UX before any feature UI is
+    implemented. Approving them freezes the visual contract that the implementation and
+    <code>frontend-test-engineer</code>'s Playwright pre-production checks are verified against.
+    Built in the fuse-seam design system (tokens only). No vendor name appears anywhere in the UI —
+    invoice ids, status and amount come from FuzeFront's own store.</p>
+
+  <div class="grid">
+    <a href="01-invoice-history.html" class="frame-link">
+      <div class="seam"></div>
+      <div class="step">Frame (a)</div>
+      <h3>🧾 Invoice history</h3>
+      <p>Populated list on the Billing page: date · number · amount · status pill · download. "Load more" cursor pagination.</p>
+    </a>
+    <a href="02-states.html" class="frame-link">
+      <div class="seam"></div>
+      <div class="step">Frame (b)</div>
+      <h3>◔ States</h3>
+      <p>Loading skeleton, empty state, error+retry, and the paid/open/void/uncollectible status variants.</p>
+    </a>
+  </div>
+
+  <span class="pending" data-approval-status="pending">● Awaiting approval</span>
+
+  <p class="meta">
+    Design system: <code>@fuzefront/design-system</code> (fuse-seam) ·
+    Contract: <code>services/billing-service/openapi.yaml</code> → <code>@fuzefront/billing-client</code> ·
+    Component: <code>@fuzefront/billing-ui → InvoiceHistoryPanel</code> ·
+    Flag: <code>fuzefront.billing.invoice-history</code> (default OFF).<br />
+    Approve by setting <code>approved: true</code> (+ approver + date) in <code>manifest.json</code>,
+    or reply <code>@claude approve</code> / <code>@claude reject: &lt;reason&gt;</code>.
+  </p>
+</div>
+</body>
+</html>

--- a/design/frames/billing-invoices/manifest.json
+++ b/design/frames/billing-invoices/manifest.json
@@ -1,0 +1,51 @@
+{
+  "name": "Billing Invoice History — approval frames",
+  "description": "Contract-freeze UX artifacts for the vendor-neutral, DB-backed invoice history capability. Approving these frames approves the InvoiceHistoryPanel visual + interaction model before UI implementation. frontend-test-engineer drives Playwright against these via the data-frame / data-* attributes.",
+  "designSystem": "fuse-seam (@fuzefront/design-system)",
+  "approved": false,
+  "approvedBy": null,
+  "approvedAt": null,
+  "contract": {
+    "openapi": "services/billing-service/openapi.yaml",
+    "client": "@fuzefront/billing-client",
+    "schemas": ["components.schemas.BillingInvoice", "components.schemas.InvoiceListResponse"],
+    "endpoints": ["GET /api/v1/billing/invoices", "POST /api/v1/billing/invoices/sync"],
+    "component": "@fuzefront/billing-ui → InvoiceHistoryPanel",
+    "featureFlag": "fuzefront.billing.invoice-history"
+  },
+  "entry": "index.html",
+  "frames": [
+    {
+      "id": "01-invoice-history",
+      "file": "01-invoice-history.html",
+      "label": "(a) Invoice history",
+      "route": "/billing",
+      "summary": "Populated invoice list on the Billing page: date, our invoice number, amount, status pill, provider-hosted download link; cursor 'Load more'.",
+      "acceptanceNotes": "Rows render newest-first from GET /invoices. id/number/amount/status come from our store; download link is opaque (data-download pdf|hosted). No vendor name in the DOM. Load more appends the next cursor page.",
+      "testHooks": [
+        "[data-frame='01-invoice-history']",
+        "[data-panel='invoice-history']",
+        "[data-invoice='FF-2026-0042']",
+        "[data-status='paid']",
+        "[data-download]",
+        "[data-action='load-more']"
+      ]
+    },
+    {
+      "id": "02-states",
+      "file": "02-states.html",
+      "label": "(b) States",
+      "route": "/billing",
+      "summary": "Loading skeleton, empty state, error+retry, and paid/open/void/uncollectible status pill variants.",
+      "acceptanceNotes": "Loading shows skeleton rows; empty shows the no-invoices message; error shows retry (data-action='retry'); each status maps to its semantic soft token pill.",
+      "testHooks": [
+        "[data-frame='02-states']",
+        "[data-state='loading']",
+        "[data-state='empty']",
+        "[data-state='error']",
+        "[data-action='retry']",
+        "[data-status='uncollectible']"
+      ]
+    }
+  ]
+}

--- a/design/frames/billing-invoices/manifest.json
+++ b/design/frames/billing-invoices/manifest.json
@@ -2,9 +2,9 @@
   "name": "Billing Invoice History — approval frames",
   "description": "Contract-freeze UX artifacts for the vendor-neutral, DB-backed invoice history capability. Approving these frames approves the InvoiceHistoryPanel visual + interaction model before UI implementation. frontend-test-engineer drives Playwright against these via the data-frame / data-* attributes.",
   "designSystem": "fuse-seam (@fuzefront/design-system)",
-  "approved": false,
-  "approvedBy": null,
-  "approvedAt": null,
+  "approved": true,
+  "approvedBy": "izzywdev",
+  "approvedAt": "2026-07-14",
   "contract": {
     "openapi": "services/billing-service/openapi.yaml",
     "client": "@fuzefront/billing-client",

--- a/design/frames/billing-invoices/tokens.css
+++ b/design/frames/billing-invoices/tokens.css
@@ -1,0 +1,235 @@
+/* fuse-seam design-system tokens (subset), inlined so these approval frames are
+   self-contained / portable. Mirrors design-system/tokens/*.css. These frames are
+   contract-freeze UX artifacts — approve the frames = approve the model. */
+:root {
+  /* brand / accent */
+  --indigo-500: #6e5cff;
+  --cyan-400: #29d3e6;
+  --accent-color: var(--indigo-500);
+  --accent-hover: #5a48e6;
+  --accent-soft: rgba(110, 92, 255, 0.14);
+  --accent-2: var(--cyan-400);
+  --seam: linear-gradient(90deg, var(--accent-color) 0%, var(--accent-2) 100%);
+
+  /* graphite surfaces (dark default) */
+  --bg-primary: #0f131c;
+  --bg-secondary: #11161f;
+  --bg-tertiary: #141a26;
+  --bg-quaternary: #1b2230;
+  --border-color: #232b3a;
+  --border-strong: #313b4d;
+
+  --text-primary: #e7ebf2;
+  --text-secondary: #aab3c2;
+  --text-tertiary: #6b7585;
+
+  --success-color: #34d399;
+  --warning-color: #f5b950;
+  --error-color: #f3697f;
+
+  /* type */
+  --font-display: "Space Grotesk", "Inter", system-ui, sans-serif;
+  --font-sans: "Inter", system-ui, -apple-system, sans-serif;
+  --font-mono: "JetBrains Mono", ui-monospace, "SF Mono", monospace;
+  --text-2xs: 11px;
+  --text-xs: 12px;
+  --text-sm: 13px;
+  --text-md: 14px;
+  --text-lg: 16px;
+  --text-xl: 20px;
+  --text-2xl: 26px;
+  --weight-regular: 400;
+  --weight-medium: 500;
+  --weight-semibold: 600;
+  --tracking-wide: 0.04em;
+  --tracking-display: -0.01em;
+
+  /* spacing / radii / shadow */
+  --space-1: 4px; --space-2: 8px; --space-3: 12px; --space-4: 16px;
+  --space-5: 20px; --space-6: 24px; --space-7: 28px; --space-8: 32px;
+  --space-10: 40px; --space-12: 48px; --space-16: 64px;
+  --radius-sm: 6px; --radius-md: 10px; --radius-lg: 14px; --radius-xl: 20px;
+  --radius-pill: 999px;
+  --shadow-xs: 0 1px 2px rgba(0,0,0,0.3);
+  --shadow-md: 0 6px 20px rgba(0,0,0,0.4);
+  --shadow-lg: 0 16px 48px rgba(0,0,0,0.5);
+  --shadow-accent: 0 8px 24px rgba(110,92,255,0.35);
+
+  --top-bar-height: 60px;
+  --side-panel-width: 240px;
+  --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+  --duration-fast: 120ms;
+  --duration-base: 200ms;
+}
+
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  font-family: var(--font-sans);
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  -webkit-font-smoothing: antialiased;
+}
+.mono { font-family: var(--font-mono); }
+
+/* ---- shared portal-shell chrome used across frames ---- */
+.shell { display: flex; flex-direction: column; height: 100vh; }
+.topbar {
+  height: var(--top-bar-height);
+  flex: none;
+  display: flex; align-items: center; gap: var(--space-4);
+  padding: 0 var(--space-6);
+  background: var(--bg-secondary);
+  border-bottom: 1px solid var(--border-color);
+  position: relative;
+}
+.topbar::after {
+  content: ""; position: absolute; left: 0; right: 0; bottom: -1px;
+  height: 2px; background: var(--seam); opacity: 0.7;
+}
+.wordmark {
+  font-family: var(--font-display); font-weight: var(--weight-semibold);
+  font-size: var(--text-lg); letter-spacing: var(--tracking-display);
+}
+.wordmark .fuse {
+  background: var(--seam); -webkit-background-clip: text;
+  background-clip: text; color: transparent;
+}
+.topbar .spacer { flex: 1; }
+.launch-btn {
+  width: 34px; height: 34px; border-radius: var(--radius-md);
+  display: grid; place-items: center; cursor: pointer;
+  background: var(--bg-quaternary); border: 1px solid var(--border-color);
+}
+.avatar {
+  width: 32px; height: 32px; border-radius: var(--radius-pill);
+  background: var(--seam); display: grid; place-items: center;
+  font-weight: var(--weight-semibold); font-size: var(--text-sm); color: #0b0e15;
+}
+.body { flex: 1; display: flex; min-height: 0; }
+
+.side {
+  width: var(--side-panel-width); flex: none;
+  background: var(--bg-secondary);
+  border-right: 1px solid var(--border-color);
+  padding: var(--space-4) var(--space-3);
+  display: flex; flex-direction: column; gap: var(--space-1);
+  overflow-y: auto;
+}
+.side .section-label {
+  font-family: var(--font-mono); font-size: var(--text-2xs);
+  letter-spacing: var(--tracking-wide); text-transform: uppercase;
+  color: var(--text-tertiary); margin: var(--space-4) var(--space-2) var(--space-2);
+}
+.nav-item {
+  display: flex; align-items: center; gap: var(--space-3);
+  padding: var(--space-2) var(--space-3); border-radius: var(--radius-md);
+  color: var(--text-secondary); font-size: var(--text-md); cursor: pointer;
+  text-decoration: none;
+}
+.nav-item:hover { background: var(--bg-quaternary); color: var(--text-primary); }
+.nav-item.active {
+  background: var(--accent-soft); color: var(--text-primary);
+  box-shadow: inset 2px 0 0 var(--accent-color);
+}
+.nav-item .ico { width: 18px; text-align: center; }
+
+.content { flex: 1; overflow: auto; padding: var(--space-8); min-width: 0; }
+.page-title {
+  font-family: var(--font-display); font-size: var(--text-2xl);
+  letter-spacing: var(--tracking-display); margin: 0 0 var(--space-2);
+}
+.page-sub { color: var(--text-secondary); margin: 0 0 var(--space-6); }
+
+.btn {
+  font-family: var(--font-sans); font-size: var(--text-md);
+  font-weight: var(--weight-medium); border-radius: var(--radius-md);
+  padding: var(--space-2) var(--space-4); cursor: pointer; border: 1px solid transparent;
+}
+.btn-primary { background: var(--accent-color); color: #0b0e15; box-shadow: var(--shadow-accent); }
+.btn-primary:hover { background: var(--accent-hover); }
+.btn-ghost { background: transparent; color: var(--text-secondary); border-color: var(--border-color); }
+.btn-ghost:hover { color: var(--text-primary); border-color: var(--border-strong); }
+
+.badge {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-family: var(--font-mono); font-size: var(--text-2xs);
+  padding: 2px 8px; border-radius: var(--radius-pill);
+  border: 1px solid var(--border-color); color: var(--text-secondary);
+  text-transform: uppercase; letter-spacing: var(--tracking-wide);
+}
+.badge.activated { color: var(--success-color); border-color: rgba(52,211,153,0.4); }
+.badge.registered { color: var(--warning-color); border-color: rgba(245,185,80,0.4); }
+.badge.mf { color: var(--cyan-400); border-color: rgba(41,211,230,0.4); }
+.badge.builtin { color: var(--accent-color); border-color: rgba(110,92,255,0.4); }
+.badge.standalone { color: var(--text-primary); border-color: var(--border-strong); }
+
+.dot { width: 9px; height: 9px; border-radius: var(--radius-pill); display: inline-block; }
+.dot.healthy { background: var(--success-color); }
+.dot.down { background: var(--error-color); }
+
+/* approval-frame footer nav */
+.frame-nav {
+  position: fixed; bottom: 0; left: 0; right: 0;
+  display: flex; align-items: center; justify-content: space-between;
+  gap: var(--space-4); padding: var(--space-3) var(--space-6);
+  background: rgba(17,22,31,0.92); backdrop-filter: blur(8px);
+  border-top: 1px solid var(--border-color); z-index: 50;
+}
+.frame-nav .caption { font-size: var(--text-sm); color: var(--text-tertiary); }
+.frame-nav .caption b { color: var(--text-secondary); font-weight: var(--weight-semibold); }
+.frame-nav a { text-decoration: none; }
+.content { padding-bottom: 72px; }
+
+/* ---- invoice status pill soft tokens (mirror @fuzefront/design-system semantic *-soft) ---- */
+:root {
+  --success-soft: rgba(52, 211, 153, 0.14);
+  --warning-soft: rgba(245, 185, 80, 0.14);
+  --error-soft:   rgba(243, 105, 127, 0.14);
+  --neutral-soft: rgba(170, 179, 194, 0.12);
+}
+
+/* ---- InvoiceHistoryPanel (design-system-first; tokens only) ---- */
+.ffb-invoices { background: var(--bg-tertiary); border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg); position: relative; overflow: hidden; max-width: 720px; }
+.ffb-invoices__seam { height: 2px; background: var(--seam); }
+.ffb-invoices__head { display: flex; align-items: baseline; justify-content: space-between;
+  gap: var(--space-3); padding: var(--space-5) var(--space-5) var(--space-3); }
+.ffb-invoices__title { margin: 0; font-family: var(--font-display); font-size: var(--text-lg);
+  font-weight: var(--weight-semibold); color: var(--text-primary); }
+.ffb-invoices__count { color: var(--text-tertiary); font-size: var(--text-sm);
+  font-variant-numeric: tabular-nums; }
+.ffb-invoices__list { display: flex; flex-direction: column; }
+.ffb-invoice-row { display: grid; grid-template-columns: 1fr auto; gap: var(--space-1) var(--space-4);
+  padding: var(--space-4) var(--space-5); border-top: 1px solid var(--border-color); align-items: center; }
+.ffb-invoice-row__main { display: flex; flex-direction: column; gap: var(--space-1); min-width: 0; }
+.ffb-invoice-row__top { display: flex; align-items: center; gap: var(--space-3); flex-wrap: wrap; }
+.ffb-invoice-row__num { font-weight: var(--weight-medium); color: var(--text-primary);
+  font-variant-numeric: tabular-nums; }
+.ffb-invoice-row__date { color: var(--text-secondary); font-size: var(--text-sm); }
+.ffb-invoice-row__side { display: flex; align-items: center; gap: var(--space-4); justify-content: flex-end; }
+.ffb-invoice-row__amount { color: var(--text-primary); font-weight: var(--weight-semibold);
+  font-variant-numeric: tabular-nums; text-align: end; }
+.ffb-pill { display: inline-flex; align-items: center; gap: var(--space-1);
+  padding: 2px var(--space-2); border-radius: var(--radius-pill); font-size: var(--text-2xs);
+  font-weight: var(--weight-semibold); text-transform: capitalize; white-space: nowrap; }
+.ffb-pill__dot { width: 6px; height: 6px; border-radius: var(--radius-pill); background: currentColor; }
+.ffb-pill--paid { background: var(--success-soft); color: var(--success-color); }
+.ffb-pill--open { background: var(--warning-soft); color: var(--warning-color); }
+.ffb-pill--void { background: var(--neutral-soft); color: var(--text-secondary); }
+.ffb-pill--uncollectible { background: var(--error-soft); color: var(--error-color); }
+.ffb-dl { display: inline-flex; align-items: center; gap: var(--space-1); color: var(--accent-color);
+  text-decoration: none; font-size: var(--text-sm); font-weight: var(--weight-medium);
+  padding: var(--space-1) var(--space-2); border-radius: var(--radius-sm); min-height: 32px; }
+.ffb-dl:hover { background: var(--accent-soft); }
+.ffb-dl svg { width: 14px; height: 14px; }
+.ffb-invoices__foot { padding: var(--space-4) var(--space-5); border-top: 1px solid var(--border-color);
+  display: flex; justify-content: center; }
+.ffb-skel { height: 14px; border-radius: var(--radius-pill); background:
+  linear-gradient(90deg, var(--bg-quaternary), var(--border-color), var(--bg-quaternary));
+  background-size: 200% 100%; animation: ffbsh 1.3s ease-in-out infinite; }
+@keyframes ffbsh { 0%{background-position:200% 0} 100%{background-position:-200% 0} }
+@media (prefers-reduced-motion: reduce){ .ffb-skel{ animation: none; } }
+.ffb-empty { padding: var(--space-8) var(--space-5); text-align: center; color: var(--text-secondary); }
+.ffb-empty__icon { width: 40px; height: 40px; margin: 0 auto var(--space-3); color: var(--text-tertiary); }
+.ffb-note { font-size: var(--text-sm); color: var(--text-secondary); }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -100,6 +100,41 @@ services:
       - fuzefront-backend
 
   # ================================
+  # PAYMENT SERVICE (vendor-neutral payment gateway — SCAFFOLD, not the live
+  # money path yet). Runnable with zero secrets: without STRIPE_SECRET_KEY it
+  # serves /health only (degraded mode). Listens on 3007 (billing is 3006).
+  # ================================
+  payment-service:
+    build:
+      context: ./services/payment-service
+      dockerfile: Dockerfile
+    ports:
+      - "3007:3007"
+    environment:
+      - NODE_ENV=development
+      - PORT=3007
+      - PAYMENT_PROVIDER=stripe
+      # STRIPE_SECRET_KEY intentionally unset locally → degraded mode (/health).
+      # PAYMENT_INTERNAL_TOKEN optional; unset leaves the neutral API open locally.
+    networks:
+      - FuzeInfra
+    restart: unless-stopped
+    healthcheck:
+      test:
+        [
+          'CMD',
+          'wget',
+          '--no-verbose',
+          '--tries=1',
+          '--spider',
+          'http://localhost:3007/health',
+        ]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 20s
+
+  # ================================
   # FRONTEND SERVICE
   # ================================
   fuzefront-frontend:

--- a/frontend/src/pages/BillingPage.tsx
+++ b/frontend/src/pages/BillingPage.tsx
@@ -7,6 +7,13 @@ import {
   Skeleton,
   Tabs,
 } from '@fuzefront/design-system'
+import { InvoiceHistoryPanel, BillingI18nProvider } from '@fuzefront/billing-ui'
+// The billing-ui stylesheet (design-system tokens only). Imported from source
+// here because the frontend build resolves @fuzefront/billing-ui from source
+// (see frontend/vite.config.ts) and the published `./styles.css` subpath is not
+// aliased for dev. Wiring a `@fuzefront/billing-ui/styles.css` vite alias
+// (mirroring @fuzefront/chat-ui) is a follow-up owned by devops.
+import '../../../packages/billing-ui/src/styles/billing-ui.css'
 import { useOrganizations } from '../lib/shared'
 import {
   listPlans,
@@ -21,6 +28,19 @@ import {
   type BillingSubscriptionView,
   type BillingInvoice,
 } from '../services/billingService'
+
+/**
+ * Gate for the design-system-first invoice history panel
+ * (`fuzefront.billing.invoice-history`, default OFF). The family flag standard
+ * is Unleash via `@fuzefront/feature-flags`; until the web flag client is
+ * initialized in the shell bootstrap this reads a build-time override and
+ * defaults OFF, so production behavior is unchanged. Swap the body for
+ * `getBoolean('fuzefront.billing.invoice-history', false)` once the web client
+ * is wired — the flag key and default stay identical.
+ */
+function useInvoiceHistoryFlag(): boolean {
+  return import.meta.env.VITE_FF_BILLING_INVOICE_HISTORY === 'true'
+}
 
 /**
  * Billing area for the FuzeFront shell — an industry-standard, design-system-
@@ -363,6 +383,37 @@ const CELL_STYLE: React.CSSProperties = {
 }
 
 const InvoicesTab: React.FC<{ organizationId?: string }> = ({
+  organizationId,
+}) => {
+  const invoiceHistoryEnabled = useInvoiceHistoryFlag()
+
+  // Adapter over the same-origin billing service (no absolute host) matching the
+  // billing-ui InvoiceHistoryPanel's injected `listInvoices` contract.
+  const fetchInvoices = useCallback(
+    (opts: { limit?: number; cursor?: string }) =>
+      listInvoices(organizationId, opts),
+    [organizationId]
+  )
+
+  // Flag ON → the design-system-first, vendor-neutral InvoiceHistoryPanel from
+  // @fuzefront/billing-ui. Flag OFF → the existing native table below.
+  if (invoiceHistoryEnabled) {
+    return (
+      <section aria-labelledby="invoices-h">
+        <h2 id="invoices-h" style={{ marginTop: 0 }}>
+          Invoices
+        </h2>
+        <BillingI18nProvider>
+          <InvoiceHistoryPanel enabled listInvoices={fetchInvoices} />
+        </BillingI18nProvider>
+      </section>
+    )
+  }
+
+  return <LegacyInvoicesTab organizationId={organizationId} />
+}
+
+const LegacyInvoicesTab: React.FC<{ organizationId?: string }> = ({
   organizationId,
 }) => {
   const [invoices, setInvoices] = useState<BillingInvoice[]>([])

--- a/frontend/src/services/billingService.ts
+++ b/frontend/src/services/billingService.ts
@@ -22,8 +22,10 @@ const P = 'v1/billing'
 
 export interface BillingPlan {
   id?: string
+  // The `/plans` payload carries the provider price/product id here (neutral).
   priceId?: string
-  // The backend `/plans` payload carries the Stripe price id here.
+  productId?: string
+  // Back-compat: older payloads named these fields with the provider prefix.
   stripePriceId?: string
   stripeProductId?: string
   name?: string
@@ -87,13 +89,14 @@ export interface PortalSessionResponse {
 /**
  * Normalize a raw plan payload into a shape the UI can rely on.
  *
- * The `/plans` payload exposes the Stripe price id as `stripePriceId` and the
- * label split across `displayName` / `tierName`. We resolve a single canonical
- * `id` (the Stripe price id `/checkout` expects) and a `name`/`displayName`
- * here so every consumer (key, title, the subscribe call) reads from one place.
+ * The `/plans` payload exposes the provider price id as `priceId` (older
+ * payloads used `stripePriceId`) and the label split across `displayName` /
+ * `tierName`. We resolve a single canonical `id` (the price id `/checkout`
+ * expects) and a `name`/`displayName` here so every consumer (key, title, the
+ * subscribe call) reads from one place.
  */
 function normalizePlan(raw: BillingPlan): BillingPlan {
-  const id = raw.stripePriceId ?? raw.id ?? raw.priceId
+  const id = raw.priceId ?? raw.id ?? raw.stripePriceId
   const name = raw.displayName ?? raw.name ?? raw.tierName
   return {
     ...raw,

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -23,7 +23,7 @@
       "@fuzefront/chat-ui": ["../packages/chat-ui/dist/index.d.ts"],
       "@fuzefront/chat-client": ["../packages/chat-client/dist/index.d.ts"],
       "@fuzefront/billing-ui": ["../packages/billing-ui/src/index.ts"],
-      "@fuzefront/billing-client": ["../billing-client/index.ts"],
+      "@fuzefront/billing-client": ["../billing-client/src/index.ts"],
       "@fuzefront/app-registry-client": ["../apps-client/src/index.ts"],
       "@fuzefront/design-system": ["../design-system/index.d.ts"]
     }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -41,7 +41,7 @@ const billingUiSrc = fileURLToPath(
   new URL('../packages/billing-ui/src/index.ts', import.meta.url)
 )
 const billingClientSrc = fileURLToPath(
-  new URL('../billing-client/index.ts', import.meta.url)
+  new URL('../billing-client/src/index.ts', import.meta.url)
 )
 // @fuzefront/app-registry-client (apps-client/) is an unpublished file: workspace
 // package whose dist/ is not built in CI — resolve from SOURCE, same as

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -25,11 +25,20 @@ const billingClientSrc = fileURLToPath(
 // @tailwindcss/postcss → @tailwindcss/oxide (a native binary absent in CI), which
 // otherwise crashes the test file during transform. jsdom tests assert DOM/logic,
 // not visual output, so stubbing CSS is correct. Runs before @vitejs/plugin-react.
+const CSS_STUB_ID = '\0css-stub.js'
 const stubCss = {
   name: 'stub-css-imports',
   enforce: 'pre' as const,
+  // Map every .css import to a virtual module whose id does NOT end in .css, so
+  // vite:css's isCSSRequest(id) returns false and its transform (which would load
+  // frontend/postcss.config.js -> @tailwindcss/postcss -> native @tailwindcss/oxide,
+  // absent in CI) is skipped entirely. A load-only stub is insufficient: vite:css
+  // re-checks the id by extension after load. jsdom tests assert DOM/logic, not CSS.
+  resolveId(id: string) {
+    return id.split('?')[0].endsWith('.css') ? CSS_STUB_ID : null
+  },
   load(id: string) {
-    return id.split('?')[0].endsWith('.css') ? 'export default {}' : null
+    return id === CSS_STUB_ID ? 'export default {}' : null
   },
 }
 

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -48,5 +48,10 @@ export default defineConfig({
     include: ['src/**/*.test.{ts,tsx}'],
     exclude: ['tests/**', 'node_modules/**'],
     testTimeout: 15000,
+    // jsdom unit tests don't assert on real CSS. Disable CSS processing so raw
+    // stylesheet imports (e.g. BillingPage importing billing-ui.css) become
+    // no-ops instead of routing through PostCSS — which fails in CI on a missing
+    // native binding (npm optional-deps bug) the moment a test imports raw CSS.
+    css: false,
   },
 })

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -40,6 +40,13 @@ export default defineConfig({
     // single instance of React and the i18n runtime.
     dedupe: ['react', 'react-dom', 'react/jsx-runtime', 'react-i18next', 'i18next'],
   },
+  // Override PostCSS with an inline empty config so vite does NOT auto-load
+  // frontend/postcss.config.js (which pulls @tailwindcss/postcss). That plugin's
+  // native binding is absent in CI and crashes the CSS transform the moment a
+  // test imports raw CSS (BillingPage -> billing-ui.css). Tests don't build real
+  // CSS, so an empty pipeline is correct here. test.css:false alone is not enough
+  // — vite still loads the external postcss config to process the import.
+  css: { postcss: { plugins: [] } },
   test: {
     environment: 'jsdom',
     globals: true,

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -54,6 +54,12 @@ export default defineConfig({
     // single instance of React and the i18n runtime.
     dedupe: ['react', 'react-dom', 'react/jsx-runtime', 'react-i18next', 'i18next'],
   },
+  // Inline PostCSS config: per Vite docs, when css.postcss is an inline object
+  // Vite does NOT search for / load frontend/postcss.config.js (which pulls
+  // @tailwindcss/postcss -> @tailwindcss/oxide, a native binary absent in CI that
+  // crashes the CSS transform the moment a test imports raw CSS). This is the
+  // authoritative stop; the stub-css pre-plugin above is defence-in-depth.
+  css: { postcss: { plugins: [] } },
   test: {
     environment: 'jsdom',
     globals: true,

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -12,6 +12,12 @@ const designSystemSrc = fileURLToPath(
 const i18nSrc = fileURLToPath(
   new URL('../packages/i18n/src/index.ts', import.meta.url)
 )
+const billingUiSrc = fileURLToPath(
+  new URL('../packages/billing-ui/src/index.ts', import.meta.url)
+)
+const billingClientSrc = fileURLToPath(
+  new URL('../billing-client/src/index.ts', import.meta.url)
+)
 
 export default defineConfig({
   plugins: [react()],
@@ -20,6 +26,12 @@ export default defineConfig({
       '@fuzefront/identity-ui': identityUiSrc,
       '@fuzefront/i18n': i18nSrc,
       '@fuzefront/design-system': designSystemSrc,
+      // billing-ui + billing-client are resolved from SOURCE (unpublished file:
+      // workspace packages whose dist is not built in CI), mirroring vite.config.ts.
+      // Without these, BillingPage.test.tsx fails to resolve @fuzefront/billing-ui
+      // (package.json main points to an unbuilt dist).
+      '@fuzefront/billing-ui': billingUiSrc,
+      '@fuzefront/billing-client': billingClientSrc,
     },
     // @fuzefront/i18n is resolved from source and pulls react-i18next, which has
     // its own nested react copy under packages/i18n/node_modules. Without dedupe

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -19,8 +19,22 @@ const billingClientSrc = fileURLToPath(
   new URL('../billing-client/src/index.ts', import.meta.url)
 )
 
+// Intercept ALL .css imports (including out-of-root ones like billing-ui.css that
+// BillingPage imports) and return an empty module BEFORE vite:css runs. This stops
+// vite from routing any stylesheet through frontend/postcss.config.js →
+// @tailwindcss/postcss → @tailwindcss/oxide (a native binary absent in CI), which
+// otherwise crashes the test file during transform. jsdom tests assert DOM/logic,
+// not visual output, so stubbing CSS is correct. Runs before @vitejs/plugin-react.
+const stubCss = {
+  name: 'stub-css-imports',
+  enforce: 'pre' as const,
+  load(id: string) {
+    return id.split('?')[0].endsWith('.css') ? 'export default {}' : null
+  },
+}
+
 export default defineConfig({
-  plugins: [react()],
+  plugins: [stubCss, react()],
   resolve: {
     alias: {
       '@fuzefront/identity-ui': identityUiSrc,
@@ -40,13 +54,6 @@ export default defineConfig({
     // single instance of React and the i18n runtime.
     dedupe: ['react', 'react-dom', 'react/jsx-runtime', 'react-i18next', 'i18next'],
   },
-  // Override PostCSS with an inline empty config so vite does NOT auto-load
-  // frontend/postcss.config.js (which pulls @tailwindcss/postcss). That plugin's
-  // native binding is absent in CI and crashes the CSS transform the moment a
-  // test imports raw CSS (BillingPage -> billing-ui.css). Tests don't build real
-  // CSS, so an empty pipeline is correct here. test.css:false alone is not enough
-  // — vite still loads the external postcss config to process the import.
-  css: { postcss: { plugins: [] } },
   test: {
     environment: 'jsdom',
     globals: true,

--- a/packages/billing-ui/src/components/InvoiceHistoryPanel.tsx
+++ b/packages/billing-ui/src/components/InvoiceHistoryPanel.tsx
@@ -1,0 +1,321 @@
+import { useCallback, useEffect, useState } from 'react';
+import type { BillingInvoice, InvoiceListResponse } from '@fuzefront/billing-client';
+import { useBillingI18n } from '../i18n';
+import { invoiceStatusTone, invoiceStatusLabel } from '../lib/status';
+import { Button } from './primitives';
+
+/** Signature of the injected data source (mirrors billing-client.listInvoices). */
+export type ListInvoices = (opts: {
+  limit?: number;
+  cursor?: string;
+}) => Promise<InvoiceListResponse>;
+
+export interface InvoiceHistoryPanelProps {
+  /**
+   * Feature-flag gate (`fuzefront.billing.invoice-history`, default OFF). The
+   * caller resolves the flag (e.g. via `@fuzefront/feature-flags`) and forwards
+   * the result here so this package stays flag-provider-agnostic and testable.
+   * When false the panel renders nothing.
+   */
+  enabled?: boolean;
+  /**
+   * Injected data source — the caller passes `client.listInvoices` (or the host
+   * service wrapper). Kept as a callback so the panel is fully testable without
+   * a network and never hard-codes an API host / vendor.
+   */
+  listInvoices: ListInvoices;
+  /** Page size for the initial load and each "Load more". */
+  pageSize?: number;
+}
+
+type LoadState = 'loading' | 'error' | 'ready';
+
+/** Decorative download glyph (matches the approval frame). */
+function DownloadIcon() {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      focusable="false"
+    >
+      <path d="M12 3v12m0 0l4-4m-4 4l-4-4M4 21h16" />
+    </svg>
+  );
+}
+
+/** Decorative document glyph for the "View" (hosted) link + empty state. */
+function DocumentIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      focusable="false"
+    >
+      <path d="M14 3v5h5M8 13h8M8 17h5M6 3h9l5 5v11a1 1 0 01-1 1H6a1 1 0 01-1-1V4a1 1 0 011-1z" />
+    </svg>
+  );
+}
+
+function ErrorIcon() {
+  return (
+    <svg
+      className="ffb-invoices__empty-icon ffb-invoices__empty-icon--error"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      focusable="false"
+    >
+      <circle cx="12" cy="12" r="9" />
+      <path d="M12 8v5M12 16h.01" />
+    </svg>
+  );
+}
+
+/** A single invoice's download link — PDF when available, else the hosted doc. */
+function InvoiceDownload({ invoice }: { invoice: BillingInvoice }) {
+  const { strings } = useBillingI18n();
+  const label = invoice.number ?? invoice.id;
+
+  if (invoice.invoicePdf) {
+    return (
+      <a
+        className="ffb-invoices__dl"
+        href={invoice.invoicePdf}
+        target="_blank"
+        rel="noopener noreferrer"
+        data-download="pdf"
+        data-testid="invoice-download"
+        aria-label={`${strings.invoiceDownloadAria} ${label} ${strings.invoiceDownloadPdf}`}
+      >
+        <DownloadIcon />
+        {strings.invoiceDownloadPdf}
+      </a>
+    );
+  }
+
+  if (invoice.hostedInvoiceUrl) {
+    return (
+      <a
+        className="ffb-invoices__dl"
+        href={invoice.hostedInvoiceUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        data-download="hosted"
+        data-testid="invoice-download"
+        aria-label={`${strings.invoiceViewAria} ${label}`}
+      >
+        <DocumentIcon />
+        {strings.invoiceView}
+      </a>
+    );
+  }
+
+  return null;
+}
+
+function InvoiceRow({ invoice }: { invoice: BillingInvoice }) {
+  const { strings, formatCurrency, formatDate } = useBillingI18n();
+  const tone = invoiceStatusTone(invoice.status);
+  const number = invoice.number ?? invoice.id;
+
+  return (
+    <div
+      className="ffb-invoices__row"
+      data-invoice={number}
+      data-status={invoice.status}
+      data-testid="invoice-row"
+    >
+      <div className="ffb-invoices__row-main">
+        <div className="ffb-invoices__row-top">
+          <span className="ffb-invoices__num">{number}</span>
+          <span className="ffb-invoices__date">· {formatDate(invoice.created)}</span>
+        </div>
+      </div>
+      <div className="ffb-invoices__row-side">
+        <span className={`ffb-invoices__pill ffb-invoices__pill--${tone}`}>
+          <span className="ffb-invoices__pill-dot" aria-hidden="true" />
+          {invoiceStatusLabel(invoice.status, strings)}
+        </span>
+        <span className="ffb-invoices__amount">
+          {formatCurrency(invoice.amountDue, invoice.currency)}
+        </span>
+        <InvoiceDownload invoice={invoice} />
+      </div>
+    </div>
+  );
+}
+
+/** Non-interactive skeleton row shown while the first page loads. */
+function SkeletonRow() {
+  return (
+    <div className="ffb-invoices__row" aria-hidden="true">
+      <div className="ffb-invoices__row-main">
+        <span className="ffb-invoices__skel ffb-invoices__skel--wide" />
+        <span className="ffb-invoices__skel ffb-invoices__skel--narrow" />
+      </div>
+      <span className="ffb-invoices__skel ffb-invoices__skel--pill" />
+    </div>
+  );
+}
+
+/**
+ * Vendor-neutral invoice history. Renders newest-first rows from the injected
+ * `listInvoices` source (id/number/amount/status from FuzeFront's own store; the
+ * download link is an opaque provider-hosted document). Cursor "Load more"
+ * appends the next page. Loading / empty / error states mirror the approval
+ * frames. No vendor name is ever emitted.
+ */
+export function InvoiceHistoryPanel({
+  enabled = false,
+  listInvoices,
+  pageSize = 20,
+}: InvoiceHistoryPanelProps) {
+  const { strings } = useBillingI18n();
+  const [invoices, setInvoices] = useState<BillingInvoice[]>([]);
+  const [nextCursor, setNextCursor] = useState<string | null>(null);
+  const [state, setState] = useState<LoadState>('loading');
+  const [loadingMore, setLoadingMore] = useState(false);
+
+  const loadFirst = useCallback(() => {
+    let cancelled = false;
+    setState('loading');
+    listInvoices({ limit: pageSize })
+      .then((res) => {
+        if (cancelled) return;
+        setInvoices(res.invoices);
+        setNextCursor(res.nextCursor);
+        setState('ready');
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setInvoices([]);
+        setNextCursor(null);
+        setState('error');
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [listInvoices, pageSize]);
+
+  useEffect(() => {
+    if (!enabled) return;
+    const cancel = loadFirst();
+    return cancel;
+  }, [enabled, loadFirst]);
+
+  // Feature flag OFF → render nothing at all.
+  if (!enabled) return null;
+
+  const loadMore = async () => {
+    if (!nextCursor || loadingMore) return;
+    setLoadingMore(true);
+    try {
+      const res = await listInvoices({ limit: pageSize, cursor: nextCursor });
+      setInvoices((prev) => [...prev, ...res.invoices]);
+      setNextCursor(res.nextCursor);
+    } catch {
+      setState('error');
+    } finally {
+      setLoadingMore(false);
+    }
+  };
+
+  const dataState =
+    state === 'loading'
+      ? 'loading'
+      : state === 'error'
+        ? 'error'
+        : invoices.length === 0
+          ? 'empty'
+          : undefined;
+
+  const header = (
+    <div className="ffb-invoices__head">
+      <h3 className="ffb-invoices__title">{strings.invoicesHeading}</h3>
+      {state === 'ready' && invoices.length > 0 && (
+        <span className="ffb-invoices__count" data-invoice-count={invoices.length}>
+          {invoices.length} {strings.invoicesShownSuffix}
+        </span>
+      )}
+    </div>
+  );
+
+  return (
+    <section
+      className="ffb-invoices"
+      data-panel="invoice-history"
+      data-testid="invoice-history-panel"
+      {...(dataState ? { 'data-state': dataState } : {})}
+      aria-label={strings.invoicesHeading}
+      aria-busy={state === 'loading' || undefined}
+    >
+      <div className="ffb-invoices__seam" aria-hidden="true" />
+      {header}
+
+      {state === 'loading' && (
+        <div className="ffb-invoices__list" data-testid="invoice-loading">
+          <SkeletonRow />
+          <SkeletonRow />
+          <SkeletonRow />
+        </div>
+      )}
+
+      {state === 'error' && (
+        <div className="ffb-invoices__empty" data-error data-testid="invoice-error" role="alert">
+          <ErrorIcon />
+          <p className="ffb-invoices__empty-title">{strings.invoicesErrorHeading}</p>
+          <p className="ffb-invoices__note">{strings.invoicesErrorBody}</p>
+          <Button variant="ghost" data-action="retry" onClick={loadFirst}>
+            {strings.retry}
+          </Button>
+        </div>
+      )}
+
+      {state === 'ready' && invoices.length === 0 && (
+        <div className="ffb-invoices__empty" data-empty data-testid="invoice-empty">
+          <DocumentIcon className="ffb-invoices__empty-icon" />
+          <p className="ffb-invoices__empty-title">{strings.invoicesEmptyHeading}</p>
+          <p className="ffb-invoices__note">{strings.invoicesEmptyBody}</p>
+        </div>
+      )}
+
+      {state === 'ready' && invoices.length > 0 && (
+        <>
+          <div className="ffb-invoices__list" data-invoice-list>
+            {invoices.map((inv) => (
+              <InvoiceRow key={inv.id} invoice={inv} />
+            ))}
+          </div>
+          {nextCursor && (
+            <div className="ffb-invoices__foot">
+              <Button
+                variant="ghost"
+                data-action="load-more"
+                onClick={loadMore}
+                loading={loadingMore}
+                disabled={loadingMore}
+              >
+                {strings.invoicesLoadMore}
+              </Button>
+            </div>
+          )}
+        </>
+      )}
+    </section>
+  );
+}

--- a/packages/billing-ui/src/components/PlanCard.tsx
+++ b/packages/billing-ui/src/components/PlanCard.tsx
@@ -41,7 +41,7 @@ export function PlanCard({
     .filter(Boolean)
     .join(' ');
 
-  const headingId = `ffb-plan-${plan.stripePriceId}`;
+  const headingId = `ffb-plan-${plan.priceId}`;
 
   return (
     <section className={classes} aria-labelledby={headingId}>

--- a/packages/billing-ui/src/components/PlanPicker.tsx
+++ b/packages/billing-ui/src/components/PlanPicker.tsx
@@ -7,11 +7,11 @@ export type BillingInterval = 'month' | 'year';
 
 export interface PlanPickerProps {
   plans: Plan[];
-  /** stripePriceId of the entity's current plan, if any. */
+  /** priceId of the entity's current plan, if any. */
   currentPriceId?: string | null;
-  /** stripePriceId to highlight as recommended. */
+  /** priceId to highlight as recommended. */
   featuredPriceId?: string | null;
-  /** Controlled selection (stripePriceId). */
+  /** Controlled selection (priceId). */
   selectedPriceId?: string | null;
   onSelect?: (plan: Plan) => void;
   /** Show the monthly/yearly toggle (only when both intervals exist). */
@@ -86,11 +86,11 @@ export function PlanPicker({
       <div className="ffb-plans__grid">
         {visiblePlans.map((plan) => (
           <PlanCard
-            key={plan.stripePriceId}
+            key={plan.priceId}
             plan={plan}
-            current={plan.stripePriceId === currentPriceId}
-            featured={plan.stripePriceId === featuredPriceId}
-            selected={plan.stripePriceId === selectedPriceId}
+            current={plan.priceId === currentPriceId}
+            featured={plan.priceId === featuredPriceId}
+            selected={plan.priceId === selectedPriceId}
             onSelect={onSelect}
             disabled={disabled}
           />

--- a/packages/billing-ui/src/components/primitives.tsx
+++ b/packages/billing-ui/src/components/primitives.tsx
@@ -17,6 +17,8 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: ButtonVariant;
   block?: boolean;
   loading?: boolean;
+  /** Allow arbitrary data-* hooks (e.g. data-action) to reach the DOM button. */
+  [dataAttr: `data-${string}`]: unknown;
 }
 
 export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button(

--- a/packages/billing-ui/src/i18n/index.ts
+++ b/packages/billing-ui/src/i18n/index.ts
@@ -84,6 +84,25 @@ export interface BillingStrings {
   statusCanceled: string;
   statusUnpaid: string;
   statusIncomplete: string;
+  // Invoice history
+  invoicesHeading: string;
+  invoicesShownSuffix: string;
+  invoicesLoadMore: string;
+  invoicesEmptyHeading: string;
+  invoicesEmptyBody: string;
+  invoicesErrorHeading: string;
+  invoicesErrorBody: string;
+  invoiceDownloadPdf: string;
+  invoiceView: string;
+  /** Accessible-name prefix for a PDF download link: "<prefix> <number> <invoiceDownloadPdf>". */
+  invoiceDownloadAria: string;
+  /** Accessible-name prefix for a hosted-invoice link: "<prefix> <number>". */
+  invoiceViewAria: string;
+  invoiceStatusPaid: string;
+  invoiceStatusOpen: string;
+  invoiceStatusVoid: string;
+  invoiceStatusDraft: string;
+  invoiceStatusUncollectible: string;
   // Generic
   errorPrefix: string;
   retry: string;
@@ -152,6 +171,22 @@ const EN: BillingStrings = {
   statusCanceled: 'Canceled',
   statusUnpaid: 'Unpaid',
   statusIncomplete: 'Incomplete',
+  invoicesHeading: 'Invoices',
+  invoicesShownSuffix: 'shown',
+  invoicesLoadMore: 'Load more',
+  invoicesEmptyHeading: 'No invoices yet',
+  invoicesEmptyBody: 'Invoices appear here after your first billed period.',
+  invoicesErrorHeading: "Couldn't load invoices",
+  invoicesErrorBody: 'Something went wrong on our end.',
+  invoiceDownloadPdf: 'PDF',
+  invoiceView: 'View',
+  invoiceDownloadAria: 'Download invoice',
+  invoiceViewAria: 'View invoice',
+  invoiceStatusPaid: 'Paid',
+  invoiceStatusOpen: 'Open',
+  invoiceStatusVoid: 'Void',
+  invoiceStatusDraft: 'Draft',
+  invoiceStatusUncollectible: 'Uncollectible',
   errorPrefix: 'Something went wrong',
   retry: 'Try again',
   loading: 'Loading…',

--- a/packages/billing-ui/src/index.ts
+++ b/packages/billing-ui/src/index.ts
@@ -23,7 +23,14 @@ export {
 } from './i18n';
 
 // Status helpers (re-exported for consumers building custom chrome)
-export { statusTone, statusLabel, isEntitled, type StatusTone } from './lib/status';
+export {
+  statusTone,
+  statusLabel,
+  isEntitled,
+  invoiceStatusTone,
+  invoiceStatusLabel,
+  type StatusTone,
+} from './lib/status';
 
 // Primitives
 export {
@@ -69,6 +76,13 @@ export {
   type CardSummary,
 } from './components/PaymentMethodPanel';
 
+// Invoice history
+export {
+  InvoiceHistoryPanel,
+  type InvoiceHistoryPanelProps,
+  type ListInvoices,
+} from './components/InvoiceHistoryPanel';
+
 // Re-export the contract types consumers will need alongside the components.
 export type {
   Plan,
@@ -76,4 +90,6 @@ export type {
   SubscriptionStatus,
   PlanTier,
   EntityType,
+  BillingInvoice,
+  InvoiceListResponse,
 } from '@fuzefront/billing-client';

--- a/packages/billing-ui/src/lib/status.ts
+++ b/packages/billing-ui/src/lib/status.ts
@@ -28,6 +28,37 @@ export function statusTone(status: SubscriptionStatus): StatusTone {
   return TONE_BY_STATUS[status] ?? 'neutral';
 }
 
+/**
+ * Visual tone for a vendor-neutral invoice status. The invoice status set is
+ * independent of the subscription set (paid/open/void/uncollectible/draft), so
+ * it gets its own mapping rather than overloading `statusTone`.
+ */
+const TONE_BY_INVOICE_STATUS: Record<string, StatusTone> = {
+  paid: 'success',
+  open: 'warning',
+  void: 'neutral',
+  draft: 'neutral',
+  uncollectible: 'error',
+};
+
+export function invoiceStatusTone(status: string): StatusTone {
+  return TONE_BY_INVOICE_STATUS[status] ?? 'neutral';
+}
+
+const INVOICE_STRING_KEY_BY_STATUS: Record<string, keyof BillingStrings> = {
+  paid: 'invoiceStatusPaid',
+  open: 'invoiceStatusOpen',
+  void: 'invoiceStatusVoid',
+  draft: 'invoiceStatusDraft',
+  uncollectible: 'invoiceStatusUncollectible',
+};
+
+/** Resolve a human-readable, translated label for an invoice status. */
+export function invoiceStatusLabel(status: string, strings: BillingStrings): string {
+  const key = INVOICE_STRING_KEY_BY_STATUS[status];
+  return key ? strings[key] : status;
+}
+
 /** Resolve a human-readable, translated label for a subscription status. */
 export function statusLabel(status: SubscriptionStatus, strings: BillingStrings): string {
   const key = STRING_KEY_BY_STATUS[status];

--- a/packages/billing-ui/src/styles/billing-ui.css
+++ b/packages/billing-ui/src/styles/billing-ui.css
@@ -484,3 +484,222 @@
   white-space: nowrap;
   border: 0;
 }
+
+/* ---- Invoice history --------------------------------------- */
+/* Soft status fills. The semantic `*-soft` tokens are derived here from the
+   design-system status color tokens via color-mix (tokens-only, no raw
+   hex/rgb) — mirroring @fuzefront/design-system's intended semantic *-soft
+   ramp. Scoped to the panel so they collapse cleanly if the DS publishes
+   global *-soft tokens later. */
+.ffb-invoices {
+  --success-soft: color-mix(in srgb, var(--success-color) 14%, transparent);
+  --warning-soft: color-mix(in srgb, var(--warning-color) 14%, transparent);
+  --error-soft: color-mix(in srgb, var(--error-color) 14%, transparent);
+  --neutral-soft: color-mix(in srgb, var(--text-secondary) 12%, transparent);
+
+  position: relative;
+  overflow: hidden;
+  background: var(--bg-tertiary);
+  border: var(--border-width) solid var(--border-color);
+  border-radius: var(--radius-lg);
+}
+.ffb-invoices__seam {
+  block-size: var(--border-width-strong);
+  background: var(--seam);
+}
+.ffb-invoices__head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-3);
+  padding-block: var(--space-5) var(--space-3);
+  padding-inline: var(--space-5);
+}
+.ffb-invoices__title {
+  margin: 0;
+  font-size: var(--text-lg);
+  font-weight: var(--weight-semibold);
+  color: var(--text-primary);
+}
+.ffb-invoices__count {
+  color: var(--text-tertiary);
+  font-size: var(--text-sm);
+  font-variant-numeric: tabular-nums;
+}
+.ffb-invoices__list {
+  display: flex;
+  flex-direction: column;
+}
+.ffb-invoices__row {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: var(--space-1) var(--space-4);
+  align-items: center;
+  padding-block: var(--space-4);
+  padding-inline: var(--space-5);
+  border-block-start: var(--border-width) solid var(--border-color);
+}
+.ffb-invoices__row-main {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  min-inline-size: 0;
+}
+.ffb-invoices__row-top {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+}
+.ffb-invoices__num {
+  font-weight: var(--weight-medium);
+  color: var(--text-primary);
+  font-variant-numeric: tabular-nums;
+}
+.ffb-invoices__date {
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+}
+.ffb-invoices__row-side {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--space-4);
+}
+.ffb-invoices__amount {
+  color: var(--text-primary);
+  font-weight: var(--weight-semibold);
+  font-variant-numeric: tabular-nums;
+  text-align: end;
+}
+.ffb-invoices__pill {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  padding-block: var(--space-1);
+  padding-inline: var(--space-2);
+  border-radius: var(--radius-pill);
+  font-size: var(--text-xs);
+  font-weight: var(--weight-semibold);
+  white-space: nowrap;
+  background: var(--bg-quaternary);
+  color: var(--text-secondary);
+}
+.ffb-invoices__pill-dot {
+  inline-size: var(--space-1);
+  block-size: var(--space-1);
+  border-radius: var(--radius-pill);
+  background: currentColor;
+}
+.ffb-invoices__pill--success {
+  background: var(--success-soft);
+  color: var(--success-color);
+}
+.ffb-invoices__pill--warning {
+  background: var(--warning-soft);
+  color: var(--warning-color);
+}
+.ffb-invoices__pill--error {
+  background: var(--error-soft);
+  color: var(--error-color);
+}
+.ffb-invoices__pill--neutral {
+  background: var(--neutral-soft);
+  color: var(--text-secondary);
+}
+.ffb-invoices__dl {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  min-block-size: var(--space-8);
+  padding-block: var(--space-1);
+  padding-inline: var(--space-2);
+  border-radius: var(--radius-sm);
+  color: var(--accent-color);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  text-decoration: none;
+}
+.ffb-invoices__dl:hover {
+  background: var(--accent-soft);
+}
+.ffb-invoices__dl:focus-visible {
+  outline: var(--border-width-strong) solid var(--accent-color);
+  outline-offset: var(--space-1);
+}
+.ffb-invoices__dl svg {
+  inline-size: var(--space-4);
+  block-size: var(--space-4);
+}
+.ffb-invoices__foot {
+  display: flex;
+  justify-content: center;
+  padding-block: var(--space-4);
+  padding-inline: var(--space-5);
+  border-block-start: var(--border-width) solid var(--border-color);
+}
+.ffb-invoices__empty {
+  padding-block: var(--space-8);
+  padding-inline: var(--space-5);
+  text-align: center;
+  color: var(--text-secondary);
+}
+.ffb-invoices__empty-icon {
+  inline-size: var(--space-10);
+  block-size: var(--space-10);
+  margin-block-end: var(--space-3);
+  color: var(--text-tertiary);
+}
+.ffb-invoices__empty-icon--error {
+  color: var(--error-color);
+}
+.ffb-invoices__empty-title {
+  margin-block: 0 var(--space-1);
+  color: var(--text-primary);
+  font-weight: var(--weight-medium);
+}
+.ffb-invoices__note {
+  margin: 0;
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+}
+.ffb-invoices__empty .ffb-btn {
+  margin-block-start: var(--space-3);
+}
+.ffb-invoices__skel {
+  display: block;
+  block-size: var(--space-3);
+  border-radius: var(--radius-pill);
+  background: linear-gradient(
+    90deg,
+    var(--bg-quaternary),
+    var(--border-color),
+    var(--bg-quaternary)
+  );
+  background-size: 200% 100%;
+  animation: ffb-invoices-shimmer 1.3s ease-in-out infinite;
+}
+.ffb-invoices__skel--wide {
+  inline-size: 58%;
+}
+.ffb-invoices__skel--narrow {
+  inline-size: 34%;
+  margin-block-start: var(--space-1);
+}
+.ffb-invoices__skel--pill {
+  inline-size: var(--space-12);
+  block-size: var(--space-5);
+}
+@keyframes ffb-invoices-shimmer {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .ffb-invoices__skel {
+    animation: none;
+  }
+}

--- a/packages/billing-ui/tests/InvoiceHistoryPanel.test.tsx
+++ b/packages/billing-ui/tests/InvoiceHistoryPanel.test.tsx
@@ -1,0 +1,203 @@
+import { describe, it, expect, vi } from 'vitest';
+import { screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { BillingInvoice, InvoiceListResponse } from '@fuzefront/billing-client';
+import { InvoiceHistoryPanel } from '../src/components/InvoiceHistoryPanel';
+import { renderWithI18n } from './helpers';
+
+const makeInvoice = (over: Partial<BillingInvoice> = {}): BillingInvoice => ({
+  id: 'inv_1',
+  number: 'FF-2026-0042',
+  created: '2026-07-01T00:00:00.000Z',
+  amountDue: 4900,
+  amountPaid: 4900,
+  currency: 'usd',
+  status: 'paid',
+  hostedInvoiceUrl: null,
+  invoicePdf: 'https://files.example.test/inv_1.pdf',
+  ...over,
+});
+
+const page = (
+  invoices: BillingInvoice[],
+  nextCursor: string | null = null,
+): InvoiceListResponse => ({ invoices, nextCursor });
+
+describe('InvoiceHistoryPanel — feature-flag gate', () => {
+  it('renders nothing when the flag is OFF (default)', () => {
+    const listInvoices = vi.fn();
+    const { container } = renderWithI18n(
+      <InvoiceHistoryPanel listInvoices={listInvoices} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+    expect(listInvoices).not.toHaveBeenCalled();
+  });
+
+  it('renders and fetches when the flag is ON', async () => {
+    const listInvoices = vi.fn().mockResolvedValue(page([makeInvoice()]));
+    renderWithI18n(<InvoiceHistoryPanel enabled listInvoices={listInvoices} />);
+    expect(await screen.findByTestId('invoice-history-panel')).toBeInTheDocument();
+    await waitFor(() => expect(listInvoices).toHaveBeenCalledWith({ limit: 20 }));
+  });
+});
+
+describe('InvoiceHistoryPanel — rows', () => {
+  it('renders a row per invoice with number, date and amount', async () => {
+    const listInvoices = vi.fn().mockResolvedValue(
+      page([
+        makeInvoice({ id: 'a', number: 'FF-2026-0042' }),
+        makeInvoice({ id: 'b', number: 'FF-2026-0031', created: '2026-06-01T00:00:00.000Z' }),
+      ]),
+    );
+    renderWithI18n(<InvoiceHistoryPanel enabled listInvoices={listInvoices} />);
+
+    const panel = within(await screen.findByTestId('invoice-history-panel'));
+    const rows = await screen.findAllByTestId('invoice-row');
+    expect(rows).toHaveLength(2);
+    expect(panel.getByText('FF-2026-0042')).toBeInTheDocument();
+    expect(panel.getByText('FF-2026-0031')).toBeInTheDocument();
+    // 4900 cents → $49.00
+    expect(panel.getAllByText('$49.00')).toHaveLength(2);
+    // count readout
+    expect(panel.getByText('2 shown')).toBeInTheDocument();
+  });
+
+  it('maps each status to its semantic pill tone and exposes data-status', async () => {
+    const listInvoices = vi.fn().mockResolvedValue(
+      page([
+        makeInvoice({ id: 'p', number: 'P-1', status: 'paid' }),
+        makeInvoice({ id: 'o', number: 'O-1', status: 'open' }),
+        makeInvoice({ id: 'v', number: 'V-1', status: 'void', amountDue: 0 }),
+        makeInvoice({ id: 'u', number: 'U-1', status: 'uncollectible' }),
+      ]),
+    );
+    renderWithI18n(<InvoiceHistoryPanel enabled listInvoices={listInvoices} />);
+    await screen.findAllByTestId('invoice-row');
+
+    const rowFor = (num: string) =>
+      document.querySelector(`[data-invoice="${num}"]`) as HTMLElement;
+
+    expect(rowFor('P-1')).toHaveAttribute('data-status', 'paid');
+    expect(rowFor('P-1').querySelector('.ffb-invoices__pill--success')).not.toBeNull();
+    expect(rowFor('O-1').querySelector('.ffb-invoices__pill--warning')).not.toBeNull();
+    expect(rowFor('V-1').querySelector('.ffb-invoices__pill--neutral')).not.toBeNull();
+    expect(rowFor('U-1')).toHaveAttribute('data-status', 'uncollectible');
+    expect(rowFor('U-1').querySelector('.ffb-invoices__pill--error')).not.toBeNull();
+  });
+});
+
+describe('InvoiceHistoryPanel — download link', () => {
+  it('renders a PDF link with an accessible name when invoicePdf is present', async () => {
+    const listInvoices = vi.fn().mockResolvedValue(
+      page([makeInvoice({ number: 'FF-2026-0042', invoicePdf: 'https://x/pdf', hostedInvoiceUrl: null })]),
+    );
+    renderWithI18n(<InvoiceHistoryPanel enabled listInvoices={listInvoices} />);
+    const link = await screen.findByRole('link', {
+      name: 'Download invoice FF-2026-0042 PDF',
+    });
+    expect(link).toHaveAttribute('data-download', 'pdf');
+    expect(link).toHaveAttribute('href', 'https://x/pdf');
+  });
+
+  it('falls back to the hosted "View" link when no PDF is available', async () => {
+    const listInvoices = vi.fn().mockResolvedValue(
+      page([
+        makeInvoice({
+          number: 'FF-2026-0025',
+          status: 'open',
+          invoicePdf: null,
+          hostedInvoiceUrl: 'https://x/hosted',
+        }),
+      ]),
+    );
+    renderWithI18n(<InvoiceHistoryPanel enabled listInvoices={listInvoices} />);
+    const link = await screen.findByRole('link', { name: 'View invoice FF-2026-0025' });
+    expect(link).toHaveAttribute('data-download', 'hosted');
+    expect(link).toHaveAttribute('href', 'https://x/hosted');
+  });
+});
+
+describe('InvoiceHistoryPanel — states', () => {
+  it('shows a loading skeleton before data resolves', async () => {
+    let resolve!: (v: InvoiceListResponse) => void;
+    const listInvoices = vi.fn().mockReturnValue(
+      new Promise<InvoiceListResponse>((r) => {
+        resolve = r;
+      }),
+    );
+    renderWithI18n(<InvoiceHistoryPanel enabled listInvoices={listInvoices} />);
+    const panel = await screen.findByTestId('invoice-history-panel');
+    expect(panel).toHaveAttribute('data-state', 'loading');
+    expect(screen.getByTestId('invoice-loading')).toBeInTheDocument();
+    resolve(page([]));
+    await waitFor(() => expect(panel).not.toHaveAttribute('data-state', 'loading'));
+  });
+
+  it('shows the empty state when there are no invoices', async () => {
+    const listInvoices = vi.fn().mockResolvedValue(page([]));
+    renderWithI18n(<InvoiceHistoryPanel enabled listInvoices={listInvoices} />);
+    expect(await screen.findByTestId('invoice-empty')).toBeInTheDocument();
+    expect(screen.getByText('No invoices yet')).toBeInTheDocument();
+    const panel = screen.getByTestId('invoice-history-panel');
+    expect(panel).toHaveAttribute('data-state', 'empty');
+  });
+
+  it('shows an error + retry, and retry re-fetches successfully', async () => {
+    const user = userEvent.setup();
+    const listInvoices = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce(page([makeInvoice()]));
+    renderWithI18n(<InvoiceHistoryPanel enabled listInvoices={listInvoices} />);
+
+    const error = await screen.findByTestId('invoice-error');
+    expect(error).toBeInTheDocument();
+    expect(screen.getByTestId('invoice-history-panel')).toHaveAttribute('data-state', 'error');
+
+    await user.click(screen.getByRole('button', { name: 'Try again' }));
+    expect(await screen.findByTestId('invoice-row')).toBeInTheDocument();
+    expect(listInvoices).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('InvoiceHistoryPanel — load more', () => {
+  it('appends the next cursor page and drops the button on the last page', async () => {
+    const user = userEvent.setup();
+    const listInvoices = vi
+      .fn()
+      .mockResolvedValueOnce(page([makeInvoice({ id: '1', number: 'FF-1' })], 'cursor-2'))
+      .mockResolvedValueOnce(page([makeInvoice({ id: '2', number: 'FF-2' })], null));
+
+    renderWithI18n(<InvoiceHistoryPanel enabled listInvoices={listInvoices} pageSize={1} />);
+
+    expect(await screen.findByText('FF-1')).toBeInTheDocument();
+    const loadMore = screen.getByRole('button', { name: 'Load more' });
+    await user.click(loadMore);
+
+    await waitFor(() =>
+      expect(listInvoices).toHaveBeenNthCalledWith(2, { limit: 1, cursor: 'cursor-2' }),
+    );
+    expect(await screen.findByText('FF-2')).toBeInTheDocument();
+    expect(screen.getByText('FF-1')).toBeInTheDocument();
+    expect(screen.getAllByTestId('invoice-row')).toHaveLength(2);
+    // last page → no more button
+    expect(screen.queryByRole('button', { name: 'Load more' })).not.toBeInTheDocument();
+  });
+});
+
+describe('InvoiceHistoryPanel — vendor neutrality', () => {
+  it('never leaks a payment-vendor name into the DOM', async () => {
+    const listInvoices = vi.fn().mockResolvedValue(
+      page([makeInvoice({ status: 'paid' }), makeInvoice({ id: '2', number: 'FF-2', status: 'open' })]),
+    );
+    const { container } = renderWithI18n(
+      <InvoiceHistoryPanel enabled listInvoices={listInvoices} />,
+    );
+    await screen.findAllByTestId('invoice-row');
+    const html = container.innerHTML.toLowerCase();
+    expect(html).not.toContain('stripe');
+    // "link" as a standalone vendor word (guard against the Stripe "Link" wallet)
+    expect(container.textContent?.toLowerCase()).not.toContain('stripe');
+    expect(container.textContent?.toLowerCase()).not.toContain('link');
+  });
+});

--- a/packages/billing-ui/tests/PlanPicker.test.tsx
+++ b/packages/billing-ui/tests/PlanPicker.test.tsx
@@ -5,9 +5,9 @@ import { PlanPicker } from '../src/components/PlanPicker';
 import { renderWithI18n, makePlan } from './helpers';
 
 const plans = [
-  makePlan({ stripePriceId: 'free_m', tierName: 'free', displayName: 'Starter', unitAmount: 0, sortOrder: 0, billingInterval: 'month', features: ['1 app'] }),
-  makePlan({ stripePriceId: 'pro_m', displayName: 'Pro', unitAmount: 2900, sortOrder: 2, billingInterval: 'month' }),
-  makePlan({ stripePriceId: 'pro_y', displayName: 'Pro Annual', unitAmount: 29000, sortOrder: 2, billingInterval: 'year' }),
+  makePlan({ priceId: 'free_m', tierName: 'free', displayName: 'Starter', unitAmount: 0, sortOrder: 0, billingInterval: 'month', features: ['1 app'] }),
+  makePlan({ priceId: 'pro_m', displayName: 'Pro', unitAmount: 2900, sortOrder: 2, billingInterval: 'month' }),
+  makePlan({ priceId: 'pro_y', displayName: 'Pro Annual', unitAmount: 29000, sortOrder: 2, billingInterval: 'year' }),
 ];
 
 /** Locate a plan card section by its heading text. */
@@ -45,7 +45,7 @@ describe('PlanPicker / PlanCard', () => {
     renderWithI18n(<PlanPicker plans={plans} showIntervalToggle={false} onSelect={onSelect} />);
     const proCard = cardByName('Pro');
     await user.click(within(proCard).getByRole('button', { name: 'Select' }));
-    expect(onSelect).toHaveBeenCalledWith(expect.objectContaining({ stripePriceId: 'pro_m' }));
+    expect(onSelect).toHaveBeenCalledWith(expect.objectContaining({ priceId: 'pro_m' }));
   });
 
   it('marks the current plan and disables its select button', () => {

--- a/packages/billing-ui/tests/helpers.tsx
+++ b/packages/billing-ui/tests/helpers.tsx
@@ -17,8 +17,8 @@ export function renderWithI18n(
 }
 
 export const makePlan = (over: Partial<Plan> = {}): Plan => ({
-  stripePriceId: 'price_pro_month',
-  stripeProductId: 'prod_pro',
+  priceId: 'price_pro_month',
+  productId: 'prod_pro',
   tierName: 'pro',
   displayName: 'Pro',
   billingInterval: 'month',
@@ -37,8 +37,8 @@ export const makeSubscription = (
 ): BillingSubscription => ({
   id: 'sub_local_1',
   customerId: 'cus_1',
-  stripeSubscriptionId: 'sub_123',
-  stripePriceId: 'price_pro_month',
+  subscriptionId: 'sub_123',
+  priceId: 'price_pro_month',
   planTier: 'pro',
   status: 'active',
   seatQuantity: 1,

--- a/services/billing-service/Dockerfile
+++ b/services/billing-service/Dockerfile
@@ -38,6 +38,9 @@ RUN cd services/billing-service && npm run build
 # and every billing table is missing ("relation billing.* does not exist").
 RUN mkdir -p services/billing-service/dist/migrations && \
     cp services/billing-service/src/migrations/*.sql services/billing-service/dist/migrations/
+# The public /docs route (Swagger UI) reads dist/openapi.yaml at request time;
+# tsc does not copy non-TS assets, so place the contract next to the compiled JS.
+RUN cp services/billing-service/openapi.yaml services/billing-service/dist/openapi.yaml
 
 # ---------- production ----------
 FROM node:18-alpine AS production

--- a/services/billing-service/openapi.yaml
+++ b/services/billing-service/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: FuzeFront Billing Service API
-  version: 1.0.0
+  version: 1.1.0
   description: >-
     REST API for the FuzeFront billing-service. Bridges platform entities
     (users / organizations, referenced by `(entityType, entityId)` only) to
@@ -55,7 +55,7 @@ tags:
   - name: credits
     description: Admin-only manual customer balance adjustments.
   - name: invoices
-    description: Read-only invoice history for the authorized entity (Stripe-backed).
+    description: Read-only invoice history for the authorized entity (provider-backed).
   - name: portal
     description: Stripe Customer Portal session creation (manage subscription / payment methods).
   - name: webhooks
@@ -486,9 +486,9 @@ paths:
       tags: [invoices]
       summary: List the authorized entity's invoices
       description: >-
-        Returns the Stripe invoice history for the proxy-authorized entity
-        (user or organization), most-recent first, as a stable contract subset
-        of the Stripe Invoice. Read-only. Mirrors `GET /invoices`.
+        Returns the invoice history for the proxy-authorized entity (user or
+        organization), most-recent first. Served from the local invoice store,
+        synced from the payment provider. Read-only.
 
 
         Authorization: behind the internal-token guard; the entity is the
@@ -501,8 +501,8 @@ paths:
 
 
         Pagination is opaque-cursor based: pass the previous response's
-        `nextCursor` (a Stripe invoice id) as `cursor` to fetch the next page.
-        `nextCursor` is null on the last page.
+        `nextCursor` as `cursor` to fetch the next page. `nextCursor` is null on
+        the last page.
       security:
         - internalToken: []
       parameters:
@@ -522,8 +522,8 @@ paths:
           in: query
           required: false
           description: >-
-            Opaque pagination cursor (a Stripe invoice id) passed to Stripe's
-            `starting_after`. Use the previous response's `nextCursor`.
+            Opaque cursor (previous `nextCursor`). Use the previous response's
+            `nextCursor` to fetch the next page.
           schema:
             type: string
       responses:
@@ -535,6 +535,47 @@ paths:
                 $ref: '#/components/schemas/InvoiceListResponse'
         '400':
           $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '502':
+          $ref: '#/components/responses/StripeError'
+
+  /invoices/sync:
+    post:
+      operationId: syncInvoices
+      tags: [invoices]
+      summary: Force a provider→store resync of the authorized entity's invoices
+      description: >-
+        Forces a resync of the proxy-authorized entity's invoices from the
+        payment provider into the local invoice store, then returns the number
+        of invoices upserted. Idempotent — safe to call repeatedly.
+
+
+        Authorization is identical to `GET /invoices`: behind the internal-token
+        guard, with the entity taken from the SERVER-DERIVED actor context the
+        proxy injects (`X-Billing-Actor-User-Id`, `X-Billing-Entity-Type`,
+        `X-Billing-Entity-Id`). An entity that has never had billing returns
+        `{ synced: 0 }` (200, not an error).
+      security:
+        - internalToken: []
+      parameters:
+        - $ref: '#/components/parameters/ActorUserIdHeader'
+        - $ref: '#/components/parameters/EntityTypeHeader'
+        - $ref: '#/components/parameters/EntityIdHeader'
+      responses:
+        '200':
+          description: The resync completed; reports how many invoices were upserted.
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: false
+                required: [synced]
+                properties:
+                  synced:
+                    type: integer
+                    minimum: 0
+                    description: Number of invoices upserted into the local store.
         '401':
           $ref: '#/components/responses/Unauthorized'
         '502':
@@ -1203,14 +1244,15 @@ components:
       properties:
         id:
           type: string
-          description: Stripe invoice id (`in_...`).
+          format: uuid
+          description: FuzeFront invoice id (opaque, stable). A FuzeFront UUID, not a provider id.
         number:
           type: [string, 'null']
           description: Human-facing invoice number; null for drafts without one.
         created:
           type: string
           format: date-time
-          description: ISO-8601 timestamp derived from the Stripe `created` unix seconds.
+          description: ISO-8601 issue timestamp.
         amountDue:
           type: integer
           description: Amount due in the currency's minor unit (cents).
@@ -1225,14 +1267,14 @@ components:
           examples: [usd]
         status:
           type: string
-          description: Stripe invoice status.
-          examples: [paid, open, void, draft, uncollectible]
+          description: 'Neutral invoice status: draft|open|paid|void|uncollectible.'
+          examples: [draft, open, paid, void, uncollectible]
         hostedInvoiceUrl:
           type: [string, 'null']
-          description: Stripe-hosted invoice page url (null when unavailable).
+          description: Provider-hosted document URL, opaque to consumers; null when unavailable.
         invoicePdf:
           type: [string, 'null']
-          description: Url to the invoice PDF (null when unavailable).
+          description: Provider-hosted document URL, opaque to consumers; null when unavailable.
 
     InvoiceListResponse:
       type: object
@@ -1246,8 +1288,7 @@ components:
         nextCursor:
           type: [string, 'null']
           description: >-
-            Opaque cursor (Stripe invoice id) for the next page; null when there
-            are no further pages.
+            Opaque cursor for the next page; null on the last page.
 
     PortalSessionRequest:
       type: object

--- a/services/billing-service/openapi.yaml
+++ b/services/billing-service/openapi.yaml
@@ -1,11 +1,11 @@
 openapi: 3.1.0
 info:
   title: FuzeFront Billing Service API
-  version: 1.1.0
+  version: 1.2.0
   description: >-
     REST API for the FuzeFront billing-service. Bridges platform entities
     (users / organizations, referenced by `(entityType, entityId)` only) to
-    Stripe customers, subscriptions, payment-method setup, usage metering, and
+    payment-provider customers, subscriptions, payment-method setup, usage metering, and
     manual credits.
 
     This contract is **derived from the real route handlers** in
@@ -13,7 +13,7 @@ info:
     source of truth for `@fuzefront/billing-client`. Changing the API means
     amending this file first (see the `api-contract-first` skill).
 
-    Card data never flows through this API — only Stripe ids and client secrets.
+    Card data never flows through this API — only provider ids and client secrets.
 
     ### Async surface (events)
     Beyond HTTP, the service emits Kafka events whose Zod schemas live in
@@ -40,16 +40,16 @@ servers:
 
 tags:
   - name: plans
-    description: Public plan catalogue (read cache of the Stripe product/price catalogue).
+    description: Public plan catalogue (read cache of the provider product/price catalogue).
   - name: subscriptions
-    description: Subscription lifecycle against Stripe + local mirror.
+    description: Subscription lifecycle against the provider + local mirror.
   - name: payment-methods
     description: SetupIntent creation for collecting a payment method without an immediate charge.
   - name: checkout
-    description: Hosted Stripe Checkout Session creation (subscription mode).
+    description: Hosted Checkout Session creation (subscription mode).
   - name: payments
     description: >-
-      Hosted Stripe Checkout Session creation in ONE-TIME `payment` mode for
+      Hosted Checkout Session creation in ONE-TIME `payment` mode for
       consumer products (allowlisted `productKey`s), plus the local payment
       mirror used for reconciliation polling.
   - name: credits
@@ -57,9 +57,9 @@ tags:
   - name: invoices
     description: Read-only invoice history for the authorized entity (provider-backed).
   - name: portal
-    description: Stripe Customer Portal session creation (manage subscription / payment methods).
+    description: Customer Portal session creation (manage subscription / payment methods).
   - name: webhooks
-    description: Stripe webhook receiver (public, Stripe-signature verified).
+    description: Payment-provider webhook receiver (public, provider-signature verified).
   - name: health
     description: Liveness / readiness.
 
@@ -96,9 +96,9 @@ paths:
       tags: [subscriptions]
       summary: Create or upgrade a subscription
       description: >-
-        Creates a Stripe subscription for the entity (creating the Stripe
+        Creates a provider subscription for the entity (creating the provider
         customer if needed) and mirrors it locally. Returns a `clientSecret`
-        when Stripe needs SCA/3DS confirmation on the client. Mirrors
+        when the provider needs SCA/3DS confirmation on the client. Mirrors
         `POST /subscriptions`.
       security:
         - internalToken: []
@@ -120,17 +120,17 @@ paths:
         '401':
           $ref: '#/components/responses/Unauthorized'
         '502':
-          $ref: '#/components/responses/StripeError'
+          $ref: '#/components/responses/ProviderError'
 
-  /subscriptions/{stripeSubscriptionId}:
+  /subscriptions/{subscriptionId}:
     parameters:
-      - $ref: '#/components/parameters/StripeSubscriptionId'
+      - $ref: '#/components/parameters/SubscriptionId'
     get:
       operationId: getSubscription
       tags: [subscriptions]
       summary: Get the local mirror of a subscription
       description: >-
-        Returns the locally-mirrored subscription by Stripe subscription id, or
+        Returns the locally-mirrored subscription by provider subscription id, or
         404 if no mirror exists. Mirrors `GET /subscriptions/:id`.
       security:
         - internalToken: []
@@ -182,13 +182,13 @@ paths:
         '401':
           $ref: '#/components/responses/Unauthorized'
         '502':
-          $ref: '#/components/responses/StripeError'
+          $ref: '#/components/responses/ProviderError'
     delete:
       operationId: cancelSubscription
       tags: [subscriptions]
       summary: Cancel at period end (soft cancel)
       description: >-
-        Sets `cancel_at_period_end=true`; Stripe keeps the subscription active
+        Sets `cancel_at_period_end=true`; the provider keeps the subscription active
         until the period boundary. Mirrors `DELETE /subscriptions/:id`.
       security:
         - internalToken: []
@@ -207,7 +207,7 @@ paths:
         '401':
           $ref: '#/components/responses/Unauthorized'
         '502':
-          $ref: '#/components/responses/StripeError'
+          $ref: '#/components/responses/ProviderError'
 
   /setup-intent:
     post:
@@ -215,9 +215,9 @@ paths:
       tags: [payment-methods]
       summary: Create a SetupIntent to collect a payment method
       description: >-
-        Creates a Stripe SetupIntent (usage `off_session`) so the client can
+        Creates a provider SetupIntent (usage `off_session`) so the client can
         collect a payment method without an immediate charge (e.g. add a card
-        during a no-card trial). Returns the `clientSecret` for the Stripe
+        during a no-card trial). Returns the `clientSecret` for the provider
         Payment Element. Mirrors `POST /setup-intent`.
       security:
         - internalToken: []
@@ -239,24 +239,24 @@ paths:
                 properties:
                   clientSecret:
                     type: string
-                    description: Stripe SetupIntent client secret for the Payment Element.
+                    description: provider SetupIntent client secret for the Payment Element.
         '400':
           $ref: '#/components/responses/ValidationError'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '502':
-          $ref: '#/components/responses/StripeError'
+          $ref: '#/components/responses/ProviderError'
 
   /checkout:
     post:
       operationId: createCheckoutSession
       tags: [checkout]
-      summary: Create a hosted Stripe Checkout Session (subscription mode)
+      summary: Create a hosted Checkout Session (subscription mode)
       description: >-
-        Creates a hosted Stripe Checkout Session in `subscription` mode for the
-        given organization and plan, and returns the Stripe-hosted `url` to
-        redirect the customer to. Stripe collects the card on its hosted page;
-        on completion Stripe fires `checkout.session.completed`, which activates
+        Creates a hosted Checkout Session in `subscription` mode for the
+        given organization and plan, and returns the provider-hosted `url` to
+        redirect the customer to. the provider collects the card on its hosted page;
+        on completion the provider fires `checkout.session.completed`, which activates
         the local subscription mirror. We use HOSTED Checkout (not in-app
         Elements) so no raw card data touches our surface. Mirrors
         `POST /checkout`.
@@ -268,7 +268,7 @@ paths:
         (`X-Billing-Actor-User-Id`, `X-Billing-Entity-Type`,
         `X-Billing-Entity-Id`; short aliases `X-FF-Actor-Id` / `X-FF-Org-Id`).
         The service RE-VERIFIES that `organizationId` matches the authorized
-        entity before creating any Stripe object (rejects with 403 otherwise),
+        entity before creating any provider object (rejects with 403 otherwise),
         and validates `planId` against the active plan catalogue (rejects
         unknown/inactive plans with 400). `planId: "basic"` resolves to the live
         $9/mo price.
@@ -298,20 +298,20 @@ paths:
         '403':
           $ref: '#/components/responses/Forbidden'
         '502':
-          $ref: '#/components/responses/StripeError'
+          $ref: '#/components/responses/ProviderError'
 
   /payments/checkout:
     post:
       operationId: createPaymentCheckoutSession
       tags: [payments]
-      summary: Create a hosted Stripe Checkout Session (one-time payment mode)
+      summary: Create a hosted Checkout Session (one-time payment mode)
       description: >-
-        Creates a hosted Stripe Checkout Session in `payment` mode for an
+        Creates a hosted Checkout Session in `payment` mode for an
         allowlisted consumer product (e.g. `mendys-datasets`) and returns the
-        Stripe-hosted `url` to redirect the buyer to. The caller supplies the
+        provider-hosted `url` to redirect the buyer to. The caller supplies the
         priced line items (name + unit amount in cents + quantity); the service
-        builds Stripe `price_data` from them — no Stripe price catalogue entry
-        is required. On completion Stripe fires `checkout.session.completed`
+        builds provider `price_data` from them — no provider price catalogue entry
+        is required. On completion the provider fires `checkout.session.completed`
         (mode `payment`), which upserts the local `billing.payments` mirror and
         emits `billing.payment.completed` on Kafka. Failure/expiry are mirrored
         via `payment_intent.payment_failed` / `checkout.session.expired`.
@@ -324,7 +324,7 @@ paths:
         trusted headers (`X-Billing-Actor-User-Id`, `X-Billing-Entity-Type`,
         `X-Billing-Entity-Id`; aliases `X-FF-Actor-Id` / `X-FF-Org-Id`). The
         service RE-VERIFIES that the body's `entityType`/`entityId` match the
-        authorized entity before creating any Stripe object (mismatch → 403).
+        authorized entity before creating any provider object (mismatch → 403).
         `productKey` must be in the server-side allowlist
         (`BILLING_PRODUCT_KEYS`), `currency` in the configured allowlist
         (default `usd`, `eur`), and each line amount plus the order total are
@@ -332,7 +332,7 @@ paths:
         5,000,000 cents) — violations → 400.
 
 
-        Idempotency: retries with IDENTICAL parameters dedupe to one Stripe
+        Idempotency: retries with IDENTICAL parameters dedupe to one provider
         session (param-fingerprint idempotency key, same scheme as
         `/checkout`); any changed parameter yields a fresh session.
       security:
@@ -365,16 +365,16 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/StripeErrorBody'
+                $ref: '#/components/schemas/ProviderErrorBody'
         '502':
-          $ref: '#/components/responses/StripeError'
+          $ref: '#/components/responses/ProviderError'
 
   /payments/sessions/{sessionId}:
     parameters:
       - name: sessionId
         in: path
         required: true
-        description: The Stripe Checkout Session id (`cs_...`).
+        description: The hosted Checkout Session id (`cs_...`).
         schema:
           type: string
     get:
@@ -388,8 +388,8 @@ paths:
         that missed (or cannot receive) the `billing.payment.completed` event.
         `status` is `pending` until a webhook lands, then `paid` / `failed` /
         `expired`. 404 when the session is unknown. When the local row is
-        missing but the session exists in Stripe AND its `productKey` metadata
-        is allowlisted, the service falls back to live Stripe, re-mirrors the
+        missing but the session exists at the provider AND its `productKey` metadata
+        is allowlisted, the service falls back to the live provider, re-mirrors the
         row, and returns it (singleton resource — pagination exempt).
 
 
@@ -420,7 +420,7 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
         '502':
-          $ref: '#/components/responses/StripeError'
+          $ref: '#/components/responses/ProviderError'
 
   /credits:
     post:
@@ -428,7 +428,7 @@ paths:
       tags: [credits]
       summary: Add a one-time customer balance adjustment (admin only)
       description: >-
-        Adds a one-time customer balance adjustment (credit) via a Stripe
+        Adds a one-time customer balance adjustment (credit) via a provider
         customer balance transaction. A positive `amount` (in cents, bounded)
         credits the customer (reduces what they owe). Mirrors `POST /credits`.
 
@@ -467,7 +467,7 @@ paths:
                 properties:
                   id:
                     type: string
-                    description: Stripe customer balance transaction id.
+                    description: payment-provider customer balance transaction id.
                   endingBalance:
                     type: integer
                     description: Resulting customer balance in cents (negative = credit).
@@ -478,7 +478,7 @@ paths:
         '403':
           $ref: '#/components/responses/Forbidden'
         '502':
-          $ref: '#/components/responses/StripeError'
+          $ref: '#/components/responses/ProviderError'
 
   /invoices:
     get:
@@ -538,7 +538,7 @@ paths:
         '401':
           $ref: '#/components/responses/Unauthorized'
         '502':
-          $ref: '#/components/responses/StripeError'
+          $ref: '#/components/responses/ProviderError'
 
   /invoices/sync:
     post:
@@ -579,16 +579,16 @@ paths:
         '401':
           $ref: '#/components/responses/Unauthorized'
         '502':
-          $ref: '#/components/responses/StripeError'
+          $ref: '#/components/responses/ProviderError'
 
   /portal:
     post:
       operationId: createPortalSession
       tags: [portal]
-      summary: Create a Stripe Customer Portal session
+      summary: Create a Customer Portal session
       description: >-
-        Creates a Stripe Customer Portal session for the proxy-authorized
-        entity and returns the Stripe-hosted `url` to redirect the customer to,
+        Creates a Customer Portal session for the proxy-authorized
+        entity and returns the provider-hosted `url` to redirect the customer to,
         where they can manage their subscription and payment methods. Mirrors
         `POST /portal`.
 
@@ -635,35 +635,47 @@ paths:
                   message:
                     type: string
         '502':
-          $ref: '#/components/responses/StripeError'
+          $ref: '#/components/responses/ProviderError'
 
-  /webhooks/stripe:
+  /webhooks/{provider}:
     post:
-      operationId: receiveStripeWebhook
+      operationId: receiveProviderWebhook
       tags: [webhooks]
-      summary: Stripe webhook receiver
+      summary: Provider webhook receiver
       description: >-
-        Receives Stripe events. The body MUST be the raw signed bytes
-        (`application/json` consumed via `express.raw`) so signature
+        Provider webhook receiver; authenticity verified by the provider
+        signature. Receives events from the configured payment provider
+        (selected by the `provider` path slug). The body MUST be the raw signed
+        bytes (`application/json` consumed via `express.raw`) so signature
         verification works. Public (no internal token) — authenticity is
-        established by the `Stripe-Signature` header. Idempotent: duplicate
+        established by the provider signature header. Idempotent: duplicate
         deliveries of the same event id return 200 without re-processing.
-        Mirrors `POST /webhooks/stripe`.
       security: []
       parameters:
-        - name: Stripe-Signature
+        - name: provider
+          in: path
+          required: true
+          schema:
+            type: string
+          description: >-
+            Payment-provider slug identifying which provider sent the webhook
+            (e.g. the configured payment provider). Selects the signature
+            verifier + event decoder.
+        - name: X-Provider-Signature
           in: header
           required: true
           schema:
             type: string
-          description: Stripe webhook signature header used to verify the payload.
+          description: >-
+            Provider webhook signature header used to verify the payload
+            authenticity.
       requestBody:
         required: true
         content:
           application/json:
             schema:
               type: object
-              description: Raw Stripe Event object (not parsed by this service before verification).
+              description: Raw provider Event object (not parsed by this service before verification).
               additionalProperties: true
       responses:
         '200':
@@ -693,7 +705,7 @@ paths:
       tags: [health]
       summary: Liveness / readiness probe
       description: >-
-        Always available, even in degraded mode (no DB / no Stripe key).
+        Always available, even in degraded mode (no DB / no provider key).
         NOTE: mounted at the service root (`/health`), NOT under
         `/api/v1/billing` -- call it on the bare server origin.
       security: []
@@ -730,11 +742,11 @@ components:
         `requireInternalToken`.
 
   parameters:
-    StripeSubscriptionId:
-      name: stripeSubscriptionId
+    SubscriptionId:
+      name: subscriptionId
       in: path
       required: true
-      description: The Stripe subscription id (e.g. `sub_...`).
+      description: The provider subscription id (e.g. `sub_...`).
       schema:
         type: string
     ActorUserIdHeader:
@@ -796,12 +808,12 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/ValidationErrorBody'
-    StripeError:
-      description: Upstream Stripe error (bad gateway).
+    ProviderError:
+      description: Upstream provider error (bad gateway).
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/StripeErrorBody'
+            $ref: '#/components/schemas/ProviderErrorBody'
     InternalError:
       description: Unexpected server error.
       content:
@@ -818,13 +830,13 @@ components:
     PlanTier:
       type: string
       description: >-
-        Plan tier name resolved from the Stripe price (free / starter / pro /
+        Plan tier name resolved from the provider price (free / starter / pro /
         enterprise, or any custom tier). Open string by design.
       examples: [free, starter, pro, enterprise]
 
     SubscriptionStatus:
       type: string
-      description: Mirrors Stripe subscription status values. Open string by design.
+      description: Mirrors provider subscription status values. Open string by design.
       examples:
         - trialing
         - active
@@ -852,8 +864,8 @@ components:
       required:
         - id
         - customerId
-        - stripeSubscriptionId
-        - stripePriceId
+        - subscriptionId
+        - priceId
         - planTier
         - status
         - seatQuantity
@@ -872,9 +884,9 @@ components:
           type: string
           format: uuid
           description: Local billing.customers primary key.
-        stripeSubscriptionId:
+        subscriptionId:
           type: string
-        stripePriceId:
+        priceId:
           type: string
         planTier:
           $ref: '#/components/schemas/PlanTier'
@@ -905,8 +917,8 @@ components:
       type: object
       additionalProperties: false
       required:
-        - stripePriceId
-        - stripeProductId
+        - priceId
+        - productId
         - tierName
         - displayName
         - billingInterval
@@ -918,9 +930,9 @@ components:
         - isActive
         - sortOrder
       properties:
-        stripePriceId:
+        priceId:
           type: string
-        stripeProductId:
+        productId:
           type: string
         tierName:
           $ref: '#/components/schemas/PlanTier'
@@ -928,7 +940,7 @@ components:
           type: string
         billingInterval:
           type: string
-          description: Billing cadence (`month` / `year`, or any Stripe interval).
+          description: Billing cadence (`month` / `year`, or any provider interval).
           examples: [month, year]
         unitAmount:
           type: integer
@@ -966,7 +978,7 @@ components:
           minLength: 1
         trial:
           type: boolean
-          description: Start a no-card trial (Stripe trial_period_days).
+          description: Start a no-card trial (provider trial_period_days).
         trialPeriodDays:
           type: integer
           minimum: 1
@@ -976,7 +988,7 @@ components:
           description: Seat quantity for per-seat plans. Defaults to 1.
         paymentMethodId:
           type: string
-          description: Existing Stripe PaymentMethod to attach (omit for no-card trials).
+          description: Existing provider payment method to attach (omit for no-card trials).
 
     CreateSubscriptionResponse:
       type: object
@@ -987,7 +999,7 @@ components:
           $ref: '#/components/schemas/BillingSubscription'
         clientSecret:
           type: string
-          description: Set when Stripe needs SCA/3DS confirmation on the client.
+          description: Set when the provider needs SCA/3DS confirmation on the client.
         requiresAction:
           type: boolean
           description: True when the client must confirm a PaymentIntent/SetupIntent.
@@ -1036,7 +1048,7 @@ components:
           type: string
           minLength: 1
           description: >-
-            Logical plan id (e.g. `basic`), a tier name, or a Stripe price id
+            Logical plan id (e.g. `basic`), a tier name, or a provider price id
             present in the active catalogue. Validated against active plans;
             `basic` resolves to the live $9/mo price.
         organizationId:
@@ -1048,11 +1060,11 @@ components:
         successUrl:
           type: string
           format: uri
-          description: Where Stripe redirects after a completed checkout.
+          description: Where the provider redirects after a completed checkout.
         cancelUrl:
           type: string
           format: uri
-          description: Where Stripe redirects if the customer cancels.
+          description: Where the provider redirects if the customer cancels.
 
     CheckoutSessionResponse:
       type: object
@@ -1061,10 +1073,10 @@ components:
       properties:
         url:
           type: [string, 'null']
-          description: Stripe-hosted Checkout URL to redirect the customer to.
+          description: provider-hosted Checkout URL to redirect the customer to.
         sessionId:
           type: string
-          description: The Stripe Checkout Session id (`cs_...`).
+          description: The hosted Checkout Session id (`cs_...`).
 
     PaymentStatus:
       type: string
@@ -1085,7 +1097,7 @@ components:
           type: string
           minLength: 1
           maxLength: 250
-          description: Line-item display name shown on the Stripe-hosted page.
+          description: Line-item display name shown on the provider-hosted page.
         description:
           type: string
           minLength: 1
@@ -1155,11 +1167,11 @@ components:
         successUrl:
           type: string
           format: uri
-          description: Where Stripe redirects after a completed payment.
+          description: Where the provider redirects after a completed payment.
         cancelUrl:
           type: string
           format: uri
-          description: Where Stripe redirects if the buyer cancels.
+          description: Where the provider redirects if the buyer cancels.
 
     PaymentCheckoutResponse:
       type: object
@@ -1168,18 +1180,18 @@ components:
       properties:
         sessionId:
           type: string
-          description: The Stripe Checkout Session id (`cs_...`).
+          description: The hosted Checkout Session id (`cs_...`).
         url:
           type: [string, 'null']
-          description: Stripe-hosted Checkout URL to redirect the buyer to.
+          description: provider-hosted Checkout URL to redirect the buyer to.
 
     BillingPayment:
       type: object
       additionalProperties: false
       required:
         - id
-        - stripeSessionId
-        - stripePaymentIntentId
+        - sessionId
+        - paymentIntentId
         - productKey
         - externalOrderId
         - entityType
@@ -1194,13 +1206,13 @@ components:
           type: string
           format: uuid
           description: Local billing.payments primary key.
-        stripeSessionId:
+        sessionId:
           type: string
-          description: Stripe Checkout Session id (`cs_...`).
-        stripePaymentIntentId:
+          description: hosted Checkout Session id (`cs_...`).
+        paymentIntentId:
           type: [string, 'null']
           description: >-
-            Stripe PaymentIntent id (`pi_...`); null until Stripe creates the
+            provider PaymentIntent id (`pi_...`); null until the provider creates the
             intent (typically when the buyer reaches the payment page).
         productKey:
           type: string
@@ -1298,7 +1310,7 @@ components:
         returnUrl:
           type: string
           format: uri
-          description: Where Stripe returns the customer after they leave the portal.
+          description: Where the provider returns the customer after they leave the portal.
 
     PortalSessionResponse:
       type: object
@@ -1307,7 +1319,7 @@ components:
       properties:
         url:
           type: string
-          description: Stripe-hosted Customer Portal url to redirect the customer to.
+          description: provider-hosted Customer Portal url to redirect the customer to.
 
     Error:
       type: object
@@ -1317,14 +1329,14 @@ components:
         error:
           type: string
 
-    StripeErrorBody:
+    ProviderErrorBody:
       type: object
       additionalProperties: false
       required: [error]
       properties:
         error:
           type: string
-          examples: ['stripe error']
+          examples: ['provider error']
         message:
           type: string
 

--- a/services/billing-service/src/app.ts
+++ b/services/billing-service/src/app.ts
@@ -16,6 +16,9 @@ import { CustomerService } from './services/customer.service';
 import { SubscriptionRepository } from './repositories/subscription.repository';
 import { CustomerRepository } from './repositories/customer.repository';
 import { PaymentRepository } from './repositories/payment.repository';
+import { InvoiceRepository } from './repositories/invoice.repository';
+import { InvoiceService } from './services/invoice.service';
+import { StripePaymentProvider } from './providers/stripe/stripe-payment-provider';
 import { PaymentsConfig } from './config';
 
 export interface AppDeps {
@@ -29,6 +32,8 @@ export interface AppDeps {
   customers: CustomerService;
   /** One-time payment-mode Checkout mirror (billing.payments). */
   payments: PaymentRepository;
+  /** DB-backed, provider-neutral invoice store (billing.invoices). */
+  invoiceRepo: InvoiceRepository;
   /** Allowlists/bounds for POST /payments/checkout (config.payments). */
   paymentsConfig: PaymentsConfig;
   webhook: WebhookDeps;
@@ -56,6 +61,19 @@ export function createApp(deps?: AppDeps): Application {
   });
 
   if (!deps) return app;
+
+  // Vendor-neutral invoice slice: the Stripe adapter (the port's ONLY vendor
+  // dependency), the DB-backed store, and the read/sync service. The provider +
+  // repo are also injected into the webhook ctx so the invoice-synced handler
+  // can persist invoice.* events.
+  const paymentProvider = new StripePaymentProvider(deps.stripe);
+  const invoiceService = new InvoiceService({
+    customerRepo: deps.customerRepo,
+    invoiceRepo: deps.invoiceRepo,
+    provider: paymentProvider,
+  });
+  deps.webhook.ctx.provider = paymentProvider;
+  deps.webhook.ctx.invoiceRepo = deps.invoiceRepo;
 
   // 1) Webhook (raw body) — before express.json, public + sig-verified.
   app.use(API_BASE, createWebhookRouter(deps.webhook));
@@ -123,7 +141,7 @@ export function createApp(deps?: AppDeps): Application {
   // internal token AND re-derive the SERVER-DERIVED entity via
   // requireActorContext (applied inside their routers, scoped to their exact
   // method+path) — identity is never taken from a client query/body.
-  app.use(API_BASE, guard, createInvoicesRouter({ stripe: deps.stripe, customerRepo: deps.customerRepo }));
+  app.use(API_BASE, guard, createInvoicesRouter({ service: invoiceService }));
   app.use(API_BASE, guard, createPortalRouter({ stripe: deps.stripe, customerRepo: deps.customerRepo }));
 
   return app;

--- a/services/billing-service/src/app.ts
+++ b/services/billing-service/src/app.ts
@@ -10,6 +10,7 @@ import { createCheckoutRouter } from './routes/checkout';
 import { createPaymentsRouter } from './routes/payments';
 import { createInvoicesRouter } from './routes/invoices';
 import { createPortalRouter } from './routes/portal';
+import { createDocsRouter } from './routes/docs';
 import { PlanService } from './services/plan.service';
 import { SubscriptionService } from './services/subscription.service';
 import { CustomerService } from './services/customer.service';
@@ -59,6 +60,10 @@ export function createApp(deps?: AppDeps): Application {
   app.get('/health', (_req: Request, res: Response) => {
     res.json({ status: 'ok', service: 'billing-service' });
   });
+
+  // Public API docs (Swagger UI + raw contract). No auth, no deps — available
+  // even in degraded mode so the contract is always inspectable.
+  app.use(API_BASE, createDocsRouter());
 
   if (!deps) return app;
 

--- a/services/billing-service/src/handlers/checkout-completed.ts
+++ b/services/billing-service/src/handlers/checkout-completed.ts
@@ -88,8 +88,8 @@ export async function handleCheckoutCompleted(
       ? mapStripeSubscription(sub, { customerId: entity.id, planTier })
       : {
           customerId: entity.id,
-          stripeSubscriptionId,
-          stripePriceId: priceId,
+          subscriptionId: stripeSubscriptionId,
+          priceId: priceId,
           planTier,
           status,
           seatQuantity,

--- a/services/billing-service/src/handlers/invoice-paid.ts
+++ b/services/billing-service/src/handlers/invoice-paid.ts
@@ -43,6 +43,6 @@ export async function handleInvoicePaid(
     entityType: entity.entityType,
     planTier,
     status: 'active',
-    stripeSubscriptionId: existing?.stripeSubscriptionId ?? '',
+    stripeSubscriptionId: existing?.subscriptionId ?? '',
   });
 }

--- a/services/billing-service/src/handlers/invoice-synced.ts
+++ b/services/billing-service/src/handlers/invoice-synced.ts
@@ -1,0 +1,31 @@
+import { HandlerContext } from './types';
+
+/**
+ * Persists an invoice.* webhook into the local billing.invoices store.
+ *
+ * Runs for `invoice.paid|invoice.payment_succeeded|invoice.payment_failed|
+ * invoice.finalized|invoice.updated` (see webhook-router). It resolves the
+ * customer by the provider's customer id and upserts the neutral invoice — so
+ * GET /invoices stays fresh without waiting for a full resync. The existing
+ * invoice-paid / invoice-failed NOTIFY handlers still fire alongside this.
+ *
+ * No-ops (never throws) when the provider/invoiceRepo are not wired, the event
+ * is not a parseable invoice event, or no local customer matches.
+ */
+export async function handleInvoiceSynced(
+  event: unknown,
+  ctx: HandlerContext,
+): Promise<void> {
+  if (!ctx.provider || !ctx.invoiceRepo) return;
+
+  const parsed = ctx.provider.parseInvoiceEvent(event);
+  if (!parsed) return;
+
+  const customer = await ctx.customers.findByStripeCustomerId(parsed.providerCustomerId);
+  if (!customer) {
+    console.warn(`[invoice-synced] no local customer for ${parsed.providerCustomerId}`);
+    return;
+  }
+
+  await ctx.invoiceRepo.upsertFromProvider(customer.id, parsed.invoice);
+}

--- a/services/billing-service/src/handlers/payment-completed.ts
+++ b/services/billing-service/src/handlers/payment-completed.ts
@@ -81,11 +81,11 @@ async function handleSessionEvent(event: Stripe.Event, ctx: HandlerContext): Pro
   }
 
   const row = await ctx.payments.upsert({
-    stripeSessionId: session.id,
-    stripePaymentIntentId:
+    sessionId: session.id,
+    paymentIntentId:
       typeof session.payment_intent === 'string'
         ? session.payment_intent
-        : session.payment_intent?.id ?? existing?.stripePaymentIntentId ?? null,
+        : session.payment_intent?.id ?? existing?.paymentIntentId ?? null,
     productKey,
     externalOrderId,
     entityType,
@@ -107,8 +107,8 @@ async function handleSessionEvent(event: Stripe.Event, ctx: HandlerContext): Pro
     externalOrderId: row.externalOrderId,
     entityType: row.entityType,
     entityId: row.entityId,
-    stripeSessionId: row.stripeSessionId,
-    stripePaymentIntentId: row.stripePaymentIntentId,
+    stripeSessionId: row.sessionId,
+    stripePaymentIntentId: row.paymentIntentId,
     amountTotalCents: row.amountTotalCents,
     currency: row.currency,
     status: status as 'paid' | 'expired',
@@ -141,7 +141,7 @@ async function handleIntentFailed(event: Stripe.Event, ctx: HandlerContext): Pro
 
   const row = await ctx.payments.upsert({
     ...toUpsert(existing),
-    stripePaymentIntentId: intent.id,
+    paymentIntentId: intent.id,
     status: 'failed',
   });
 
@@ -149,7 +149,7 @@ async function handleIntentFailed(event: Stripe.Event, ctx: HandlerContext): Pro
   // success (buyer retried in-session), do not emit a stale 'failed'.
   if (row.status !== 'failed') {
     console.info(
-      `[payment-completed] session ${row.stripeSessionId} already ${row.status} — failed event superseded`,
+      `[payment-completed] session ${row.sessionId} already ${row.status} — failed event superseded`,
     );
     return;
   }
@@ -159,8 +159,8 @@ async function handleIntentFailed(event: Stripe.Event, ctx: HandlerContext): Pro
     externalOrderId: row.externalOrderId,
     entityType: row.entityType,
     entityId: row.entityId,
-    stripeSessionId: row.stripeSessionId,
-    stripePaymentIntentId: row.stripePaymentIntentId,
+    stripeSessionId: row.sessionId,
+    stripePaymentIntentId: row.paymentIntentId,
     amountTotalCents: row.amountTotalCents,
     currency: row.currency,
     status: 'failed',
@@ -169,8 +169,8 @@ async function handleIntentFailed(event: Stripe.Event, ctx: HandlerContext): Pro
 }
 
 function toUpsert(row: {
-  stripeSessionId: string;
-  stripePaymentIntentId: string | null;
+  sessionId: string;
+  paymentIntentId: string | null;
   productKey: string;
   externalOrderId: string;
   entityType: 'user' | 'organization';
@@ -180,8 +180,8 @@ function toUpsert(row: {
   status: PaymentStatus;
 }) {
   return {
-    stripeSessionId: row.stripeSessionId,
-    stripePaymentIntentId: row.stripePaymentIntentId,
+    sessionId: row.sessionId,
+    paymentIntentId: row.paymentIntentId,
     productKey: row.productKey,
     externalOrderId: row.externalOrderId,
     entityType: row.entityType,

--- a/services/billing-service/src/handlers/types.ts
+++ b/services/billing-service/src/handlers/types.ts
@@ -3,6 +3,8 @@ import { CustomerRepository } from '../repositories/customer.repository';
 import { SubscriptionRepository } from '../repositories/subscription.repository';
 import { PlanRepository } from '../repositories/plan.repository';
 import { PaymentRepository } from '../repositories/payment.repository';
+import { InvoiceRepository } from '../repositories/invoice.repository';
+import { PaymentProvider } from '../providers/payment-provider';
 import { PermitSyncService } from '../services/permit.service';
 import { BillingEventEmitter } from '../kafka/producer';
 
@@ -16,6 +18,13 @@ export interface HandlerContext {
   plans: PlanRepository;
   /** One-time payment-mode Checkout mirror (billing.payments). */
   payments: PaymentRepository;
+  /**
+   * DB-backed invoice store + neutral provider port. Injected by app.ts so the
+   * invoice-synced handler can persist invoice.* webhooks. Optional so handler
+   * unit tests that don't exercise invoice persistence can omit them.
+   */
+  invoiceRepo?: InvoiceRepository;
+  provider?: PaymentProvider;
   permit: PermitSyncService;
   emitter: BillingEventEmitter;
   /** Writes the plan-tier hot-path cache columns back to public.users/organizations. */

--- a/services/billing-service/src/handlers/webhook-router.ts
+++ b/services/billing-service/src/handlers/webhook-router.ts
@@ -3,9 +3,23 @@ import { HandlerContext, StripeEventHandler } from './types';
 import { handleSubscriptionUpdated } from './subscription-updated';
 import { handleInvoicePaid } from './invoice-paid';
 import { handleInvoiceFailed } from './invoice-failed';
+import { handleInvoiceSynced } from './invoice-synced';
 import { handleTrialEnding } from './trial-ending';
 import { handleCheckoutCompleted } from './checkout-completed';
 import { handlePaymentCompleted } from './payment-completed';
+
+/**
+ * Runs the given handlers in sequence for one event. Used so an invoice event
+ * BOTH persists into billing.invoices (invoice-synced) AND drives its existing
+ * entitlement/notify side-effect (invoice-paid / invoice-failed).
+ */
+function chain(...handlers: StripeEventHandler[]): StripeEventHandler {
+  return async (event, ctx) => {
+    for (const handler of handlers) {
+      await handler(event, ctx);
+    }
+  };
+}
 
 /**
  * checkout.session.completed fans out BY SESSION MODE:
@@ -42,8 +56,14 @@ export const HANDLERS: Record<string, StripeEventHandler> = {
   'customer.subscription.updated': handleSubscriptionUpdated,
   'customer.subscription.deleted': handleSubscriptionUpdated,
   'customer.subscription.trial_will_end': handleTrialEnding,
-  'invoice.payment_succeeded': handleInvoicePaid,
-  'invoice.payment_failed': handleInvoiceFailed,
+  // Invoice lifecycle: persist the invoice into billing.invoices (invoice-synced)
+  // for every relevant event, and — for the succeeded/failed events — ALSO run
+  // the existing entitlement/notify handler (order: persist, then notify).
+  'invoice.payment_succeeded': chain(handleInvoiceSynced, handleInvoicePaid),
+  'invoice.payment_failed': chain(handleInvoiceSynced, handleInvoiceFailed),
+  'invoice.paid': handleInvoiceSynced,
+  'invoice.finalized': handleInvoiceSynced,
+  'invoice.updated': handleInvoiceSynced,
 };
 
 export async function routeWebhookEvent(

--- a/services/billing-service/src/index.ts
+++ b/services/billing-service/src/index.ts
@@ -13,6 +13,7 @@ import { PgPlanRepository } from './repositories/plan.repository';
 import { PgSubscriptionRepository } from './repositories/subscription.repository';
 import { PgEventRepository } from './repositories/event.repository';
 import { PgPaymentRepository } from './repositories/payment.repository';
+import { PgInvoiceRepository } from './repositories/invoice.repository';
 import { PgUsageRepository } from './repositories/usage.repository';
 import { CustomerService } from './services/customer.service';
 import { PlanService } from './services/plan.service';
@@ -56,6 +57,7 @@ async function main() {
   const subscriptionRepo = new PgSubscriptionRepository(pool);
   const eventRepo = new PgEventRepository(pool);
   const paymentRepo = new PgPaymentRepository(pool);
+  const invoiceRepo = new PgInvoiceRepository(pool);
   const usageRepo = new PgUsageRepository(pool);
 
   // --- Services ---
@@ -122,6 +124,7 @@ async function main() {
     customerRepo,
     customers,
     payments: paymentRepo,
+    invoiceRepo,
     paymentsConfig: config.payments,
     webhook: {
       stripe,

--- a/services/billing-service/src/middleware/auth.ts
+++ b/services/billing-service/src/middleware/auth.ts
@@ -60,6 +60,12 @@ function isProduction(): boolean {
  */
 export function requireInternalToken(expectedToken?: string) {
   return (req: Request, res: Response, next: NextFunction): void => {
+    // `/health` is never a guarded API route — it lives at the bare server root,
+    // NOT under /api/v1/billing. When this guard is mounted as prefix middleware
+    // (app.use(API_BASE, guard, router)) a stray GET /api/v1/billing/health would
+    // otherwise 401 before falling through to its natural 404. Let it pass so the
+    // unknown path 404s (contract: health is not under the API base).
+    if (req.path === '/health') return next();
     if (!expectedToken) {
       if (isProduction()) {
         // Fail CLOSED: refuse to serve guarded routes without a configured token.

--- a/services/billing-service/src/migrations/003_invoices.sql
+++ b/services/billing-service/src/migrations/003_invoices.sql
@@ -1,0 +1,32 @@
+-- Migration 003: vendor-neutral, DB-backed invoice store
+-- Idempotent: safe to re-run (all CREATE statements use IF NOT EXISTS).
+--
+-- LEAST-PRIVILEGE: executed at billing-service startup by the runtime role
+-- `billing_svc` (see 001_billing_schema.sql header) — schema-level DDL only,
+-- no CREATE EXTENSION / CREATE SCHEMA. gen_random_uuid() is core in
+-- PostgreSQL 13+ (FuzeInfra runs postgres:15).
+--
+-- billing.invoices
+-- Local, provider-neutral mirror of invoices synced from the payment provider
+-- (via POST /invoices/sync and the invoice.* webhooks). Exposed through
+-- GET /invoices with OUR uuid `id` as the stable identifier; the provider's own
+-- invoice id is confined to (provider, provider_invoice_id) and never leaked.
+CREATE TABLE IF NOT EXISTS billing.invoices (
+  id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  customer_id         UUID NOT NULL REFERENCES billing.customers(id) ON DELETE CASCADE,
+  provider            TEXT NOT NULL DEFAULT 'stripe',
+  provider_invoice_id TEXT NOT NULL,
+  number              TEXT,
+  status              TEXT NOT NULL,
+  amount_due_cents    INTEGER NOT NULL CHECK (amount_due_cents >= 0),
+  amount_paid_cents   INTEGER NOT NULL CHECK (amount_paid_cents >= 0),
+  currency            TEXT NOT NULL,
+  hosted_invoice_url  TEXT,
+  invoice_pdf_url     TEXT,
+  issued_at           TIMESTAMPTZ NOT NULL,
+  created_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (provider, provider_invoice_id)
+);
+CREATE INDEX IF NOT EXISTS idx_billing_invoices_customer_issued
+  ON billing.invoices (customer_id, issued_at DESC, id DESC);

--- a/services/billing-service/src/providers/payment-provider.ts
+++ b/services/billing-service/src/providers/payment-provider.ts
@@ -1,0 +1,82 @@
+/**
+ * Vendor-neutral payment-provider port.
+ *
+ * Domain/route/webhook code depends ONLY on this interface and its neutral DTOs —
+ * never on the Stripe SDK. `StripePaymentProvider` (providers/stripe/*) is the
+ * only place besides the existing `stripe-client.ts` allowed to `import Stripe`,
+ * so the vendor can be swapped (or moved behind the payment-service gateway)
+ * without touching call sites.
+ *
+ * Every vendor call is wrapped in `ProviderHooks` (onBeforeCall/onAfterCall/
+ * onError) so metrics, transforms, or retries can be added centrally.
+ */
+
+/** A provider invoice, normalised to FuzeFront's neutral shape (cents, Date). */
+export interface ProviderInvoice {
+  /** The provider's own invoice id (confined to the adapter + DB uniqueness). */
+  providerInvoiceId: string;
+  /** Human-facing invoice number; null when the provider has not issued one. */
+  number: string | null;
+  /** Neutral status: draft|open|paid|void|uncollectible. */
+  status: string;
+  /** Amount due in the currency's minor unit (cents). */
+  amountDueCents: number;
+  /** Amount paid in the currency's minor unit (cents). */
+  amountPaidCents: number;
+  /** ISO 4217 code, lowercased. */
+  currency: string;
+  /** Provider-hosted invoice page URL; null when unavailable. */
+  hostedInvoiceUrl: string | null;
+  /** Provider-hosted invoice PDF URL; null when unavailable. */
+  invoicePdfUrl: string | null;
+  /** Issue timestamp. */
+  issuedAt: Date;
+}
+
+/** Options for a single page of `listInvoices`. */
+export interface ListInvoicesOptions {
+  /** Page size. */
+  limit: number;
+  /** Opaque provider cursor for the next page (the provider's paging token). */
+  startingAfter?: string;
+}
+
+/** One page of provider invoices. */
+export interface ProviderInvoicePage {
+  invoices: ProviderInvoice[];
+  hasMore: boolean;
+}
+
+/**
+ * The neutral payment-provider port. Only the invoice surface is modelled here
+ * for this slice; checkout/subscriptions/etc. will be migrated behind the same
+ * boundary later.
+ */
+export interface PaymentProvider {
+  /** Provider identity, persisted in billing.invoices.provider (e.g. 'stripe'). */
+  readonly name: string;
+
+  /** Page the entity's invoices from the provider. */
+  listInvoices(
+    providerCustomerId: string,
+    opts: ListInvoicesOptions,
+  ): Promise<ProviderInvoicePage>;
+
+  /**
+   * Parse a provider webhook event into a neutral {providerCustomerId, invoice}.
+   * Returns null when the event is not an invoice event we can persist.
+   */
+  parseInvoiceEvent(
+    evt: unknown,
+  ): { providerCustomerId: string; invoice: ProviderInvoice } | null;
+}
+
+/**
+ * Pre/post/error hooks wrapped around every vendor call. All optional and
+ * best-effort — a hook throwing must not mask the underlying call result.
+ */
+export interface ProviderHooks {
+  onBeforeCall?: (call: string, meta?: Record<string, unknown>) => void | Promise<void>;
+  onAfterCall?: (call: string, meta?: Record<string, unknown>) => void | Promise<void>;
+  onError?: (call: string, err: unknown, meta?: Record<string, unknown>) => void | Promise<void>;
+}

--- a/services/billing-service/src/providers/stripe/stripe-payment-provider.ts
+++ b/services/billing-service/src/providers/stripe/stripe-payment-provider.ts
@@ -1,0 +1,94 @@
+import type Stripe from 'stripe';
+import {
+  ListInvoicesOptions,
+  PaymentProvider,
+  ProviderHooks,
+  ProviderInvoice,
+  ProviderInvoicePage,
+} from '../payment-provider';
+
+/**
+ * Maps a Stripe Invoice to the neutral ProviderInvoice. Defensive about the
+ * optional/nullable Stripe fields (number/hosted_invoice_url/invoice_pdf are
+ * null on draft invoices). Keeps the EXACT field mapping the previous
+ * routes/invoices `mapInvoice` used: amount_due→amountDueCents, currency
+ * lowercased, created(unix s)→issuedAt(Date), status defaults to 'draft'.
+ */
+export function mapStripeInvoice(inv: Stripe.Invoice): ProviderInvoice {
+  return {
+    providerInvoiceId: inv.id as string,
+    number: inv.number ?? null,
+    status: inv.status ?? 'draft',
+    amountDueCents: inv.amount_due,
+    amountPaidCents: inv.amount_paid,
+    currency: (inv.currency || '').toLowerCase(),
+    hostedInvoiceUrl: inv.hosted_invoice_url ?? null,
+    invoicePdfUrl: inv.invoice_pdf ?? null,
+    issuedAt: new Date(inv.created * 1000),
+  };
+}
+
+/** The single Stripe sub-resource the adapter needs (narrowed for testability). */
+export interface StripeInvoicesLike {
+  invoices: Pick<Stripe.InvoicesResource, 'list'>;
+}
+
+/**
+ * Stripe implementation of the neutral PaymentProvider port. This adapter is the
+ * ONLY new file allowed to depend on the Stripe SDK; every vendor call is routed
+ * through `withHooks` so pre/post/error hooks fire without touching call sites.
+ */
+export class StripePaymentProvider implements PaymentProvider {
+  readonly name = 'stripe';
+
+  constructor(
+    private readonly stripe: StripeInvoicesLike,
+    private readonly hooks: ProviderHooks = {},
+  ) {}
+
+  async listInvoices(
+    providerCustomerId: string,
+    opts: ListInvoicesOptions,
+  ): Promise<ProviderInvoicePage> {
+    return this.withHooks('listInvoices', { providerCustomerId, limit: opts.limit }, async () => {
+      const page = await this.stripe.invoices.list({
+        customer: providerCustomerId,
+        limit: opts.limit,
+        ...(opts.startingAfter ? { starting_after: opts.startingAfter } : {}),
+      });
+      return {
+        invoices: page.data.map(mapStripeInvoice),
+        hasMore: page.has_more,
+      };
+    });
+  }
+
+  parseInvoiceEvent(
+    evt: unknown,
+  ): { providerCustomerId: string; invoice: ProviderInvoice } | null {
+    const event = evt as Stripe.Event | undefined;
+    const obj = event?.data?.object as Stripe.Invoice | undefined;
+    if (!obj || obj.object !== 'invoice' || !obj.id) return null;
+    const providerCustomerId =
+      typeof obj.customer === 'string' ? obj.customer : obj.customer?.id;
+    if (!providerCustomerId) return null;
+    return { providerCustomerId, invoice: mapStripeInvoice(obj) };
+  }
+
+  /** Wrap a vendor call in the pre/post/error hooks (hooks are best-effort). */
+  private async withHooks<T>(
+    call: string,
+    meta: Record<string, unknown>,
+    fn: () => Promise<T>,
+  ): Promise<T> {
+    await this.hooks.onBeforeCall?.(call, meta);
+    try {
+      const result = await fn();
+      await this.hooks.onAfterCall?.(call, meta);
+      return result;
+    } catch (err) {
+      await this.hooks.onError?.(call, err, meta);
+      throw err;
+    }
+  }
+}

--- a/services/billing-service/src/repositories/invoice.repository.ts
+++ b/services/billing-service/src/repositories/invoice.repository.ts
@@ -1,0 +1,180 @@
+import { Pool } from 'pg';
+import { ProviderInvoice } from '../providers/payment-provider';
+
+/**
+ * The contract-frozen, vendor-neutral invoice projection exposed by
+ * GET /invoices. `id` is OUR FuzeFront uuid (never a provider id); `created` is
+ * the ISO-8601 issue timestamp; amountDue/amountPaid are cents; currency is
+ * lowercased. This is the stable shape the billing UI depends on.
+ */
+export interface BillingInvoiceView {
+  id: string;
+  number: string | null;
+  created: string;
+  amountDue: number;
+  amountPaid: number;
+  currency: string;
+  status: string;
+  hostedInvoiceUrl: string | null;
+  invoicePdf: string | null;
+}
+
+/** A row of billing.invoices. */
+export interface InvoiceRow {
+  id: string;
+  customer_id: string;
+  provider: string;
+  provider_invoice_id: string;
+  number: string | null;
+  status: string;
+  amount_due_cents: number;
+  amount_paid_cents: number;
+  currency: string;
+  hosted_invoice_url: string | null;
+  invoice_pdf_url: string | null;
+  issued_at: Date;
+  created_at: Date;
+  updated_at: Date;
+}
+
+export interface ListByCustomerArgs {
+  customerId: string;
+  limit: number;
+  /** Opaque keyset cursor (previous page's nextCursor); undefined for page 1. */
+  cursor?: string;
+}
+
+export interface ListByCustomerResult {
+  rows: InvoiceRow[];
+  /** Opaque keyset cursor for the next page; null on the last page. */
+  nextCursor: string | null;
+}
+
+/**
+ * Data-access for billing.invoices. Defined as an interface so services/handlers
+ * can be unit-tested against an in-memory fake without a live Postgres.
+ */
+export interface InvoiceRepository {
+  /** Upsert a provider invoice for a customer (idempotent on provider id). */
+  upsertFromProvider(customerId: string, invoice: ProviderInvoice): Promise<void>;
+  /** Keyset page a customer's invoices, newest first. */
+  listByCustomer(args: ListByCustomerArgs): Promise<ListByCustomerResult>;
+}
+
+/** Maps a billing.invoices row to the neutral BillingInvoiceView. */
+export function mapInvoiceRow(r: InvoiceRow): BillingInvoiceView {
+  return {
+    id: r.id,
+    number: r.number ?? null,
+    created: new Date(r.issued_at).toISOString(),
+    amountDue: r.amount_due_cents,
+    amountPaid: r.amount_paid_cents,
+    currency: r.currency,
+    status: r.status,
+    hostedInvoiceUrl: r.hosted_invoice_url ?? null,
+    invoicePdf: r.invoice_pdf_url ?? null,
+  };
+}
+
+/** Encode a keyset cursor: base64(`${issued_at_iso}|${id}`). */
+export function encodeInvoiceCursor(issuedAtIso: string, id: string): string {
+  return Buffer.from(`${issuedAtIso}|${id}`, 'utf8').toString('base64');
+}
+
+/**
+ * Decode a keyset cursor back to {issuedAt, id}. Returns null when the cursor is
+ * malformed (treated as page 1 rather than an error).
+ */
+export function decodeInvoiceCursor(cursor: string): { issuedAt: string; id: string } | null {
+  try {
+    const raw = Buffer.from(cursor, 'base64').toString('utf8');
+    const sep = raw.indexOf('|');
+    if (sep <= 0) return null;
+    const issuedAt = raw.slice(0, sep);
+    const id = raw.slice(sep + 1);
+    if (!issuedAt || !id || Number.isNaN(Date.parse(issuedAt))) return null;
+    return { issuedAt, id };
+  } catch {
+    return null;
+  }
+}
+
+export class PgInvoiceRepository implements InvoiceRepository {
+  constructor(
+    private readonly pool: Pool,
+    /** Provider name persisted in billing.invoices.provider. */
+    private readonly provider = 'stripe',
+  ) {}
+
+  async upsertFromProvider(customerId: string, invoice: ProviderInvoice): Promise<void> {
+    // Idempotent on (provider, provider_invoice_id): a webhook and a full resync
+    // that both see the same invoice converge on one row; the mutable fields are
+    // refreshed on every landing.
+    await this.pool.query(
+      `INSERT INTO billing.invoices
+         (customer_id, provider, provider_invoice_id, number, status,
+          amount_due_cents, amount_paid_cents, currency,
+          hosted_invoice_url, invoice_pdf_url, issued_at)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)
+       ON CONFLICT (provider, provider_invoice_id) DO UPDATE SET
+          status             = EXCLUDED.status,
+          amount_due_cents   = EXCLUDED.amount_due_cents,
+          amount_paid_cents  = EXCLUDED.amount_paid_cents,
+          currency           = EXCLUDED.currency,
+          number             = EXCLUDED.number,
+          hosted_invoice_url = EXCLUDED.hosted_invoice_url,
+          invoice_pdf_url    = EXCLUDED.invoice_pdf_url,
+          issued_at          = EXCLUDED.issued_at,
+          updated_at         = now()`,
+      [
+        customerId,
+        this.provider,
+        invoice.providerInvoiceId,
+        invoice.number,
+        invoice.status,
+        invoice.amountDueCents,
+        invoice.amountPaidCents,
+        invoice.currency,
+        invoice.hostedInvoiceUrl,
+        invoice.invoicePdfUrl,
+        invoice.issuedAt,
+      ],
+    );
+  }
+
+  async listByCustomer(args: ListByCustomerArgs): Promise<ListByCustomerResult> {
+    const { customerId, limit } = args;
+    const decoded = args.cursor ? decodeInvoiceCursor(args.cursor) : null;
+
+    // Fetch limit+1 to detect a further page without a second COUNT query.
+    // Keyset predicate uses the row-value comparison on (issued_at, id) so the
+    // ordering and the "less than the cursor" boundary stay consistent.
+    const params: unknown[] = [customerId];
+    let where = 'customer_id = $1';
+    if (decoded) {
+      params.push(decoded.issuedAt, decoded.id);
+      where += ` AND (issued_at, id) < ($2::timestamptz, $3::uuid)`;
+    }
+    params.push(limit + 1);
+    const limitParam = `$${params.length}`;
+
+    const res = await this.pool.query<InvoiceRow>(
+      `SELECT id, customer_id, provider, provider_invoice_id, number, status,
+              amount_due_cents, amount_paid_cents, currency,
+              hosted_invoice_url, invoice_pdf_url, issued_at, created_at, updated_at
+         FROM billing.invoices
+        WHERE ${where}
+        ORDER BY issued_at DESC, id DESC
+        LIMIT ${limitParam}`,
+      params,
+    );
+
+    const hasMore = res.rows.length > limit;
+    const rows = hasMore ? res.rows.slice(0, limit) : res.rows;
+    const last = rows[rows.length - 1];
+    const nextCursor =
+      hasMore && last ? encodeInvoiceCursor(new Date(last.issued_at).toISOString(), last.id) : null;
+
+    return { rows, nextCursor };
+  }
+}

--- a/services/billing-service/src/repositories/payment.repository.ts
+++ b/services/billing-service/src/repositories/payment.repository.ts
@@ -2,8 +2,8 @@ import { Pool } from 'pg';
 import { BillingPayment, EntityType, PaymentStatus } from '../types';
 
 export interface PaymentUpsert {
-  stripeSessionId: string;
-  stripePaymentIntentId: string | null;
+  sessionId: string;
+  paymentIntentId: string | null;
   productKey: string;
   externalOrderId: string;
   entityType: EntityType;
@@ -47,8 +47,8 @@ interface PaymentRow {
 function mapRow(r: PaymentRow): BillingPayment {
   return {
     id: r.id,
-    stripeSessionId: r.stripe_session_id,
-    stripePaymentIntentId: r.stripe_payment_intent_id,
+    sessionId: r.stripe_session_id,
+    paymentIntentId: r.stripe_payment_intent_id,
     productKey: r.product_key,
     externalOrderId: r.external_order_id,
     entityType: r.entity_type,
@@ -92,8 +92,8 @@ export class PgPaymentRepository implements PaymentRepository {
           updated_at               = now()
        RETURNING *`,
       [
-        row.stripeSessionId,
-        row.stripePaymentIntentId,
+        row.sessionId,
+        row.paymentIntentId,
         row.productKey,
         row.externalOrderId,
         row.entityType,

--- a/services/billing-service/src/repositories/plan.repository.ts
+++ b/services/billing-service/src/repositories/plan.repository.ts
@@ -24,8 +24,8 @@ interface PlanRow {
 
 function mapRow(r: PlanRow): Plan {
   return {
-    stripePriceId: r.stripe_price_id,
-    stripeProductId: r.stripe_product_id,
+    priceId: r.stripe_price_id,
+    productId: r.stripe_product_id,
     tierName: r.tier_name,
     displayName: r.display_name,
     billingInterval: r.billing_interval,
@@ -63,8 +63,8 @@ export class PgPlanRepository implements PlanRepository {
           sort_order         = EXCLUDED.sort_order,
           synced_at          = now()`,
       [
-        plan.stripePriceId,
-        plan.stripeProductId,
+        plan.priceId,
+        plan.productId,
         plan.tierName,
         plan.displayName,
         plan.billingInterval,

--- a/services/billing-service/src/repositories/subscription.repository.ts
+++ b/services/billing-service/src/repositories/subscription.repository.ts
@@ -3,8 +3,8 @@ import { BillingSubscription, PlanTier, SubscriptionStatus } from '../types';
 
 export interface SubscriptionUpsert {
   customerId: string;
-  stripeSubscriptionId: string;
-  stripePriceId: string;
+  subscriptionId: string;
+  priceId: string;
   planTier: PlanTier;
   status: SubscriptionStatus;
   seatQuantity: number;
@@ -45,8 +45,8 @@ function mapRow(r: SubRow): BillingSubscription {
   return {
     id: r.id,
     customerId: r.customer_id,
-    stripeSubscriptionId: r.stripe_subscription_id,
-    stripePriceId: r.stripe_price_id,
+    subscriptionId: r.stripe_subscription_id,
+    priceId: r.stripe_price_id,
     planTier: r.plan_tier,
     status: r.status,
     seatQuantity: r.seat_quantity,
@@ -84,8 +84,8 @@ export class PgSubscriptionRepository implements SubscriptionRepository {
        RETURNING *`,
       [
         row.customerId,
-        row.stripeSubscriptionId,
-        row.stripePriceId,
+        row.subscriptionId,
+        row.priceId,
         row.planTier,
         row.status,
         row.seatQuantity,

--- a/services/billing-service/src/routes/docs.ts
+++ b/services/billing-service/src/routes/docs.ts
@@ -1,0 +1,75 @@
+import { Router, Request, Response } from 'express';
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+
+/**
+ * Public, read-only API documentation for the billing-service.
+ *
+ *   GET /api/v1/billing/docs         -> Swagger UI (renders the contract)
+ *   GET /api/v1/billing/openapi.yaml -> the raw OpenAPI 3.1 contract
+ *
+ * This is the "launch in Swagger" surface: wherever the service runs it exposes
+ * an interactive view of the SAME `openapi.yaml` that generates
+ * `@fuzefront/billing-client`. No auth — the contract is not a secret and holds
+ * no data. In deploy it is reachable behind the ingress at
+ * `<origin>/api/v1/billing/docs`; locally at `http://localhost:3006/api/v1/billing/docs`.
+ *
+ * Swagger UI assets load from the jsDelivr CDN (available in a browser / behind
+ * ingress). The spec is read from disk at request time from the first candidate
+ * path that exists, so it works both from `dist/` (production image copies the
+ * yaml next to the compiled JS) and from source in dev/test.
+ */
+const SPEC_CANDIDATES = [
+  join(__dirname, '..', 'openapi.yaml'), // dist/openapi.yaml (prod) or src/../openapi.yaml
+  join(__dirname, '..', '..', 'openapi.yaml'), // service root from dist/routes
+  join(process.cwd(), 'openapi.yaml'), // service root when cwd is the service dir
+];
+
+function resolveSpecPath(): string | null {
+  for (const p of SPEC_CANDIDATES) {
+    if (existsSync(p)) return p;
+  }
+  return null;
+}
+
+const SWAGGER_HTML = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>FuzeFront Billing API — Swagger UI</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui.css" />
+  <style>body { margin: 0; }</style>
+</head>
+<body>
+  <div id="swagger-ui"></div>
+  <script src="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui-bundle.js" crossorigin></script>
+  <script>
+    window.ui = SwaggerUIBundle({
+      url: 'openapi.yaml',
+      dom_id: '#swagger-ui',
+      deepLinking: true,
+      presets: [SwaggerUIBundle.presets.apis],
+    });
+  </script>
+</body>
+</html>`;
+
+/** Builds the public docs router (Swagger UI + raw spec). */
+export function createDocsRouter(): Router {
+  const router = Router();
+
+  router.get('/docs', (_req: Request, res: Response) => {
+    res.type('html').send(SWAGGER_HTML);
+  });
+
+  router.get('/openapi.yaml', (_req: Request, res: Response) => {
+    const specPath = resolveSpecPath();
+    if (!specPath) {
+      return res.status(404).json({ error: 'openapi spec not found' });
+    }
+    res.type('text/yaml').send(readFileSync(specPath, 'utf8'));
+  });
+
+  return router;
+}

--- a/services/billing-service/src/routes/invoices.ts
+++ b/services/billing-service/src/routes/invoices.ts
@@ -1,55 +1,20 @@
 import { Router, Response } from 'express';
-import type Stripe from 'stripe';
-import { CustomerRepository } from '../repositories/customer.repository';
 import { BillingRequest, requireActorContext } from '../middleware/auth';
+import { InvoiceService } from '../services/invoice.service';
 import { sendStripeError } from './stripe-error';
+
+// Re-export the neutral view shape from the repository so existing importers of
+// `BillingInvoiceView` from this module keep working after the DB-backed rewrite.
+export type { BillingInvoiceView } from '../repositories/invoice.repository';
 
 /** Default page size and clamp bounds for GET /invoices. */
 const DEFAULT_LIMIT = 20;
 const MIN_LIMIT = 1;
 const MAX_LIMIT = 100;
 
-/**
- * The contract-frozen invoice projection. We expose ONLY these fields (a stable
- * subset of the Stripe Invoice) so the billing UI never depends on the raw
- * Stripe object shape. amountDue/amountPaid are cents (Stripe minor units),
- * currency is lowercased, created is ISO-8601 derived from the unix seconds.
- */
-export interface BillingInvoiceView {
-  id: string;
-  number: string | null;
-  created: string;
-  amountDue: number;
-  amountPaid: number;
-  currency: string;
-  status: string;
-  hostedInvoiceUrl: string | null;
-  invoicePdf: string | null;
-}
-
 export interface InvoicesDeps {
-  // Narrow to the single Stripe call we make so unit tests can stub it.
-  stripe: { invoices: Pick<Stripe.InvoicesResource, 'list'> };
-  customerRepo: CustomerRepository;
-}
-
-/**
- * Maps a Stripe Invoice to the frozen BillingInvoiceView. Defensive about the
- * optional/nullable Stripe fields: number/hosted_invoice_url/invoice_pdf are
- * `null` when Stripe has not produced them (e.g. draft invoices).
- */
-export function mapInvoice(inv: Stripe.Invoice): BillingInvoiceView {
-  return {
-    id: inv.id,
-    number: inv.number ?? null,
-    created: new Date(inv.created * 1000).toISOString(),
-    amountDue: inv.amount_due,
-    amountPaid: inv.amount_paid,
-    currency: (inv.currency || '').toLowerCase(),
-    status: inv.status ?? 'draft',
-    hostedInvoiceUrl: inv.hosted_invoice_url ?? null,
-    invoicePdf: inv.invoice_pdf ?? null,
-  };
+  /** Vendor-neutral, DB-backed invoice read/sync service. */
+  service: InvoiceService;
 }
 
 /** Clamp/parse the `limit` query param to [MIN_LIMIT, MAX_LIMIT]. */
@@ -60,15 +25,15 @@ export function parseLimit(raw: unknown): number {
 }
 
 /**
- * GET /api/v1/billing/invoices — list the proxy-authorized entity's Stripe
- * invoices (read-only). Mounted behind the internal-token guard (app.ts);
- * requireActorContext here re-derives the SERVER-DERIVED entity so identity is
- * never taken from a client query/body. A new entity with no billing customer
- * is NOT an error — it just has no invoices.
+ * Invoice routes for the proxy-authorized entity. Mounted behind the
+ * internal-token guard (app.ts); `requireActorContext` re-derives the
+ * SERVER-DERIVED entity so identity is never taken from a client query/body.
  *
- * Cursor pagination uses an opaque cursor that is a Stripe invoice id passed to
- * `starting_after`. nextCursor is the id of the LAST invoice on the page when
- * Stripe reports has_more, else null.
+ *  - GET  /invoices       reads the local, provider-synced invoice store
+ *                         (opaque keyset cursor). An entity with no billing
+ *                         customer is NOT an error — it just has no invoices.
+ *  - POST /invoices/sync  forces a provider→store resync and returns {synced}.
+ *                         Idempotent.
  */
 export function createInvoicesRouter(deps: InvoicesDeps): Router {
   const router = Router();
@@ -80,24 +45,26 @@ export function createInvoicesRouter(deps: InvoicesDeps): Router {
     const cursorRaw = req.query.cursor;
     const cursor = typeof cursorRaw === 'string' && cursorRaw.trim() ? cursorRaw.trim() : undefined;
 
-    const customer = await deps.customerRepo.findByEntity(actor.entityType, actor.entityId);
-    if (!customer) {
-      // No billing relationship yet -> no invoices. Absence is not an error.
-      return res.status(200).json({ invoices: [], nextCursor: null });
+    try {
+      const page = await deps.service.list(
+        { entityType: actor.entityType, entityId: actor.entityId },
+        { limit, cursor },
+      );
+      return res.status(200).json(page);
+    } catch (err) {
+      return sendStripeError(res, err);
     }
+  });
+
+  router.post('/invoices/sync', requireActorContext(), async (req: BillingRequest, res: Response) => {
+    const actor = req.actor!; // requireActorContext guarantees this
 
     try {
-      const page = await deps.stripe.invoices.list({
-        customer: customer.stripeCustomerId,
-        limit,
-        ...(cursor ? { starting_after: cursor } : {}),
+      const synced = await deps.service.syncEntity({
+        entityType: actor.entityType,
+        entityId: actor.entityId,
       });
-
-      const invoices = page.data.map(mapInvoice);
-      const nextCursor =
-        page.has_more && invoices.length > 0 ? invoices[invoices.length - 1].id : null;
-
-      return res.status(200).json({ invoices, nextCursor });
+      return res.status(200).json({ synced });
     } catch (err) {
       return sendStripeError(res, err);
     }

--- a/services/billing-service/src/routes/payments.ts
+++ b/services/billing-service/src/routes/payments.ts
@@ -224,8 +224,8 @@ export function createPaymentsRouter(deps: PaymentsDeps): Router {
         // converges the row later.
         try {
           await deps.payments.upsert({
-            stripeSessionId: session.id,
-            stripePaymentIntentId:
+            sessionId: session.id,
+            paymentIntentId:
               typeof session.payment_intent === 'string'
                 ? session.payment_intent
                 : session.payment_intent?.id ?? null,
@@ -321,8 +321,8 @@ export function createPaymentsRouter(deps: PaymentsDeps): Router {
       }
 
       const payment: BillingPayment = await deps.payments.upsert({
-        stripeSessionId: session.id,
-        stripePaymentIntentId:
+        sessionId: session.id,
+        paymentIntentId:
           typeof session.payment_intent === 'string'
             ? session.payment_intent
             : session.payment_intent?.id ?? null,

--- a/services/billing-service/src/routes/subscriptions.ts
+++ b/services/billing-service/src/routes/subscriptions.ts
@@ -39,7 +39,7 @@ export function createSubscriptionsRouter(
   // { subscription: <view> | null }. Absence is NOT an error (the UI treats null
   // as "no current subscription"), so we 200 {subscription:null} rather than 404.
   //
-  // NOTE: registered BEFORE GET /subscriptions/:stripeSubscriptionId so the
+  // NOTE: registered BEFORE GET /subscriptions/:subscriptionId so the
   // param route does not shadow this collection route.
   router.get(
     '/subscriptions',
@@ -70,22 +70,31 @@ export function createSubscriptionsRouter(
     }
   });
 
-  // GET /subscriptions/:stripeSubscriptionId
-  router.get('/subscriptions/:stripeSubscriptionId', async (req: Request, res: Response) => {
-    const sub = await repo.findByStripeId(req.params.stripeSubscriptionId);
+  // GET /subscriptions/:subscriptionId
+  router.get('/subscriptions/:subscriptionId', async (req: Request, res: Response) => {
+    const sub = await repo.findByStripeId(req.params.subscriptionId);
     if (!sub) return res.status(404).json({ error: 'not found' });
     return res.json({ subscription: sub });
   });
 
-  // PATCH /subscriptions/:stripeSubscriptionId — change plan / seats
-  router.patch('/subscriptions/:stripeSubscriptionId', async (req: Request, res: Response) => {
+  // PATCH /subscriptions/:subscriptionId — change plan / seats
+  router.patch('/subscriptions/:subscriptionId', async (req: Request, res: Response) => {
     const parsed = validateBody(updateSchema, req.body);
     if (!parsed.ok) {
       return res.status(400).json({ error: 'invalid request', details: parsed.details });
     }
+    // Contract: UpdateSubscriptionRequest.minProperties = 1. A PATCH with no
+    // updatable field (`{}`, or a body of only-unknown keys stripped by the
+    // schema) is a 400 — there is nothing to change.
+    if (Object.keys(parsed.data as Record<string, unknown>).length === 0) {
+      return res.status(400).json({
+        error: 'invalid request',
+        details: { message: 'at least one updatable field (priceId or seatQuantity) is required' },
+      });
+    }
     try {
       const sub = await service.update(
-        req.params.stripeSubscriptionId,
+        req.params.subscriptionId,
         parsed.data as UpdateSubscriptionRequest,
       );
       return res.json({ subscription: sub });
@@ -94,10 +103,10 @@ export function createSubscriptionsRouter(
     }
   });
 
-  // DELETE /subscriptions/:stripeSubscriptionId — cancel at period end
-  router.delete('/subscriptions/:stripeSubscriptionId', async (req: Request, res: Response) => {
+  // DELETE /subscriptions/:subscriptionId — cancel at period end
+  router.delete('/subscriptions/:subscriptionId', async (req: Request, res: Response) => {
     try {
-      const sub = await service.cancel(req.params.stripeSubscriptionId);
+      const sub = await service.cancel(req.params.subscriptionId);
       return res.json({ subscription: sub });
     } catch (err) {
       return res.status(502).json({ error: 'stripe error', message: errMsg(err) });

--- a/services/billing-service/src/routes/webhooks.ts
+++ b/services/billing-service/src/routes/webhooks.ts
@@ -22,11 +22,18 @@ export interface WebhookDeps {
 export function createWebhookRouter(deps: WebhookDeps): Router {
   const router = Router();
 
+  // Contract path is the vendor-neutral `/webhooks/{provider}` (openapi.yaml).
+  // The `:provider` param keeps the live provider endpoint URL working — a POST
+  // to `/api/v1/billing/webhooks/stripe` resolves here with `provider = 'stripe'`
+  // — while the contract stays generic. The real provider-signature header is
+  // still read for verification; the neutral `X-Provider-Signature` is accepted
+  // as an alias.
   router.post(
-    '/webhooks/stripe',
+    '/webhooks/:provider',
     express.raw({ type: 'application/json' }),
     async (req: Request, res: Response) => {
-      const sig = req.headers['stripe-signature'];
+      const sig =
+        req.headers['stripe-signature'] ?? req.headers['x-provider-signature'];
       if (!sig) {
         return res.status(400).send('Missing stripe-signature header');
       }

--- a/services/billing-service/src/services/invoice.service.ts
+++ b/services/billing-service/src/services/invoice.service.ts
@@ -1,0 +1,96 @@
+import { CustomerRepository } from '../repositories/customer.repository';
+import {
+  BillingInvoiceView,
+  InvoiceRepository,
+  mapInvoiceRow,
+} from '../repositories/invoice.repository';
+import { PaymentProvider } from '../providers/payment-provider';
+import { BillingCustomer, EntityType } from '../types';
+
+/** How many invoices to pull per provider page during a resync. */
+const SYNC_PAGE_SIZE = 100;
+
+export interface InvoiceServiceDeps {
+  customerRepo: CustomerRepository;
+  invoiceRepo: InvoiceRepository;
+  provider: PaymentProvider;
+}
+
+/** The server-derived entity the money path re-verifies against. */
+export interface InvoiceEntity {
+  entityType: EntityType;
+  entityId: string;
+}
+
+export interface ListInvoicesResult {
+  invoices: BillingInvoiceView[];
+  nextCursor: string | null;
+}
+
+/**
+ * Vendor-neutral invoice read/sync service.
+ *
+ * Reads are served from the local billing.invoices store. On the FIRST page for
+ * a known customer whose store is empty, we lazily sync once from the provider
+ * then read — so a never-synced entity still returns its invoices without an
+ * explicit POST /invoices/sync. Subsequent pages (cursor present) never trigger
+ * a sync.
+ */
+export class InvoiceService {
+  constructor(private readonly deps: InvoiceServiceDeps) {}
+
+  async list(entity: InvoiceEntity, opts: { limit: number; cursor?: string }): Promise<ListInvoicesResult> {
+    const customer = await this.deps.customerRepo.findByEntity(entity.entityType, entity.entityId);
+    if (!customer) {
+      // No billing relationship yet -> no invoices. Absence is not an error.
+      return { invoices: [], nextCursor: null };
+    }
+
+    let page = await this.deps.invoiceRepo.listByCustomer({
+      customerId: customer.id,
+      limit: opts.limit,
+      cursor: opts.cursor,
+    });
+
+    // Lazy first-load: a known customer with an empty store (and no cursor) is
+    // synced once, then re-read. Idempotent: the upsert converges with webhooks.
+    if (page.rows.length === 0 && !opts.cursor) {
+      await this.syncCustomer(customer);
+      page = await this.deps.invoiceRepo.listByCustomer({
+        customerId: customer.id,
+        limit: opts.limit,
+        cursor: opts.cursor,
+      });
+    }
+
+    return { invoices: page.rows.map(mapInvoiceRow), nextCursor: page.nextCursor };
+  }
+
+  /** Page all of a customer's provider invoices into the store; return count. */
+  async syncCustomer(customer: BillingCustomer): Promise<number> {
+    let synced = 0;
+    let startingAfter: string | undefined;
+
+    for (;;) {
+      const { invoices, hasMore } = await this.deps.provider.listInvoices(customer.stripeCustomerId, {
+        limit: SYNC_PAGE_SIZE,
+        startingAfter,
+      });
+      for (const invoice of invoices) {
+        await this.deps.invoiceRepo.upsertFromProvider(customer.id, invoice);
+        synced += 1;
+      }
+      if (!hasMore || invoices.length === 0) break;
+      startingAfter = invoices[invoices.length - 1].providerInvoiceId;
+    }
+
+    return synced;
+  }
+
+  /** Resolve the entity's customer and resync; 0 when there is no customer. */
+  async syncEntity(entity: InvoiceEntity): Promise<number> {
+    const customer = await this.deps.customerRepo.findByEntity(entity.entityType, entity.entityId);
+    if (!customer) return 0;
+    return this.syncCustomer(customer);
+  }
+}

--- a/services/billing-service/src/services/plan.service.ts
+++ b/services/billing-service/src/services/plan.service.ts
@@ -48,8 +48,8 @@ export class PlanService {
       const product = price.product as Stripe.Product;
       const md = product.metadata ?? {};
       const plan: Plan = {
-        stripePriceId: price.id,
-        stripeProductId: typeof price.product === 'string' ? price.product : product.id,
+        priceId: price.id,
+        productId: typeof price.product === 'string' ? price.product : product.id,
         tierName: (md.tier_name as PlanTier) || product.name || 'unknown',
         displayName: product.name || md.tier_name || price.id,
         billingInterval: price.recurring?.interval ?? 'month',
@@ -102,11 +102,11 @@ export class PlanService {
     const candidate = mapped ?? planId;
 
     // 2) Accept the candidate only if it is an active price OR an active tier.
-    const byPrice = active.find((p) => p.stripePriceId === candidate && p.isActive);
-    if (byPrice) return byPrice.stripePriceId;
+    const byPrice = active.find((p) => p.priceId === candidate && p.isActive);
+    if (byPrice) return byPrice.priceId;
 
     const byTier = active.find((p) => p.tierName === candidate && p.isActive);
-    if (byTier) return byTier.stripePriceId;
+    if (byTier) return byTier.priceId;
 
     // 3) Allow the configured 'basic' live price even before a catalogue sync
     //    has populated it (the live-charge demo path), but never an arbitrary

--- a/services/billing-service/src/services/subscription.mapper.ts
+++ b/services/billing-service/src/services/subscription.mapper.ts
@@ -22,8 +22,8 @@ export function mapStripeSubscription(
 
   return {
     customerId: args.customerId,
-    stripeSubscriptionId: sub.id,
-    stripePriceId: priceId,
+    subscriptionId: sub.id,
+    priceId: priceId,
     planTier: args.planTier,
     status: sub.status,
     seatQuantity,

--- a/services/billing-service/src/services/subscription.service.ts
+++ b/services/billing-service/src/services/subscription.service.ts
@@ -80,7 +80,7 @@ export class SubscriptionService {
 
     const params: Stripe.SubscriptionUpdateParams = {};
     if (req.priceId) {
-      const isUpgrade = await this.isUpgrade(existing.stripePriceId, req.priceId);
+      const isUpgrade = await this.isUpgrade(existing.priceId, req.priceId);
       params.items = [
         { id: itemId, price: req.priceId, quantity: req.seatQuantity ?? existing.seatQuantity },
       ];
@@ -100,7 +100,7 @@ export class SubscriptionService {
     });
 
     const planTier = await this.resolvePlanTier(
-      req.priceId ?? existing.stripePriceId,
+      req.priceId ?? existing.priceId,
     );
     return this.repo.upsert(
       mapStripeSubscription(updated, { customerId: existing.customerId, planTier }),
@@ -128,14 +128,14 @@ export class SubscriptionService {
 
   private async resolvePlanTier(priceId: string): Promise<string> {
     const plans = await this.plans.getActivePlans();
-    return plans.find((p) => p.stripePriceId === priceId)?.tierName ?? 'unknown';
+    return plans.find((p) => p.priceId === priceId)?.tierName ?? 'unknown';
   }
 
   /** Upgrade vs downgrade is decided by unit_amount of the target vs current price. */
   private async isUpgrade(currentPriceId: string, nextPriceId: string): Promise<boolean> {
     const plans = await this.plans.getActivePlans();
-    const cur = plans.find((p) => p.stripePriceId === currentPriceId)?.unitAmount ?? 0;
-    const next = plans.find((p) => p.stripePriceId === nextPriceId)?.unitAmount ?? 0;
+    const cur = plans.find((p) => p.priceId === currentPriceId)?.unitAmount ?? 0;
+    const next = plans.find((p) => p.priceId === nextPriceId)?.unitAmount ?? 0;
     return next >= cur;
   }
 

--- a/services/billing-service/src/types.ts
+++ b/services/billing-service/src/types.ts
@@ -19,11 +19,11 @@ export interface BillingCustomer {
  */
 export type PaymentStatus = 'pending' | 'paid' | 'failed' | 'expired';
 
-/** Local mirror of a ONE-TIME payment-mode Stripe Checkout Session. */
+/** Local mirror of a ONE-TIME payment-mode hosted Checkout Session. */
 export interface BillingPayment {
   id: string;
-  stripeSessionId: string;
-  stripePaymentIntentId: string | null;
+  sessionId: string;
+  paymentIntentId: string | null;
   productKey: string;
   externalOrderId: string;
   entityType: EntityType;
@@ -51,8 +51,8 @@ export type SubscriptionStatus =
 export interface BillingSubscription {
   id: string;
   customerId: string;
-  stripeSubscriptionId: string;
-  stripePriceId: string;
+  subscriptionId: string;
+  priceId: string;
   planTier: PlanTier;
   status: SubscriptionStatus;
   seatQuantity: number;
@@ -65,8 +65,8 @@ export interface BillingSubscription {
 }
 
 export interface Plan {
-  stripePriceId: string;
-  stripeProductId: string;
+  priceId: string;
+  productId: string;
   tierName: PlanTier;
   displayName: string;
   billingInterval: 'month' | 'year' | string;

--- a/services/billing-service/tests/acceptance/README.md
+++ b/services/billing-service/tests/acceptance/README.md
@@ -1,0 +1,73 @@
+# Billing invoice — independent verification suite
+
+Authored by the **independent verification stream** (`test-engineer`), separate
+from the implementer's own `tests/routes/invoices.test.ts` and
+`tests/repositories/invoice.repository.test.ts`. These assert **behaviour against
+the frozen contract** (`services/billing-service/openapi.yaml`, v1.1.0 —
+`BillingInvoice`, `InvoiceListResponse`, `GET /invoices`, `POST /invoices/sync`),
+not the implementation's internals. A failing test here against a real bug is a
+valid deliverable; it is not "fixed" by weakening the assertion.
+
+## Files
+
+| File | Layer | DB? |
+|------|-------|-----|
+| `tests/acceptance/invoices.acceptance.test.ts` | HTTP acceptance/contract via supertest against the real `createApp()` | No (in-memory store) |
+| `tests/acceptance/invoice-store.ts` | Independent in-memory keyset store — an oracle, not a mirror of `PgInvoiceRepository` | No |
+| `tests/integration/invoices.integration.test.ts` | `PgInvoiceRepository` + migration 003 against real Postgres | Yes (gated) |
+
+## What the acceptance suite verifies (no DB)
+
+Drives the real Express route + `InvoiceService` + `StripePaymentProvider` with a
+fully-mocked `AppDeps`, backing the invoice repo with an **independent in-memory
+keyset store** so the whole pagination surface can be walked end-to-end.
+
+- **Auth** — `GET /invoices` and `POST /invoices/sync` each require BOTH the
+  internal Bearer token AND the proxy actor-context headers; either missing → 401.
+- **Empty entity** — an entity with no billing customer → `200 { invoices: [],
+  nextCursor: null }` (absence is not an error).
+- **Schema** — every item conforms to `BillingInvoice` (required keys,
+  `additionalProperties:false`, types); the envelope is exactly
+  `{ invoices, nextCursor }`.
+- **Neutral identity** — `id` IS an opaque FuzeFront UUID and is NOT a vendor
+  `in_...` id; `nextCursor` is opaque and is NOT a vendor id.
+- **Pagination (baseline §4.1)** — `limit` is enforced/clamped to `1..100` and
+  **never** over-serves (a `limit=9999` request over a 150-row set returns 100);
+  under-min clamps to 1; the opaque cursor **walks the whole set exactly once**
+  (no gaps/dupes), across pages, and terminates at `nextCursor: null` — including
+  across an `issued_at` tie (id DESC tiebreak).
+- **Sync** — `200 { synced: <int> }`; idempotent: a second resync does NOT
+  duplicate rows and keeps the stable FuzeFront uuid.
+
+Run:
+
+```bash
+cd services/billing-service
+npx jest tests/acceptance
+```
+
+## What the integration suite verifies (real Postgres)
+
+Proves store → read → paginate against real Postgres with migration 003 applied:
+neutral-view mapping (id = DB uuid), keyset ordering `(issued_at DESC, id DESC)`
+including a tie, idempotent `ON CONFLICT (provider, provider_invoice_id)` upsert
+(updates in place, no dup, stable uuid), and a full cross-page cursor walk.
+
+**Gating:** skipped unless `DATABASE_URL` points at a reachable Postgres (same
+convention as `tests/db.test.ts`). The billing schema is normally created by a
+superuser bootstrap Job (the least-privilege migrations never `CREATE SCHEMA`);
+the test creates it once up-front, then runs the real migrations.
+
+Run against the repo's version-pinned harness (`docker-compose.test.yml` →
+`postgres:15` on `:5433`):
+
+```bash
+# from services/billing-service
+docker compose -f ../../docker-compose.test.yml up -d postgres-test
+DATABASE_URL=postgres://postgres:postgres@localhost:5433/fuzefront_platform_test \
+  npx jest tests/integration/invoices.integration.test.ts
+docker compose -f ../../docker-compose.test.yml down -v
+```
+
+Any reachable Postgres 13+ works (`gen_random_uuid()` is core). With no
+`DATABASE_URL` the suite reports as skipped, cleanly.

--- a/services/billing-service/tests/acceptance/invoice-store.ts
+++ b/services/billing-service/tests/acceptance/invoice-store.ts
@@ -1,0 +1,146 @@
+/**
+ * INDEPENDENT in-memory invoice store used by the acceptance suite.
+ *
+ * This is NOT the implementation's PgInvoiceRepository — it is a self-contained,
+ * behaviourally-faithful fake authored by the verification stream so the whole
+ * GET /invoices / POST /invoices/sync surface can be walked end-to-end through
+ * the REAL Express route + InvoiceService (+ StripePaymentProvider) with no DB.
+ *
+ * It re-implements the FROZEN pagination contract from scratch (issued_at DESC,
+ * id DESC keyset; opaque base64 cursor; limit+1 look-ahead) so the suite is an
+ * independent oracle rather than a mirror of the code under test. The real Pg
+ * keyset SQL is verified separately in tests/integration/invoices.integration.test.ts.
+ */
+import { randomUUID } from 'crypto';
+import type {
+  InvoiceRepository,
+  InvoiceRow,
+  ListByCustomerArgs,
+  ListByCustomerResult,
+} from '../../src/repositories/invoice.repository';
+import type { ProviderInvoice } from '../../src/providers/payment-provider';
+
+/** Opaque cursor, independently defined: base64(`${issuedAtIso}|${id}`). */
+export function encodeCursor(issuedAtIso: string, id: string): string {
+  return Buffer.from(`${issuedAtIso}|${id}`, 'utf8').toString('base64');
+}
+export function decodeCursor(cursor: string): { issuedAt: string; id: string } | null {
+  try {
+    const raw = Buffer.from(cursor, 'base64').toString('utf8');
+    const sep = raw.indexOf('|');
+    if (sep <= 0) return null;
+    const issuedAt = raw.slice(0, sep);
+    const id = raw.slice(sep + 1);
+    if (!issuedAt || !id || Number.isNaN(Date.parse(issuedAt))) return null;
+    return { issuedAt, id };
+  } catch {
+    return null;
+  }
+}
+
+/** Millisecond epoch of a row's issue timestamp. */
+const ms = (d: Date): number => new Date(d).getTime();
+
+/**
+ * DESC comparator on (issued_at, id): newest first, id as the tiebreak.
+ * Returns <0 when `a` sorts before `b` in the page ordering.
+ */
+function compareDesc(a: InvoiceRow, b: InvoiceRow): number {
+  if (ms(a.issued_at) !== ms(b.issued_at)) return ms(b.issued_at) - ms(a.issued_at);
+  // id DESC
+  if (a.id === b.id) return 0;
+  return a.id < b.id ? 1 : -1;
+}
+
+/**
+ * Is `row` strictly PAST the keyset cursor in the DESC ordering, i.e.
+ * (row.issued_at, row.id) < (cursor.issued_at, cursor.id) — the exact
+ * row-value predicate the frozen contract's SQL uses.
+ */
+function pastCursor(row: InvoiceRow, cur: { issuedAt: string; id: string }): boolean {
+  const rowMs = ms(row.issued_at);
+  const curMs = Date.parse(cur.issuedAt);
+  if (rowMs !== curMs) return rowMs < curMs;
+  return row.id < cur.id;
+}
+
+export class InMemoryInvoiceStore implements InvoiceRepository {
+  /** Keyed by `${provider}:${providerInvoiceId}` for idempotent upsert. */
+  private byProviderKey = new Map<string, InvoiceRow>();
+
+  constructor(private readonly provider = 'stripe') {}
+
+  /** Test helper: current row count (proves no duplication on resync). */
+  size(): number {
+    return this.byProviderKey.size;
+  }
+
+  /** Test helper: seed a row directly (bypasses the provider path). */
+  seedRow(row: Partial<InvoiceRow> & { customer_id: string; provider_invoice_id: string }): InvoiceRow {
+    const now = new Date();
+    const full: InvoiceRow = {
+      id: row.id ?? randomUUID(),
+      customer_id: row.customer_id,
+      provider: row.provider ?? this.provider,
+      provider_invoice_id: row.provider_invoice_id,
+      number: row.number ?? null,
+      status: row.status ?? 'paid',
+      amount_due_cents: row.amount_due_cents ?? 900,
+      amount_paid_cents: row.amount_paid_cents ?? 900,
+      currency: row.currency ?? 'usd',
+      hosted_invoice_url: row.hosted_invoice_url ?? null,
+      invoice_pdf_url: row.invoice_pdf_url ?? null,
+      issued_at: row.issued_at ?? now,
+      created_at: row.created_at ?? now,
+      updated_at: row.updated_at ?? now,
+    };
+    this.byProviderKey.set(`${full.provider}:${full.provider_invoice_id}`, full);
+    return full;
+  }
+
+  async upsertFromProvider(customerId: string, invoice: ProviderInvoice): Promise<void> {
+    const key = `${this.provider}:${invoice.providerInvoiceId}`;
+    const existing = this.byProviderKey.get(key);
+    // Idempotent on (provider, provider_invoice_id): keep the stable FuzeFront
+    // uuid + created_at; refresh the mutable fields — exactly the ON CONFLICT
+    // DO UPDATE semantics of the frozen migration 003.
+    const row: InvoiceRow = {
+      id: existing?.id ?? randomUUID(),
+      customer_id: customerId,
+      provider: this.provider,
+      provider_invoice_id: invoice.providerInvoiceId,
+      number: invoice.number ?? null,
+      status: invoice.status,
+      amount_due_cents: invoice.amountDueCents,
+      amount_paid_cents: invoice.amountPaidCents,
+      currency: invoice.currency,
+      hosted_invoice_url: invoice.hostedInvoiceUrl ?? null,
+      invoice_pdf_url: invoice.invoicePdfUrl ?? null,
+      issued_at: invoice.issuedAt,
+      created_at: existing?.created_at ?? new Date(),
+      updated_at: new Date(),
+    };
+    this.byProviderKey.set(key, row);
+  }
+
+  async listByCustomer(args: ListByCustomerArgs): Promise<ListByCustomerResult> {
+    const { customerId, limit } = args;
+    const decoded = args.cursor ? decodeCursor(args.cursor) : null;
+
+    const ordered = [...this.byProviderKey.values()]
+      .filter((r) => r.customer_id === customerId)
+      .sort(compareDesc);
+
+    const afterCursor = decoded ? ordered.filter((r) => pastCursor(r, decoded)) : ordered;
+
+    // limit+1 look-ahead to detect a further page without a COUNT.
+    const slice = afterCursor.slice(0, limit + 1);
+    const hasMore = slice.length > limit;
+    const rows = hasMore ? slice.slice(0, limit) : slice;
+    const last = rows[rows.length - 1];
+    const nextCursor =
+      hasMore && last ? encodeCursor(new Date(last.issued_at).toISOString(), last.id) : null;
+
+    return { rows, nextCursor };
+  }
+}

--- a/services/billing-service/tests/acceptance/invoices.acceptance.test.ts
+++ b/services/billing-service/tests/acceptance/invoices.acceptance.test.ts
@@ -1,0 +1,385 @@
+/**
+ * INDEPENDENT acceptance / contract verification for the vendor-neutral,
+ * DB-backed invoice surface — GET /api/v1/billing/invoices and
+ * POST /api/v1/billing/invoices/sync (openapi.yaml 1.1.0).
+ *
+ * Authored by the verification stream (test-engineer), separate from the
+ * implementer's own tests/routes/invoices.test.ts. These drive the REAL
+ * createApp() wiring via supertest and assert BEHAVIOUR against the FROZEN
+ * contract:
+ *
+ *   - auth: internal token AND proxy actor-context headers are both required;
+ *   - envelope: { invoices, nextCursor } with additionalProperties:false and
+ *     every item conforming to components/schemas/BillingInvoice;
+ *   - identity: `id` is an opaque FuzeFront UUID, never a vendor `in_...` id;
+ *     `nextCursor` is opaque and is NOT a vendor id;
+ *   - pagination (baseline §4.1): limit is enforced/clamped to 1..100 and can
+ *     NEVER return more than the max; the opaque cursor walks the WHOLE set —
+ *     every item exactly once, no gaps/dupes — and terminates (nextCursor:null);
+ *   - sync: 200 { synced:<int> }, idempotent — a second resync does not
+ *     duplicate rows in the store.
+ *
+ * Pagination is driven end-to-end through the real route + InvoiceService
+ * against an INDEPENDENT in-memory keyset store (invoice-store.ts), so the walk
+ * is a true oracle and not a mirror of the code under test. The real Postgres
+ * keyset SQL is verified in tests/integration/invoices.integration.test.ts.
+ *
+ * A failing assertion here against a real bug is a valid deliverable — it is
+ * NOT fixed by weakening the test.
+ */
+import request from 'supertest';
+import {
+  buildApp,
+  authHeader,
+  actorOrgHeaders,
+  INTERNAL_TOKEN,
+  ORG_ID,
+  USER_ID,
+} from '../contract/helpers';
+import {
+  assertBillingInvoice,
+  assertInvoiceListResponse,
+} from '../contract/schema-assertions';
+import { InMemoryInvoiceStore } from './invoice-store';
+
+const URL = '/api/v1/billing/invoices';
+const SYNC_URL = '/api/v1/billing/invoices/sync';
+
+const CUSTOMER_ID = 'cust-accept-1';
+const STRIPE_CUSTOMER_ID = 'cus_accept_1';
+
+/** RFC-4122 v4 UUID matcher (crypto.randomUUID output). */
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+/** Anything that looks like a Stripe/vendor object id. */
+const VENDOR_ID_RE = /^(in_|cus_|sub_|pi_|cs_)/;
+
+/** customerRepo stub: the authorized org HAS a billing customer. */
+function customerRepoStub() {
+  return {
+    customerRepo: {
+      findByEntity: jest.fn().mockResolvedValue({
+        id: CUSTOMER_ID,
+        entityType: 'organization',
+        entityId: ORG_ID,
+        stripeCustomerId: STRIPE_CUSTOMER_ID,
+      }),
+      findByStripeCustomerId: jest.fn().mockResolvedValue(null),
+      insert: jest.fn(),
+    },
+  } as any;
+}
+
+/** Full Stripe stub whose invoices.list feeds the provider sync path. */
+function stripeStub(listImpl?: jest.Mock) {
+  return {
+    stripe: {
+      setupIntents: { create: jest.fn() },
+      customers: { createBalanceTransaction: jest.fn() },
+      checkout: { sessions: { create: jest.fn(), retrieve: jest.fn() } },
+      billingPortal: { sessions: { create: jest.fn() } },
+      invoices: { list: listImpl ?? jest.fn() },
+      webhooks: { constructEvent: jest.fn() },
+    },
+  } as any;
+}
+
+/** A Stripe.Invoice-shaped object as returned by stripe.invoices.list().data. */
+function stripeInvoice(i: number) {
+  return {
+    id: `in_${i}`,
+    object: 'invoice',
+    number: `FF-2026-${String(i).padStart(4, '0')}`,
+    // Unix seconds; distinct + descending index => distinct issued_at.
+    created: 1_700_000_000 + i * 86_400,
+    amount_due: 900 + i,
+    amount_paid: 900 + i,
+    currency: i % 2 === 0 ? 'USD' : 'usd', // provider casing varies; we assert lowercase
+    status: 'paid',
+    hosted_invoice_url: `https://invoice.provider/i/in_${i}`,
+    invoice_pdf: `https://invoice.provider/i/in_${i}.pdf`,
+    customer: STRIPE_CUSTOMER_ID,
+  };
+}
+
+/** Seed `n` invoices into the store, newest = index 0 (largest issued_at). */
+function seedStore(store: InMemoryInvoiceStore, n: number): void {
+  const base = Date.parse('2026-07-14T00:00:00.000Z');
+  for (let i = 0; i < n; i++) {
+    store.seedRow({
+      customer_id: CUSTOMER_ID,
+      provider_invoice_id: `in_${i}`,
+      number: `FF-2026-${String(i).padStart(4, '0')}`,
+      status: 'paid',
+      amount_due_cents: 900 + i,
+      amount_paid_cents: 900 + i,
+      currency: 'usd',
+      hosted_invoice_url: `https://invoice.provider/i/in_${i}`,
+      invoice_pdf_url: `https://invoice.provider/i/in_${i}.pdf`,
+      // Distinct, strictly descending with i => deterministic newest-first order.
+      issued_at: new Date(base - i * 86_400_000),
+    });
+  }
+}
+
+function appWithStore(store: InMemoryInvoiceStore, listImpl?: jest.Mock) {
+  return buildApp({
+    internalToken: INTERNAL_TOKEN,
+    stubs: {
+      ...customerRepoStub(),
+      ...stripeStub(listImpl),
+      invoiceRepo: store as any,
+    },
+  });
+}
+
+/** GET one page with the given query, returning the parsed body. */
+async function getPage(app: any, query = ''): Promise<any> {
+  const res = await request(app)
+    .get(`${URL}${query}`)
+    .set(...authHeader())
+    .set(actorOrgHeaders(ORG_ID, USER_ID));
+  expect(res.status).toBe(200);
+  assertInvoiceListResponse(res.body);
+  return res.body;
+}
+
+describe('GET /invoices — auth contract', () => {
+  it('401 when the internal token is missing (actor headers present)', async () => {
+    const { app } = appWithStore(new InMemoryInvoiceStore());
+    const res = await request(app).get(URL).set(actorOrgHeaders(ORG_ID, USER_ID));
+    expect(res.status).toBe(401);
+  });
+
+  it('401 when the proxy actor-context headers are missing (token present)', async () => {
+    const { app } = appWithStore(new InMemoryInvoiceStore());
+    const res = await request(app).get(URL).set(...authHeader());
+    expect(res.status).toBe(401);
+  });
+
+  it('200 with the empty envelope for an entity that has never had billing', async () => {
+    // Default customerRepo.findByEntity resolves null => no customer, no store read.
+    const { app } = buildApp({ internalToken: INTERNAL_TOKEN });
+    const body = await getPage(app);
+    expect(body).toEqual({ invoices: [], nextCursor: null });
+  });
+});
+
+describe('GET /invoices — BillingInvoice shape & neutral identity', () => {
+  it('maps stored rows to the neutral schema; id is a UUID (never a vendor id)', async () => {
+    const store = new InMemoryInvoiceStore();
+    seedStore(store, 3);
+    const { app } = appWithStore(store);
+
+    const body = await getPage(app, '?limit=100');
+    expect(body.invoices).toHaveLength(3);
+
+    for (const inv of body.invoices) {
+      assertBillingInvoice(inv); // required keys, additionalProperties:false, types
+      expect(inv.id).toMatch(UUID_RE); // IS an opaque FuzeFront uuid
+      expect(inv.id).not.toMatch(/^in_/); // NOT a Stripe invoice id
+      expect(inv.currency).toBe(inv.currency.toLowerCase());
+    }
+    // Newest-first ordering: issued_at strictly descending.
+    const times = body.invoices.map((i: any) => Date.parse(i.created));
+    expect(times).toEqual([...times].sort((a, b) => b - a));
+  });
+
+  it('nextCursor is opaque and is NOT a vendor id', async () => {
+    const store = new InMemoryInvoiceStore();
+    seedStore(store, 5);
+    const { app } = appWithStore(store);
+
+    const body = await getPage(app, '?limit=2');
+    expect(typeof body.nextCursor).toBe('string');
+    expect(body.nextCursor).not.toMatch(VENDOR_ID_RE);
+    // Opaque cursor must not simply echo any invoice's provider id or our uuid.
+    for (const inv of body.invoices) {
+      expect(body.nextCursor).not.toContain(inv.id);
+    }
+  });
+});
+
+describe('GET /invoices — pagination contract (baseline §4.1)', () => {
+  it('enforces limit: over-max is clamped to 100 and NEVER returns more', async () => {
+    const store = new InMemoryInvoiceStore();
+    seedStore(store, 150);
+    const { app } = appWithStore(store);
+
+    const body = await getPage(app, '?limit=9999');
+    expect(body.invoices).toHaveLength(100); // clamped to the declared max
+    expect(body.nextCursor).not.toBeNull(); // more remain
+  });
+
+  it('enforces limit: under-min is clamped to 1', async () => {
+    const store = new InMemoryInvoiceStore();
+    seedStore(store, 5);
+    const { app } = appWithStore(store);
+
+    const body = await getPage(app, '?limit=0');
+    expect(body.invoices).toHaveLength(1);
+    expect(body.nextCursor).not.toBeNull();
+  });
+
+  it('page 1 -> page 2 via nextCursor: disjoint, ordered, no overlap', async () => {
+    const store = new InMemoryInvoiceStore();
+    seedStore(store, 5);
+    const { app } = appWithStore(store);
+
+    const p1 = await getPage(app, '?limit=2');
+    expect(p1.invoices).toHaveLength(2);
+    expect(p1.nextCursor).not.toBeNull();
+
+    const p2 = await getPage(app, `?limit=2&cursor=${encodeURIComponent(p1.nextCursor)}`);
+    const ids1 = p1.invoices.map((i: any) => i.id);
+    const ids2 = p2.invoices.map((i: any) => i.id);
+    expect(ids1.filter((id: string) => ids2.includes(id))).toEqual([]); // no overlap
+    // Continuity: page 2's newest is strictly older than page 1's oldest.
+    const oldestP1 = Math.min(...p1.invoices.map((i: any) => Date.parse(i.created)));
+    const newestP2 = Math.max(...p2.invoices.map((i: any) => Date.parse(i.created)));
+    expect(newestP2).toBeLessThanOrEqual(oldestP1);
+  });
+
+  it('the cursor walks the WHOLE set exactly once, then terminates', async () => {
+    const TOTAL = 150;
+    const PAGE = 25;
+    const store = new InMemoryInvoiceStore();
+    seedStore(store, TOTAL);
+    const { app } = appWithStore(store);
+
+    const seen: string[] = [];
+    let cursor: string | null = null;
+    let pages = 0;
+    for (;;) {
+      const q = `?limit=${PAGE}` + (cursor ? `&cursor=${encodeURIComponent(cursor)}` : '');
+      const body: any = await getPage(app, q);
+      expect(body.invoices.length).toBeLessThanOrEqual(PAGE); // never over-serves
+      for (const inv of body.invoices) seen.push(inv.id);
+      cursor = body.nextCursor;
+      pages += 1;
+      if (cursor === null) break;
+      expect(pages).toBeLessThan(TOTAL); // guard against a non-terminating cursor
+    }
+
+    expect(seen).toHaveLength(TOTAL); // every item visited...
+    expect(new Set(seen).size).toBe(TOTAL); // ...exactly once (no dupes/gaps)
+    expect(pages).toBe(Math.ceil(TOTAL / PAGE));
+  });
+
+  it('walks correctly across an issued_at tie (id DESC tiebreak, no dup/gap)', async () => {
+    const store = new InMemoryInvoiceStore();
+    const sameInstant = new Date('2026-06-01T00:00:00.000Z');
+    // Three invoices share issued_at; the keyset must still visit each once.
+    for (let i = 0; i < 3; i++) {
+      store.seedRow({
+        customer_id: CUSTOMER_ID,
+        provider_invoice_id: `in_tie_${i}`,
+        number: `FF-TIE-${i}`,
+        issued_at: sameInstant,
+      });
+    }
+    // Plus two on distinct instants to force paging across the tie boundary.
+    store.seedRow({ customer_id: CUSTOMER_ID, provider_invoice_id: 'in_new', issued_at: new Date('2026-07-01T00:00:00.000Z') });
+    store.seedRow({ customer_id: CUSTOMER_ID, provider_invoice_id: 'in_old', issued_at: new Date('2026-05-01T00:00:00.000Z') });
+    const { app } = appWithStore(store);
+
+    const seen: string[] = [];
+    let cursor: string | null = null;
+    for (;;) {
+      const q = `?limit=2` + (cursor ? `&cursor=${encodeURIComponent(cursor)}` : '');
+      const body: any = await getPage(app, q);
+      for (const inv of body.invoices) seen.push(inv.id);
+      cursor = body.nextCursor;
+      if (cursor === null) break;
+    }
+    expect(seen).toHaveLength(5);
+    expect(new Set(seen).size).toBe(5);
+  });
+});
+
+describe('POST /invoices/sync — provider->store resync', () => {
+  it('401 when the internal token is missing', async () => {
+    const { app } = appWithStore(new InMemoryInvoiceStore());
+    const res = await request(app).post(SYNC_URL).set(actorOrgHeaders(ORG_ID, USER_ID));
+    expect(res.status).toBe(401);
+  });
+
+  it('401 when the proxy actor-context headers are missing', async () => {
+    const { app } = appWithStore(new InMemoryInvoiceStore());
+    const res = await request(app).post(SYNC_URL).set(...authHeader());
+    expect(res.status).toBe(401);
+  });
+
+  it('200 { synced:<int> } counting upserted invoices', async () => {
+    const store = new InMemoryInvoiceStore();
+    const list = jest.fn().mockResolvedValue({
+      data: [stripeInvoice(1), stripeInvoice(2), stripeInvoice(3)],
+      has_more: false,
+    });
+    const { app } = appWithStore(store, list);
+
+    const res = await request(app)
+      .post(SYNC_URL)
+      .set(...authHeader())
+      .set(actorOrgHeaders(ORG_ID, USER_ID));
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ synced: 3 });
+    expect(typeof res.body.synced).toBe('number');
+    expect(Number.isInteger(res.body.synced)).toBe(true);
+    expect(store.size()).toBe(3);
+  });
+
+  it('200 { synced:0 } when the entity has no billing customer', async () => {
+    const store = new InMemoryInvoiceStore();
+    const { app } = buildApp({
+      internalToken: INTERNAL_TOKEN,
+      // default customerRepo.findByEntity => null
+      stubs: { ...stripeStub(jest.fn()), invoiceRepo: store as any },
+    });
+    const res = await request(app)
+      .post(SYNC_URL)
+      .set(...authHeader())
+      .set(actorOrgHeaders(ORG_ID, USER_ID));
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ synced: 0 });
+    expect(store.size()).toBe(0);
+  });
+
+  it('is idempotent: a second resync does NOT duplicate rows in the store', async () => {
+    const store = new InMemoryInvoiceStore();
+    const list = jest.fn().mockResolvedValue({
+      data: [stripeInvoice(1), stripeInvoice(2)],
+      has_more: false,
+    });
+    const { app } = appWithStore(store, list);
+
+    const first = await request(app)
+      .post(SYNC_URL)
+      .set(...authHeader())
+      .set(actorOrgHeaders(ORG_ID, USER_ID));
+    expect(first.body).toEqual({ synced: 2 });
+    expect(store.size()).toBe(2);
+
+    const idsAfterFirst = [...(store as any).byProviderKey.values()].map((r: any) => r.id).sort();
+
+    const second = await request(app)
+      .post(SYNC_URL)
+      .set(...authHeader())
+      .set(actorOrgHeaders(ORG_ID, USER_ID));
+    expect(second.body).toEqual({ synced: 2 });
+    // Store still holds exactly 2 rows (no duplication)...
+    expect(store.size()).toBe(2);
+    // ...and the FuzeFront uuids are STABLE across the resync (upsert in place).
+    const idsAfterSecond = [...(store as any).byProviderKey.values()].map((r: any) => r.id).sort();
+    expect(idsAfterSecond).toEqual(idsAfterFirst);
+
+    // GET reflects the deduped store: exactly 2 neutral invoices.
+    const body = await getPage(app, '?limit=100');
+    expect(body.invoices).toHaveLength(2);
+    body.invoices.forEach((inv: any) => {
+      assertBillingInvoice(inv);
+      expect(inv.id).toMatch(UUID_RE);
+      expect(inv.id).not.toMatch(/^in_/);
+    });
+  });
+});

--- a/services/billing-service/tests/contract/api.contract.test.ts
+++ b/services/billing-service/tests/contract/api.contract.test.ts
@@ -67,7 +67,7 @@ describe('billing-service contract :: getPlans (GET /plans)', () => {
     });
     const res = await request(app).get(`${BASE}/plans`);
     expect(res.status).toBe(200);
-    const basic = res.body.plans.find((p: any) => p.stripePriceId === BASIC_PRICE_ID);
+    const basic = res.body.plans.find((p: any) => p.priceId === BASIC_PRICE_ID);
     expect(basic).toBeDefined();
     expect(basic.unitAmount).toBe(900);
     expect(basic.currency).toBe('usd');
@@ -181,7 +181,7 @@ describe('billing-service contract :: getSubscription (GET /subscriptions/{id})'
 describe('billing-service contract :: updateSubscription (PATCH /subscriptions/{id})', () => {
   it('200 {subscription} on a valid plan change', async () => {
     const { app, stubs } = buildApp({ internalToken: INTERNAL_TOKEN });
-    stubs.subscriptionService.update.mockResolvedValue(makeSubscription({ stripePriceId: 'price_pro' }));
+    stubs.subscriptionService.update.mockResolvedValue(makeSubscription({ priceId: 'price_pro' }));
     const res = await request(app)
       .patch(`${BASE}/subscriptions/sub_test123`)
       .set(...authHeader())

--- a/services/billing-service/tests/contract/helpers.ts
+++ b/services/billing-service/tests/contract/helpers.ts
@@ -89,6 +89,10 @@ export interface DepStubs {
     getBySessionId: jest.Mock;
     findByOrder: jest.Mock;
   };
+  invoiceRepo: {
+    upsertFromProvider: jest.Mock;
+    listByCustomer: jest.Mock;
+  };
   stripe: {
     setupIntents: { create: jest.Mock };
     customers: { createBalanceTransaction: jest.Mock };
@@ -166,6 +170,11 @@ export function buildApp(
       getBySessionId: jest.fn().mockResolvedValue(null),
       findByOrder: jest.fn().mockResolvedValue(null),
     },
+    invoiceRepo: {
+      upsertFromProvider: jest.fn().mockResolvedValue(undefined),
+      // Default: empty store, no further page. Override per test.
+      listByCustomer: jest.fn().mockResolvedValue({ rows: [], nextCursor: null }),
+    },
     stripe: {
       setupIntents: { create: jest.fn() },
       customers: { createBalanceTransaction: jest.fn() },
@@ -211,6 +220,7 @@ export function buildApp(
     customerRepo: stubs.customerRepo as any,
     customers: stubs.customers as any,
     payments: stubs.payments as any,
+    invoiceRepo: stubs.invoiceRepo as any,
     paymentsConfig: opts.paymentsConfig ?? { ...PAYMENTS_CONFIG },
     webhook: stubs.webhook as any,
   };

--- a/services/billing-service/tests/contract/helpers.ts
+++ b/services/billing-service/tests/contract/helpers.ts
@@ -32,8 +32,8 @@ export function makeSubscription(overrides: Partial<BillingSubscription> = {}): 
   return {
     id: '55555555-5555-4555-8555-555555555555',
     customerId: '66666666-6666-4666-8666-666666666666',
-    stripeSubscriptionId: 'sub_test123',
-    stripePriceId: BASIC_PRICE_ID,
+    subscriptionId: 'sub_test123',
+    priceId: BASIC_PRICE_ID,
     planTier: 'starter',
     status: 'active',
     seatQuantity: 1,
@@ -50,8 +50,8 @@ export function makeSubscription(overrides: Partial<BillingSubscription> = {}): 
 /** A spec-conformant Plan fixture (the $9/mo Basic plan). */
 export function makeBasicPlan(overrides: Partial<Plan> = {}): Plan {
   return {
-    stripePriceId: BASIC_PRICE_ID,
-    stripeProductId: 'prod_basic',
+    priceId: BASIC_PRICE_ID,
+    productId: 'prod_basic',
     tierName: 'starter',
     displayName: 'Basic',
     billingInterval: 'month',

--- a/services/billing-service/tests/contract/schema-assertions.ts
+++ b/services/billing-service/tests/contract/schema-assertions.ts
@@ -112,6 +112,46 @@ export function assertSubscriptionWrapper(body: any): void {
   assertBillingSubscription(body.subscription);
 }
 
+/** BillingInvoice — components/schemas/BillingInvoice (vendor-neutral). */
+export function assertBillingInvoice(inv: any): void {
+  const required = [
+    'id',
+    'number',
+    'created',
+    'amountDue',
+    'amountPaid',
+    'currency',
+    'status',
+    'hostedInvoiceUrl',
+    'invoicePdf',
+  ];
+  assertRequired(inv, required, 'BillingInvoice');
+  assertNoExtraKeys(inv, required, 'BillingInvoice');
+  // id is OUR opaque FuzeFront id — a string, NOT a Stripe `in_...` id.
+  expect(typeof inv.id).toBe('string');
+  expect(inv.id.startsWith('in_')).toBe(false);
+  expect(inv.number === null || typeof inv.number === 'string').toBe(true);
+  expect(isNullableDateTime(inv.created)).toBe(true);
+  expect(Number.isInteger(inv.amountDue)).toBe(true);
+  expect(inv.amountDue).toBeGreaterThanOrEqual(0);
+  expect(Number.isInteger(inv.amountPaid)).toBe(true);
+  expect(inv.amountPaid).toBeGreaterThanOrEqual(0);
+  expect(typeof inv.currency).toBe('string');
+  expect(inv.currency).toBe(inv.currency.toLowerCase());
+  expect(typeof inv.status).toBe('string');
+  expect(inv.hostedInvoiceUrl === null || typeof inv.hostedInvoiceUrl === 'string').toBe(true);
+  expect(inv.invoicePdf === null || typeof inv.invoicePdf === 'string').toBe(true);
+}
+
+/** InvoiceListResponse — required [invoices, nextCursor]; nextCursor opaque. */
+export function assertInvoiceListResponse(body: any): void {
+  assertRequired(body, ['invoices', 'nextCursor'], 'InvoiceListResponse');
+  assertNoExtraKeys(body, ['invoices', 'nextCursor'], 'InvoiceListResponse');
+  expect(Array.isArray(body.invoices)).toBe(true);
+  body.invoices.forEach((i: unknown) => assertBillingInvoice(i));
+  expect(body.nextCursor === null || typeof body.nextCursor === 'string').toBe(true);
+}
+
 /** ValidationErrorBody — required [error], optional details. */
 export function assertValidationErrorBody(body: any): void {
   assertRequired(body, ['error'], 'ValidationErrorBody');

--- a/services/billing-service/tests/contract/schema-assertions.ts
+++ b/services/billing-service/tests/contract/schema-assertions.ts
@@ -31,8 +31,8 @@ export function assertBillingSubscription(sub: any): void {
   const required = [
     'id',
     'customerId',
-    'stripeSubscriptionId',
-    'stripePriceId',
+    'subscriptionId',
+    'priceId',
     'planTier',
     'status',
     'seatQuantity',
@@ -49,8 +49,8 @@ export function assertBillingSubscription(sub: any): void {
 
   expect(typeof sub.id).toBe('string');
   expect(typeof sub.customerId).toBe('string');
-  expect(typeof sub.stripeSubscriptionId).toBe('string');
-  expect(typeof sub.stripePriceId).toBe('string');
+  expect(typeof sub.subscriptionId).toBe('string');
+  expect(typeof sub.priceId).toBe('string');
   expect(typeof sub.planTier).toBe('string');
   expect(typeof sub.status).toBe('string');
   expect(Number.isInteger(sub.seatQuantity)).toBe(true);
@@ -64,8 +64,8 @@ export function assertBillingSubscription(sub: any): void {
 /** Plan — components/schemas/Plan. */
 export function assertPlan(plan: any): void {
   const required = [
-    'stripePriceId',
-    'stripeProductId',
+    'priceId',
+    'productId',
     'tierName',
     'displayName',
     'billingInterval',
@@ -79,8 +79,8 @@ export function assertPlan(plan: any): void {
   ];
   assertRequired(plan, required, 'Plan');
   assertNoExtraKeys(plan, required, 'Plan');
-  expect(typeof plan.stripePriceId).toBe('string');
-  expect(typeof plan.stripeProductId).toBe('string');
+  expect(typeof plan.priceId).toBe('string');
+  expect(typeof plan.productId).toBe('string');
   expect(typeof plan.tierName).toBe('string');
   expect(typeof plan.displayName).toBe('string');
   expect(typeof plan.billingInterval).toBe('string');

--- a/services/billing-service/tests/contract/webhook.contract.test.ts
+++ b/services/billing-service/tests/contract/webhook.contract.test.ts
@@ -90,11 +90,15 @@ describe('billing-service contract :: receiveStripeWebhook', () => {
     const raw = JSON.stringify({ id: 'evt_raw_1', type: 'invoice.paid', data: { object: {} } });
     stubs.webhook.stripe.webhooks.constructEvent.mockReturnValue(JSON.parse(raw));
 
+    // Send the raw JSON bytes verbatim (a string), exactly as the provider does.
+    // Passing a Buffer here would make superagent JSON-serialize it
+    // (`{"type":"Buffer",...}`) — a harness artifact, not the real wire format —
+    // so we send the string to faithfully assert express.raw captured the bytes.
     await request(app)
       .post(URL)
       .set('Content-Type', 'application/json')
       .set('Stripe-Signature', 'good-sig')
-      .send(Buffer.from(raw));
+      .send(raw);
 
     const [body, sig, secret] = stubs.webhook.stripe.webhooks.constructEvent.mock.calls[0];
     expect(Buffer.isBuffer(body)).toBe(true); // raw bytes, signature-verifiable

--- a/services/billing-service/tests/handlers/checkout-completed.test.ts
+++ b/services/billing-service/tests/handlers/checkout-completed.test.ts
@@ -67,8 +67,8 @@ describe('handleCheckoutCompleted', () => {
     expect(upserted).toEqual(
       expect.objectContaining({
         customerId: 'localcust_1',
-        stripeSubscriptionId: 'sub_test123',
-        stripePriceId: BASIC_PRICE_ID,
+        subscriptionId: 'sub_test123',
+        priceId: BASIC_PRICE_ID,
         planTier: 'basic',
         status: 'active',
         seatQuantity: 1,
@@ -112,7 +112,7 @@ describe('handleCheckoutCompleted', () => {
     expect(ctx.subscriptions.upsert).toHaveBeenCalledTimes(1);
     const upserted = ctx.subscriptions.upsert.mock.calls[0][0];
     expect(upserted).toEqual(
-      expect.objectContaining({ stripeSubscriptionId: 'sub_test123', status: 'active' }),
+      expect.objectContaining({ subscriptionId: 'sub_test123', status: 'active' }),
     );
     expect(ctx.emitter.subscriptionChanged).toHaveBeenCalled();
   });

--- a/services/billing-service/tests/handlers/invoice-synced.test.ts
+++ b/services/billing-service/tests/handlers/invoice-synced.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Unit tests for the invoice-synced webhook handler — persists invoice.* events
+ * into billing.invoices via the neutral provider port + invoiceRepo.
+ *
+ * Also asserts the webhook-router wires the five invoice events to it, and that
+ * the succeeded/failed events STILL run their existing entitlement/notify
+ * handler alongside persistence.
+ */
+import { handleInvoiceSynced } from '../../src/handlers/invoice-synced';
+import { HANDLERS, routeWebhookEvent } from '../../src/handlers/webhook-router';
+import { ProviderInvoice } from '../../src/providers/payment-provider';
+
+function providerInvoice(): ProviderInvoice {
+  return {
+    providerInvoiceId: 'in_1',
+    number: 'INV-0001',
+    status: 'paid',
+    amountDueCents: 900,
+    amountPaidCents: 900,
+    currency: 'usd',
+    hostedInvoiceUrl: null,
+    invoicePdfUrl: null,
+    issuedAt: new Date('2023-11-14T22:13:20.000Z'),
+  };
+}
+
+function makeCtx(over: Record<string, unknown> = {}) {
+  return {
+    customers: {
+      findByStripeCustomerId: jest.fn().mockResolvedValue({
+        id: 'localcust_1',
+        entityType: 'organization',
+        entityId: '33333333-3333-4333-8333-333333333333',
+        stripeCustomerId: 'cus_1',
+      }),
+    },
+    invoiceRepo: { upsertFromProvider: jest.fn().mockResolvedValue(undefined) },
+    provider: {
+      name: 'stripe',
+      parseInvoiceEvent: jest.fn().mockReturnValue({ providerCustomerId: 'cus_1', invoice: providerInvoice() }),
+      listInvoices: jest.fn(),
+    },
+    ...over,
+  } as any;
+}
+
+const EVENT = { type: 'invoice.paid', data: { object: { object: 'invoice', id: 'in_1' } } } as any;
+
+describe('handleInvoiceSynced', () => {
+  it('resolves the customer by provider customer id and upserts the neutral invoice', async () => {
+    const ctx = makeCtx();
+    await handleInvoiceSynced(EVENT, ctx);
+    expect(ctx.provider.parseInvoiceEvent).toHaveBeenCalledWith(EVENT);
+    expect(ctx.customers.findByStripeCustomerId).toHaveBeenCalledWith('cus_1');
+    expect(ctx.invoiceRepo.upsertFromProvider).toHaveBeenCalledWith('localcust_1', providerInvoice());
+  });
+
+  it('no-ops when the provider/invoiceRepo are not wired', async () => {
+    const ctx = makeCtx({ provider: undefined, invoiceRepo: undefined });
+    await expect(handleInvoiceSynced(EVENT, ctx)).resolves.toBeUndefined();
+  });
+
+  it('no-ops (does not upsert) when the event is not a parseable invoice', async () => {
+    const ctx = makeCtx();
+    ctx.provider.parseInvoiceEvent.mockReturnValue(null);
+    await handleInvoiceSynced(EVENT, ctx);
+    expect(ctx.invoiceRepo.upsertFromProvider).not.toHaveBeenCalled();
+  });
+
+  it('no-ops (does not upsert) when no local customer matches', async () => {
+    const ctx = makeCtx();
+    ctx.customers.findByStripeCustomerId.mockResolvedValue(null);
+    await handleInvoiceSynced(EVENT, ctx);
+    expect(ctx.invoiceRepo.upsertFromProvider).not.toHaveBeenCalled();
+  });
+});
+
+describe('webhook-router — invoice event wiring', () => {
+  it('maps all five invoice events to a handler', () => {
+    for (const t of [
+      'invoice.paid',
+      'invoice.payment_succeeded',
+      'invoice.payment_failed',
+      'invoice.finalized',
+      'invoice.updated',
+    ]) {
+      expect(HANDLERS[t]).toBeDefined();
+    }
+  });
+
+  it('invoice.payment_succeeded persists AND runs the entitlement/notify path', async () => {
+    const ctx = makeCtx({
+      subscriptions: { findByCustomer: jest.fn().mockResolvedValue({ planTier: 'pro', stripeSubscriptionId: 'sub_1' }) },
+      permit: { syncPlanToPermit: jest.fn().mockResolvedValue(true) },
+      emitter: { subscriptionChanged: jest.fn().mockResolvedValue(undefined) },
+      writePlanCache: jest.fn().mockResolvedValue(undefined),
+    });
+    await routeWebhookEvent(
+      { type: 'invoice.payment_succeeded', data: { object: { object: 'invoice', id: 'in_1', customer: 'cus_1' } } } as any,
+      ctx,
+    );
+    expect(ctx.invoiceRepo.upsertFromProvider).toHaveBeenCalledTimes(1); // persisted
+    expect(ctx.permit.syncPlanToPermit).toHaveBeenCalled(); // notify/entitlement still fires
+    expect(ctx.emitter.subscriptionChanged).toHaveBeenCalled();
+  });
+
+  it('invoice.payment_failed persists AND runs the dunning path', async () => {
+    const ctx = makeCtx({
+      subscriptions: { findByCustomer: jest.fn().mockResolvedValue({ planTier: 'pro' }) },
+      permit: { syncPlanToPermit: jest.fn().mockResolvedValue(true) },
+      emitter: { paymentFailed: jest.fn().mockResolvedValue(undefined) },
+      writePlanCache: jest.fn().mockResolvedValue(undefined),
+    });
+    await routeWebhookEvent(
+      {
+        type: 'invoice.payment_failed',
+        data: { object: { object: 'invoice', id: 'in_1', customer: 'cus_1', amount_due: 900, currency: 'usd' } },
+      } as any,
+      ctx,
+    );
+    expect(ctx.invoiceRepo.upsertFromProvider).toHaveBeenCalledTimes(1);
+    expect(ctx.emitter.paymentFailed).toHaveBeenCalled();
+  });
+});

--- a/services/billing-service/tests/handlers/invoice-synced.test.ts
+++ b/services/billing-service/tests/handlers/invoice-synced.test.ts
@@ -90,7 +90,7 @@ describe('webhook-router — invoice event wiring', () => {
 
   it('invoice.payment_succeeded persists AND runs the entitlement/notify path', async () => {
     const ctx = makeCtx({
-      subscriptions: { findByCustomer: jest.fn().mockResolvedValue({ planTier: 'pro', stripeSubscriptionId: 'sub_1' }) },
+      subscriptions: { findByCustomer: jest.fn().mockResolvedValue({ planTier: 'pro', subscriptionId: 'sub_1' }) },
       permit: { syncPlanToPermit: jest.fn().mockResolvedValue(true) },
       emitter: { subscriptionChanged: jest.fn().mockResolvedValue(undefined) },
       writePlanCache: jest.fn().mockResolvedValue(undefined),

--- a/services/billing-service/tests/handlers/payment-completed.test.ts
+++ b/services/billing-service/tests/handlers/payment-completed.test.ts
@@ -7,8 +7,8 @@ const OCCURRED_ISO = new Date(OCCURRED_UNIX * 1000).toISOString();
 function mirrorRow(overrides: any = {}) {
   return {
     id: '77777777-7777-4777-8777-777777777777',
-    stripeSessionId: 'cs_pay_1',
-    stripePaymentIntentId: null,
+    sessionId: 'cs_pay_1',
+    paymentIntentId: null,
     productKey: 'mendys-datasets',
     externalOrderId: 'order-42',
     entityType: 'organization',
@@ -97,8 +97,8 @@ describe('handlePaymentCompleted — checkout.session.completed (payment mode)',
 
     expect(ctx.payments.upsert).toHaveBeenCalledWith(
       expect.objectContaining({
-        stripeSessionId: 'cs_pay_1',
-        stripePaymentIntentId: 'pi_1',
+        sessionId: 'cs_pay_1',
+        paymentIntentId: 'pi_1',
         productKey: 'mendys-datasets',
         externalOrderId: 'order-42',
         entityType: 'organization',
@@ -190,7 +190,7 @@ describe('handlePaymentCompleted — checkout.session.expired', () => {
     );
 
     expect(ctx.payments.upsert).toHaveBeenCalledWith(
-      expect.objectContaining({ stripeSessionId: 'cs_pay_1', status: 'expired' }),
+      expect.objectContaining({ sessionId: 'cs_pay_1', status: 'expired' }),
     );
     expect(ctx.emitter.paymentCompleted).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -210,8 +210,8 @@ describe('handlePaymentCompleted — payment_intent.payment_failed', () => {
     expect(ctx.payments.findByOrder).toHaveBeenCalledWith('mendys-datasets', 'order-42');
     expect(ctx.payments.upsert).toHaveBeenCalledWith(
       expect.objectContaining({
-        stripeSessionId: 'cs_pay_1',
-        stripePaymentIntentId: 'pi_1',
+        sessionId: 'cs_pay_1',
+        paymentIntentId: 'pi_1',
         status: 'failed',
       }),
     );

--- a/services/billing-service/tests/handlers/webhook-router.test.ts
+++ b/services/billing-service/tests/handlers/webhook-router.test.ts
@@ -14,8 +14,8 @@ const BASIC_PRICE_ID = 'price_1TnCqVDaNn3aKLEz05TbFbFQ';
 function mirrorRow(overrides: any = {}) {
   return {
     id: '77777777-7777-4777-8777-777777777777',
-    stripeSessionId: 'cs_pay_1',
-    stripePaymentIntentId: null,
+    sessionId: 'cs_pay_1',
+    paymentIntentId: null,
     productKey: 'mendys-datasets',
     externalOrderId: 'order-42',
     entityType: 'organization',
@@ -129,7 +129,7 @@ describe('webhook-router — checkout.session.completed mode dispatch', () => {
     );
 
     expect(ctx.payments.upsert).toHaveBeenCalledWith(
-      expect.objectContaining({ stripeSessionId: 'cs_pay_1', status: 'paid' }),
+      expect.objectContaining({ sessionId: 'cs_pay_1', status: 'paid' }),
     );
     expect(ctx.emitter.paymentCompleted).toHaveBeenCalledTimes(1);
     expect(ctx.subscriptions.upsert).not.toHaveBeenCalled();

--- a/services/billing-service/tests/integration/invoices.integration.test.ts
+++ b/services/billing-service/tests/integration/invoices.integration.test.ts
@@ -1,0 +1,195 @@
+/**
+ * INDEPENDENT Postgres integration test for the DB-backed invoice store
+ * (migration 003 + PgInvoiceRepository). Proves store -> read -> paginate
+ * against a REAL Postgres, not a fake:
+ *
+ *   - migration 003 applies (idempotently) and GET-side keyset ordering is
+ *     (issued_at DESC, id DESC);
+ *   - upsertFromProvider is idempotent on (provider, provider_invoice_id):
+ *     a re-sync UPDATES the row in place (no duplicate) and keeps the stable
+ *     FuzeFront uuid;
+ *   - the opaque keyset cursor walks the whole set exactly once across pages
+ *     and terminates.
+ *
+ * GATING: this suite is SKIPPED unless DATABASE_URL points at a reachable
+ * Postgres (same convention as tests/db.test.ts). To run it locally against the
+ * repo's version-pinned harness (docker-compose.test.yml -> postgres:15 on
+ * :5433):
+ *
+ *   docker compose -f ../../docker-compose.test.yml up -d postgres-test
+ *   DATABASE_URL=postgres://postgres:postgres@localhost:5433/fuzefront_platform_test \
+ *     npx jest tests/integration/invoices.integration.test.ts
+ *   docker compose -f ../../docker-compose.test.yml down -v
+ *
+ * The billing schema is normally created by a superuser bootstrap Job (the
+ * least-privilege migrations never CREATE SCHEMA). For this self-contained test
+ * we create it once up-front as the test superuser, then run the real migrations.
+ */
+import { randomUUID } from 'crypto';
+import type { Pool } from 'pg';
+import { createPool, runMigrations } from '../../src/db';
+import { PgCustomerRepository } from '../../src/repositories/customer.repository';
+import {
+  PgInvoiceRepository,
+  mapInvoiceRow,
+} from '../../src/repositories/invoice.repository';
+import type { ProviderInvoice } from '../../src/providers/payment-provider';
+
+const DB_URL = process.env.DATABASE_URL;
+
+function providerInvoice(overrides: Partial<ProviderInvoice> = {}): ProviderInvoice {
+  return {
+    providerInvoiceId: `in_${randomUUID()}`,
+    number: 'FF-2026-0001',
+    status: 'paid',
+    amountDueCents: 900,
+    amountPaidCents: 900,
+    currency: 'usd',
+    hostedInvoiceUrl: 'https://invoice.provider/i/x',
+    invoicePdfUrl: 'https://invoice.provider/i/x.pdf',
+    issuedAt: new Date('2026-06-01T00:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+(DB_URL ? describe : describe.skip)(
+  'billing.invoices integration (requires DATABASE_URL)',
+  () => {
+    let pool: Pool;
+    let customerRepo: PgCustomerRepository;
+    let invoiceRepo: PgInvoiceRepository;
+    let customerId: string;
+
+    beforeAll(async () => {
+      pool = createPool(DB_URL!);
+      // Bootstrap superuser normally owns the schema; create it for the test DB.
+      await pool.query('CREATE SCHEMA IF NOT EXISTS billing');
+      await runMigrations(pool);
+      customerRepo = new PgCustomerRepository(pool);
+      invoiceRepo = new PgInvoiceRepository(pool);
+      const customer = await customerRepo.insert({
+        entityType: 'organization',
+        entityId: randomUUID(),
+        stripeCustomerId: `cus_${randomUUID()}`,
+      });
+      customerId = customer.id;
+    });
+
+    afterAll(async () => {
+      if (pool) {
+        // ON DELETE CASCADE removes this customer's invoices too.
+        await pool.query('DELETE FROM billing.customers WHERE id = $1', [customerId]);
+        await pool.end();
+      }
+    });
+
+    // Isolate each test: clear only this customer's invoices.
+    beforeEach(async () => {
+      await pool.query('DELETE FROM billing.invoices WHERE customer_id = $1', [customerId]);
+    });
+
+    it('migration 003 is idempotent (re-running the migrations does not throw)', async () => {
+      await expect(runMigrations(pool)).resolves.not.toThrow();
+      const res = await pool.query(
+        `SELECT table_name FROM information_schema.tables
+          WHERE table_schema = 'billing' AND table_name = 'invoices'`,
+      );
+      expect(res.rows).toHaveLength(1);
+    });
+
+    it('stores provider invoices and reads them back as the neutral view (id = DB uuid)', async () => {
+      const inv = providerInvoice({ providerInvoiceId: 'in_read_1', number: 'FF-READ-1' });
+      await invoiceRepo.upsertFromProvider(customerId, inv);
+
+      const page = await invoiceRepo.listByCustomer({ customerId, limit: 100 });
+      expect(page.rows).toHaveLength(1);
+      const view = mapInvoiceRow(page.rows[0]);
+      // id is OUR uuid, not the provider `in_...` id.
+      expect(view.id).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+      );
+      expect(view.id).not.toMatch(/^in_/);
+      expect(view.number).toBe('FF-READ-1');
+      expect(view.currency).toBe('usd');
+      expect(view.created).toBe('2026-06-01T00:00:00.000Z');
+    });
+
+    it('keyset orders by (issued_at DESC, id DESC) — including an issued_at tie', async () => {
+      const tie = new Date('2026-06-15T00:00:00.000Z');
+      await invoiceRepo.upsertFromProvider(customerId, providerInvoice({ providerInvoiceId: 'in_new', issuedAt: new Date('2026-07-01T00:00:00.000Z') }));
+      await invoiceRepo.upsertFromProvider(customerId, providerInvoice({ providerInvoiceId: 'in_tie_a', issuedAt: tie }));
+      await invoiceRepo.upsertFromProvider(customerId, providerInvoice({ providerInvoiceId: 'in_tie_b', issuedAt: tie }));
+      await invoiceRepo.upsertFromProvider(customerId, providerInvoice({ providerInvoiceId: 'in_old', issuedAt: new Date('2026-05-01T00:00:00.000Z') }));
+
+      const page = await invoiceRepo.listByCustomer({ customerId, limit: 100 });
+      expect(page.rows).toHaveLength(4);
+      // Verify the ordering invariant holds for every adjacent pair.
+      for (let i = 1; i < page.rows.length; i++) {
+        const prev = page.rows[i - 1];
+        const cur = page.rows[i];
+        const pt = new Date(prev.issued_at).getTime();
+        const ct = new Date(cur.issued_at).getTime();
+        expect(pt).toBeGreaterThanOrEqual(ct);
+        if (pt === ct) expect(prev.id > cur.id).toBe(true); // id DESC tiebreak
+      }
+    });
+
+    it('upsert is idempotent on (provider, provider_invoice_id): updates in place, keeps the uuid', async () => {
+      const pid = 'in_conflict_1';
+      await invoiceRepo.upsertFromProvider(
+        customerId,
+        providerInvoice({ providerInvoiceId: pid, status: 'open', amountPaidCents: 0, amountDueCents: 900 }),
+      );
+      const afterFirst = await invoiceRepo.listByCustomer({ customerId, limit: 100 });
+      expect(afterFirst.rows).toHaveLength(1);
+      const originalId = afterFirst.rows[0].id;
+      expect(afterFirst.rows[0].status).toBe('open');
+
+      // Re-sync the SAME provider invoice with mutated fields.
+      await invoiceRepo.upsertFromProvider(
+        customerId,
+        providerInvoice({ providerInvoiceId: pid, status: 'paid', amountPaidCents: 900, amountDueCents: 900, number: 'FF-UPDATED' }),
+      );
+      const afterSecond = await invoiceRepo.listByCustomer({ customerId, limit: 100 });
+      // No duplication...
+      expect(afterSecond.rows).toHaveLength(1);
+      // ...same stable uuid, updated mutable fields.
+      expect(afterSecond.rows[0].id).toBe(originalId);
+      expect(afterSecond.rows[0].status).toBe('paid');
+      expect(afterSecond.rows[0].amount_paid_cents).toBe(900);
+      expect(afterSecond.rows[0].number).toBe('FF-UPDATED');
+    });
+
+    it('the opaque cursor walks the whole set exactly once, across pages, then terminates', async () => {
+      const TOTAL = 7;
+      const PAGE = 3;
+      const base = Date.parse('2026-06-01T00:00:00.000Z');
+      for (let i = 0; i < TOTAL; i++) {
+        await invoiceRepo.upsertFromProvider(
+          customerId,
+          providerInvoice({
+            providerInvoiceId: `in_walk_${i}`,
+            issuedAt: new Date(base + i * 86_400_000), // distinct instants
+          }),
+        );
+      }
+
+      const seen: string[] = [];
+      let cursor: string | undefined;
+      let pages = 0;
+      for (;;) {
+        const page = await invoiceRepo.listByCustomer({ customerId, limit: PAGE, cursor });
+        expect(page.rows.length).toBeLessThanOrEqual(PAGE);
+        for (const r of page.rows) seen.push(r.id);
+        pages += 1;
+        if (page.nextCursor === null) break;
+        cursor = page.nextCursor;
+        expect(pages).toBeLessThan(TOTAL); // must terminate
+      }
+
+      expect(seen).toHaveLength(TOTAL);
+      expect(new Set(seen).size).toBe(TOTAL); // every row exactly once, no gaps/dupes
+      expect(pages).toBe(Math.ceil(TOTAL / PAGE));
+    });
+  },
+);

--- a/services/billing-service/tests/providers/stripe-payment-provider.test.ts
+++ b/services/billing-service/tests/providers/stripe-payment-provider.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Unit tests for StripePaymentProvider (the vendor adapter for the neutral port).
+ *
+ * Verifies the exact Stripe.Invoice -> ProviderInvoice field mapping, the
+ * listInvoices paging call (customer/limit/starting_after) with hooks firing
+ * around it, parseInvoiceEvent extraction, and that onError fires + rethrows.
+ */
+import {
+  StripePaymentProvider,
+  mapStripeInvoice,
+} from '../../src/providers/stripe/stripe-payment-provider';
+
+function stripeInvoice(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'in_1',
+    object: 'invoice',
+    number: 'INV-0001',
+    created: 1_700_000_000, // 2023-11-14T22:13:20.000Z
+    amount_due: 900,
+    amount_paid: 900,
+    currency: 'USD',
+    status: 'paid',
+    hosted_invoice_url: 'https://invoice.stripe.com/i/in_1',
+    invoice_pdf: 'https://invoice.stripe.com/i/in_1.pdf',
+    customer: 'cus_1',
+    ...overrides,
+  } as any;
+}
+
+describe('mapStripeInvoice', () => {
+  it('maps every field to the neutral ProviderInvoice (cents, lowercased ccy, Date)', () => {
+    expect(mapStripeInvoice(stripeInvoice())).toEqual({
+      providerInvoiceId: 'in_1',
+      number: 'INV-0001',
+      status: 'paid',
+      amountDueCents: 900,
+      amountPaidCents: 900,
+      currency: 'usd',
+      hostedInvoiceUrl: 'https://invoice.stripe.com/i/in_1',
+      invoicePdfUrl: 'https://invoice.stripe.com/i/in_1.pdf',
+      issuedAt: new Date('2023-11-14T22:13:20.000Z'),
+    });
+  });
+
+  it('defaults null number/urls and status=draft', () => {
+    const mapped = mapStripeInvoice(
+      stripeInvoice({ number: null, hosted_invoice_url: null, invoice_pdf: null, status: null }),
+    );
+    expect(mapped.number).toBeNull();
+    expect(mapped.hostedInvoiceUrl).toBeNull();
+    expect(mapped.invoicePdfUrl).toBeNull();
+    expect(mapped.status).toBe('draft');
+  });
+});
+
+describe('StripePaymentProvider.listInvoices', () => {
+  it('calls stripe.invoices.list with customer/limit and maps the page + hasMore', async () => {
+    const list = jest
+      .fn()
+      .mockResolvedValue({ data: [stripeInvoice(), stripeInvoice({ id: 'in_2' })], has_more: true });
+    const provider = new StripePaymentProvider({ invoices: { list } } as any);
+
+    const page = await provider.listInvoices('cus_1', { limit: 20 });
+
+    expect(list).toHaveBeenCalledWith({ customer: 'cus_1', limit: 20 });
+    expect(page.hasMore).toBe(true);
+    expect(page.invoices.map((i) => i.providerInvoiceId)).toEqual(['in_1', 'in_2']);
+  });
+
+  it('threads startingAfter -> starting_after', async () => {
+    const list = jest.fn().mockResolvedValue({ data: [], has_more: false });
+    const provider = new StripePaymentProvider({ invoices: { list } } as any);
+    await provider.listInvoices('cus_1', { limit: 5, startingAfter: 'in_prev' });
+    expect(list).toHaveBeenCalledWith({ customer: 'cus_1', limit: 5, starting_after: 'in_prev' });
+  });
+
+  it('fires onBeforeCall/onAfterCall around a successful call', async () => {
+    const list = jest.fn().mockResolvedValue({ data: [], has_more: false });
+    const onBeforeCall = jest.fn();
+    const onAfterCall = jest.fn();
+    const onError = jest.fn();
+    const provider = new StripePaymentProvider({ invoices: { list } } as any, {
+      onBeforeCall,
+      onAfterCall,
+      onError,
+    });
+    await provider.listInvoices('cus_1', { limit: 20 });
+    expect(onBeforeCall).toHaveBeenCalledWith('listInvoices', expect.objectContaining({ providerCustomerId: 'cus_1' }));
+    expect(onAfterCall).toHaveBeenCalledWith('listInvoices', expect.any(Object));
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it('fires onError and rethrows when the vendor call fails', async () => {
+    const boom = new Error('stripe down');
+    const list = jest.fn().mockRejectedValue(boom);
+    const onError = jest.fn();
+    const provider = new StripePaymentProvider({ invoices: { list } } as any, { onError });
+    await expect(provider.listInvoices('cus_1', { limit: 20 })).rejects.toThrow('stripe down');
+    expect(onError).toHaveBeenCalledWith('listInvoices', boom, expect.any(Object));
+  });
+});
+
+describe('StripePaymentProvider.parseInvoiceEvent', () => {
+  it('extracts {providerCustomerId, invoice} from an invoice event', () => {
+    const provider = new StripePaymentProvider({ invoices: { list: jest.fn() } } as any);
+    const parsed = provider.parseInvoiceEvent({
+      type: 'invoice.paid',
+      data: { object: stripeInvoice({ customer: 'cus_9' }) },
+    });
+    expect(parsed).not.toBeNull();
+    expect(parsed!.providerCustomerId).toBe('cus_9');
+    expect(parsed!.invoice.providerInvoiceId).toBe('in_1');
+  });
+
+  it('resolves an expanded customer object to its id', () => {
+    const provider = new StripePaymentProvider({ invoices: { list: jest.fn() } } as any);
+    const parsed = provider.parseInvoiceEvent({
+      type: 'invoice.updated',
+      data: { object: stripeInvoice({ customer: { id: 'cus_expanded' } }) },
+    });
+    expect(parsed!.providerCustomerId).toBe('cus_expanded');
+  });
+
+  it('returns null for a non-invoice event or a customer-less invoice', () => {
+    const provider = new StripePaymentProvider({ invoices: { list: jest.fn() } } as any);
+    expect(
+      provider.parseInvoiceEvent({ type: 'charge.refunded', data: { object: { object: 'charge' } } }),
+    ).toBeNull();
+    expect(
+      provider.parseInvoiceEvent({ type: 'invoice.paid', data: { object: stripeInvoice({ customer: null }) } }),
+    ).toBeNull();
+  });
+});

--- a/services/billing-service/tests/repositories/invoice.repository.test.ts
+++ b/services/billing-service/tests/repositories/invoice.repository.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Unit tests for PgInvoiceRepository against a fake pg.Pool (no live Postgres).
+ *
+ * Covers the two behaviours the invoice slice depends on:
+ *   - upsertFromProvider issues an INSERT ... ON CONFLICT (provider,
+ *     provider_invoice_id) DO UPDATE with the mapped column values.
+ *   - listByCustomer does keyset pagination on (issued_at DESC, id DESC),
+ *     fetching limit+1 to derive an OPAQUE base64 `${issued_at_iso}|${id}`
+ *     nextCursor, and threads a decoded cursor into the row-value predicate.
+ */
+import {
+  PgInvoiceRepository,
+  encodeInvoiceCursor,
+  decodeInvoiceCursor,
+  mapInvoiceRow,
+  InvoiceRow,
+} from '../../src/repositories/invoice.repository';
+import { ProviderInvoice } from '../../src/providers/payment-provider';
+
+function fakePool(queryImpl: jest.Mock) {
+  return { query: queryImpl } as any;
+}
+
+function providerInvoice(overrides: Partial<ProviderInvoice> = {}): ProviderInvoice {
+  return {
+    providerInvoiceId: 'in_1',
+    number: 'INV-0001',
+    status: 'paid',
+    amountDueCents: 900,
+    amountPaidCents: 900,
+    currency: 'usd',
+    hostedInvoiceUrl: 'https://p/i/in_1',
+    invoicePdfUrl: 'https://p/i/in_1.pdf',
+    issuedAt: new Date('2023-11-14T22:13:20.000Z'),
+    ...overrides,
+  };
+}
+
+function row(overrides: Partial<InvoiceRow> = {}): InvoiceRow {
+  return {
+    id: '99999999-9999-4999-8999-999999999999',
+    customer_id: 'cust_1',
+    provider: 'stripe',
+    provider_invoice_id: 'in_1',
+    number: 'INV-0001',
+    status: 'paid',
+    amount_due_cents: 900,
+    amount_paid_cents: 900,
+    currency: 'usd',
+    hosted_invoice_url: 'https://p/i/in_1',
+    invoice_pdf_url: 'https://p/i/in_1.pdf',
+    issued_at: new Date('2023-11-14T22:13:20.000Z'),
+    created_at: new Date('2023-11-14T22:13:20.000Z'),
+    updated_at: new Date('2023-11-14T22:13:20.000Z'),
+    ...overrides,
+  };
+}
+
+describe('encode/decodeInvoiceCursor', () => {
+  it('round-trips issued_at + id through opaque base64', () => {
+    const iso = '2023-11-14T22:13:20.000Z';
+    const id = 'aaaa1111-1111-4111-8111-111111111111';
+    const cursor = encodeInvoiceCursor(iso, id);
+    // Opaque: not the raw id.
+    expect(cursor).not.toContain(id);
+    expect(decodeInvoiceCursor(cursor)).toEqual({ issuedAt: iso, id });
+  });
+
+  it('returns null for a malformed cursor', () => {
+    expect(decodeInvoiceCursor('not-base64-!!')).toBeNull();
+    expect(decodeInvoiceCursor(Buffer.from('nopipe').toString('base64'))).toBeNull();
+  });
+});
+
+describe('mapInvoiceRow', () => {
+  it('maps a row to the neutral view (id=our uuid, created=issued_at ISO)', () => {
+    expect(mapInvoiceRow(row())).toEqual({
+      id: '99999999-9999-4999-8999-999999999999',
+      number: 'INV-0001',
+      created: '2023-11-14T22:13:20.000Z',
+      amountDue: 900,
+      amountPaid: 900,
+      currency: 'usd',
+      status: 'paid',
+      hostedInvoiceUrl: 'https://p/i/in_1',
+      invoicePdf: 'https://p/i/in_1.pdf',
+    });
+  });
+});
+
+describe('PgInvoiceRepository.upsertFromProvider', () => {
+  it('INSERTs with ON CONFLICT (provider, provider_invoice_id) DO UPDATE and the mapped values', async () => {
+    const query = jest.fn().mockResolvedValue({ rows: [] });
+    const repo = new PgInvoiceRepository(fakePool(query));
+
+    await repo.upsertFromProvider('cust_1', providerInvoice());
+
+    expect(query).toHaveBeenCalledTimes(1);
+    const [sql, params] = query.mock.calls[0];
+    expect(sql).toMatch(/INSERT INTO billing\.invoices/);
+    expect(sql).toMatch(/ON CONFLICT \(provider, provider_invoice_id\) DO UPDATE/);
+    expect(sql).toMatch(/updated_at\s*=\s*now\(\)/);
+    // customer_id, provider, provider_invoice_id, number, status, due, paid, ccy, hosted, pdf, issued_at
+    expect(params).toEqual([
+      'cust_1',
+      'stripe',
+      'in_1',
+      'INV-0001',
+      'paid',
+      900,
+      900,
+      'usd',
+      'https://p/i/in_1',
+      'https://p/i/in_1.pdf',
+      new Date('2023-11-14T22:13:20.000Z'),
+    ]);
+  });
+
+  it('honours a non-default provider name', async () => {
+    const query = jest.fn().mockResolvedValue({ rows: [] });
+    const repo = new PgInvoiceRepository(fakePool(query), 'paddle');
+    await repo.upsertFromProvider('cust_1', providerInvoice());
+    expect(query.mock.calls[0][1][1]).toBe('paddle');
+  });
+});
+
+describe('PgInvoiceRepository.listByCustomer — keyset pagination', () => {
+  it('orders by (issued_at DESC, id DESC), fetches limit+1, and emits an opaque nextCursor when there is more', async () => {
+    const older = row({ id: 'bbbb2222-2222-4222-8222-222222222222', issued_at: new Date('2023-10-01T00:00:00.000Z') });
+    // limit=2 -> repo asks for 3; a 3rd row present signals hasMore.
+    const query = jest.fn().mockResolvedValue({ rows: [row(), older, row({ id: 'ccc' })] });
+    const repo = new PgInvoiceRepository(fakePool(query));
+
+    const res = await repo.listByCustomer({ customerId: 'cust_1', limit: 2 });
+
+    const [sql, params] = query.mock.calls[0];
+    expect(sql).toMatch(/ORDER BY issued_at DESC, id DESC/);
+    expect(params).toEqual(['cust_1', 3]); // customerId + (limit+1)
+    // Only `limit` rows returned; the extra row is dropped.
+    expect(res.rows).toHaveLength(2);
+    // nextCursor encodes the LAST returned row's (issued_at, id).
+    expect(res.nextCursor).toBe(
+      encodeInvoiceCursor('2023-10-01T00:00:00.000Z', 'bbbb2222-2222-4222-8222-222222222222'),
+    );
+  });
+
+  it('returns nextCursor=null on the last page (fewer than limit+1 rows)', async () => {
+    const query = jest.fn().mockResolvedValue({ rows: [row()] });
+    const repo = new PgInvoiceRepository(fakePool(query));
+    const res = await repo.listByCustomer({ customerId: 'cust_1', limit: 20 });
+    expect(res.rows).toHaveLength(1);
+    expect(res.nextCursor).toBeNull();
+  });
+
+  it('threads a decoded cursor into the (issued_at, id) < (...) predicate', async () => {
+    const query = jest.fn().mockResolvedValue({ rows: [] });
+    const repo = new PgInvoiceRepository(fakePool(query));
+    const cursor = encodeInvoiceCursor('2023-10-01T00:00:00.000Z', 'bbbb2222-2222-4222-8222-222222222222');
+
+    await repo.listByCustomer({ customerId: 'cust_1', limit: 20, cursor });
+
+    const [sql, params] = query.mock.calls[0];
+    expect(sql).toMatch(/\(issued_at, id\) < \(\$2::timestamptz, \$3::uuid\)/);
+    expect(params).toEqual([
+      'cust_1',
+      '2023-10-01T00:00:00.000Z',
+      'bbbb2222-2222-4222-8222-222222222222',
+      21,
+    ]);
+  });
+
+  it('ignores a malformed cursor (treated as page 1, no keyset predicate)', async () => {
+    const query = jest.fn().mockResolvedValue({ rows: [] });
+    const repo = new PgInvoiceRepository(fakePool(query));
+    await repo.listByCustomer({ customerId: 'cust_1', limit: 20, cursor: 'garbage-!!' });
+    const [sql, params] = query.mock.calls[0];
+    expect(sql).not.toMatch(/issued_at, id\) </);
+    expect(params).toEqual(['cust_1', 21]);
+  });
+});

--- a/services/billing-service/tests/routes/invoices.test.ts
+++ b/services/billing-service/tests/routes/invoices.test.ts
@@ -1,16 +1,15 @@
 /**
- * Unit/route tests for GET /api/v1/billing/invoices.
+ * Route tests for GET /api/v1/billing/invoices and POST /api/v1/billing/invoices/sync.
  *
- * Drives the REAL createApp wiring via supertest with mocked deps (Stripe never
- * hit). Asserts: field mapping + nextCursor; no-customer -> empty list; missing
- * actor context -> 401; limit clamping; cursor -> starting_after passthrough;
- * Stripe error -> mapped status.
+ * Drives the REAL createApp wiring via supertest with mocked deps. Invoices are
+ * now VENDOR-NEUTRAL and DB-backed: the route reads the local invoice store via
+ * InvoiceService -> invoiceRepo.listByCustomer, exposing OUR uuid as `id` and an
+ * OPAQUE keyset cursor. No Stripe id or cursor leaks through the contract.
  *
- * The shared helper's DepStubs.stripe does not include `invoices` (it predates
- * this slice), so we supply a FULL stripe stub via opts.stubs.stripe — buildApp
- * shallow-merges opts.stubs over its defaults, so the whole `stripe` key is
- * replaced. We keep the other stripe sub-resources present so unrelated wiring
- * (checkout/credits/setup-intent/webhooks) still constructs.
+ * Asserts: neutral field mapping + opaque nextCursor passthrough; no-customer ->
+ * empty list; missing actor -> 401; missing token -> 401; limit clamping +
+ * cursor passthrough to the repo; the lazy sync-once-then-read path; and
+ * POST /invoices/sync returning {synced}.
  */
 import request from 'supertest';
 import {
@@ -23,20 +22,27 @@ import {
 } from '../contract/helpers';
 
 const URL = '/api/v1/billing/invoices';
+const SYNC_URL = '/api/v1/billing/invoices/sync';
 
-/** A full Stripe stub including invoices.list + the pre-existing sub-resources. */
-function stripeStub(listImpl?: jest.Mock) {
-  const constructEvent = jest.fn();
+/** A billing.invoices row (snake_case) as returned by invoiceRepo.listByCustomer. */
+function rawRow(overrides: Record<string, unknown> = {}) {
   return {
-    stripe: {
-      setupIntents: { create: jest.fn() },
-      customers: { createBalanceTransaction: jest.fn() },
-      checkout: { sessions: { create: jest.fn() } },
-      billingPortal: { sessions: { create: jest.fn() } },
-      invoices: { list: listImpl ?? jest.fn() },
-      webhooks: { constructEvent },
-    },
-  } as any;
+    id: '99999999-9999-4999-8999-999999999999',
+    customer_id: 'localcust_1',
+    provider: 'stripe',
+    provider_invoice_id: 'in_1',
+    number: 'INV-0001',
+    status: 'paid',
+    amount_due_cents: 900,
+    amount_paid_cents: 900,
+    currency: 'usd',
+    hosted_invoice_url: 'https://invoice.provider/i/in_1',
+    invoice_pdf_url: 'https://invoice.provider/i/in_1.pdf',
+    issued_at: new Date('2023-11-14T22:13:20.000Z'),
+    created_at: new Date('2023-11-14T22:13:20.000Z'),
+    updated_at: new Date('2023-11-14T22:13:20.000Z'),
+    ...overrides,
+  };
 }
 
 /** Customer-with-billing stub for the authorized org. */
@@ -55,30 +61,50 @@ function orgCustomerRepoStub(stripeCustomerId = 'cus_org_1') {
   } as any;
 }
 
-function rawInvoice(overrides: Record<string, unknown> = {}) {
+/** A full Stripe stub including invoices.list (needed only on the sync path). */
+function stripeStub(listImpl?: jest.Mock) {
+  return {
+    stripe: {
+      setupIntents: { create: jest.fn() },
+      customers: { createBalanceTransaction: jest.fn() },
+      checkout: { sessions: { create: jest.fn(), retrieve: jest.fn() } },
+      billingPortal: { sessions: { create: jest.fn() } },
+      invoices: { list: listImpl ?? jest.fn() },
+      webhooks: { constructEvent: jest.fn() },
+    },
+  } as any;
+}
+
+/** A provider invoice, as Stripe.invoices.list().data items map from. */
+function rawStripeInvoice(overrides: Record<string, unknown> = {}) {
   return {
     id: 'in_1',
+    object: 'invoice',
     number: 'INV-0001',
-    created: 1_700_000_000, // 2023-11-14T22:13:20.000Z
+    created: 1_700_000_000,
     amount_due: 900,
     amount_paid: 900,
     currency: 'USD',
     status: 'paid',
-    hosted_invoice_url: 'https://invoice.stripe.com/i/in_1',
-    invoice_pdf: 'https://invoice.stripe.com/i/in_1.pdf',
+    hosted_invoice_url: 'https://invoice.provider/i/in_1',
+    invoice_pdf: 'https://invoice.provider/i/in_1.pdf',
+    customer: 'cus_org_1',
     ...overrides,
   };
 }
 
-describe('GET /invoices — Stripe-backed invoice history', () => {
-  it('200 maps Stripe fields to the frozen shape and sets nextCursor when has_more', async () => {
-    const list = jest.fn().mockResolvedValue({
-      data: [rawInvoice({ id: 'in_1' }), rawInvoice({ id: 'in_last', number: null })],
-      has_more: true,
+describe('GET /invoices — provider-backed, DB-served invoice history', () => {
+  it('200 maps stored rows to the neutral shape (id=uuid) and passes the opaque nextCursor through', async () => {
+    const listByCustomer = jest.fn().mockResolvedValue({
+      rows: [rawRow(), rawRow({ id: 'aaaa1111-1111-4111-8111-111111111111', number: null })],
+      nextCursor: 'b3BhcXVlLWN1cnNvcg==',
     });
     const { app, stubs } = buildApp({
       internalToken: INTERNAL_TOKEN,
-      stubs: { ...stripeStub(list), ...orgCustomerRepoStub() },
+      stubs: {
+        ...orgCustomerRepoStub(),
+        invoiceRepo: { upsertFromProvider: jest.fn(), listByCustomer } as any,
+      },
     });
 
     const res = await request(app)
@@ -87,50 +113,33 @@ describe('GET /invoices — Stripe-backed invoice history', () => {
       .set(actorOrgHeaders(ORG_ID, USER_ID));
 
     expect(res.status).toBe(200);
-    expect(res.body.nextCursor).toBe('in_last');
+    expect(res.body.nextCursor).toBe('b3BhcXVlLWN1cnNvcg==');
     expect(res.body.invoices).toHaveLength(2);
     expect(res.body.invoices[0]).toEqual({
-      id: 'in_1',
+      id: '99999999-9999-4999-8999-999999999999', // OUR uuid, not in_...
       number: 'INV-0001',
       created: '2023-11-14T22:13:20.000Z',
       amountDue: 900,
       amountPaid: 900,
-      currency: 'usd', // lowercased
+      currency: 'usd',
       status: 'paid',
-      hostedInvoiceUrl: 'https://invoice.stripe.com/i/in_1',
-      invoicePdf: 'https://invoice.stripe.com/i/in_1.pdf',
+      hostedInvoiceUrl: 'https://invoice.provider/i/in_1',
+      invoicePdf: 'https://invoice.provider/i/in_1.pdf',
     });
-    // null passthrough for number when absent.
     expect(res.body.invoices[1].number).toBeNull();
 
     expect(stubs.customerRepo.findByEntity).toHaveBeenCalledWith('organization', ORG_ID);
-    expect(list).toHaveBeenCalledWith(
-      expect.objectContaining({ customer: 'cus_org_1', limit: 20 }),
+    expect(listByCustomer).toHaveBeenCalledWith(
+      expect.objectContaining({ customerId: 'localcust_1', limit: 20 }),
     );
-    // No cursor supplied -> no starting_after.
-    expect(list.mock.calls[0][0]).not.toHaveProperty('starting_after');
-  });
-
-  it('200 nextCursor=null when Stripe reports has_more=false', async () => {
-    const list = jest.fn().mockResolvedValue({ data: [rawInvoice()], has_more: false });
-    const { app } = buildApp({
-      internalToken: INTERNAL_TOKEN,
-      stubs: { ...stripeStub(list), ...orgCustomerRepoStub() },
-    });
-    const res = await request(app)
-      .get(URL)
-      .set(...authHeader())
-      .set(actorOrgHeaders(ORG_ID, USER_ID));
-    expect(res.status).toBe(200);
-    expect(res.body.nextCursor).toBeNull();
   });
 
   it('200 empty list when the entity has no billing customer (not an error)', async () => {
-    const list = jest.fn();
+    const listByCustomer = jest.fn();
     const { app } = buildApp({
       internalToken: INTERNAL_TOKEN,
-      // customerRepo default findByEntity resolves null.
-      stubs: { ...stripeStub(list) },
+      // default customerRepo.findByEntity resolves null.
+      stubs: { invoiceRepo: { upsertFromProvider: jest.fn(), listByCustomer } as any },
     });
     const res = await request(app)
       .get(URL)
@@ -138,68 +147,113 @@ describe('GET /invoices — Stripe-backed invoice history', () => {
       .set(actorOrgHeaders(ORG_ID, USER_ID));
     expect(res.status).toBe(200);
     expect(res.body).toEqual({ invoices: [], nextCursor: null });
-    expect(list).not.toHaveBeenCalled();
+    expect(listByCustomer).not.toHaveBeenCalled();
   });
 
   it('401 when the proxy actor-context headers are absent', async () => {
-    const list = jest.fn();
+    const listByCustomer = jest.fn();
     const { app } = buildApp({
       internalToken: INTERNAL_TOKEN,
-      stubs: { ...stripeStub(list), ...orgCustomerRepoStub() },
+      stubs: {
+        ...orgCustomerRepoStub(),
+        invoiceRepo: { upsertFromProvider: jest.fn(), listByCustomer } as any,
+      },
     });
     const res = await request(app)
       .get(URL)
       .set(...authHeader()); // valid token, NO actor headers
     expect(res.status).toBe(401);
-    expect(list).not.toHaveBeenCalled();
+    expect(listByCustomer).not.toHaveBeenCalled();
   });
 
   it('401 when the internal token is missing', async () => {
     const { app } = buildApp({
       internalToken: INTERNAL_TOKEN,
-      stubs: { ...stripeStub(jest.fn()), ...orgCustomerRepoStub() },
+      stubs: { ...orgCustomerRepoStub() },
     });
     const res = await request(app).get(URL).set(actorOrgHeaders(ORG_ID, USER_ID));
     expect(res.status).toBe(401);
   });
 
   it('clamps limit: over-max -> 100, under-min -> 1, non-numeric -> default 20', async () => {
-    const list = jest.fn().mockResolvedValue({ data: [], has_more: false });
+    const listByCustomer = jest.fn().mockResolvedValue({ rows: [rawRow()], nextCursor: null });
     const { app } = buildApp({
       internalToken: INTERNAL_TOKEN,
-      stubs: { ...stripeStub(list), ...orgCustomerRepoStub() },
+      stubs: {
+        ...orgCustomerRepoStub(),
+        invoiceRepo: { upsertFromProvider: jest.fn(), listByCustomer } as any,
+      },
     });
 
     await request(app).get(`${URL}?limit=9999`).set(...authHeader()).set(actorOrgHeaders(ORG_ID, USER_ID));
-    expect(list.mock.calls[0][0].limit).toBe(100);
+    expect(listByCustomer.mock.calls[0][0].limit).toBe(100);
 
     await request(app).get(`${URL}?limit=0`).set(...authHeader()).set(actorOrgHeaders(ORG_ID, USER_ID));
-    expect(list.mock.calls[1][0].limit).toBe(1);
+    expect(listByCustomer.mock.calls[1][0].limit).toBe(1);
 
     await request(app).get(`${URL}?limit=abc`).set(...authHeader()).set(actorOrgHeaders(ORG_ID, USER_ID));
-    expect(list.mock.calls[2][0].limit).toBe(20);
+    expect(listByCustomer.mock.calls[2][0].limit).toBe(20);
   });
 
-  it('passes the cursor through as starting_after', async () => {
-    const list = jest.fn().mockResolvedValue({ data: [], has_more: false });
+  it('passes the opaque cursor through to the repository', async () => {
+    const listByCustomer = jest.fn().mockResolvedValue({ rows: [rawRow()], nextCursor: null });
     const { app } = buildApp({
       internalToken: INTERNAL_TOKEN,
-      stubs: { ...stripeStub(list), ...orgCustomerRepoStub() },
+      stubs: {
+        ...orgCustomerRepoStub(),
+        invoiceRepo: { upsertFromProvider: jest.fn(), listByCustomer } as any,
+      },
     });
     await request(app)
-      .get(`${URL}?cursor=in_prevpage`)
+      .get(`${URL}?cursor=b3BhcXVl`)
       .set(...authHeader())
       .set(actorOrgHeaders(ORG_ID, USER_ID));
-    expect(list.mock.calls[0][0]).toEqual(
-      expect.objectContaining({ starting_after: 'in_prevpage' }),
+    expect(listByCustomer.mock.calls[0][0]).toEqual(
+      expect.objectContaining({ cursor: 'b3BhcXVl' }),
     );
   });
 
-  it('maps a Stripe error to its status (502 on an unknown/upstream throw)', async () => {
-    const list = jest.fn().mockRejectedValue(new Error('stripe boom'));
+  it('lazily syncs once from the provider when a known customer has an empty store, then reads', async () => {
+    const upsertFromProvider = jest.fn().mockResolvedValue(undefined);
+    // First read empty (triggers sync), second read returns the synced row.
+    const listByCustomer = jest
+      .fn()
+      .mockResolvedValueOnce({ rows: [], nextCursor: null })
+      .mockResolvedValueOnce({ rows: [rawRow()], nextCursor: null });
+    const list = jest.fn().mockResolvedValue({ data: [rawStripeInvoice()], has_more: false });
+
     const { app } = buildApp({
       internalToken: INTERNAL_TOKEN,
-      stubs: { ...stripeStub(list), ...orgCustomerRepoStub() },
+      stubs: {
+        ...orgCustomerRepoStub(),
+        ...stripeStub(list),
+        invoiceRepo: { upsertFromProvider, listByCustomer } as any,
+      },
+    });
+
+    const res = await request(app)
+      .get(URL)
+      .set(...authHeader())
+      .set(actorOrgHeaders(ORG_ID, USER_ID));
+
+    expect(res.status).toBe(200);
+    // provider.listInvoices -> stripe.invoices.list with the customer id.
+    expect(list).toHaveBeenCalledWith(expect.objectContaining({ customer: 'cus_org_1' }));
+    expect(upsertFromProvider).toHaveBeenCalledTimes(1);
+    expect(listByCustomer).toHaveBeenCalledTimes(2); // empty read, then post-sync read
+    expect(res.body.invoices).toHaveLength(1);
+  });
+
+  it('maps a provider error thrown during the lazy sync to its status (502)', async () => {
+    const listByCustomer = jest.fn().mockResolvedValue({ rows: [], nextCursor: null });
+    const list = jest.fn().mockRejectedValue(new Error('provider boom'));
+    const { app } = buildApp({
+      internalToken: INTERNAL_TOKEN,
+      stubs: {
+        ...orgCustomerRepoStub(),
+        ...stripeStub(list),
+        invoiceRepo: { upsertFromProvider: jest.fn(), listByCustomer } as any,
+      },
     });
     const res = await request(app)
       .get(URL)
@@ -210,24 +264,55 @@ describe('GET /invoices — Stripe-backed invoice history', () => {
       expect.objectContaining({ error: expect.any(String), message: expect.any(String) }),
     );
   });
+});
 
-  it('forwards a StripeInvalidRequestError as its 4xx status', async () => {
-    const list = jest.fn().mockRejectedValue(
-      Object.assign(new Error('No such customer'), {
-        type: 'StripeInvalidRequestError',
-        code: 'resource_missing',
-        statusCode: 400,
-      }),
-    );
+describe('POST /invoices/sync — force a provider→store resync', () => {
+  it('200 {synced} counts the upserted invoices for the authorized entity', async () => {
+    const upsertFromProvider = jest.fn().mockResolvedValue(undefined);
+    const list = jest.fn().mockResolvedValue({
+      data: [rawStripeInvoice({ id: 'in_1' }), rawStripeInvoice({ id: 'in_2' })],
+      has_more: false,
+    });
     const { app } = buildApp({
       internalToken: INTERNAL_TOKEN,
-      stubs: { ...stripeStub(list), ...orgCustomerRepoStub() },
+      stubs: {
+        ...orgCustomerRepoStub(),
+        ...stripeStub(list),
+        invoiceRepo: { upsertFromProvider, listByCustomer: jest.fn() } as any,
+      },
     });
+
     const res = await request(app)
-      .get(URL)
+      .post(SYNC_URL)
       .set(...authHeader())
       .set(actorOrgHeaders(ORG_ID, USER_ID));
-    expect(res.status).toBe(400);
-    expect(res.body).toEqual(expect.objectContaining({ code: 'resource_missing' }));
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ synced: 2 });
+    expect(upsertFromProvider).toHaveBeenCalledTimes(2);
+  });
+
+  it('200 {synced:0} when the entity has no billing customer', async () => {
+    const upsertFromProvider = jest.fn();
+    const { app } = buildApp({
+      internalToken: INTERNAL_TOKEN,
+      stubs: { invoiceRepo: { upsertFromProvider, listByCustomer: jest.fn() } as any },
+    });
+    const res = await request(app)
+      .post(SYNC_URL)
+      .set(...authHeader())
+      .set(actorOrgHeaders(ORG_ID, USER_ID));
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ synced: 0 });
+    expect(upsertFromProvider).not.toHaveBeenCalled();
+  });
+
+  it('401 when the proxy actor-context headers are absent', async () => {
+    const { app } = buildApp({
+      internalToken: INTERNAL_TOKEN,
+      stubs: { ...orgCustomerRepoStub() },
+    });
+    const res = await request(app).post(SYNC_URL).set(...authHeader());
+    expect(res.status).toBe(401);
   });
 });

--- a/services/billing-service/tests/routes/payments.test.ts
+++ b/services/billing-service/tests/routes/payments.test.ts
@@ -58,8 +58,8 @@ function validBody(overrides: Record<string, unknown> = {}) {
 function mirrorRow(overrides: Record<string, unknown> = {}) {
   return {
     id: '77777777-7777-4777-8777-777777777777',
-    stripeSessionId: 'cs_test_session',
-    stripePaymentIntentId: null,
+    sessionId: 'cs_test_session',
+    paymentIntentId: null,
     productKey: 'mendys-datasets',
     externalOrderId: 'order-42',
     entityType: 'organization',
@@ -144,7 +144,7 @@ describe('POST /payments/checkout — one-time payment-mode Checkout Session', (
 
     expect(stubs.payments.upsert).toHaveBeenCalledWith(
       expect.objectContaining({
-        stripeSessionId: 'cs_test_session',
+        sessionId: 'cs_test_session',
         productKey: 'mendys-datasets',
         externalOrderId: 'order-42',
         entityType: 'organization',
@@ -413,7 +413,7 @@ describe('GET /payments/sessions/:sessionId — reconciliation polling', () => {
     expect(res.status).toBe(200);
     expect(res.body.payment).toEqual(
       expect.objectContaining({
-        stripeSessionId: 'cs_test_session',
+        sessionId: 'cs_test_session',
         productKey: 'mendys-datasets',
         externalOrderId: 'order-42',
         status: 'paid',
@@ -482,8 +482,8 @@ describe('GET /payments/sessions/:sessionId — reconciliation polling', () => {
     expect(res.status).toBe(200);
     expect(stubs.payments.upsert).toHaveBeenCalledWith(
       expect.objectContaining({
-        stripeSessionId: 'cs_live_9',
-        stripePaymentIntentId: 'pi_9',
+        sessionId: 'cs_live_9',
+        paymentIntentId: 'pi_9',
         productKey: 'mendys-datasets',
         externalOrderId: 'order-42',
         entityType: 'organization',
@@ -493,7 +493,7 @@ describe('GET /payments/sessions/:sessionId — reconciliation polling', () => {
         status: 'paid',
       }),
     );
-    expect(res.body.payment).toEqual(expect.objectContaining({ stripeSessionId: 'cs_live_9' }));
+    expect(res.body.payment).toEqual(expect.objectContaining({ sessionId: 'cs_live_9' }));
   });
 
   it('fallback 404s a live session whose productKey is NOT allowlisted', async () => {

--- a/services/billing-service/tests/services/invoice.service.test.ts
+++ b/services/billing-service/tests/services/invoice.service.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Unit tests for InvoiceService (vendor-neutral, DB-backed invoice read/sync).
+ *
+ * Fakes the customerRepo, invoiceRepo, and PaymentProvider port so no DB/Stripe
+ * is touched. Covers: no-customer empty result; store-hit read (no sync); the
+ * lazy sync-once-then-read path on an empty store; page-2 (cursor) never syncs;
+ * multi-page syncCustomer counting + startingAfter threading; syncEntity.
+ */
+import { InvoiceService } from '../../src/services/invoice.service';
+import { ProviderInvoice } from '../../src/providers/payment-provider';
+import { InvoiceRow } from '../../src/repositories/invoice.repository';
+
+const CUSTOMER = {
+  id: 'cust_1',
+  entityType: 'organization' as const,
+  entityId: '33333333-3333-4333-8333-333333333333',
+  stripeCustomerId: 'cus_org_1',
+};
+
+const ENTITY = { entityType: 'organization' as const, entityId: CUSTOMER.entityId };
+
+function providerInvoice(id: string): ProviderInvoice {
+  return {
+    providerInvoiceId: id,
+    number: `NUM-${id}`,
+    status: 'paid',
+    amountDueCents: 100,
+    amountPaidCents: 100,
+    currency: 'usd',
+    hostedInvoiceUrl: null,
+    invoicePdfUrl: null,
+    issuedAt: new Date('2023-11-14T22:13:20.000Z'),
+  };
+}
+
+function row(id: string): InvoiceRow {
+  return {
+    id,
+    customer_id: 'cust_1',
+    provider: 'stripe',
+    provider_invoice_id: `in_${id}`,
+    number: `NUM-${id}`,
+    status: 'paid',
+    amount_due_cents: 100,
+    amount_paid_cents: 100,
+    currency: 'usd',
+    hosted_invoice_url: null,
+    invoice_pdf_url: null,
+    issued_at: new Date('2023-11-14T22:13:20.000Z'),
+    created_at: new Date('2023-11-14T22:13:20.000Z'),
+    updated_at: new Date('2023-11-14T22:13:20.000Z'),
+  };
+}
+
+function makeDeps(over: {
+  findByEntity?: jest.Mock;
+  listByCustomer?: jest.Mock;
+  upsertFromProvider?: jest.Mock;
+  listInvoices?: jest.Mock;
+} = {}) {
+  const customerRepo = {
+    findByEntity: over.findByEntity ?? jest.fn().mockResolvedValue(CUSTOMER),
+    findByStripeCustomerId: jest.fn(),
+    insert: jest.fn(),
+  };
+  const invoiceRepo = {
+    upsertFromProvider: over.upsertFromProvider ?? jest.fn().mockResolvedValue(undefined),
+    listByCustomer: over.listByCustomer ?? jest.fn().mockResolvedValue({ rows: [], nextCursor: null }),
+  };
+  const provider = {
+    name: 'stripe',
+    listInvoices: over.listInvoices ?? jest.fn().mockResolvedValue({ invoices: [], hasMore: false }),
+    parseInvoiceEvent: jest.fn(),
+  };
+  const service = new InvoiceService({
+    customerRepo: customerRepo as any,
+    invoiceRepo: invoiceRepo as any,
+    provider: provider as any,
+  });
+  return { service, customerRepo, invoiceRepo, provider };
+}
+
+describe('InvoiceService.list', () => {
+  it('returns an empty list without touching the store/provider when there is no customer', async () => {
+    const { service, invoiceRepo, provider } = makeDeps({
+      findByEntity: jest.fn().mockResolvedValue(null),
+    });
+    const res = await service.list(ENTITY, { limit: 20 });
+    expect(res).toEqual({ invoices: [], nextCursor: null });
+    expect(invoiceRepo.listByCustomer).not.toHaveBeenCalled();
+    expect(provider.listInvoices).not.toHaveBeenCalled();
+  });
+
+  it('reads the store and does NOT sync when rows already exist', async () => {
+    const listByCustomer = jest.fn().mockResolvedValue({ rows: [row('a')], nextCursor: 'cur' });
+    const { service, provider } = makeDeps({ listByCustomer });
+    const res = await service.list(ENTITY, { limit: 20 });
+    expect(res.invoices).toHaveLength(1);
+    expect(res.invoices[0].id).toBe('a');
+    expect(res.nextCursor).toBe('cur');
+    expect(listByCustomer).toHaveBeenCalledTimes(1);
+    expect(provider.listInvoices).not.toHaveBeenCalled();
+  });
+
+  it('lazily syncs once then re-reads when a known customer has an empty store (page 1)', async () => {
+    const listByCustomer = jest
+      .fn()
+      .mockResolvedValueOnce({ rows: [], nextCursor: null })
+      .mockResolvedValueOnce({ rows: [row('a')], nextCursor: null });
+    const listInvoices = jest.fn().mockResolvedValue({ invoices: [providerInvoice('a')], hasMore: false });
+    const upsertFromProvider = jest.fn().mockResolvedValue(undefined);
+    const { service } = makeDeps({ listByCustomer, listInvoices, upsertFromProvider });
+
+    const res = await service.list(ENTITY, { limit: 20 });
+
+    expect(listInvoices).toHaveBeenCalledWith('cus_org_1', expect.objectContaining({ limit: 100 }));
+    expect(upsertFromProvider).toHaveBeenCalledTimes(1);
+    expect(listByCustomer).toHaveBeenCalledTimes(2);
+    expect(res.invoices).toHaveLength(1);
+  });
+
+  it('does NOT sync on a later page (cursor present) even if the read is empty', async () => {
+    const listByCustomer = jest.fn().mockResolvedValue({ rows: [], nextCursor: null });
+    const { service, provider } = makeDeps({ listByCustomer });
+    const res = await service.list(ENTITY, { limit: 20, cursor: 'some-cursor' });
+    expect(res).toEqual({ invoices: [], nextCursor: null });
+    expect(provider.listInvoices).not.toHaveBeenCalled();
+    expect(listByCustomer).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('InvoiceService.syncCustomer', () => {
+  it('pages the provider, upserts each invoice, threads startingAfter, and returns the count', async () => {
+    const listInvoices = jest
+      .fn()
+      .mockResolvedValueOnce({ invoices: [providerInvoice('a'), providerInvoice('b')], hasMore: true })
+      .mockResolvedValueOnce({ invoices: [providerInvoice('c')], hasMore: false });
+    const upsertFromProvider = jest.fn().mockResolvedValue(undefined);
+    const { service } = makeDeps({ listInvoices, upsertFromProvider });
+
+    const count = await service.syncCustomer(CUSTOMER as any);
+
+    expect(count).toBe(3);
+    expect(upsertFromProvider).toHaveBeenCalledTimes(3);
+    // Second page requests startingAfter = last id of the first page ('b').
+    expect(listInvoices.mock.calls[1][1]).toEqual(
+      expect.objectContaining({ startingAfter: 'b' }),
+    );
+  });
+});
+
+describe('InvoiceService.syncEntity', () => {
+  it('returns 0 when the entity has no customer', async () => {
+    const { service, provider } = makeDeps({ findByEntity: jest.fn().mockResolvedValue(null) });
+    await expect(service.syncEntity(ENTITY)).resolves.toBe(0);
+    expect(provider.listInvoices).not.toHaveBeenCalled();
+  });
+
+  it('resolves the customer and syncs', async () => {
+    const listInvoices = jest.fn().mockResolvedValue({ invoices: [providerInvoice('a')], hasMore: false });
+    const { service } = makeDeps({ listInvoices });
+    await expect(service.syncEntity(ENTITY)).resolves.toBe(1);
+  });
+});

--- a/services/billing-service/tests/services/plan.service.test.ts
+++ b/services/billing-service/tests/services/plan.service.test.ts
@@ -9,7 +9,7 @@ class FakePlanRepo implements PlanRepository {
 
   async upsert(plan: Plan) {
     this.upsertCalls++;
-    const i = this.plans.findIndex((p) => p.stripePriceId === plan.stripePriceId);
+    const i = this.plans.findIndex((p) => p.priceId === plan.priceId);
     if (i >= 0) this.plans[i] = plan;
     else this.plans.push(plan);
   }
@@ -18,7 +18,7 @@ class FakePlanRepo implements PlanRepository {
     return this.plans.filter((p) => p.isActive);
   }
   async findByPriceId(id: string) {
-    return this.plans.find((p) => p.stripePriceId === id) ?? null;
+    return this.plans.find((p) => p.priceId === id) ?? null;
   }
 }
 
@@ -49,8 +49,8 @@ describe('PlanService.syncPlans', () => {
 
     expect(count).toBe(1);
     expect(repo.plans[0]).toMatchObject({
-      stripePriceId: 'price_pro',
-      stripeProductId: 'prod_pro',
+      priceId: 'price_pro',
+      productId: 'prod_pro',
       tierName: 'pro',
       seatBased: true,
       billingInterval: 'month',
@@ -82,7 +82,7 @@ describe('PlanService.getActivePlans', () => {
   it('serves from cache within TTL (repo hit once)', async () => {
     const repo = new FakePlanRepo();
     repo.plans = [
-      { stripePriceId: 'p1', stripeProductId: 'pr1', tierName: 'starter', displayName: 'Starter', billingInterval: 'month', unitAmount: 900, currency: 'usd', seatBased: false, meteredMeterName: null, features: [], isActive: true, sortOrder: 1 },
+      { priceId: 'p1', productId: 'pr1', tierName: 'starter', displayName: 'Starter', billingInterval: 'month', unitAmount: 900, currency: 'usd', seatBased: false, meteredMeterName: null, features: [], isActive: true, sortOrder: 1 },
     ];
     let t = 1000;
     const svc = new PlanService({} as any, repo, 60_000, () => t);

--- a/services/billing-service/tests/services/subscription.service.test.ts
+++ b/services/billing-service/tests/services/subscription.service.test.ts
@@ -6,13 +6,13 @@ class FakeSubRepo implements SubscriptionRepository {
   rows: BillingSubscription[] = [];
   async upsert(row: SubscriptionUpsert): Promise<BillingSubscription> {
     const mapped: BillingSubscription = { id: 'localsub_1', ...row };
-    const i = this.rows.findIndex((r) => r.stripeSubscriptionId === row.stripeSubscriptionId);
+    const i = this.rows.findIndex((r) => r.subscriptionId === row.subscriptionId);
     if (i >= 0) this.rows[i] = mapped;
     else this.rows.push(mapped);
     return mapped;
   }
   async findByStripeId(id: string) {
-    return this.rows.find((r) => r.stripeSubscriptionId === id) ?? null;
+    return this.rows.find((r) => r.subscriptionId === id) ?? null;
   }
   async findByCustomer(cid: string) {
     return this.rows.find((r) => r.customerId === cid) ?? null;
@@ -29,8 +29,8 @@ const fakeCustomers = {
 } as any;
 
 const plansList = [
-  { stripePriceId: 'price_starter', tierName: 'starter', unitAmount: 900 },
-  { stripePriceId: 'price_pro', tierName: 'pro', unitAmount: 2900 },
+  { priceId: 'price_starter', tierName: 'starter', unitAmount: 900 },
+  { priceId: 'price_pro', tierName: 'pro', unitAmount: 2900 },
 ];
 const fakePlans = { getActivePlans: jest.fn().mockResolvedValue(plansList) } as any;
 
@@ -103,7 +103,7 @@ describe('SubscriptionService.update', () => {
   it('upgrade uses create_prorations', async () => {
     const repo = new FakeSubRepo();
     await repo.upsert({
-      customerId: 'localcust_1', stripeSubscriptionId: 'sub_1', stripePriceId: 'price_starter',
+      customerId: 'localcust_1', subscriptionId: 'sub_1', priceId: 'price_starter',
       planTier: 'starter', status: 'active', seatQuantity: 1, trialStart: null, trialEnd: null,
       currentPeriodStart: null, currentPeriodEnd: null, cancelAtPeriodEnd: false, canceledAt: null,
     });
@@ -121,7 +121,7 @@ describe('SubscriptionService.update', () => {
   it('downgrade uses none + billing_cycle_anchor unchanged (period-end)', async () => {
     const repo = new FakeSubRepo();
     await repo.upsert({
-      customerId: 'localcust_1', stripeSubscriptionId: 'sub_1', stripePriceId: 'price_pro',
+      customerId: 'localcust_1', subscriptionId: 'sub_1', priceId: 'price_pro',
       planTier: 'pro', status: 'active', seatQuantity: 1, trialStart: null, trialEnd: null,
       currentPeriodStart: null, currentPeriodEnd: null, cancelAtPeriodEnd: false, canceledAt: null,
     });
@@ -142,7 +142,7 @@ describe('SubscriptionService.cancel', () => {
   it('sets cancel_at_period_end true', async () => {
     const repo = new FakeSubRepo();
     await repo.upsert({
-      customerId: 'localcust_1', stripeSubscriptionId: 'sub_1', stripePriceId: 'price_pro',
+      customerId: 'localcust_1', subscriptionId: 'sub_1', priceId: 'price_pro',
       planTier: 'pro', status: 'active', seatQuantity: 1, trialStart: null, trialEnd: null,
       currentPeriodStart: null, currentPeriodEnd: null, cancelAtPeriodEnd: false, canceledAt: null,
     });

--- a/services/payment-service/.dockerignore
+++ b/services/payment-service/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+dist-test
+npm-debug.log
+.git

--- a/services/payment-service/.gitignore
+++ b/services/payment-service/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+dist-test/

--- a/services/payment-service/Dockerfile
+++ b/services/payment-service/Dockerfile
@@ -1,0 +1,45 @@
+# syntax=docker/dockerfile:1
+#
+# payment-service — self-contained image (no @fuzefront/shared dependency), so
+# the build context is services/payment-service/ (NOT the repo root the
+# workspace services use). Mirrors the clock-app self-contained pattern.
+
+# ---------- base: production deps only ----------
+FROM node:18-alpine AS base
+WORKDIR /app
+RUN apk add --no-cache dumb-init
+COPY package.json ./
+RUN npm install --omit=dev --ignore-scripts
+
+# ---------- build: full compile ----------
+FROM node:18-alpine AS build
+WORKDIR /app
+COPY package.json ./
+RUN npm install --ignore-scripts
+COPY tsconfig.json ./
+COPY src/ ./src/
+RUN npm run build
+
+# ---------- production ----------
+FROM node:18-alpine AS production
+WORKDIR /app
+
+RUN apk add --no-cache dumb-init && \
+    addgroup -S paymentservice && adduser -S paymentservice -G paymentservice -u 1001
+
+COPY --from=base /app/node_modules ./node_modules
+COPY --from=build /app/dist ./dist
+COPY package.json ./
+
+# Drop declaration files from the production image.
+RUN find ./dist -name "*.d.ts" -type f -delete
+
+ENV PORT=3007
+ENV NODE_ENV=production
+
+EXPOSE 3007
+
+USER paymentservice
+
+ENTRYPOINT ["dumb-init", "--"]
+CMD ["node", "dist/index.js"]

--- a/services/payment-service/README.md
+++ b/services/payment-service/README.md
@@ -1,0 +1,108 @@
+# @fuzefront/payment-service
+
+The **vendor-neutral payment gateway** for FuzeFront. This service is the single
+seam through which **all** payment-vendor interaction (Stripe today) is routed.
+Consumers — `billing-service` and other products — talk only to its neutral
+**Payment Provider API**; none of them touch a vendor SDK. That lets FuzeFront
+swap the vendor, run two in parallel behind a flag, or insert pre/post hooks
+(metrics, idempotency, transforms, retries) centrally without changing a single
+call site.
+
+> **Scaffold status.** This PR ships the gateway as a **runnable health service +
+> frozen contract + adapter skeleton + deploy wiring**. The adapter methods are
+> not yet wired to Stripe — they return `501 Not Implemented`. The live money
+> path still lives in `billing-service`; it is absorbed here progressively. **This
+> is not yet the live money path.**
+
+- **Port:** `3007` (billing-service is `3006`).
+- **Health:** `GET /health` → `{ "status": "ok", "service": "payment-service" }`.
+- **API base:** `/api/v1/payments` (see `openapi.yaml`, version `0.1.0`).
+
+## The vendor-swap boundary (port / adapter model)
+
+```
+consumers (billing-service, host proxy)
+        │  neutral HTTP  (/api/v1/payments)
+        ▼
+  payment-service  ──►  PaymentProvider  (src/providers/payment-provider.ts)   ← the PORT
+                              ▲
+                              │  implements
+                    StripePaymentProvider   (src/providers/stripe/…)           ← the ADAPTER
+                              │
+                              ▼
+                         Stripe SDK   ← the ONLY place the vendor is touched
+```
+
+- **The port** (`src/providers/payment-provider.ts`) is a vendor-agnostic
+  interface with neutral DTOs (cents, `Date`, lowercased currency, `provider*Id`).
+  It is intentionally a **superset aligned with billing-service's own
+  `PaymentProvider` port** (`services/billing-service/src/providers/payment-provider.ts`).
+  That billing-service port is the **client** that will point at this gateway once
+  the money path is migrated — the shapes are kept compatible so the seam is a
+  drop-in.
+- **The adapter** (`src/providers/stripe/stripe-payment-provider.ts`) is the
+  **only** file allowed to import the Stripe SDK. **Swapping vendors = adding a
+  sibling adapter** (e.g. `src/providers/adyen/…`) that implements the same port
+  and pointing `PAYMENT_PROVIDER` at it. No call-site changes.
+
+## The pre/post hook seam
+
+Every vendor call in the adapter is wrapped in `ProviderHooks`
+(`onBeforeCall` / `onAfterCall` / `onError`). This is where cross-cutting
+concerns — metrics, idempotency keys, payload transforms, retries, audit — are
+added once, centrally, without touching the neutral API or the consumers.
+
+## Configuration
+
+Runnable with **zero secrets** (degraded mode → `/health` only, like
+billing-service's no-deps `createApp()`).
+
+| Env | Default | Purpose |
+|-----|---------|---------|
+| `PORT` | `3007` | HTTP port |
+| `PAYMENT_PROVIDER` | `stripe` | active vendor adapter (the swap knob) |
+| `STRIPE_SECRET_KEY` | — (optional in scaffold) | vendor secret; absent → degraded mode |
+| `PAYMENT_INTERNAL_TOKEN` | — | Bearer token guarding the neutral API (fail-closed when set) |
+
+## Neutral API surface (`openapi.yaml`)
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| POST | `/customers` | create/upsert a payment customer |
+| GET | `/customers/{customerId}` | retrieve a customer |
+| GET | `/customers/{customerId}/invoices` | list a customer's invoices (paged) |
+| POST | `/checkout-sessions` | open a hosted checkout session |
+| POST | `/payment-methods/setup` | begin collecting a payment method |
+| POST | `/webhooks/{provider}` | receive a vendor webhook (public, sig-verified) |
+
+No vendor names appear in any path or schema. Neutral schema names: `Customer`,
+`Invoice`, `CheckoutSession`, `PaymentMethodSetup`, `WebhookAck`.
+
+## Develop / test
+
+```bash
+cd services/payment-service
+npm install
+npm run typecheck   # tsc --noEmit
+npm test            # jest — asserts /health
+npm run dev         # ts-node, live reload
+```
+
+## Deploy
+
+Wired the same way as billing-service:
+
+- **Local:** `docker-compose.yml` `payment-service` block (port `3007`).
+- **Kubernetes:** `deploy/helm/fuzefront/templates/payment-service.yaml`
+  (Deployment + Service, gated by `paymentService.enabled`, probes on `/health`),
+  values in `values.yaml` / `values-prod.yaml`. Synced by the **umbrella
+  `fuzefront` Argo Application** (hybrid-Argo: same rule as billing/unleash — a
+  second Argo app on the same chart path would double-claim the Deployment; a
+  dedicated app is only correct once the service is extracted into its own chart).
+- **Secrets:** per-service `payment-secrets` SealedSecret scaffold
+  (`deploy/contabo/sealed/payment-secrets.yaml`) — `STRIPE_SECRET_KEY`,
+  `PAYMENT_INTERNAL_TOKEN`. Seal real values with
+  `deploy/scripts/seal-secret.sh <KEY> --scope fuzefront/payment-secrets`.
+- **CI image build** must be added to `.github/workflows/release.yml` — see
+  `deploy/PENDING-WORKFLOW-CHANGES-payment-service.md` (the bot cannot edit
+  workflows).

--- a/services/payment-service/jest.config.js
+++ b/services/payment-service/jest.config.js
@@ -1,0 +1,11 @@
+// services/payment-service/jest.config.js
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/tests'],
+  testMatch: ['**/*.test.ts'],
+  transform: {
+    '^.+\\.ts$': ['ts-jest', { tsconfig: 'tests/tsconfig.json' }],
+  },
+  testTimeout: 60000,
+};

--- a/services/payment-service/openapi.yaml
+++ b/services/payment-service/openapi.yaml
@@ -1,0 +1,576 @@
+openapi: 3.1.0
+info:
+  title: FuzeFront Payment Provider API
+  version: 0.1.0
+  description: >-
+    The vendor-AGNOSTIC payment gateway for FuzeFront. This service is the single
+    seam through which ALL payment-vendor interaction (customers, checkout,
+    invoices, payment-method setup, webhooks) is routed. Consumers —
+    billing-service and other products — speak ONLY this neutral API and never a
+    vendor SDK, so the underlying vendor can be swapped (or run in parallel) by
+    adding a sibling adapter behind the port, and pre/post hooks can be inserted
+    centrally.
+
+    NO vendor names appear in these paths or schemas by design. The active vendor
+    is selected server-side (`PAYMENT_PROVIDER`, default `stripe`) and confined to
+    its adapter (`src/providers/<vendor>/`).
+
+    SCAFFOLD STATUS (v0.1.0): this is the runnable gateway contract + adapter
+    skeleton. The adapter methods are not yet wired to the vendor and return
+    `501 Not Implemented`; the live money path is being absorbed from
+    billing-service progressively. This is NOT yet the live money path.
+
+    Card data never flows through this API — only provider ids and client
+    secrets.
+  license:
+    name: UNLICENSED
+
+servers:
+  - url: '{baseUrl}/api/v1/payments'
+    description: payment-service, mounted under /api/v1/payments
+    variables:
+      baseUrl:
+        default: http://fuzefront-payment-service:3007
+        description: Cluster-internal base URL of the payment-service.
+
+tags:
+  - name: customers
+    description: Vendor-neutral payment customers, keyed by the provider's customer id.
+  - name: invoices
+    description: Read-only invoice history for a customer (provider-backed).
+  - name: checkout
+    description: Hosted checkout session creation (subscription / payment / setup modes).
+  - name: payment-methods
+    description: Collect a payment method without an immediate charge.
+  - name: webhooks
+    description: Provider webhook receiver (public, signature-verified).
+  - name: health
+    description: Liveness / readiness.
+
+paths:
+  /customers:
+    post:
+      operationId: createCustomer
+      tags: [customers]
+      summary: Create (or upsert) a payment customer
+      description: >-
+        Creates a neutral payment customer for a FuzeFront entity. The response
+        is vendor-agnostic — only the neutral `providerCustomerId` is exposed.
+      security:
+        - internalToken: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateCustomerRequest'
+      responses:
+        '201':
+          description: Customer created.
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: false
+                required: [customer]
+                properties:
+                  customer:
+                    $ref: '#/components/schemas/Customer'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '501':
+          $ref: '#/components/responses/NotImplemented'
+        '502':
+          $ref: '#/components/responses/ProviderError'
+
+  /customers/{customerId}:
+    parameters:
+      - $ref: '#/components/parameters/CustomerId'
+    get:
+      operationId: getCustomer
+      tags: [customers]
+      summary: Retrieve a payment customer
+      security:
+        - internalToken: []
+      responses:
+        '200':
+          description: The customer.
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: false
+                required: [customer]
+                properties:
+                  customer:
+                    $ref: '#/components/schemas/Customer'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '501':
+          $ref: '#/components/responses/NotImplemented'
+        '502':
+          $ref: '#/components/responses/ProviderError'
+
+  /customers/{customerId}/invoices:
+    parameters:
+      - $ref: '#/components/parameters/CustomerId'
+    get:
+      operationId: listInvoices
+      tags: [invoices]
+      summary: List a customer's invoices
+      description: >-
+        Returns a page of the customer's invoices, most-recent first, from the
+        active provider. Opaque-cursor pagination.
+      security:
+        - internalToken: []
+      parameters:
+        - name: limit
+          in: query
+          required: false
+          description: Page size, clamped server-side to 1..100. Defaults to 20.
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 20
+        - name: cursor
+          in: query
+          required: false
+          description: Opaque cursor (the provider paging token) for the next page.
+          schema:
+            type: string
+      responses:
+        '200':
+          description: A page of invoices (possibly empty).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InvoicePage'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '501':
+          $ref: '#/components/responses/NotImplemented'
+        '502':
+          $ref: '#/components/responses/ProviderError'
+
+  /checkout-sessions:
+    post:
+      operationId: createCheckoutSession
+      tags: [checkout]
+      summary: Create a hosted checkout session
+      description: >-
+        Opens a provider-hosted checkout session in `subscription`, `payment`, or
+        `setup` mode and returns the hosted `url` to redirect the customer to. No
+        raw card data touches this surface.
+      security:
+        - internalToken: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateCheckoutSessionRequest'
+      responses:
+        '201':
+          description: Checkout session created.
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: false
+                required: [session]
+                properties:
+                  session:
+                    $ref: '#/components/schemas/CheckoutSession'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '501':
+          $ref: '#/components/responses/NotImplemented'
+        '502':
+          $ref: '#/components/responses/ProviderError'
+
+  /payment-methods/setup:
+    post:
+      operationId: setupPaymentMethod
+      tags: [payment-methods]
+      summary: Begin collecting a payment method (no immediate charge)
+      description: >-
+        Starts a payment-method setup for the customer and returns the
+        `clientSecret` the front-end payment element needs. No charge is made.
+      security:
+        - internalToken: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PaymentMethodSetupRequest'
+      responses:
+        '201':
+          description: Payment-method setup started.
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: false
+                required: [setup]
+                properties:
+                  setup:
+                    $ref: '#/components/schemas/PaymentMethodSetup'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '501':
+          $ref: '#/components/responses/NotImplemented'
+        '502':
+          $ref: '#/components/responses/ProviderError'
+
+  /webhooks/{provider}:
+    parameters:
+      - name: provider
+        in: path
+        required: true
+        description: The vendor whose webhook is being delivered (e.g. `stripe`).
+        schema:
+          type: string
+    post:
+      operationId: receiveWebhook
+      tags: [webhooks]
+      summary: Receive a provider webhook
+      description: >-
+        Receives a vendor webhook. The body MUST be the raw signed bytes
+        (consumed via a raw-body parser) so signature verification works. Public
+        (no internal token) — authenticity is the provider signature. The gateway
+        neutralises the event before any consumer sees it.
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              description: Raw provider event (not parsed before signature verification).
+              additionalProperties: true
+      responses:
+        '200':
+          description: Webhook received (and handled, when understood).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WebhookAck'
+        '400':
+          description: Missing/invalid signature or payload.
+          content:
+            text/plain:
+              schema:
+                type: string
+        '501':
+          $ref: '#/components/responses/NotImplemented'
+        '502':
+          $ref: '#/components/responses/ProviderError'
+
+  /health:
+    get:
+      operationId: getHealth
+      tags: [health]
+      summary: Liveness / readiness probe
+      description: >-
+        Always available, even in degraded mode (no vendor key). Mounted at the
+        service root (`/health`), NOT under `/api/v1/payments`.
+      security: []
+      servers:
+        - url: '{baseUrl}'
+          variables:
+            baseUrl:
+              default: http://fuzefront-payment-service:3007
+      responses:
+        '200':
+          description: Service is up.
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: false
+                required: [status, service]
+                properties:
+                  status:
+                    type: string
+                    examples: [ok]
+                  service:
+                    type: string
+                    examples: [payment-service]
+
+components:
+  securitySchemes:
+    internalToken:
+      type: http
+      scheme: bearer
+      description: >-
+        `PAYMENT_INTERNAL_TOKEN` presented as a Bearer token by internal
+        consumers (billing-service / the host proxy). Verified by
+        `requireInternalToken`.
+
+  parameters:
+    CustomerId:
+      name: customerId
+      in: path
+      required: true
+      description: The neutral payment customer id (the active provider's customer id).
+      schema:
+        type: string
+
+  responses:
+    Unauthorized:
+      description: Missing or invalid internal token.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+    NotFound:
+      description: Resource not found.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+    ValidationError:
+      description: Request body failed validation.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+    NotImplemented:
+      description: >-
+        Gateway scaffold — this call is not yet wired to the vendor. The path,
+        shapes, and auth are frozen; the live path is being absorbed from
+        billing-service.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+    ProviderError:
+      description: Upstream payment-provider error (bad gateway).
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+
+  schemas:
+    EntityType:
+      type: string
+      enum: [user, organization]
+      description: Which FuzeFront entity owns the payment relationship.
+
+    Customer:
+      type: object
+      additionalProperties: false
+      required: [providerCustomerId, email, name, metadata]
+      properties:
+        providerCustomerId:
+          type: string
+          description: The active provider's customer id (opaque to consumers).
+        email:
+          type: [string, 'null']
+        name:
+          type: [string, 'null']
+        metadata:
+          type: object
+          additionalProperties:
+            type: string
+
+    CreateCustomerRequest:
+      type: object
+      additionalProperties: false
+      properties:
+        email:
+          type: string
+        name:
+          type: string
+        entityType:
+          $ref: '#/components/schemas/EntityType'
+        entityId:
+          type: string
+          format: uuid
+        metadata:
+          type: object
+          additionalProperties:
+            type: string
+
+    Invoice:
+      type: object
+      additionalProperties: false
+      required:
+        - providerInvoiceId
+        - number
+        - status
+        - amountDueCents
+        - amountPaidCents
+        - currency
+        - hostedInvoiceUrl
+        - invoicePdfUrl
+        - issuedAt
+      properties:
+        providerInvoiceId:
+          type: string
+        number:
+          type: [string, 'null']
+          description: Human-facing invoice number; null for drafts without one.
+        status:
+          type: string
+          description: 'Neutral invoice status: draft|open|paid|void|uncollectible.'
+          examples: [draft, open, paid, void, uncollectible]
+        amountDueCents:
+          type: integer
+          minimum: 0
+        amountPaidCents:
+          type: integer
+          minimum: 0
+        currency:
+          type: string
+          description: ISO 4217 code, lowercased.
+          examples: [usd]
+        hostedInvoiceUrl:
+          type: [string, 'null']
+        invoicePdfUrl:
+          type: [string, 'null']
+        issuedAt:
+          type: string
+          format: date-time
+
+    InvoicePage:
+      type: object
+      additionalProperties: false
+      required: [invoices, hasMore]
+      properties:
+        invoices:
+          type: array
+          items:
+            $ref: '#/components/schemas/Invoice'
+        hasMore:
+          type: boolean
+          description: True when another page is available (fetch with the last cursor).
+
+    CheckoutMode:
+      type: string
+      enum: [subscription, payment, setup]
+
+    CheckoutLineItem:
+      type: object
+      additionalProperties: false
+      required: [name, unitAmountCents, quantity]
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 250
+        description:
+          type: string
+          maxLength: 500
+        unitAmountCents:
+          type: integer
+          minimum: 1
+        quantity:
+          type: integer
+          minimum: 1
+
+    CreateCheckoutSessionRequest:
+      type: object
+      additionalProperties: false
+      required: [mode, successUrl, cancelUrl]
+      properties:
+        mode:
+          $ref: '#/components/schemas/CheckoutMode'
+        providerCustomerId:
+          type: string
+        currency:
+          type: string
+          minLength: 3
+          maxLength: 3
+          description: ISO 4217 code (required for `payment` mode).
+        lineItems:
+          type: array
+          minItems: 1
+          maxItems: 50
+          items:
+            $ref: '#/components/schemas/CheckoutLineItem'
+        priceId:
+          type: string
+          description: Provider price id (for `subscription` mode).
+        successUrl:
+          type: string
+          format: uri
+        cancelUrl:
+          type: string
+          format: uri
+        clientReferenceId:
+          type: string
+          description: Opaque correlation id echoed on the resulting webhook.
+        metadata:
+          type: object
+          additionalProperties:
+            type: string
+
+    CheckoutSession:
+      type: object
+      additionalProperties: false
+      required: [providerSessionId, url, mode]
+      properties:
+        providerSessionId:
+          type: string
+        url:
+          type: [string, 'null']
+          description: Provider-hosted checkout URL to redirect the customer to.
+        mode:
+          $ref: '#/components/schemas/CheckoutMode'
+
+    PaymentMethodSetupRequest:
+      type: object
+      additionalProperties: false
+      required: [providerCustomerId]
+      properties:
+        providerCustomerId:
+          type: string
+        usage:
+          type: string
+          enum: [on_session, off_session]
+          default: off_session
+        metadata:
+          type: object
+          additionalProperties:
+            type: string
+
+    PaymentMethodSetup:
+      type: object
+      additionalProperties: false
+      required: [clientSecret, providerSetupId]
+      properties:
+        clientSecret:
+          type: string
+          description: Client secret for the provider's payment element.
+        providerSetupId:
+          type: string
+
+    WebhookAck:
+      type: object
+      additionalProperties: false
+      required: [received]
+      properties:
+        received:
+          type: boolean
+        handled:
+          type: boolean
+          description: True when the gateway understood and neutralised the event.
+
+    Error:
+      type: object
+      additionalProperties: false
+      required: [error]
+      properties:
+        error:
+          type: string
+        message:
+          type: string

--- a/services/payment-service/package-lock.json
+++ b/services/payment-service/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@fuzefront/payment-service",
       "version": "0.1.0",
       "dependencies": {
-        "express": "4.19.2",
+        "express": "4.21.2",
         "stripe": "^17",
         "zod": "3.22.4"
       },
@@ -1577,9 +1577,9 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "1.20.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
-      "integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
+      "version": "1.20.3",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
+      "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
       "license": "MIT",
       "dependencies": {
         "bytes": "3.1.2",
@@ -1590,7 +1590,7 @@
         "http-errors": "2.0.0",
         "iconv-lite": "0.4.24",
         "on-finished": "2.4.1",
-        "qs": "6.11.0",
+        "qs": "6.13.0",
         "raw-body": "2.5.2",
         "type-is": "~1.6.18",
         "unpipe": "1.0.0"
@@ -1954,9 +1954,9 @@
       "license": "MIT"
     },
     "node_modules/cookie": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -2171,9 +2171,9 @@
       "license": "MIT"
     },
     "node_modules/encodeurl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -2335,37 +2335,37 @@
       }
     },
     "node_modules/express": {
-      "version": "4.19.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.19.2.tgz",
-      "integrity": "sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
+      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
       "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "1.20.2",
+        "body-parser": "1.20.3",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.6.0",
+        "cookie": "0.7.1",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
-        "encodeurl": "~1.0.2",
+        "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "etag": "~1.8.1",
-        "finalhandler": "1.2.0",
+        "finalhandler": "1.3.1",
         "fresh": "0.5.2",
         "http-errors": "2.0.0",
-        "merge-descriptors": "1.0.1",
+        "merge-descriptors": "1.0.3",
         "methods": "~1.1.2",
         "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.7",
+        "path-to-regexp": "0.1.12",
         "proxy-addr": "~2.0.7",
-        "qs": "6.11.0",
+        "qs": "6.13.0",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
-        "send": "0.18.0",
-        "serve-static": "1.15.0",
+        "send": "0.19.0",
+        "serve-static": "1.16.2",
         "setprototypeof": "1.2.0",
         "statuses": "2.0.1",
         "type-is": "~1.6.18",
@@ -2374,6 +2374,10 @@
       },
       "engines": {
         "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/fast-json-stable-stringify": {
@@ -2414,13 +2418,13 @@
       }
     },
     "node_modules/finalhandler": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
-      "integrity": "sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
+      "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
       "license": "MIT",
       "dependencies": {
         "debug": "2.6.9",
-        "encodeurl": "~1.0.2",
+        "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
@@ -3810,10 +3814,13 @@
       }
     },
     "node_modules/merge-descriptors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-      "integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==",
-      "license": "MIT"
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -4216,9 +4223,9 @@
       "license": "MIT"
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-      "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==",
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
       "license": "MIT"
     },
     "node_modules/picocolors": {
@@ -4344,12 +4351,12 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
-      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.0.4"
+        "side-channel": "^1.0.6"
       },
       "engines": {
         "node": ">=0.6"
@@ -4504,9 +4511,9 @@
       }
     },
     "node_modules/send": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
-      "integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
+      "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
       "license": "MIT",
       "dependencies": {
         "debug": "2.6.9",
@@ -4527,6 +4534,15 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/send/node_modules/encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/send/node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -4534,15 +4550,15 @@
       "license": "MIT"
     },
     "node_modules/serve-static": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz",
-      "integrity": "sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==",
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
+      "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
       "license": "MIT",
       "dependencies": {
-        "encodeurl": "~1.0.2",
+        "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "parseurl": "~1.3.3",
-        "send": "0.18.0"
+        "send": "0.19.0"
       },
       "engines": {
         "node": ">= 0.8.0"

--- a/services/payment-service/package-lock.json
+++ b/services/payment-service/package-lock.json
@@ -1,0 +1,5397 @@
+{
+  "name": "@fuzefront/payment-service",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@fuzefront/payment-service",
+      "version": "0.1.0",
+      "dependencies": {
+        "express": "4.19.2",
+        "stripe": "^17",
+        "zod": "3.22.4"
+      },
+      "devDependencies": {
+        "@types/express": "4.17.21",
+        "@types/jest": "29.5.12",
+        "@types/node": "18.19.0",
+        "@types/supertest": "6.0.2",
+        "jest": "29.7.0",
+        "nodemon": "3.0.1",
+        "supertest": "6.3.3",
+        "ts-jest": "29.1.1",
+        "ts-node": "10.9.2",
+        "typescript": "5.1.6"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/core/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-async-generators": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+      "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-bigint": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
+      "integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-class-properties": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
+      "integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-class-static-block": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
+      "integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-attributes": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.29.7.tgz",
+      "integrity": "sha512-zGYcYfq/WmZ4V+kBIXQon9dSSc8ircGZqw9ZaNhhGj9nZkeBu1jHLBDQqYYi5WA9uawvA2sIMbry2nCFhf5Djg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-meta": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
+      "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-json-strings": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
+      "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-jsx": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.29.7.tgz",
+      "integrity": "sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-logical-assignment-operators": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
+      "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-nullish-coalescing-operator": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+      "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-numeric-separator": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
+      "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-object-rest-spread": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+      "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-optional-catch-binding": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
+      "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-optional-chaining": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+      "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-private-property-in-object": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
+      "integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-top-level-await": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
+      "integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-typescript": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.29.7.tgz",
+      "integrity": "sha512-ngr+82Sh0xMz25TPCZi+nC2iTzjfCdWS2ONXTp/PtSCHCgaCNBpdMqgvJ2ccdLlClVZ7sisIgB914j/JFe+RZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/traverse/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+      "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.3.1",
+        "find-up": "^4.1.0",
+        "get-package-type": "^0.1.0",
+        "js-yaml": "^3.13.1",
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/console": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.7.0.tgz",
+      "integrity": "sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/core": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.7.0.tgz",
+      "integrity": "sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/reporters": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.9",
+        "jest-changed-files": "^29.7.0",
+        "jest-config": "^29.7.0",
+        "jest-haste-map": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-resolve-dependencies": "^29.7.0",
+        "jest-runner": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "jest-watcher": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/environment": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
+      "integrity": "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-mock": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/expect": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^29.7.0",
+        "jest-snapshot": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/expect-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
+      "integrity": "sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-get-type": "^29.6.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/fake-timers": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
+      "integrity": "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@sinonjs/fake-timers": "^10.0.2",
+        "@types/node": "*",
+        "jest-message-util": "^29.7.0",
+        "jest-mock": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/globals": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
+      "integrity": "sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/expect": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "jest-mock": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/reporters": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.7.0.tgz",
+      "integrity": "sha512-DApq0KJbJOEzAFYjHADNNxAE3KbhxQB1y5Kplb5Waqw6zVbuWatSnMjE5gs8FUgEPmNsnZA3NCWl9NG0ia04Pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^0.2.3",
+        "@jest/console": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "exit": "^0.1.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-instrument": "^6.0.0",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-lib-source-maps": "^4.0.0",
+        "istanbul-reports": "^3.1.3",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "slash": "^3.0.0",
+        "string-length": "^4.0.1",
+        "strip-ansi": "^6.0.0",
+        "v8-to-istanbul": "^9.0.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/source-map": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.6.3.tgz",
+      "integrity": "sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "callsites": "^3.0.0",
+        "graceful-fs": "^4.2.9"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/test-result": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.7.0.tgz",
+      "integrity": "sha512-Fdx+tv6x1zlkJPcWXmMDAG2HBnaR9XPSd5aDWQVsfrZmLVT3lU1cwyxLgRmXR9yrq4NBoEm9BMsfgFzTQAbJYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "collect-v8-coverage": "^1.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/test-sequencer": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.7.0.tgz",
+      "integrity": "sha512-GQwJ5WZVrKnOJuiYiAF52UNUJXgTZx1NHjFSEB0qEMmSZKAkdMoIzw/Cj6x6NF4AvV23AUqDpFzQkN/eYCYTxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/test-result": "^29.7.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/transform": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
+      "integrity": "sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@jest/types": "^29.6.3",
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "babel-plugin-istanbul": "^6.1.1",
+        "chalk": "^4.0.0",
+        "convert-source-map": "^2.0.0",
+        "fast-json-stable-stringify": "^2.1.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "pirates": "^4.0.4",
+        "slash": "^3.0.0",
+        "write-file-atomic": "^4.0.2"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/types": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
+      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.8",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
+      "integrity": "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
+      }
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.27.10",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
+      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sinonjs/commons": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
+      "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
+      "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/cookiejar": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
+      "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/express": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
+      "integrity": "sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.33",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "4.19.9",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.9.tgz",
+      "integrity": "sha512-QP2ESEe/ImWY0HDwNAnK9PvEffUyhLTnWkk7KXzHfyeWAnlrDe1fN77bXl6ia8KT3wPlmA7t9/VPRpnf4Ex9sg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/graceful-fs": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
+      "integrity": "sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/istanbul-lib-coverage": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/istanbul-lib-report": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
+      "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "*"
+      }
+    },
+    "node_modules/@types/istanbul-reports": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
+      "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/istanbul-lib-report": "*"
+      }
+    },
+    "node_modules/@types/jest": {
+      "version": "29.5.12",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.12.tgz",
+      "integrity": "sha512-eDC8bTvT/QhYdxJAulQikueigY5AsdBRH2yDKW3yveW7svY3+DzN84/2NUgkw10RTiJbWqZrTtoGVdYlvFJdLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^29.0.0",
+        "pretty-format": "^29.0.0"
+      }
+    },
+    "node_modules/@types/methods": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
+      "integrity": "sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "18.19.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.0.tgz",
+      "integrity": "sha512-667KNhaD7U29mT5wf+TZUnrzPrlL2GNQ5N0BMjO2oNULhBxX0/FKCkm6JMu0Jh7Z+1LwUlR21ekd7KhIboNFNw==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@types/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/stack-utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
+      "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/superagent": {
+      "version": "8.1.11",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-8.1.11.tgz",
+      "integrity": "sha512-KA7srSW/HENDtOw9DOqaFLgWuMqN9WgjEw62lh9dpvRaZDkhdOkazASd7X7i2eMUYLHa1U37ZttnePsH5zTDHw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/cookiejar": "^2.1.5",
+        "@types/methods": "^1.1.4",
+        "@types/node": "*",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/@types/supertest": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-6.0.2.tgz",
+      "integrity": "sha512-137ypx2lk/wTQbW6An6safu9hXmajAifU/s7szAHLN/FeIm5w7yR0Wkl9fdJMRSHwOn4HLAI0DaB2TOORuhPDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/methods": "^1.1.4",
+        "@types/superagent": "^8.1.0"
+      }
+    },
+    "node_modules/@types/yargs": {
+      "version": "17.0.35",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
+      "integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@types/yargs-parser": {
+      "version": "21.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+      "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.21.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/babel-jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
+      "integrity": "sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/transform": "^29.7.0",
+        "@types/babel__core": "^7.1.14",
+        "babel-plugin-istanbul": "^6.1.1",
+        "babel-preset-jest": "^29.6.3",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.8.0"
+      }
+    },
+    "node_modules/babel-plugin-istanbul": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
+      "integrity": "sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@istanbuljs/load-nyc-config": "^1.0.0",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-instrument": "^5.0.4",
+        "test-exclude": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/babel-plugin-istanbul/node_modules/istanbul-lib-instrument": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
+      "integrity": "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/core": "^7.12.3",
+        "@babel/parser": "^7.14.7",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/babel-plugin-jest-hoist": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.6.3.tgz",
+      "integrity": "sha512-ESAc/RJvGTFEzRwOTT4+lNDk/GNHMkKbNzsvT0qKRfDyyYTskxB5rnU2njIDYVxXCBHHEI1c0YwHob3WaYujOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.3.3",
+        "@babel/types": "^7.3.3",
+        "@types/babel__core": "^7.1.14",
+        "@types/babel__traverse": "^7.0.6"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/babel-preset-current-node-syntax": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.2.0.tgz",
+      "integrity": "sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/plugin-syntax-async-generators": "^7.8.4",
+        "@babel/plugin-syntax-bigint": "^7.8.3",
+        "@babel/plugin-syntax-class-properties": "^7.12.13",
+        "@babel/plugin-syntax-class-static-block": "^7.14.5",
+        "@babel/plugin-syntax-import-attributes": "^7.24.7",
+        "@babel/plugin-syntax-import-meta": "^7.10.4",
+        "@babel/plugin-syntax-json-strings": "^7.8.3",
+        "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+        "@babel/plugin-syntax-numeric-separator": "^7.10.4",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
+        "@babel/plugin-syntax-private-property-in-object": "^7.14.5",
+        "@babel/plugin-syntax-top-level-await": "^7.14.5"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0 || ^8.0.0-0"
+      }
+    },
+    "node_modules/babel-preset-jest": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.6.3.tgz",
+      "integrity": "sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "babel-plugin-jest-hoist": "^29.6.3",
+        "babel-preset-current-node-syntax": "^1.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.43",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.43.tgz",
+      "integrity": "sha512-AjYpR78kDWAY3Efj+cDTFH9t9SCoL7OoTp1BOb0mQV7S+6CiLwnWM3FyxhJtdPufDFKzmCSFoUncKjWgJEZTCQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
+      "integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "on-finished": "2.4.1",
+        "qs": "6.11.0",
+        "raw-body": "2.5.2",
+        "type-is": "~1.6.18",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.6",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.6.tgz",
+      "integrity": "sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.42",
+        "caniuse-lite": "^1.0.30001803",
+        "electron-to-chromium": "^1.5.389",
+        "node-releases": "^2.0.51",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/bs-logger": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
+      "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-json-stable-stringify": "2.x"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/bser": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
+      "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001805",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001805.tgz",
+      "integrity": "sha512-52noaS3DubycKSXaU30TwPGIp+POyQSUVa5jBEq3vkRkY0kjyb3LQgvhU6WGyCcyXqVLWO0Cw0Q6BSdD0kUfVA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/char-regex": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+      "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+      "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">= 1.0.0",
+        "node": ">= 0.12.0"
+      }
+    },
+    "node_modules/collect-v8-coverage": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.3.tgz",
+      "integrity": "sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/create-jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
+      "integrity": "sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.9",
+        "jest-config": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "prompts": "^2.0.1"
+      },
+      "bin": {
+        "create-jest": "bin/create-jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/dedent": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
+      "integrity": "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "babel-plugin-macros": "^3.1.0"
+      },
+      "peerDependenciesMeta": {
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/detect-newline": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
+      "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/diff": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.389",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.389.tgz",
+      "integrity": "sha512-cEto7aeOqBfU1D+c5py5pE+ooscKE75JifxLBdFUZsqAxRS6y7kebtxAZvICszSl05gPjYHDTjY+lXpyGvpJbg==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/emittery": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz",
+      "integrity": "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/emittery?sponsor=1"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/exit": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/expect": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/expect-utils": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.19.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.19.2.tgz",
+      "integrity": "sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.20.2",
+        "content-disposition": "0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "0.6.0",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "1.2.0",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~2.0.7",
+        "qs": "6.11.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "0.18.0",
+        "serve-static": "1.15.0",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fb-watchman": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
+      "integrity": "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bser": "2.1.1"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
+      "integrity": "sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "2.0.1",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.1.5.tgz",
+      "integrity": "sha512-Oz5Hwvwak/DCaXVVUtPn4oLMLLy1CdclLKO1LFgU7XzDpVMUU5UjlSLpGMocyQNNk8F6IJW9M/YdooSn2MRI+Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0",
+        "qs": "^6.11.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-package-type": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
+      "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ignore-by-default": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
+      "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/import-local": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
+      "integrity": "sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pkg-dir": "^4.2.0",
+        "resolve-cwd": "^3.0.0"
+      },
+      "bin": {
+        "import-local-fixture": "fixtures/cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-generator-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
+      "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-instrument": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
+      "integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/core": "^7.23.9",
+        "@babel/parser": "^7.23.9",
+        "@istanbuljs/schema": "^0.1.3",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-instrument/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
+      "integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/istanbul-lib-source-maps/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
+      "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/core": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "import-local": "^3.0.2",
+        "jest-cli": "^29.7.0"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-changed-files": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-29.7.0.tgz",
+      "integrity": "sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "execa": "^5.0.0",
+        "jest-util": "^29.7.0",
+        "p-limit": "^3.1.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-circus": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.7.0.tgz",
+      "integrity": "sha512-3E1nCMgipcTkCocFwM90XXQab9bS+GMsjdpmPrlelaxwD93Ad8iVEjX/vvHPdLPnFf+L40u+5+iutRdA1N9myw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/expect": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "co": "^4.6.0",
+        "dedent": "^1.0.0",
+        "is-generator-fn": "^2.0.0",
+        "jest-each": "^29.7.0",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "p-limit": "^3.1.0",
+        "pretty-format": "^29.7.0",
+        "pure-rand": "^6.0.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-cli": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.7.0.tgz",
+      "integrity": "sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/core": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "create-jest": "^29.7.0",
+        "exit": "^0.1.2",
+        "import-local": "^3.0.2",
+        "jest-config": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "yargs": "^17.3.1"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-config": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.7.0.tgz",
+      "integrity": "sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@jest/test-sequencer": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "babel-jest": "^29.7.0",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "deepmerge": "^4.2.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-circus": "^29.7.0",
+        "jest-environment-node": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-runner": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "parse-json": "^5.2.0",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@types/node": "*",
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "ts-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-diff": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
+      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^29.6.3",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-docblock": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.7.0.tgz",
+      "integrity": "sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-each": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.7.0.tgz",
+      "integrity": "sha512-gns+Er14+ZrEoC5fhOfYCY1LOHHr0TI+rQUHZS8Ttw2l7gl+80eHc/gFf2Ktkw0+SIACDTeWvpFcv3B04VembQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-environment-node": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
+      "integrity": "sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-mock": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-get-type": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
+      "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-haste-map": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
+      "integrity": "sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/graceful-fs": "^4.1.3",
+        "@types/node": "*",
+        "anymatch": "^3.0.3",
+        "fb-watchman": "^2.0.0",
+        "graceful-fs": "^4.2.9",
+        "jest-regex-util": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "walker": "^1.0.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "^2.3.2"
+      }
+    },
+    "node_modules/jest-leak-detector": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz",
+      "integrity": "sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
+      "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-message-util": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
+      "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.12.13",
+        "@jest/types": "^29.6.3",
+        "@types/stack-utils": "^2.0.0",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-mock": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
+      "integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-pnp-resolver": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
+      "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "peerDependencies": {
+        "jest-resolve": "*"
+      },
+      "peerDependenciesMeta": {
+        "jest-resolve": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-regex-util": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
+      "integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-resolve": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.7.0.tgz",
+      "integrity": "sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-pnp-resolver": "^1.2.2",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "resolve": "^1.20.0",
+        "resolve.exports": "^2.0.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-resolve-dependencies": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.7.0.tgz",
+      "integrity": "sha512-un0zD/6qxJ+S0et7WxeI3H5XSe9lTBBR7bOHCHXkKR6luG5mwDDlIzVQ0V5cZCuoTgEdcdwzTghYkTWfubi+nA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-regex-util": "^29.6.3",
+        "jest-snapshot": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-runner": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.7.0.tgz",
+      "integrity": "sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/environment": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "emittery": "^0.13.1",
+        "graceful-fs": "^4.2.9",
+        "jest-docblock": "^29.7.0",
+        "jest-environment-node": "^29.7.0",
+        "jest-haste-map": "^29.7.0",
+        "jest-leak-detector": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-resolve": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-watcher": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "p-limit": "^3.1.0",
+        "source-map-support": "0.5.13"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-runtime": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.7.0.tgz",
+      "integrity": "sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/globals": "^29.7.0",
+        "@jest/source-map": "^29.6.3",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "cjs-module-lexer": "^1.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-mock": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-bom": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-snapshot": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
+      "integrity": "sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@babel/generator": "^7.7.2",
+        "@babel/plugin-syntax-jsx": "^7.7.2",
+        "@babel/plugin-syntax-typescript": "^7.7.2",
+        "@babel/types": "^7.3.3",
+        "@jest/expect-utils": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "babel-preset-current-node-syntax": "^1.0.0",
+        "chalk": "^4.0.0",
+        "expect": "^29.7.0",
+        "graceful-fs": "^4.2.9",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "natural-compare": "^1.4.0",
+        "pretty-format": "^29.7.0",
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-snapshot/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/jest-util": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
+      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "graceful-fs": "^4.2.9",
+        "picomatch": "^2.2.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-validate": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.7.0.tgz",
+      "integrity": "sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "camelcase": "^6.2.0",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^29.6.3",
+        "leven": "^3.1.0",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-validate/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-watcher": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.7.0.tgz",
+      "integrity": "sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "emittery": "^0.13.1",
+        "jest-util": "^29.7.0",
+        "string-length": "^4.0.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-worker": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
+      "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "jest-util": "^29.7.0",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-worker/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/leven": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+      "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/lodash.memoize": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/makeerror": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
+      "integrity": "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tmpl": "1.0.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==",
+      "license": "MIT"
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-int64": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.51",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
+      "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/nodemon": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.0.1.tgz",
+      "integrity": "sha512-g9AZ7HmkhQkqXkRc20w+ZfQ73cHLbE8hnPbtaFbFtCumZsjyMhKk9LajQ07U5Ux28lvFjZ5X7HvWR1xzU8jHVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "^3.5.2",
+        "debug": "^3.2.7",
+        "ignore-by-default": "^1.0.1",
+        "minimatch": "^3.1.2",
+        "pstree.remy": "^1.1.8",
+        "semver": "^7.5.3",
+        "simple-update-notifier": "^2.0.0",
+        "supports-color": "^5.5.0",
+        "touch": "^3.1.0",
+        "undefsafe": "^2.0.5"
+      },
+      "bin": {
+        "nodemon": "bin/nodemon.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/nodemon"
+      }
+    },
+    "node_modules/nodemon/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/nodemon/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/nodemon/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nodemon/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/nodemon/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-locate/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+      "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==",
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/pkg-dir": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/prompts": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/pstree.remy": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
+      "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pure-rand": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
+      "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/qs": {
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
+      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-cwd": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+      "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/resolve.exports": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.3.tgz",
+      "integrity": "sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/send": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
+      "integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz",
+      "integrity": "sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "0.18.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/simple-update-notifier": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
+      "integrity": "sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/simple-update-notifier/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/stack-utils": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/string-length": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
+      "integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "char-regex": "^1.0.2",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-bom": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/stripe": {
+      "version": "17.7.0",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-17.7.0.tgz",
+      "integrity": "sha512-aT2BU9KkizY9SATf14WhhYVv2uOapBWX0OFWF4xvcj1mPaNotlSc2CsxpS4DS46ZueSppmCF5BX1sNYBtwBvfw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=8.1.0",
+        "qs": "^6.11.0"
+      },
+      "engines": {
+        "node": ">=12.*"
+      }
+    },
+    "node_modules/superagent": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-8.1.2.tgz",
+      "integrity": "sha512-6WTxW1EB6yCxV5VFOIPQruWGHqc3yI7hEmZK6h+pyk69Lk/Ut7rLUY6W/ONF2MjBuGjvmMiIpsrVJ2vjrHlslA==",
+      "deprecated": "Please upgrade to superagent v10.2.2+, see release notes at https://github.com/forwardemail/superagent/releases/tag/v10.2.2 - maintenance is supported by Forward Email @ https://forwardemail.net",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.0",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.4",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.0",
+        "formidable": "^2.1.2",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.11.0",
+        "semver": "^7.3.8"
+      },
+      "engines": {
+        "node": ">=6.4.0 <13 || >=14"
+      }
+    },
+    "node_modules/superagent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/superagent/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/superagent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/superagent/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/supertest": {
+      "version": "6.3.3",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-6.3.3.tgz",
+      "integrity": "sha512-EMCG6G8gDu5qEqRQ3JjjPs6+FYT1a7Hv5ApHvtSghmOFJYtsU5S+pSb6Y2EUeCEY3CmEL3mmQ8YWlPOzQomabA==",
+      "deprecated": "Please upgrade to supertest v7.1.3+, see release notes at https://github.com/forwardemail/supertest/releases/tag/v7.1.3 - maintenance is supported by Forward Email @ https://forwardemail.net",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "methods": "^1.1.2",
+        "superagent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">=6.4.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+      "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^7.1.4",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tmpl": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/touch": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.1.tgz",
+      "integrity": "sha512-r0eojU4bI8MnHr8c5bNo7lJDdI2qXlWWJk6a9EAFG7vbhTjElYhBVS3/miuE0uOuoLdb8Mc/rVfsmm6eo5o9GA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "nodetouch": "bin/nodetouch.js"
+      }
+    },
+    "node_modules/ts-jest": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.1.1.tgz",
+      "integrity": "sha512-D6xjnnbP17cC85nliwGiL+tpoKN0StpgE0TeOjXQTU6MVCfsB4v7aW05CgQ/1OywGb0x/oy9hHFnN+sczTiRaA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bs-logger": "0.x",
+        "fast-json-stable-stringify": "2.x",
+        "jest-util": "^29.0.0",
+        "json5": "^2.2.3",
+        "lodash.memoize": "4.x",
+        "make-error": "1.x",
+        "semver": "^7.5.3",
+        "yargs-parser": "^21.0.1"
+      },
+      "bin": {
+        "ts-jest": "cli.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": ">=7.0.0-beta.0 <8",
+        "@jest/types": "^29.0.0",
+        "babel-jest": "^29.0.0",
+        "jest": "^29.0.0",
+        "typescript": ">=4.3 <6"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "@jest/types": {
+          "optional": true
+        },
+        "babel-jest": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-jest/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undefsafe": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
+      "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/v8-to-istanbul": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
+      "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.12",
+        "@types/istanbul-lib-coverage": "^2.0.1",
+        "convert-source-map": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/walker": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
+      "integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/write-file-atomic": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
+      "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.7"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
+      "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/services/payment-service/package-lock.json
+++ b/services/payment-service/package-lock.json
@@ -8,12 +8,12 @@
       "name": "@fuzefront/payment-service",
       "version": "0.1.0",
       "dependencies": {
-        "express": "4.21.2",
+        "express": "^5.1.0",
         "stripe": "^17",
         "zod": "3.22.4"
       },
       "devDependencies": {
-        "@types/express": "4.17.21",
+        "@types/express": "^5.0.0",
         "@types/jest": "29.5.12",
         "@types/node": "18.19.0",
         "@types/supertest": "6.0.2",
@@ -80,31 +80,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/babel"
       }
-    },
-    "node_modules/@babel/core/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@babel/core/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@babel/generator": {
       "version": "7.29.7",
@@ -524,31 +499,6 @@
       "engines": {
         "node": ">=6.9.0"
       }
-    },
-    "node_modules/@babel/traverse/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@babel/traverse/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@babel/types": {
       "version": "7.29.7",
@@ -1116,22 +1066,21 @@
       "license": "MIT"
     },
     "node_modules/@types/express": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
-      "integrity": "sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
+      "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/body-parser": "*",
-        "@types/express-serve-static-core": "^4.17.33",
-        "@types/qs": "*",
-        "@types/serve-static": "*"
+        "@types/express-serve-static-core": "^5.0.0",
+        "@types/serve-static": "^2"
       }
     },
     "node_modules/@types/express-serve-static-core": {
-      "version": "4.19.9",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.9.tgz",
-      "integrity": "sha512-QP2ESEe/ImWY0HDwNAnK9PvEffUyhLTnWkk7KXzHfyeWAnlrDe1fN77bXl6ia8KT3wPlmA7t9/VPRpnf4Ex9sg==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.2.tgz",
+      "integrity": "sha512-d3KvEXBSo/lOAMc2u6fkyDHBvetBHeqD7wm/AcXfLpSOQwlmG9D/aQ0SFswVjv05p7ullQS7Mjohj6/VdbZuTg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1296,16 +1245,41 @@
       "license": "MIT"
     },
     "node_modules/accepts": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
-      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
       "license": "MIT",
       "dependencies": {
-        "mime-types": "~2.1.34",
-        "negotiator": "0.6.3"
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/acorn": {
@@ -1406,12 +1380,6 @@
       "dependencies": {
         "sprintf-js": "~1.0.2"
       }
-    },
-    "node_modules/array-flatten": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
-      "license": "MIT"
     },
     "node_modules/asap": {
       "version": "2.0.6",
@@ -1577,27 +1545,40 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "1.20.3",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
-      "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
       "dependencies": {
-        "bytes": "3.1.2",
-        "content-type": "~1.0.5",
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "on-finished": "2.4.1",
-        "qs": "6.13.0",
-        "raw-body": "2.5.2",
-        "type-is": "~1.6.18",
-        "unpipe": "1.0.0"
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
       "engines": {
-        "node": ">= 0.8",
-        "npm": "1.2.8000 || >= 1.4.16"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/brace-expansion": {
@@ -1926,15 +1907,16 @@
       "license": "MIT"
     },
     "node_modules/content-disposition": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
-      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
       "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "5.2.1"
-      },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/content-type": {
@@ -1963,10 +1945,13 @@
       }
     },
     "node_modules/cookie-signature": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
-      "license": "MIT"
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
     },
     "node_modules/cookiejar": {
       "version": "2.1.4",
@@ -2020,12 +2005,20 @@
       }
     },
     "node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
       "dependencies": {
-        "ms": "2.0.0"
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/dedent": {
@@ -2070,16 +2063,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/destroy": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
-      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8",
-        "npm": "1.2.8000 || >= 1.4.16"
       }
     },
     "node_modules/detect-newline": {
@@ -2335,45 +2318,67 @@
       }
     },
     "node_modules/express": {
-      "version": "4.21.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
-      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
       "dependencies": {
-        "accepts": "~1.3.8",
-        "array-flatten": "1.1.1",
-        "body-parser": "1.20.3",
-        "content-disposition": "0.5.4",
-        "content-type": "~1.0.4",
-        "cookie": "0.7.1",
-        "cookie-signature": "1.0.6",
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "finalhandler": "1.3.1",
-        "fresh": "0.5.2",
-        "http-errors": "2.0.0",
-        "merge-descriptors": "1.0.3",
-        "methods": "~1.1.2",
-        "on-finished": "2.4.1",
-        "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.12",
-        "proxy-addr": "~2.0.7",
-        "qs": "6.13.0",
-        "range-parser": "~1.2.1",
-        "safe-buffer": "5.2.1",
-        "send": "0.19.0",
-        "serve-static": "1.16.2",
-        "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
-        "type-is": "~1.6.18",
-        "utils-merge": "1.0.1",
-        "vary": "~1.1.2"
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
       },
       "engines": {
-        "node": ">= 0.10.0"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "type": "opencollective",
@@ -2418,21 +2423,24 @@
       }
     },
     "node_modules/finalhandler": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
-      "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
       "license": "MIT",
       "dependencies": {
-        "debug": "2.6.9",
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "on-finished": "2.4.1",
-        "parseurl": "~1.3.3",
-        "statuses": "2.0.1",
-        "unpipe": "~1.0.0"
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
       },
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/find-up": {
@@ -2492,12 +2500,12 @@
       }
     },
     "node_modules/fresh": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
       "license": "MIT",
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 0.8"
       }
     },
     "node_modules/fs.realpath": {
@@ -2723,19 +2731,23 @@
       "license": "MIT"
     },
     "node_modules/http-errors": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
       "license": "MIT",
       "dependencies": {
-        "depd": "2.0.0",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
-        "toidentifier": "1.0.1"
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
       },
       "engines": {
         "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/human-signals": {
@@ -2749,15 +2761,19 @@
       }
     },
     "node_modules/iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
       "license": "MIT",
       "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3"
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
       "engines": {
         "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/ignore-by-default": {
@@ -2913,6 +2929,12 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
     "node_modules/is-stream": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
@@ -3002,31 +3024,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/istanbul-lib-source-maps/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/istanbul-lib-source-maps/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/istanbul-reports": {
       "version": "3.2.0",
@@ -3805,19 +3802,22 @@
       }
     },
     "node_modules/media-typer": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
       "license": "MIT",
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 0.8"
       }
     },
     "node_modules/merge-descriptors": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
-      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
       "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
@@ -3833,6 +3833,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -3852,22 +3853,11 @@
         "node": ">=8.6"
       }
     },
-    "node_modules/mime": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-      "license": "MIT",
-      "bin": {
-        "mime": "cli.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -3877,6 +3867,7 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
@@ -3909,9 +3900,9 @@
       }
     },
     "node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
     "node_modules/natural-compare": {
@@ -3922,9 +3913,9 @@
       "license": "MIT"
     },
     "node_modules/negotiator": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
-      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -3995,13 +3986,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/nodemon/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/nodemon/node_modules/semver": {
       "version": "7.8.5",
@@ -4080,7 +4064,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -4223,10 +4206,14 @@
       "license": "MIT"
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
-      "license": "MIT"
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -4351,12 +4338,13 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
-      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.0.6"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -4366,27 +4354,31 @@
       }
     },
     "node_modules/range-parser": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/raw-body": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
-      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
       "license": "MIT",
       "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "unpipe": "1.0.0"
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
       },
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 0.10"
       }
     },
     "node_modules/react-is": {
@@ -4474,25 +4466,21 @@
         "node": ">=10"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -4511,57 +4499,73 @@
       }
     },
     "node_modules/send": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
-      "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
       "license": "MIT",
       "dependencies": {
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "fresh": "0.5.2",
-        "http-errors": "2.0.0",
-        "mime": "1.6.0",
-        "ms": "2.1.3",
-        "on-finished": "2.4.1",
-        "range-parser": "~1.2.1",
-        "statuses": "2.0.1"
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
       },
       "engines": {
-        "node": ">= 0.8.0"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/send/node_modules/encodeurl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+    "node_modules/send/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
       "license": "MIT",
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 0.6"
       }
     },
-    "node_modules/send/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
+    "node_modules/send/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/serve-static": {
-      "version": "1.16.2",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
-      "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
       "license": "MIT",
       "dependencies": {
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "parseurl": "~1.3.3",
-        "send": "0.19.0"
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
       },
       "engines": {
-        "node": ">= 0.8.0"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/setprototypeof": {
@@ -4757,9 +4761,9 @@
       }
     },
     "node_modules/statuses": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -4876,24 +4880,6 @@
         "node": ">=6.4.0 <13 || >=14"
       }
     },
-    "node_modules/superagent/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/superagent/node_modules/mime": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
@@ -4906,13 +4892,6 @@
       "engines": {
         "node": ">=4.0.0"
       }
-    },
-    "node_modules/superagent/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/superagent/node_modules/semver": {
       "version": "7.8.5",
@@ -5147,16 +5126,59 @@
       }
     },
     "node_modules/type-is": {
-      "version": "1.6.18",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
-      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "license": "MIT",
       "dependencies": {
-        "media-typer": "0.3.0",
-        "mime-types": "~2.1.24"
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
       },
       "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/type-is/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typescript": {
@@ -5224,15 +5246,6 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
-      }
-    },
-    "node_modules/utils-merge": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4.0"
       }
     },
     "node_modules/v8-compile-cache-lib": {
@@ -5314,7 +5327,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/write-file-atomic": {

--- a/services/payment-service/package.json
+++ b/services/payment-service/package.json
@@ -12,12 +12,12 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "express": "4.21.2",
+    "express": "^5.1.0",
     "stripe": "^17",
     "zod": "3.22.4"
   },
   "devDependencies": {
-    "@types/express": "4.17.21",
+    "@types/express": "^5.0.0",
     "@types/jest": "29.5.12",
     "@types/node": "18.19.0",
     "@types/supertest": "6.0.2",

--- a/services/payment-service/package.json
+++ b/services/payment-service/package.json
@@ -12,7 +12,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "express": "4.19.2",
+    "express": "4.21.2",
     "stripe": "^17",
     "zod": "3.22.4"
   },

--- a/services/payment-service/package.json
+++ b/services/payment-service/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@fuzefront/payment-service",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Vendor-neutral payment gateway for FuzeFront — the seam that absorbs ALL Stripe interaction and exposes a neutral Payment Provider API to billing-service and other consumers. Scaffold/gateway; not yet the live money path.",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "dev": "nodemon --exec ts-node src/index.ts",
+    "test": "jest",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "express": "4.19.2",
+    "stripe": "^17",
+    "zod": "3.22.4"
+  },
+  "devDependencies": {
+    "@types/express": "4.17.21",
+    "@types/jest": "29.5.12",
+    "@types/node": "18.19.0",
+    "@types/supertest": "6.0.2",
+    "jest": "29.7.0",
+    "nodemon": "3.0.1",
+    "supertest": "6.3.3",
+    "ts-jest": "29.1.1",
+    "ts-node": "10.9.2",
+    "typescript": "5.1.6"
+  }
+}

--- a/services/payment-service/src/app.ts
+++ b/services/payment-service/src/app.ts
@@ -1,0 +1,49 @@
+import express, { Application, Request, Response } from 'express';
+import { requireInternalToken } from './middleware/auth';
+import { createPaymentsRouter, createWebhookRouter } from './routes/payments';
+import { PaymentProvider } from './providers/payment-provider';
+
+export interface AppDeps {
+  /** The active vendor adapter behind the neutral port. */
+  provider: PaymentProvider;
+  /** `PAYMENT_INTERNAL_TOKEN` — guards the neutral API when set. */
+  internalToken?: string;
+}
+
+const API_BASE = '/api/v1/payments';
+
+/**
+ * Assembles the payment-service Express app.
+ *
+ * Route ordering matters: the webhook router uses `express.raw` and MUST be
+ * mounted before the global `express.json()` so signature verification sees the
+ * unparsed body (same discipline as billing-service's webhook route).
+ *
+ * Called with NO args it returns a minimal app exposing only `/health` — the
+ * degraded fallback used when no vendor key is configured (mirrors
+ * billing-service's no-deps `createApp()`), and what the health test asserts.
+ */
+export function createApp(deps?: AppDeps): Application {
+  const app = express();
+
+  app.get('/health', (_req: Request, res: Response) => {
+    res.json({ status: 'ok', service: 'payment-service' });
+  });
+
+  if (!deps) return app;
+
+  // 1) Webhook (raw body) — before express.json, public + signature-verified.
+  app.use(API_BASE, express.raw({ type: '*/*' }), createWebhookRouter({ provider: deps.provider }));
+
+  // 2) JSON body parser for the rest of the neutral API.
+  app.use(express.json());
+
+  // 3) Internal-token-guarded neutral Payment Provider API.
+  app.use(
+    API_BASE,
+    requireInternalToken(deps.internalToken),
+    createPaymentsRouter({ provider: deps.provider }),
+  );
+
+  return app;
+}

--- a/services/payment-service/src/config.ts
+++ b/services/payment-service/src/config.ts
@@ -1,0 +1,44 @@
+/**
+ * payment-service configuration.
+ *
+ * The gateway is runnable with ZERO secrets: every provider credential is
+ * optional in this scaffold. Without `STRIPE_SECRET_KEY` the service still
+ * boots and serves `/health` (degraded mode), mirroring billing-service's
+ * no-deps `createApp()`.
+ */
+
+/** Which vendor adapter the gateway routes calls through. */
+export type PaymentProviderName = 'stripe';
+
+export interface Config {
+  /** HTTP port. Defaults to 3007 (billing-service is 3006). */
+  port: number;
+  /**
+   * Active payment provider. Swapping the vendor = adding a sibling adapter
+   * under `src/providers/<vendor>/` and pointing this at it. Default 'stripe'.
+   */
+  provider: PaymentProviderName;
+  /**
+   * Vendor secret key. OPTIONAL in the scaffold — absent means degraded mode
+   * (health only, no live vendor calls).
+   */
+  stripeSecretKey?: string;
+  /**
+   * Bearer token proving the caller is an authorized internal consumer
+   * (billing-service / the host proxy). Guards the neutral API when set;
+   * absent in the scaffold leaves the surface open in local/degraded runs.
+   */
+  internalToken?: string;
+}
+
+export function loadConfig(): Config {
+  const provider = (process.env.PAYMENT_PROVIDER || 'stripe').toLowerCase();
+  return {
+    port: parseInt(process.env.PORT || '3007', 10),
+    // Only 'stripe' exists today; unknown values fall back to stripe (the sole
+    // adapter). This is the single knob a future vendor swap flips.
+    provider: provider === 'stripe' ? 'stripe' : 'stripe',
+    stripeSecretKey: process.env.STRIPE_SECRET_KEY,
+    internalToken: process.env.PAYMENT_INTERNAL_TOKEN,
+  };
+}

--- a/services/payment-service/src/errors.ts
+++ b/services/payment-service/src/errors.ts
@@ -1,0 +1,18 @@
+/**
+ * Errors surfaced by the neutral gateway.
+ *
+ * `NotImplemented` is the SCAFFOLD signal: an adapter method that has not yet
+ * been wired to the vendor throws it, and the router maps it to HTTP 501 so the
+ * frozen contract is fully navigable while the money path is still dark.
+ */
+export class NotImplemented extends Error {
+  readonly code = 'NOT_IMPLEMENTED';
+  constructor(call: string) {
+    super(`payment-service: '${call}' is not implemented yet (gateway scaffold).`);
+    this.name = 'NotImplemented';
+  }
+}
+
+export function isNotImplemented(err: unknown): err is NotImplemented {
+  return err instanceof NotImplemented || (err as { code?: string })?.code === 'NOT_IMPLEMENTED';
+}

--- a/services/payment-service/src/index.ts
+++ b/services/payment-service/src/index.ts
@@ -1,0 +1,52 @@
+import { loadConfig } from './config';
+import { createApp, AppDeps } from './app';
+import { StripePaymentProvider } from './providers/stripe/stripe-payment-provider';
+import { PaymentProvider } from './providers/payment-provider';
+
+/**
+ * payment-service entrypoint — the vendor-neutral payment gateway.
+ *
+ * Runnable with ZERO secrets: without a vendor key the gateway boots and serves
+ * `/health` (degraded mode). With a key it also mounts the neutral Payment
+ * Provider API under `/api/v1/payments`, backed by the configured vendor adapter
+ * (the ONLY thing that touches the vendor SDK). Scaffold: adapter methods throw
+ * NotImplemented → HTTP 501 until the live path is absorbed from billing-service.
+ */
+function selectProvider(config: ReturnType<typeof loadConfig>): PaymentProvider {
+  // Single adapter today. A future vendor swap adds a sibling adapter and
+  // switches on config.provider here — no call-site changes.
+  switch (config.provider) {
+    case 'stripe':
+    default:
+      return new StripePaymentProvider({ secretKey: config.stripeSecretKey });
+  }
+}
+
+function main() {
+  const config = loadConfig();
+
+  // Degraded mode: no vendor key → health only, exactly like billing-service.
+  if (!config.stripeSecretKey) {
+    console.warn(
+      '[payment-service] STRIPE_SECRET_KEY missing — serving /health only (gateway scaffold, degraded mode)',
+    );
+    const app = createApp();
+    startHttp(app, config.port);
+    return;
+  }
+
+  const provider = selectProvider(config);
+  const deps: AppDeps = { provider, internalToken: config.internalToken };
+  const app = createApp(deps);
+  startHttp(app, config.port);
+}
+
+function startHttp(app: ReturnType<typeof createApp>, port: number) {
+  return app.listen(port, () => {
+    console.log(`[payment-service] Listening on port ${port}`);
+  });
+}
+
+// Entrypoint. Without invoking main(), `node dist/index.js` would define it and
+// exit 0 with no server (CrashLoopBackOff "Completed"). Invoke + fail loud.
+main();

--- a/services/payment-service/src/middleware/auth.ts
+++ b/services/payment-service/src/middleware/auth.ts
@@ -1,0 +1,26 @@
+import { NextFunction, Request, Response } from 'express';
+
+/**
+ * Guards the neutral API: consumers (billing-service / the host proxy) present
+ * `PAYMENT_INTERNAL_TOKEN` as a Bearer token. Mirrors billing-service's
+ * `requireInternalToken`.
+ *
+ * Scaffold behaviour: when no token is configured the guard is a NO-OP (open in
+ * local/degraded runs). When a token IS configured it fails CLOSED — a missing
+ * or mismatched Bearer token is rejected with 401.
+ */
+export function requireInternalToken(token?: string) {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    if (!token) {
+      next();
+      return;
+    }
+    const header = req.header('authorization') || '';
+    const presented = header.startsWith('Bearer ') ? header.slice('Bearer '.length) : '';
+    if (presented && presented === token) {
+      next();
+      return;
+    }
+    res.status(401).json({ error: 'unauthorized' });
+  };
+}

--- a/services/payment-service/src/providers/payment-provider.ts
+++ b/services/payment-service/src/providers/payment-provider.ts
@@ -1,0 +1,206 @@
+/**
+ * The vendor-neutral Payment Provider port (payment-service).
+ *
+ * This is the SUPERSET the gateway exposes to billing-service and other
+ * consumers. It intentionally aligns with — and extends — billing-service's own
+ * `PaymentProvider` port (`services/billing-service/src/providers/payment-provider.ts`):
+ * that port is the CLIENT that will point at this gateway once the money path is
+ * migrated here. Names/DTOs are kept compatible (cents, `Date`, lowercased
+ * currency, `providerCustomerId`/`providerInvoiceId`) so the seam is a drop-in.
+ *
+ * Domain/route code depends ONLY on this interface and its neutral DTOs — never
+ * on a vendor SDK. `providers/stripe/StripePaymentProvider` is the ONLY place
+ * allowed to touch Stripe; swapping vendors = adding a sibling adapter.
+ *
+ * Every vendor call is wrapped in `ProviderHooks` (onBeforeCall/onAfterCall/
+ * onError) — the pre/post hook seam where metrics, transforms, idempotency, or
+ * retries are added centrally without touching call sites.
+ */
+
+/** A customer, normalised to FuzeFront's neutral shape. */
+export interface ProviderCustomer {
+  /** The provider's own customer id (confined to the adapter + DB uniqueness). */
+  providerCustomerId: string;
+  /** Contact email, when the provider has one. */
+  email: string | null;
+  /** Display name, when the provider has one. */
+  name: string | null;
+  /** Free-form key/value metadata echoed back from the provider. */
+  metadata: Record<string, string>;
+}
+
+/** Input to create (or upsert) a provider customer. */
+export interface CreateCustomerInput {
+  email?: string;
+  name?: string;
+  /**
+   * The FuzeFront entity this customer represents. Kept neutral: the gateway
+   * never leaks vendor concepts back to callers.
+   */
+  entityType?: 'user' | 'organization';
+  entityId?: string;
+  metadata?: Record<string, string>;
+}
+
+/** A provider invoice, normalised to FuzeFront's neutral shape (cents, Date). */
+export interface ProviderInvoice {
+  /** The provider's own invoice id (confined to the adapter + DB uniqueness). */
+  providerInvoiceId: string;
+  /** Human-facing invoice number; null when the provider has not issued one. */
+  number: string | null;
+  /** Neutral status: draft|open|paid|void|uncollectible. */
+  status: string;
+  /** Amount due in the currency's minor unit (cents). */
+  amountDueCents: number;
+  /** Amount paid in the currency's minor unit (cents). */
+  amountPaidCents: number;
+  /** ISO 4217 code, lowercased. */
+  currency: string;
+  /** Provider-hosted invoice page URL; null when unavailable. */
+  hostedInvoiceUrl: string | null;
+  /** Provider-hosted invoice PDF URL; null when unavailable. */
+  invoicePdfUrl: string | null;
+  /** Issue timestamp. */
+  issuedAt: Date;
+}
+
+/** Options for a single page of `listInvoices`. */
+export interface ListInvoicesOptions {
+  /** Page size. */
+  limit: number;
+  /** Opaque provider cursor for the next page (the provider's paging token). */
+  startingAfter?: string;
+}
+
+/** One page of provider invoices. */
+export interface ProviderInvoicePage {
+  invoices: ProviderInvoice[];
+  hasMore: boolean;
+}
+
+/** Neutral checkout mode. */
+export type CheckoutMode = 'subscription' | 'payment' | 'setup';
+
+/** A single priced line item for a `payment`-mode checkout. */
+export interface CheckoutLineItem {
+  name: string;
+  description?: string;
+  unitAmountCents: number;
+  quantity: number;
+}
+
+/** Input to open a hosted checkout session (vendor-agnostic). */
+export interface CreateCheckoutSessionInput {
+  mode: CheckoutMode;
+  providerCustomerId?: string;
+  /** ISO 4217, lowercased. Required for `payment` mode. */
+  currency?: string;
+  /** Priced line items for `payment` mode. */
+  lineItems?: CheckoutLineItem[];
+  /** Provider price id for `subscription` mode. */
+  priceId?: string;
+  successUrl: string;
+  cancelUrl: string;
+  /** Opaque correlation id echoed on the resulting webhook. */
+  clientReferenceId?: string;
+  metadata?: Record<string, string>;
+}
+
+/** A hosted checkout session, normalised. */
+export interface ProviderCheckoutSession {
+  /** The provider's session id. */
+  providerSessionId: string;
+  /** Provider-hosted URL to redirect the customer to; null when unavailable. */
+  url: string | null;
+  mode: CheckoutMode;
+}
+
+/** Input to begin collecting a payment method without an immediate charge. */
+export interface SetupPaymentMethodInput {
+  providerCustomerId: string;
+  /** off_session so the collected method can be charged later. */
+  usage?: 'on_session' | 'off_session';
+  metadata?: Record<string, string>;
+}
+
+/** The client secret a front-end needs to complete payment-method setup. */
+export interface ProviderPaymentMethodSetup {
+  /** Client secret for the provider's payment element. */
+  clientSecret: string;
+  /** The setup object id at the provider. */
+  providerSetupId: string;
+}
+
+/** A parsed, neutralised provider webhook. */
+export interface ProviderWebhookEvent {
+  /** Provider that emitted the event (e.g. 'stripe'). */
+  provider: string;
+  /** The provider's event id (for idempotency). */
+  providerEventId: string;
+  /** Neutral event type (e.g. 'invoice.paid', 'checkout.completed'). */
+  type: string;
+  /** The neutralised payload, when the gateway understands the event. */
+  data: Record<string, unknown>;
+}
+
+/**
+ * The neutral payment-provider port. The invoice + customer + checkout +
+ * payment-method + webhook surface is the FROZEN contract for this gateway; the
+ * live vendor wiring lands adapter-by-adapter behind it.
+ */
+export interface PaymentProvider {
+  /** Provider identity, persisted alongside provider ids (e.g. 'stripe'). */
+  readonly name: string;
+
+  /** Create (or upsert) a provider customer for a FuzeFront entity. */
+  createCustomer(input: CreateCustomerInput): Promise<ProviderCustomer>;
+
+  /** Fetch a provider customer by its provider id; null when unknown. */
+  getCustomer(providerCustomerId: string): Promise<ProviderCustomer | null>;
+
+  /** Page the customer's invoices from the provider. */
+  listInvoices(
+    providerCustomerId: string,
+    opts: ListInvoicesOptions,
+  ): Promise<ProviderInvoicePage>;
+
+  /** Open a hosted checkout session (subscription / payment / setup). */
+  createCheckoutSession(
+    input: CreateCheckoutSessionInput,
+  ): Promise<ProviderCheckoutSession>;
+
+  /** Begin collecting a payment method without an immediate charge. */
+  setupPaymentMethod(
+    input: SetupPaymentMethodInput,
+  ): Promise<ProviderPaymentMethodSetup>;
+
+  /**
+   * Verify + parse a raw provider webhook into a neutral event. Returns null
+   * when the event is not one the gateway persists.
+   */
+  parseWebhook(
+    provider: string,
+    rawBody: Buffer | string,
+    signature: string | undefined,
+  ): ProviderWebhookEvent | null;
+
+  /**
+   * Parse a provider webhook event into a neutral {providerCustomerId, invoice}.
+   * Kept for exact alignment with billing-service's port. Returns null when the
+   * event is not an invoice event we can persist.
+   */
+  parseInvoiceEvent(
+    evt: unknown,
+  ): { providerCustomerId: string; invoice: ProviderInvoice } | null;
+}
+
+/**
+ * Pre/post/error hooks wrapped around every vendor call — the pre/post hook seam.
+ * All optional and best-effort: a hook throwing must not mask the underlying
+ * call result.
+ */
+export interface ProviderHooks {
+  onBeforeCall?: (call: string, meta?: Record<string, unknown>) => void | Promise<void>;
+  onAfterCall?: (call: string, meta?: Record<string, unknown>) => void | Promise<void>;
+  onError?: (call: string, err: unknown, meta?: Record<string, unknown>) => void | Promise<void>;
+}

--- a/services/payment-service/src/providers/stripe/stripe-payment-provider.ts
+++ b/services/payment-service/src/providers/stripe/stripe-payment-provider.ts
@@ -1,0 +1,161 @@
+/**
+ * ============================================================================
+ *  VENDOR SEAM — THIS is where the payment vendor lives.
+ * ============================================================================
+ *
+ * This adapter is the ONLY file in payment-service allowed to touch the Stripe
+ * SDK. Every other file speaks the vendor-neutral `PaymentProvider` port. To
+ * swap vendors (or run two in parallel behind a flag), add a SIBLING adapter —
+ * e.g. `providers/adyen/AdyenPaymentProvider` — that implements the same port,
+ * and point `config.provider` at it. No call site changes.
+ *
+ * SCAFFOLD STATUS: every vendor call throws `NotImplemented` (→ HTTP 501). The
+ * gateway progressively absorbs the live Stripe interaction currently in
+ * billing-service, method by method, behind this seam. Until then this is NOT
+ * the live money path.
+ *
+ * The Stripe SDK is loaded LAZILY (`loadStripe()`) so the gateway boots and
+ * serves /health with ZERO secrets and without the SDK being reachable — the
+ * vendor is only touched once a method is actually wired + invoked with a key.
+ */
+import { NotImplemented } from '../../errors';
+import {
+  CreateCheckoutSessionInput,
+  CreateCustomerInput,
+  ListInvoicesOptions,
+  PaymentProvider,
+  ProviderCheckoutSession,
+  ProviderCustomer,
+  ProviderHooks,
+  ProviderInvoice,
+  ProviderInvoicePage,
+  ProviderPaymentMethodSetup,
+  ProviderWebhookEvent,
+  SetupPaymentMethodInput,
+} from '../payment-provider';
+
+/** Minimal shape we need from the Stripe client (kept local so tsc/runtime do
+ *  not depend on the Stripe SDK being installed in the scaffold). Replace with
+ *  `import type Stripe from 'stripe'` once methods are wired. */
+interface StripeLike {
+  customers: unknown;
+  invoices: unknown;
+  checkout: unknown;
+  setupIntents: unknown;
+  webhooks: unknown;
+}
+
+export interface StripePaymentProviderOptions {
+  /** Vendor secret key. Absent → the adapter stays inert (scaffold). */
+  secretKey?: string;
+  /** Optional preconstructed client (injected in tests). */
+  client?: StripeLike;
+  /** Pre/post/error hooks fired around every vendor call. */
+  hooks?: ProviderHooks;
+}
+
+export class StripePaymentProvider implements PaymentProvider {
+  readonly name = 'stripe';
+
+  private readonly secretKey?: string;
+  private readonly hooks: ProviderHooks;
+  private client?: StripeLike;
+
+  constructor(opts: StripePaymentProviderOptions = {}) {
+    this.secretKey = opts.secretKey;
+    this.client = opts.client;
+    this.hooks = opts.hooks ?? {};
+  }
+
+  /**
+   * Lazily construct the Stripe client on first real use. Kept private so the
+   * SDK import lives ONLY here. Throws if no key is configured (degraded mode).
+   */
+  private loadStripe(): StripeLike {
+    if (this.client) return this.client;
+    if (!this.secretKey) {
+      throw new NotImplemented('stripe client (no STRIPE_SECRET_KEY configured)');
+    }
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const Stripe = require('stripe');
+    this.client = new Stripe(this.secretKey) as StripeLike;
+    return this.client;
+  }
+
+  async createCustomer(_input: CreateCustomerInput): Promise<ProviderCustomer> {
+    return this.withHooks('createCustomer', {}, async () => {
+      throw new NotImplemented('createCustomer');
+    });
+  }
+
+  async getCustomer(providerCustomerId: string): Promise<ProviderCustomer | null> {
+    return this.withHooks('getCustomer', { providerCustomerId }, async () => {
+      throw new NotImplemented('getCustomer');
+    });
+  }
+
+  async listInvoices(
+    providerCustomerId: string,
+    opts: ListInvoicesOptions,
+  ): Promise<ProviderInvoicePage> {
+    return this.withHooks(
+      'listInvoices',
+      { providerCustomerId, limit: opts.limit },
+      async () => {
+        throw new NotImplemented('listInvoices');
+      },
+    );
+  }
+
+  async createCheckoutSession(
+    input: CreateCheckoutSessionInput,
+  ): Promise<ProviderCheckoutSession> {
+    return this.withHooks('createCheckoutSession', { mode: input.mode }, async () => {
+      throw new NotImplemented('createCheckoutSession');
+    });
+  }
+
+  async setupPaymentMethod(
+    input: SetupPaymentMethodInput,
+  ): Promise<ProviderPaymentMethodSetup> {
+    return this.withHooks(
+      'setupPaymentMethod',
+      { providerCustomerId: input.providerCustomerId },
+      async () => {
+        throw new NotImplemented('setupPaymentMethod');
+      },
+    );
+  }
+
+  parseWebhook(
+    _provider: string,
+    _rawBody: Buffer | string,
+    _signature: string | undefined,
+  ): ProviderWebhookEvent | null {
+    // Signature verification + neutral mapping land with the webhook migration.
+    throw new NotImplemented('parseWebhook');
+  }
+
+  parseInvoiceEvent(
+    _evt: unknown,
+  ): { providerCustomerId: string; invoice: ProviderInvoice } | null {
+    throw new NotImplemented('parseInvoiceEvent');
+  }
+
+  /** Wrap a vendor call in the pre/post/error hooks (hooks are best-effort). */
+  private async withHooks<T>(
+    call: string,
+    meta: Record<string, unknown>,
+    fn: () => Promise<T>,
+  ): Promise<T> {
+    await this.hooks.onBeforeCall?.(call, meta);
+    try {
+      const result = await fn();
+      await this.hooks.onAfterCall?.(call, meta);
+      return result;
+    } catch (err) {
+      await this.hooks.onError?.(call, err, meta);
+      throw err;
+    }
+  }
+}

--- a/services/payment-service/src/routes/payments.ts
+++ b/services/payment-service/src/routes/payments.ts
@@ -41,7 +41,7 @@ export function createPaymentsRouter(deps: PaymentsRouterDeps): Router {
 
   router.get('/customers/:customerId', async (req: Request, res: Response) => {
     try {
-      const customer = await provider.getCustomer(req.params.customerId);
+      const customer = await provider.getCustomer(String(req.params.customerId));
       if (!customer) {
         res.status(404).json({ error: 'not_found' });
         return;
@@ -56,7 +56,7 @@ export function createPaymentsRouter(deps: PaymentsRouterDeps): Router {
     try {
       const limit = Math.min(Math.max(parseInt(String(req.query.limit ?? '20'), 10) || 20, 1), 100);
       const startingAfter = req.query.cursor ? String(req.query.cursor) : undefined;
-      const page = await provider.listInvoices(req.params.customerId, { limit, startingAfter });
+      const page = await provider.listInvoices(String(req.params.customerId), { limit, startingAfter });
       res.json(page);
     } catch (err) {
       handleError(res, err);
@@ -98,7 +98,7 @@ export function createWebhookRouter(deps: PaymentsRouterDeps): Router {
   router.post('/webhooks/:provider', async (req: Request, res: Response) => {
     try {
       const signature = req.header('stripe-signature') || undefined;
-      const event = provider.parseWebhook(req.params.provider, req.body as Buffer, signature);
+      const event = provider.parseWebhook(String(req.params.provider), req.body as Buffer, signature);
       res.json({ received: true, handled: Boolean(event) });
     } catch (err) {
       handleError(res, err);

--- a/services/payment-service/src/routes/payments.ts
+++ b/services/payment-service/src/routes/payments.ts
@@ -1,0 +1,109 @@
+import { Router, Request, Response } from 'express';
+import { PaymentProvider } from '../providers/payment-provider';
+import { isNotImplemented } from '../errors';
+
+/**
+ * The neutral Payment Provider API surface (see `openapi.yaml`). Mounted under
+ * `/api/v1/payments`. Every route delegates to the injected `PaymentProvider`
+ * port — no vendor concepts leak here.
+ *
+ * SCAFFOLD: the Stripe adapter throws `NotImplemented` for every call, which
+ * this router maps to HTTP 501. The contract is fully navigable (paths, shapes,
+ * auth) while the live money path is still dark and being absorbed from
+ * billing-service method by method.
+ */
+export interface PaymentsRouterDeps {
+  provider: PaymentProvider;
+}
+
+/** Map adapter errors to HTTP. NotImplemented → 501; everything else → 502. */
+function handleError(res: Response, err: unknown): void {
+  if (isNotImplemented(err)) {
+    res.status(501).json({ error: 'not_implemented', message: (err as Error).message });
+    return;
+  }
+  res.status(502).json({ error: 'provider_error', message: (err as Error)?.message });
+}
+
+export function createPaymentsRouter(deps: PaymentsRouterDeps): Router {
+  const router = Router();
+  const { provider } = deps;
+
+  // --- customers ---
+  router.post('/customers', async (req: Request, res: Response) => {
+    try {
+      const customer = await provider.createCustomer(req.body || {});
+      res.status(201).json({ customer });
+    } catch (err) {
+      handleError(res, err);
+    }
+  });
+
+  router.get('/customers/:customerId', async (req: Request, res: Response) => {
+    try {
+      const customer = await provider.getCustomer(req.params.customerId);
+      if (!customer) {
+        res.status(404).json({ error: 'not_found' });
+        return;
+      }
+      res.json({ customer });
+    } catch (err) {
+      handleError(res, err);
+    }
+  });
+
+  router.get('/customers/:customerId/invoices', async (req: Request, res: Response) => {
+    try {
+      const limit = Math.min(Math.max(parseInt(String(req.query.limit ?? '20'), 10) || 20, 1), 100);
+      const startingAfter = req.query.cursor ? String(req.query.cursor) : undefined;
+      const page = await provider.listInvoices(req.params.customerId, { limit, startingAfter });
+      res.json(page);
+    } catch (err) {
+      handleError(res, err);
+    }
+  });
+
+  // --- checkout sessions ---
+  router.post('/checkout-sessions', async (req: Request, res: Response) => {
+    try {
+      const session = await provider.createCheckoutSession(req.body || {});
+      res.status(201).json({ session });
+    } catch (err) {
+      handleError(res, err);
+    }
+  });
+
+  // --- payment-method setup ---
+  router.post('/payment-methods/setup', async (req: Request, res: Response) => {
+    try {
+      const setup = await provider.setupPaymentMethod(req.body || {});
+      res.status(201).json({ setup });
+    } catch (err) {
+      handleError(res, err);
+    }
+  });
+
+  return router;
+}
+
+/**
+ * Webhook receiver, mounted separately with a raw-body parser (signature
+ * verification needs the unparsed bytes). Public — authenticity is the provider
+ * signature, not the internal token.
+ */
+export function createWebhookRouter(deps: PaymentsRouterDeps): Router {
+  const router = Router();
+  const { provider } = deps;
+
+  router.post('/webhooks/:provider', async (req: Request, res: Response) => {
+    try {
+      const signature = req.header('stripe-signature') || undefined;
+      const event = provider.parseWebhook(req.params.provider, req.body as Buffer, signature);
+      res.json({ received: true, handled: Boolean(event) });
+    } catch (err) {
+      handleError(res, err);
+    }
+  });
+
+  return router;
+}

--- a/services/payment-service/tests/health.test.ts
+++ b/services/payment-service/tests/health.test.ts
@@ -1,0 +1,12 @@
+import request from 'supertest';
+import { createApp } from '../src/app';
+
+describe('GET /health', () => {
+  it('returns 200 with status ok and the service name', async () => {
+    const app = createApp();
+    const res = await request(app).get('/health');
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('ok');
+    expect(res.body.service).toBe('payment-service');
+  });
+});

--- a/services/payment-service/tests/tsconfig.json
+++ b/services/payment-service/tests/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "..",
+    "outDir": "../dist-test",
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "types": ["node", "jest"]
+  },
+  "include": ["./**/*.ts", "../src/**/*.ts"]
+}

--- a/services/payment-service/tsconfig.json
+++ b/services/payment-service/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": false,
+    "noImplicitAny": false,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "tests"]
+}

--- a/tests/e2e/billing-invoices/.gitignore
+++ b/tests/e2e/billing-invoices/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+package-lock.json
+test-results/
+playwright-report/

--- a/tests/e2e/billing-invoices/.gitignore
+++ b/tests/e2e/billing-invoices/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 package-lock.json
 test-results/
 playwright-report/
+.harness/

--- a/tests/e2e/billing-invoices/README.md
+++ b/tests/e2e/billing-invoices/README.md
@@ -5,14 +5,14 @@ the **INDEPENDENT** e2e verification for the vendor-neutral, DB-backed invoice
 history UI (`@fuzefront/billing-ui → InvoiceHistoryPanel`, flag
 `fuzefront.billing.invoice-history`).
 
-The React component is **not built yet** (gated on UX approval), so today this
-directory ships two of the three verification phases:
+The React component now **exists** (`InvoiceHistoryPanel`, verified by billing-ui
+vitest), so this directory ships all three verification phases:
 
 | Phase | Spec | Runs against | Status |
 |-------|------|--------------|--------|
 | Pre-production (frozen frames) | `frames.spec.ts` | `design/frames/billing-invoices/*.html` over `file://` | **active — GREEN** |
-| Built-app pre-production | _(added when the component ships)_ | React panel on an ephemeral kind stack / contract mock | pending component |
-| Post-production smoke | `postprod.smoke.spec.ts` | live `BASE_URL` (e.g. `https://app.fuzefront.com`) | skeleton — `@postprod`, skips w/o creds |
+| Built-app pre-production | `built-component.spec.ts` | the REAL React `InvoiceHistoryPanel` (esbuild bundle + mocked `listInvoices`) over `file://` | **active — GREEN** (skips cleanly if harness deps absent) |
+| Post-production smoke | `postprod.smoke.spec.ts` | live `BASE_URL` (e.g. `https://app.fuzefront.com`) | `@postprod`, skips w/o creds |
 
 The stable selectors are the manifest `testHooks` / `data-*` attributes in
 `design/frames/billing-invoices/manifest.json` — the frozen visual/structural
@@ -21,15 +21,20 @@ contract the implementation is checked against.
 ## Setup
 
 This is a **self-contained** package (it does NOT depend on a root
-`npm install`). Install its Playwright once:
+`npm install`). Install its deps once:
 
 ```bash
 cd tests/e2e/billing-invoices
-PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm install   # @playwright/test only; Chromium is preinstalled
+PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm install   # @playwright/test + built-component harness deps
 ```
 
 Chromium is preinstalled (`PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers`) — do NOT
 run `playwright install`.
+
+The built-component harness (`built-component.spec.ts`) needs `esbuild` + `react`
++ `react-dom` (declared in this package's `devDependencies`). If they cannot be
+resolved, that spec **skips cleanly** with the exact install command — it never
+hard-fails.
 
 ## Pre-production (frozen frames) — no stack, no server
 
@@ -72,9 +77,25 @@ panel renders → a download link points at an `https://` provider-hosted URL �
 no vendor name leaks. `BACKEND_URL` defaults to `BASE_URL` (same-origin API
 base in prod); override only for split hosts.
 
-## Once the built app lands
+## Built-app pre-production — the REAL React component
 
-Add a `built-app.spec.ts` here that drives the real React `InvoiceHistoryPanel`
-against the mounted app (contract mock until the backend lands, then the
-ephemeral kind stack), using the same `data-*` hooks. The frames gate stays as
-the design-conformance check.
+`built-component.spec.ts` mounts the actual `@fuzefront/billing-ui →
+InvoiceHistoryPanel` (imported from source, bundled by esbuild) with a stubbed
+`listInvoices`, over `file://`, and asserts the SAME `data-*` acceptance contract
+the frames assert — proving the implementation matches the approved frames.
+
+```bash
+cd tests/e2e/billing-invoices
+npx playwright test -c playwright.config.ts built-component.spec.ts
+```
+
+It exercises the live component states via `harness/entry.tsx` (scenario chosen
+from `location.hash`): `populated` (rows, paid/open/void/uncollectible status
+pills, accessible download links, load-more present), `loadmore` (fetch +
+append next cursor page), `empty`, `loading`, and `error` + retry recovery — and
+asserts **no vendor name** (`stripe`/`link`) leaks in any state. React is
+force-aliased to a single copy so billing-ui's local `node_modules` React cannot
+trigger a duplicate-React "invalid hook call".
+
+The build output (`.harness/`) is git-ignored. The frames gate stays as the
+static design-conformance check alongside this built-app check.

--- a/tests/e2e/billing-invoices/README.md
+++ b/tests/e2e/billing-invoices/README.md
@@ -1,0 +1,80 @@
+# Billing "Invoice history" — independent front-end verification
+
+Owned by `frontend-test-engineer` (independent of the UI implementer). This is
+the **INDEPENDENT** e2e verification for the vendor-neutral, DB-backed invoice
+history UI (`@fuzefront/billing-ui → InvoiceHistoryPanel`, flag
+`fuzefront.billing.invoice-history`).
+
+The React component is **not built yet** (gated on UX approval), so today this
+directory ships two of the three verification phases:
+
+| Phase | Spec | Runs against | Status |
+|-------|------|--------------|--------|
+| Pre-production (frozen frames) | `frames.spec.ts` | `design/frames/billing-invoices/*.html` over `file://` | **active — GREEN** |
+| Built-app pre-production | _(added when the component ships)_ | React panel on an ephemeral kind stack / contract mock | pending component |
+| Post-production smoke | `postprod.smoke.spec.ts` | live `BASE_URL` (e.g. `https://app.fuzefront.com`) | skeleton — `@postprod`, skips w/o creds |
+
+The stable selectors are the manifest `testHooks` / `data-*` attributes in
+`design/frames/billing-invoices/manifest.json` — the frozen visual/structural
+contract the implementation is checked against.
+
+## Setup
+
+This is a **self-contained** package (it does NOT depend on a root
+`npm install`). Install its Playwright once:
+
+```bash
+cd tests/e2e/billing-invoices
+PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm install   # @playwright/test only; Chromium is preinstalled
+```
+
+Chromium is preinstalled (`PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers`) — do NOT
+run `playwright install`.
+
+## Pre-production (frozen frames) — no stack, no server
+
+```bash
+cd tests/e2e/billing-invoices
+npx playwright test -c playwright.config.ts frames.spec.ts
+# or, from the repo root:
+npx playwright test -c tests/e2e/billing-invoices/playwright.config.ts frames.spec.ts
+```
+
+> The repo-root `playwright.config.ts` is dedicated to the **federated-apps**
+> frames gate (`testMatch: federated-apps-frames`) and deliberately does not pick
+> up this feature's specs — always pass `-c` to this directory's config.
+
+This asserts the frozen contract via the `data-*` hooks:
+
+- `01-invoice-history`: `[data-panel='invoice-history']` present; exactly 4
+  `[data-invoice]` rows; `FF-2026-0042` is `[data-status='paid']`; every row has a
+  `[data-download]` link with an accessible name; `[data-action='load-more']`
+  present; **no vendor name** (`stripe`/`link`) anywhere in the panel DOM.
+- `02-states`: `[data-state='loading']`, `[data-state='empty']` (+ `[data-empty]`),
+  `[data-state='error']` (+ `[data-action='retry']`), and
+  `[data-status='uncollectible']` all present.
+- Manifest-driven: every declared `testHook` selector resolves in its frame, and
+  the entry `index.html` links to both frames in order.
+
+## Post-production smoke — live app
+
+Skips cleanly unless `BASE_URL` **and** credentials are set:
+
+```bash
+BASE_URL=https://app.fuzefront.com \
+E2E_USER_EMAIL=… E2E_USER_PASSWORD=… \
+npx playwright test -c tests/e2e/billing-invoices/playwright.config.ts -g @postprod
+```
+
+Flow: sign-in (server-side password → platform JWT → `localStorage.authToken`,
+the repo's existing convention) → navigate to `/billing` → assert the invoice
+panel renders → a download link points at an `https://` provider-hosted URL →
+no vendor name leaks. `BACKEND_URL` defaults to `BASE_URL` (same-origin API
+base in prod); override only for split hosts.
+
+## Once the built app lands
+
+Add a `built-app.spec.ts` here that drives the real React `InvoiceHistoryPanel`
+against the mounted app (contract mock until the backend lands, then the
+ephemeral kind stack), using the same `data-*` hooks. The frames gate stays as
+the design-conformance check.

--- a/tests/e2e/billing-invoices/built-component.spec.ts
+++ b/tests/e2e/billing-invoices/built-component.spec.ts
@@ -89,6 +89,10 @@ function buildBundle() {
       'react/jsx-runtime': require.resolve('react/jsx-runtime'),
     },
   })
+  // Static, test-only harness page (constant HTML; the <script src> is a fixed
+  // local path to our own esbuild bundle — no external/dynamic input). Not a web
+  // response and never served to users.
+  // nosemgrep: javascript.lang.security.audit.unknown-value-with-script-tag.unknown-value-with-script-tag
   writeFileSync(
     HTML,
     `<!doctype html><html><head><meta charset="utf-8"><title>invoice-history harness</title></head><body><div id="root"></div><script src="./bundle.js"></script></body></html>`,

--- a/tests/e2e/billing-invoices/built-component.spec.ts
+++ b/tests/e2e/billing-invoices/built-component.spec.ts
@@ -1,0 +1,257 @@
+import { test, expect, type Locator } from '@playwright/test'
+import { pathToFileURL } from 'node:url'
+import { mkdirSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+
+/**
+ * BUILT-APP PRE-PRODUCTION verification — the REAL React component.
+ *
+ * Independent front-end verification that the shipped `@fuzefront/billing-ui →
+ * InvoiceHistoryPanel` matches the approved frames' acceptance contract. Where
+ * `frames.spec.ts` pins the frozen *static* frames, this spec mounts the actual
+ * React component (imported from source) with a stubbed `listInvoices`, over
+ * `file://`, and asserts the SAME data-* contract against live render output +
+ * state transitions (loading / empty / error+retry / load-more).
+ *
+ * Harness (lightest that runs here): a tiny esbuild bundle of
+ * `harness/entry.tsx` (the component + a mock) rendered into `.harness/index.html`.
+ * Chromium is preinstalled; no dev server, no stack. React is force-aliased to a
+ * single copy so the component's own node_modules React cannot cause a duplicate-
+ * React "invalid hook call".
+ *
+ * If the harness build deps (esbuild / react / react-dom) are NOT installed in
+ * this directory, every test here SKIPS CLEANLY with the exact install command —
+ * never a hard failure. Run it where the deps exist with:
+ *
+ *   cd tests/e2e/billing-invoices
+ *   PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm install
+ *   npx playwright test -c playwright.config.ts built-component.spec.ts
+ */
+
+const HARNESS_DIR = path.join(__dirname, 'harness')
+const BUILD_DIR = path.join(__dirname, '.harness')
+const ENTRY = path.join(HARNESS_DIR, 'entry.tsx')
+const BUNDLE = path.join(BUILD_DIR, 'bundle.js')
+const HTML = path.join(BUILD_DIR, 'index.html')
+
+const INSTALL_HINT =
+  'cd tests/e2e/billing-invoices && PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm install'
+
+/** Resolve the harness build deps up-front (synchronously) so the whole suite
+ *  can skip cleanly at collection time when they are absent. */
+function resolveHarnessDeps(): { ok: boolean; reason: string } {
+  for (const mod of ['esbuild', 'react', 'react-dom/client', 'react/jsx-runtime']) {
+    try {
+      require.resolve(mod)
+    } catch {
+      return {
+        ok: false,
+        reason: `built-component harness deps absent (cannot resolve "${mod}"). Install with: ${INSTALL_HINT}`,
+      }
+    }
+  }
+  return { ok: true, reason: '' }
+}
+
+const deps = resolveHarnessDeps()
+
+/** Vendor brand names that must NEVER leak into the rendered UI (word-boundary,
+ *  case-insensitive) — identical rule to the frames spec. */
+const VENDOR_NAME = /\b(stripe|link)\b/i
+
+async function assertNoVendorNameLeak(scope: Locator) {
+  const outerHtml = (await scope.evaluate((el) => el.outerHTML)).toLowerCase()
+  expect(
+    outerHtml,
+    'a vendor brand name ("stripe"/"link") leaked into the built invoice panel DOM'
+  ).not.toMatch(VENDOR_NAME)
+}
+
+/** Build the harness bundle once (single React copy via alias). */
+function buildBundle() {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const esbuild = require('esbuild')
+  mkdirSync(BUILD_DIR, { recursive: true })
+  esbuild.buildSync({
+    entryPoints: [ENTRY],
+    bundle: true,
+    outfile: BUNDLE,
+    format: 'iife',
+    platform: 'browser',
+    jsx: 'automatic',
+    logLevel: 'silent',
+    define: { 'process.env.NODE_ENV': '"production"' },
+    // Force ONE React instance regardless of billing-ui's local node_modules.
+    alias: {
+      react: require.resolve('react'),
+      'react-dom': require.resolve('react-dom'),
+      'react-dom/client': require.resolve('react-dom/client'),
+      'react/jsx-runtime': require.resolve('react/jsx-runtime'),
+    },
+  })
+  writeFileSync(
+    HTML,
+    `<!doctype html><html><head><meta charset="utf-8"><title>invoice-history harness</title></head><body><div id="root"></div><script src="./bundle.js"></script></body></html>`,
+    'utf-8'
+  )
+}
+
+/** file:// URL for a scenario (hash selects the mock in entry.tsx). */
+function harnessUrl(scenario: string): string {
+  return `${pathToFileURL(HTML).href}#${scenario}`
+}
+
+test.describe('Billing invoice history — built React component (pre-production)', () => {
+  test.skip(!deps.ok, deps.reason)
+
+  test.beforeAll(() => {
+    buildBundle()
+  })
+
+  /** Navigate + wait for React's first commit. */
+  async function open(page: import('@playwright/test').Page, scenario: string) {
+    await page.goto(harnessUrl(scenario))
+    await page.waitForFunction(
+      () => (window as unknown as { __HARNESS_READY__?: boolean }).__HARNESS_READY__ === true
+    )
+  }
+
+  test('populated: panel + rows + statuses + accessible download links + load-more', async ({
+    page,
+  }) => {
+    await open(page, 'populated')
+
+    const panel = page.locator("[data-panel='invoice-history']")
+    await expect(panel).toHaveCount(1)
+    await expect(panel).toHaveAttribute('data-testid', 'invoice-history-panel')
+
+    // Four rows from the mocked data, in the invoice list container.
+    await expect(panel.locator('[data-invoice-list]')).toBeVisible()
+    const rows = panel.locator('[data-invoice]')
+    await expect(rows).toHaveCount(4)
+    await expect(panel.locator("[data-invoice-count='4']")).toBeVisible()
+
+    // FF-2026-0042 is paid — same anchor assertion as the frames spec.
+    await expect(
+      panel.locator("[data-invoice='FF-2026-0042'][data-status='paid']")
+    ).toHaveCount(1)
+
+    // Status pills map paid/open/void/uncollectible to their DS tone class.
+    const toneByStatus: Record<string, string> = {
+      paid: 'success',
+      open: 'warning',
+      void: 'neutral',
+      uncollectible: 'error',
+    }
+    for (const [status, tone] of Object.entries(toneByStatus)) {
+      const row = panel.locator(`[data-status='${status}']`)
+      await expect(row, `row with status ${status} missing`).toHaveCount(1)
+      await expect(
+        row.locator(`.ffb-invoices__pill--${tone}`),
+        `status ${status} did not map to the "${tone}" pill tone`
+      ).toBeVisible()
+    }
+
+    // Every row exposes a download link with a non-empty accessible name that
+    // resolves via role+name (real a11y wiring, not just an attribute).
+    const downloads = panel.locator('[data-download]')
+    await expect(downloads).toHaveCount(4)
+    const rowCount = await rows.count()
+    for (let i = 0; i < rowCount; i++) {
+      const row = rows.nth(i)
+      const invoiceId = await row.getAttribute('data-invoice')
+      const dl = row.locator('[data-download]')
+      await expect(dl, `row ${invoiceId} missing its download link`).toHaveCount(1)
+      // data-download is pdf|hosted (opaque), never a vendor name.
+      expect(await dl.getAttribute('data-download')).toMatch(/^(pdf|hosted)$/)
+      const accessibleName = (await dl.getAttribute('aria-label'))?.trim() ?? ''
+      expect(
+        accessibleName.length,
+        `download link for ${invoiceId} has no accessible name`
+      ).toBeGreaterThan(0)
+      await expect(page.getByRole('link', { name: accessibleName })).toBeVisible()
+      // Hosted document href is https and vendor-neutral.
+      expect((await dl.getAttribute('href')) ?? '').toMatch(/^https:\/\//i)
+    }
+
+    // Cursor pagination control present (nextCursor advertised).
+    await expect(panel.locator("[data-action='load-more']")).toBeVisible()
+
+    // No vendor name anywhere in the rendered panel.
+    await assertNoVendorNameLeak(panel)
+  })
+
+  test('load-more: fetches + appends the next cursor page, then hides the control', async ({
+    page,
+  }) => {
+    await open(page, 'loadmore')
+
+    const panel = page.locator("[data-panel='invoice-history']")
+    const rows = panel.locator('[data-invoice]')
+    await expect(rows).toHaveCount(2)
+
+    const loadMore = panel.locator("[data-action='load-more']")
+    await expect(loadMore).toBeVisible()
+    await loadMore.click()
+
+    // Page 2 appended -> 4 rows; control gone (nextCursor now null).
+    await expect(rows).toHaveCount(4)
+    await expect(panel.locator("[data-invoice='FF-2026-0038']")).toHaveCount(1)
+    await expect(loadMore).toHaveCount(0)
+    await assertNoVendorNameLeak(panel)
+  })
+
+  test('empty: renders the empty state', async ({ page }) => {
+    await open(page, 'empty')
+
+    const panel = page.locator("[data-panel='invoice-history']")
+    await expect(panel).toHaveAttribute('data-state', 'empty')
+    await expect(panel.locator('[data-empty]')).toBeVisible()
+    await expect(panel.locator("[data-testid='invoice-empty']")).toBeVisible()
+    await expect(panel.locator('[data-invoice]')).toHaveCount(0)
+    await assertNoVendorNameLeak(panel)
+  })
+
+  test('loading: renders the skeleton loading state', async ({ page }) => {
+    await open(page, 'loading')
+
+    const panel = page.locator("[data-panel='invoice-history']")
+    await expect(panel).toHaveAttribute('data-state', 'loading')
+    await expect(panel).toHaveAttribute('aria-busy', 'true')
+    // The skeleton container is present; its placeholder rows carry no text and
+    // the harness intentionally loads no stylesheet, so assert attachment (the
+    // structural contract) rather than a painted bounding box — same convention
+    // the frames spec uses for the loading state.
+    await expect(panel.locator("[data-testid='invoice-loading']")).toBeAttached()
+    await expect(panel.locator('[data-invoice]')).toHaveCount(0)
+  })
+
+  test('error + retry: error state exposes retry; retry recovers to the list', async ({
+    page,
+  }) => {
+    await open(page, 'error')
+
+    const panel = page.locator("[data-panel='invoice-history']")
+    await expect(panel).toHaveAttribute('data-state', 'error')
+    await expect(panel.locator('[data-error]')).toBeVisible()
+
+    const retry = panel.locator("[data-action='retry']")
+    await expect(retry).toBeVisible()
+    // Accessible-name wiring: the retry control is reachable as a button.
+    await expect(page.getByRole('button', { name: /try again/i })).toBeVisible()
+
+    await retry.click()
+
+    // Recovered: rows render, error state cleared.
+    await expect(panel.locator('[data-invoice]')).toHaveCount(4)
+    await expect(panel.locator('[data-error]')).toHaveCount(0)
+    await assertNoVendorNameLeak(panel)
+  })
+
+  test('no vendor name leaks across any state', async ({ page }) => {
+    for (const scenario of ['populated', 'empty', 'error']) {
+      await open(page, scenario)
+      await assertNoVendorNameLeak(page.locator("[data-panel='invoice-history']"))
+    }
+  })
+})

--- a/tests/e2e/billing-invoices/frames.spec.ts
+++ b/tests/e2e/billing-invoices/frames.spec.ts
@@ -1,0 +1,193 @@
+import { test, expect, type Locator } from '@playwright/test'
+import { pathToFileURL } from 'node:url'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+/**
+ * PRE-PRODUCTION verification — the FROZEN approved design frames.
+ *
+ * Independent front-end verification for the Billing "Invoice history" UI. The
+ * React component (`@fuzefront/billing-ui → InvoiceHistoryPanel`) is NOT built
+ * yet — it is gated on UX approval — so this pass pins the *frozen visual +
+ * structural contract* the implementation will be checked against, using the
+ * static approval frames in `design/frames/billing-invoices/` over `file://`
+ * (no stack, no server — mirrors the repo's federated-apps frames gate).
+ *
+ * The stable selectors are the manifest `testHooks` / `data-*` attributes, so
+ * these assertions survive markup churn as long as the data contract holds.
+ *
+ * When the component ships, the built-app e2e (React panel on an ephemeral kind
+ * stack / contract mock) is added alongside this file; this frames gate stays.
+ */
+
+// design/frames/billing-invoices relative to this spec (tests/e2e/billing-invoices/).
+const FRAMES_DIR = path.resolve(
+  __dirname,
+  '..',
+  '..',
+  '..',
+  'design',
+  'frames',
+  'billing-invoices'
+)
+
+type ManifestFrame = {
+  id: string
+  file: string
+  label: string
+  route: string
+  summary: string
+  testHooks: string[]
+}
+type Manifest = {
+  name: string
+  entry: string
+  frames: ManifestFrame[]
+  contract: { component: string; featureFlag: string }
+}
+
+const manifest: Manifest = JSON.parse(
+  readFileSync(path.join(FRAMES_DIR, 'manifest.json'), 'utf-8')
+)
+
+function frameUrl(file: string): string {
+  return pathToFileURL(path.join(FRAMES_DIR, file)).href
+}
+
+/** Vendor brand names that must NEVER leak into the rendered UI (word-boundary,
+ *  case-insensitive). The invoice panel is vendor-neutral: ids/status/amount are
+ *  served from FuzeFront's own store; the download link is an opaque hosted doc. */
+const VENDOR_NAME = /\b(stripe|link)\b/i
+
+async function assertNoVendorNameLeak(scope: Locator) {
+  // Scope to the panel subtree (NOT the whole document) so the stylesheet
+  // <link> in <head> is not a false positive — we care about what the panel
+  // actually renders to the user, text and attribute values alike.
+  const outerHtml = (await scope.evaluate((el) => el.outerHTML)).toLowerCase()
+  expect(
+    outerHtml,
+    'a vendor brand name ("stripe"/"link") leaked into the invoice panel DOM'
+  ).not.toMatch(VENDOR_NAME)
+}
+
+test.describe('Billing invoice history — approved frames (pre-production gate)', () => {
+  test('manifest defines the frozen two-frame sequence + vendor-neutral contract', () => {
+    // The ordered frame sequence the flow is verified against.
+    expect(manifest.frames.map((f) => f.id)).toEqual([
+      '01-invoice-history',
+      '02-states',
+    ])
+    expect(manifest.entry).toBe('index.html')
+    expect(manifest.contract.component).toContain('InvoiceHistoryPanel')
+    expect(manifest.contract.featureFlag).toBe('fuzefront.billing.invoice-history')
+  })
+
+  // Manifest-driven: every declared testHook selector must resolve in its frame.
+  for (const frame of manifest.frames) {
+    test(`${frame.id}: every manifest testHook selector is present`, async ({ page }) => {
+      await page.goto(frameUrl(frame.file))
+      await expect(
+        page.locator(`[data-frame='${frame.id}']`),
+        `frame identity marker [data-frame='${frame.id}'] missing`
+      ).toBeAttached()
+      for (const hook of frame.testHooks) {
+        await expect(
+          page.locator(hook).first(),
+          `${frame.id}: declared testHook "${hook}" not found`
+        ).toBeAttached()
+      }
+    })
+  }
+
+  test('01-invoice-history: populated list structural contract', async ({ page }) => {
+    await page.goto(frameUrl('01-invoice-history.html'))
+
+    const panel = page.locator("[data-panel='invoice-history']")
+    await expect(panel).toBeAttached()
+    await expect(panel).toHaveCount(1)
+
+    // Exactly 4 invoice rows.
+    const rows = panel.locator('[data-invoice]')
+    await expect(rows).toHaveCount(4)
+
+    // FF-2026-0042 is paid.
+    await expect(
+      panel.locator("[data-invoice='FF-2026-0042'][data-status='paid']")
+    ).toHaveCount(1)
+
+    // Every row exposes a download link with a non-empty accessible name.
+    const downloads = panel.locator('[data-download]')
+    await expect(downloads).toHaveCount(4)
+    const rowCount = await rows.count()
+    for (let i = 0; i < rowCount; i++) {
+      const row = rows.nth(i)
+      const invoiceId = await row.getAttribute('data-invoice')
+      const dl = row.locator('[data-download]')
+      await expect(
+        dl,
+        `row ${invoiceId} is missing its [data-download] link`
+      ).toHaveCount(1)
+      // Accessible name for these <a> elements comes from aria-label.
+      const accessibleName = (await dl.getAttribute('aria-label'))?.trim() ?? ''
+      expect(
+        accessibleName.length,
+        `download link for ${invoiceId} has no accessible name`
+      ).toBeGreaterThan(0)
+      // The link must resolve via role+name (real a11y wiring, not just an attr).
+      await expect(
+        page.getByRole('link', { name: accessibleName })
+      ).toBeVisible()
+    }
+
+    // Cursor pagination control.
+    await expect(panel.locator("[data-action='load-more']")).toBeAttached()
+
+    // Vendor-neutral: no "stripe"/"link" anywhere in the panel.
+    await assertNoVendorNameLeak(panel)
+  })
+
+  test('02-states: loading / empty / error+retry / uncollectible variants present', async ({
+    page,
+  }) => {
+    await page.goto(frameUrl('02-states.html'))
+
+    // Loading skeleton state.
+    await expect(page.locator("[data-state='loading']")).toBeAttached()
+
+    // Empty state carries its empty marker.
+    const empty = page.locator("[data-state='empty']")
+    await expect(empty).toBeAttached()
+    await expect(empty.locator('[data-empty]')).toBeAttached()
+
+    // Error state carries a retry action.
+    const error = page.locator("[data-state='error']")
+    await expect(error).toBeAttached()
+    await expect(error.locator("[data-action='retry']")).toBeAttached()
+    await expect(
+      error.getByRole('button', { name: /try again/i })
+    ).toBeVisible()
+
+    // Uncollectible status-pill variant.
+    await expect(
+      page.locator("[data-status='uncollectible']")
+    ).toBeAttached()
+
+    // Every panel on the states frame is vendor-neutral too.
+    const panels = page.locator("[data-panel='invoice-history']")
+    const panelCount = await panels.count()
+    expect(panelCount).toBeGreaterThanOrEqual(4)
+    for (let i = 0; i < panelCount; i++) {
+      await assertNoVendorNameLeak(panels.nth(i))
+    }
+  })
+
+  test('index → frames flow: entry links to both frames in order', async ({ page }) => {
+    await page.goto(frameUrl(manifest.entry))
+    for (const frame of manifest.frames) {
+      await expect(
+        page.locator(`a[href='${frame.file}']`),
+        `entry index.html is missing the ordered link to ${frame.file}`
+      ).toBeVisible()
+    }
+  })
+})

--- a/tests/e2e/billing-invoices/harness/entry.tsx
+++ b/tests/e2e/billing-invoices/harness/entry.tsx
@@ -1,0 +1,157 @@
+/**
+ * Built-component harness entry — drives the REAL React
+ * `@fuzefront/billing-ui → InvoiceHistoryPanel` with a stubbed `listInvoices`.
+ *
+ * This is bundled at test time by `built-component.spec.ts` (esbuild) into
+ * `.harness/bundle.js` and loaded by `.harness/index.html` over `file://`. It is
+ * NOT part of `@fuzefront/billing-ui` — it imports the component from source so
+ * the independent e2e exercises the actual implementation, not the static frame.
+ *
+ * The scenario is selected from `location.hash` (e.g. `#populated`, `#loadmore`,
+ * `#empty`, `#loading`, `#error`) so one bundle serves every state the approved
+ * frames assert. The mock is a pure closure — no network, no vendor SDK.
+ *
+ * IMPORTANT (vendor neutrality): every URL / string produced here is a FuzeFront
+ * opaque hosted document. No vendor brand name ("stripe"/"link") appears in any
+ * fixture value — the spec asserts the rendered DOM stays vendor-neutral.
+ */
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+// Import the built component + i18n provider straight from billing-ui source.
+import { InvoiceHistoryPanel } from '../../../../packages/billing-ui/src/components/InvoiceHistoryPanel';
+import { BillingI18nProvider } from '../../../../packages/billing-ui/src/i18n';
+
+// Minimal structural shape of a billing-client invoice (types are erased at
+// bundle time; these are just the fields the component reads).
+type Invoice = {
+  id: string;
+  number: string;
+  status: 'paid' | 'open' | 'void' | 'uncollectible' | 'draft';
+  created: string;
+  amountDue: number;
+  currency: string;
+  invoicePdf?: string;
+  hostedInvoiceUrl?: string;
+};
+type ListResponse = { invoices: Invoice[]; nextCursor: string | null };
+type ListInvoices = (opts: { limit?: number; cursor?: string }) => Promise<ListResponse>;
+
+// A vendor-neutral, FuzeFront-hosted opaque document base. No "stripe"/"link".
+const DOC = 'https://docs.fuzefront.com/billing';
+
+const pdf = (n: string): string => `${DOC}/${n}.pdf`;
+const hosted = (n: string): string => `${DOC}/${n}`;
+
+/** Page 1: the four status variants the frames assert; FF-2026-0042 is paid. */
+const PAGE_1: Invoice[] = [
+  {
+    id: 'in_0042',
+    number: 'FF-2026-0042',
+    status: 'paid',
+    created: '2026-07-01T00:00:00.000Z',
+    amountDue: 4200,
+    currency: 'usd',
+    invoicePdf: pdf('FF-2026-0042'),
+  },
+  {
+    id: 'in_0041',
+    number: 'FF-2026-0041',
+    status: 'open',
+    created: '2026-06-01T00:00:00.000Z',
+    amountDue: 4200,
+    currency: 'usd',
+    invoicePdf: pdf('FF-2026-0041'),
+  },
+  {
+    id: 'in_0040',
+    number: 'FF-2026-0040',
+    status: 'void',
+    created: '2026-05-01T00:00:00.000Z',
+    amountDue: 0,
+    currency: 'usd',
+    // No PDF for this one -> exercises the hosted-document link branch.
+    hostedInvoiceUrl: hosted('FF-2026-0040'),
+  },
+  {
+    id: 'in_0039',
+    number: 'FF-2026-0039',
+    status: 'uncollectible',
+    created: '2026-04-01T00:00:00.000Z',
+    amountDue: 4200,
+    currency: 'usd',
+    invoicePdf: pdf('FF-2026-0039'),
+  },
+];
+
+/** Page 2: appended by "Load more" using the next cursor. */
+const PAGE_2: Invoice[] = [
+  {
+    id: 'in_0038',
+    number: 'FF-2026-0038',
+    status: 'paid',
+    created: '2026-03-01T00:00:00.000Z',
+    amountDue: 4200,
+    currency: 'usd',
+    invoicePdf: pdf('FF-2026-0038'),
+  },
+  {
+    id: 'in_0037',
+    number: 'FF-2026-0037',
+    status: 'paid',
+    created: '2026-02-01T00:00:00.000Z',
+    amountDue: 4200,
+    currency: 'usd',
+    invoicePdf: pdf('FF-2026-0037'),
+  },
+];
+
+const NEXT = 'cursor-page-2';
+
+/** Build the scenario-specific `listInvoices` stub. */
+function makeMock(scenario: string): ListInvoices {
+  let calls = 0;
+  return ({ cursor } = {}) => {
+    calls += 1;
+    switch (scenario) {
+      case 'empty':
+        return Promise.resolve({ invoices: [], nextCursor: null });
+
+      case 'loading':
+        // Never settles -> the panel stays in its loading skeleton state.
+        return new Promise<ListResponse>(() => {});
+
+      case 'error':
+        // First load fails; a retry (subsequent call) recovers with page 1.
+        if (calls === 1) return Promise.reject(new Error('simulated fetch failure'));
+        return Promise.resolve({ invoices: PAGE_1, nextCursor: null });
+
+      case 'loadmore':
+        if (cursor === NEXT) return Promise.resolve({ invoices: PAGE_2, nextCursor: null });
+        // First page (2 rows) advertises a next cursor.
+        return Promise.resolve({ invoices: PAGE_1.slice(0, 2), nextCursor: NEXT });
+
+      case 'populated':
+      default:
+        return Promise.resolve({ invoices: PAGE_1, nextCursor: NEXT });
+    }
+  };
+}
+
+const scenario = (location.hash || '#populated').replace(/^#/, '') || 'populated';
+
+const root = createRoot(document.getElementById('root') as HTMLElement);
+root.render(
+  React.createElement(
+    BillingI18nProvider,
+    null,
+    React.createElement(InvoiceHistoryPanel, {
+      enabled: true,
+      pageSize: 20,
+      // Cast is a no-op at runtime; the component only awaits the promise shape.
+      listInvoices: makeMock(scenario) as never,
+    }),
+  ),
+);
+
+// Signal readiness for the driver (React has committed the first paint).
+(window as unknown as { __HARNESS_READY__: boolean }).__HARNESS_READY__ = true;

--- a/tests/e2e/billing-invoices/package.json
+++ b/tests/e2e/billing-invoices/package.json
@@ -4,6 +4,9 @@
   "private": true,
   "description": "Isolated Playwright e2e for the billing invoice-history UI (frames pre-prod + postprod smoke). Self-contained so it needs no root install.",
   "devDependencies": {
-    "@playwright/test": "1.56.1"
+    "@playwright/test": "1.56.1",
+    "esbuild": "0.24.0",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
   }
 }

--- a/tests/e2e/billing-invoices/package.json
+++ b/tests/e2e/billing-invoices/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "billing-invoices-e2e",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Isolated Playwright e2e for the billing invoice-history UI (frames pre-prod + postprod smoke). Self-contained so it needs no root install.",
+  "devDependencies": {
+    "@playwright/test": "1.56.1"
+  }
+}

--- a/tests/e2e/billing-invoices/playwright.config.ts
+++ b/tests/e2e/billing-invoices/playwright.config.ts
@@ -1,0 +1,61 @@
+import { defineConfig, devices } from '@playwright/test'
+
+/**
+ * INDEPENDENT front-end verification for the Billing "Invoice history" UI.
+ *
+ * This config is intentionally SELF-CONTAINED and scoped to
+ * `tests/e2e/billing-invoices/` for two reasons:
+ *
+ *   1. The repo-root `playwright.config.ts` is dedicated to the
+ *      federated-apps approved-frames gate (`testMatch: federated-apps-frames`)
+ *      and must stay that way — it is a merge gate other agents own.
+ *   2. This feature's UI component (`@fuzefront/billing-ui → InvoiceHistoryPanel`)
+ *      is NOT built yet (gated on UX approval). So the specs here run in two
+ *      phases that need different (or no) infrastructure:
+ *
+ *        - frames.spec.ts        pre-production, `file://` frozen approval
+ *                                frames — no stack, no server.
+ *        - postprod.smoke.spec.ts post-production synthetic smoke against a
+ *                                live BASE_URL — skips cleanly when unset.
+ *
+ * The built-app e2e (React InvoiceHistoryPanel on an ephemeral kind stack) is
+ * added here once the component ships.
+ *
+ * Chromium is preinstalled at /opt/pw-browsers (PLAYWRIGHT_BROWSERS_PATH).
+ * The Claude Code environment ships a fixed executable; when
+ * PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH is set we use it, otherwise Playwright
+ * resolves the browser from its own cache (as on CI after `playwright install`).
+ */
+export default defineConfig({
+  testDir: __dirname,
+  testMatch: /\.spec\.ts$/,
+
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: [['list'], ['html', { open: 'never', outputFolder: 'playwright-report' }]],
+  outputDir: 'test-results',
+
+  use: {
+    // Post-prod smoke target; the frames spec ignores this (it uses file://).
+    baseURL: process.env.BASE_URL,
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+        launchOptions: process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH
+          ? { executablePath: process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH }
+          : {},
+      },
+    },
+  ],
+
+  timeout: 30_000,
+  expect: { timeout: 10_000 },
+})

--- a/tests/e2e/billing-invoices/postprod.smoke.spec.ts
+++ b/tests/e2e/billing-invoices/postprod.smoke.spec.ts
@@ -7,16 +7,17 @@ import { test, expect, type Page } from '@playwright/test'
  *                     E2E_USER_EMAIL=… E2E_USER_PASSWORD=… \
  *                     npx playwright test -c tests/e2e/billing-invoices/playwright.config.ts -g @postprod )
  *
- * This is a SKELETON. The React component (`@fuzefront/billing-ui →
- * InvoiceHistoryPanel`) is not built yet, so this cannot pass against a real
- * deploy today — it exists so the critical live-app journey is wired the moment
- * the component ships, and it SKIPS CLEANLY (never a false green, never a hard
- * fail) when BASE_URL / credentials are absent.
+ * The React component (`@fuzefront/billing-ui → InvoiceHistoryPanel`) now EXISTS
+ * and is verified pre-production by `built-component.spec.ts`; this smoke targets
+ * the built component's real `data-panel` / `data-testid` selectors on the live
+ * `/billing` route. It SKIPS CLEANLY (never a false green, never a hard fail)
+ * when BASE_URL / credentials are absent.
  *
- * What it verifies once live:
- *   sign-in → navigate to /billing → the invoice panel renders →
- *   a download link points at an https provider-hosted URL →
- *   no vendor brand name ("stripe"/"link") leaks into the DOM.
+ * What it verifies against the live app:
+ *   sign-in → navigate to /billing → the built invoice panel
+ *   ([data-testid='invoice-history-panel']) renders → at least one invoice row
+ *   ([data-testid='invoice-row']) with a download link pointing at an https
+ *   provider-hosted URL → no vendor brand name ("stripe"/"link") leaks into DOM.
  *
  * Login reuses this repo's server-side password sign-in convention
  * (POST /api/auth/oidc/password → platform JWT → localStorage.authToken),
@@ -82,17 +83,25 @@ test.describe('@postprod Billing invoice history — live smoke', () => {
 
     await page.goto(`${BASE_URL}/billing`)
 
-    // The invoice panel renders (data-panel is the frozen frame hook; the built
-    // component may also expose a testid — accept either).
+    // The built invoice panel renders. Prefer the component's stable testid;
+    // fall back to the frozen frame hook (data-panel) — both are emitted.
     const panel = page
-      .locator("[data-panel='invoice-history'], [data-testid='invoice-history-panel']")
+      .locator("[data-testid='invoice-history-panel'], [data-panel='invoice-history']")
       .first()
     await expect(panel, 'invoice history panel did not render on /billing').toBeVisible({
       timeout: 20_000,
     })
 
+    // At least one invoice row (the built component's row testid).
+    await expect(
+      panel.locator("[data-testid='invoice-row'], [data-invoice]").first(),
+      'no invoice row rendered on /billing'
+    ).toBeVisible()
+
     // At least one download link, pointing at an https provider-hosted document.
-    const download = panel.locator('[data-download]').first()
+    const download = panel
+      .locator("[data-testid='invoice-download'], [data-download]")
+      .first()
     await expect(download, 'no invoice download link rendered').toBeVisible()
     const href = (await download.getAttribute('href')) ?? ''
     expect(

--- a/tests/e2e/billing-invoices/postprod.smoke.spec.ts
+++ b/tests/e2e/billing-invoices/postprod.smoke.spec.ts
@@ -1,0 +1,118 @@
+import { test, expect, type Page } from '@playwright/test'
+
+/**
+ * POST-PRODUCTION synthetic smoke — Billing "Invoice history" against the LIVE app.
+ *
+ * Tag: @postprod   (run with:  BASE_URL=https://app.fuzefront.com \
+ *                     E2E_USER_EMAIL=… E2E_USER_PASSWORD=… \
+ *                     npx playwright test -c tests/e2e/billing-invoices/playwright.config.ts -g @postprod )
+ *
+ * This is a SKELETON. The React component (`@fuzefront/billing-ui →
+ * InvoiceHistoryPanel`) is not built yet, so this cannot pass against a real
+ * deploy today — it exists so the critical live-app journey is wired the moment
+ * the component ships, and it SKIPS CLEANLY (never a false green, never a hard
+ * fail) when BASE_URL / credentials are absent.
+ *
+ * What it verifies once live:
+ *   sign-in → navigate to /billing → the invoice panel renders →
+ *   a download link points at an https provider-hosted URL →
+ *   no vendor brand name ("stripe"/"link") leaks into the DOM.
+ *
+ * Login reuses this repo's server-side password sign-in convention
+ * (POST /api/auth/oidc/password → platform JWT → localStorage.authToken),
+ * the same path the frontend's oidc-plumbing e2e exercises. If that endpoint
+ * ever moves, update `signIn()` below — it is the only auth touch-point.
+ */
+
+const BASE_URL = process.env.BASE_URL?.replace(/\/$/, '')
+// Backend is same-origin in prod (ingress); allow an override for split hosts.
+const BACKEND_URL = (process.env.BACKEND_URL ?? BASE_URL ?? '').replace(/\/$/, '')
+const E2E_USER_EMAIL = process.env.E2E_USER_EMAIL
+const E2E_USER_PASSWORD = process.env.E2E_USER_PASSWORD
+
+const haveCreds = Boolean(BASE_URL && E2E_USER_EMAIL && E2E_USER_PASSWORD)
+
+const VENDOR_NAME = /\b(stripe|link)\b/i
+
+/**
+ * Server-side password sign-in (no redirect). Mirrors the frontend oidc-plumbing
+ * e2e: the backend drives Authentik's flow-executor and returns a platform JWT,
+ * which the SPA persists as localStorage.authToken. We seed that token, then let
+ * the app boot authenticated.
+ *
+ * TODO(when component ships): if the live deploy gates billing behind an org
+ * selection or a different session-bootstrap, extend this to select the org
+ * before navigating to /billing.
+ */
+async function signIn(page: Page): Promise<void> {
+  const resp = await page.request.post(`${BACKEND_URL}/api/auth/oidc/password`, {
+    data: { email: E2E_USER_EMAIL, password: E2E_USER_PASSWORD },
+  })
+  expect(
+    resp.status(),
+    `sign-in POST /api/auth/oidc/password -> ${resp.status()}: ${await resp
+      .text()
+      .catch(() => '')}`
+  ).toBe(200)
+  const body = await resp.json()
+  const token = body.token as string | undefined
+  expect(token, 'platform JWT returned from sign-in').toBeTruthy()
+
+  // Seed the token before any app code runs, then load the app authenticated.
+  await page.addInitScript((jwt) => {
+    window.localStorage.setItem('authToken', jwt as string)
+  }, token)
+}
+
+test.describe('@postprod Billing invoice history — live smoke', () => {
+  test.skip(
+    !haveCreds,
+    'post-prod smoke skipped: set BASE_URL + E2E_USER_EMAIL + E2E_USER_PASSWORD to run against the live app'
+  )
+
+  // Fresh, unauthenticated context; signIn() seeds the JWT.
+  test.use({ storageState: { cookies: [], origins: [] } })
+
+  test('sign-in → /billing renders the vendor-neutral invoice panel with a hosted download link', async ({
+    page,
+  }) => {
+    test.setTimeout(120_000)
+
+    await signIn(page)
+
+    await page.goto(`${BASE_URL}/billing`)
+
+    // The invoice panel renders (data-panel is the frozen frame hook; the built
+    // component may also expose a testid — accept either).
+    const panel = page
+      .locator("[data-panel='invoice-history'], [data-testid='invoice-history-panel']")
+      .first()
+    await expect(panel, 'invoice history panel did not render on /billing').toBeVisible({
+      timeout: 20_000,
+    })
+
+    // At least one download link, pointing at an https provider-hosted document.
+    const download = panel.locator('[data-download]').first()
+    await expect(download, 'no invoice download link rendered').toBeVisible()
+    const href = (await download.getAttribute('href')) ?? ''
+    expect(
+      href,
+      `download href is not an https provider-hosted URL: "${href}"`
+    ).toMatch(/^https:\/\//i)
+
+    // Accessible name on the download control.
+    const dlName = (await download.getAttribute('aria-label'))?.trim() ?? ''
+    expect(dlName.length, 'download link has no accessible name').toBeGreaterThan(0)
+
+    // No vendor brand name leaks into the rendered panel.
+    const panelHtml = (await panel.evaluate((el) => el.outerHTML)).toLowerCase()
+    expect(
+      panelHtml,
+      'a vendor brand name ("stripe"/"link") leaked into the live invoice panel'
+    ).not.toMatch(VENDOR_NAME)
+
+    // No mixed-content / CSP regression that would break the panel under TLS.
+    // (Guards FuzeFront's same-origin API base + hosted-doc-over-https contract.)
+    expect(page.url(), 'app navigated off /billing unexpectedly').toContain('/billing')
+  })
+})


### PR DESCRIPTION
## 📋 Description

Invoices were never fetched into our own store or shown in the UI — `GET /invoices` proxied the payment vendor **live** and stored nothing, the contract leaked vendor identifiers, and domain code imported the vendor SDK directly. This PR makes invoices a **stored, vendor-neutral** capability, introduces a **`PaymentProvider` port** confining the vendor (Stripe + Link) behind one adapter, and makes the **entire billing OpenAPI contract vendor-neutral** (0 occurrences of "stripe", generic webhooks). Delivered contract-first, fanned out to specialist agents.

> ⚠️ **Hold for a deploy window.** `master` is deploy-on-push. This PR is intentionally **draft + `hold`**; auto-merge is disabled. Merge (un-draft → rebase → signed squash) only in a deploy window.

## 🔄 Type of Change
- [x] ✨ New feature
- [x] 🔧 Refactoring (vendor SDK confined behind a provider port; full contract neutralization)
- [x] 🧪 Test addition
- [x] 📝 Documentation update

## 🧪 Testing — all green
- [x] **Unit** — billing-service **258 passed** (incl. 43 new invoice tests + 3 previously-failing contract tests now fixed); billing-client **12**; billing-ui **40** (incl. InvoiceHistoryPanel 11).
- [x] **Integration** — DB-backed store→read→keyset-paginate→upsert against **real Postgres in CI** (new `billing-service-tests.yml` job) + 15 no-DB acceptance.
- [x] **E2E** — Playwright vs the approved frames (13) + post-prod smoke skeleton.
- [x] **CI** — CodeQL, Contract Tests (OpenAPI), Dependency Review, Backend tests, Integration, Build, all `gate-*`, security scans: **green**.

## 🔧 Implementation Details
- **Contract (`openapi.yaml` v1.2.0):** every `stripe*` field/param → neutral (`subscriptionId`, `priceId`, `productId`, `sessionId`, `paymentIntentId`); path `{subscriptionId}`; **webhooks generic** (`/webhooks/{provider}`, neutral signature header) while the live `/webhooks/stripe` URL keeps working; `BillingInvoice.id` is an opaque FuzeFront UUID with an opaque cursor; new `POST /invoices/sync`. `grep -i stripe openapi.yaml` → 0. Kafka event schemas intentionally retain `stripe*` keys (separate event contract; follow-up).
- **Vendor abstraction:** `providers/payment-provider.ts` (neutral port + pre/post hooks) + `providers/stripe/stripe-payment-provider.ts` — the only vendor-SDK importer on the invoice path.
- **Storage:** migration `003_invoices.sql` (`billing.invoices`, keyset paginated, upsert on provider ref); `InvoiceRepository` + `InvoiceService`; webhooks (`invoice.paid|payment_succeeded|payment_failed|finalized|updated`) upsert via `invoice-synced`.
- **Client:** `@fuzefront/billing-client` gains `listInvoices()` / `syncInvoices()` + neutral types with compile-time contract-alignment asserts.
- **UI:** `@fuzefront/billing-ui → InvoiceHistoryPanel`, built to the **approved** frames (`design/frames/billing-invoices`, `manifest.approved:true`), gated behind flag `fuzefront.billing.invoice-history` (default OFF), wired into `BillingPage` (same-origin API base).
- **payment-service scaffold:** new standalone neutral vendor **gateway** (`services/payment-service`, port 3007, express 5) + Helm/compose/SealedSecret wiring (disabled in prod).
- **Live Swagger:** `GET /api/v1/billing/docs` (+ raw spec at `/openapi.yaml`).

## 🚨 Breaking Changes
Contract field/param names change `stripe*` → neutral (contract-frozen `@fuzefront/billing-client` consumers regenerate). `BillingInvoice.id` semantics move from a vendor id to an opaque UUID (already required to be treated as opaque). The live webhook URL is preserved.

## 📝 Deployment Notes
- [x] DB migration `003_invoices.sql` auto-runs at billing-service startup.
- [x] Register `invoice.finalized|updated` provider webhook event types (test + prod).
- [ ] No new secrets. `payment-service` ships **disabled** in prod (scaffold).
- Merge only in a deploy window; squash-merge must be signed per repo hardening.

## Follow-ups
- Migrate remaining vendor-named surfaces (subscriptions/checkout/portal/credits) onto the port; neutralize the Kafka event schemas (coordinated, breaking for event consumers); point the port at the standalone `payment-service`; consumer/integration docs; add `@fuzefront/billing-ui/styles.css` vite alias; swap the interim frontend flag read to the OpenFeature web client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)