### PR TITLE
fix(authn): route Authentik native paths under app host — restore OIDC (prod outage)

### DIFF
--- a/deploy/helm/fuzefront/templates/authentik.yaml
+++ b/deploy/helm/fuzefront/templates/authentik.yaml
@@ -284,24 +284,5 @@ spec:
   headers:
     customRequestHeaders:
       X-Forwarded-Proto: "https"
-{{- if eq .Values.ingress.className "traefik" }}
----
-# Strip the `/api/auth/idp` prefix before forwarding to authentik-server, so
-# Authentik receives its native paths (e.g. /application/o/fuzefront/). Traefik's
-# stripPrefix also sets `X-Forwarded-Prefix: /api/auth/idp`, which Authentik uses
-# to build absolute discovery/authorize URLs back under the app host + prefix —
-# keeping the issuer `https://app.fuzefront.com/api/auth/idp/...` consistent.
-apiVersion: traefik.io/v1alpha1
-kind: Middleware
-metadata:
-  name: authentik-idp-stripprefix
-  labels:
-    {{- include "fuzefront.labels" . | nindent 4 }}
-spec:
-  stripPrefix:
-    prefixes:
-      - /api/auth/idp
-    forceSlash: false
-{{- end }}
 {{- end }}
 {{- end }}

--- a/deploy/helm/fuzefront/templates/ingress.yaml
+++ b/deploy/helm/fuzefront/templates/ingress.yaml
@@ -186,9 +186,8 @@ metadata:
     app.kubernetes.io/component: authentik-idp
   annotations:
     {{- if eq .Values.ingress.className "traefik" }}
-    traefik.ingress.kubernetes.io/router.middlewares: {{ .Release.Namespace }}-authentik-idp-stripprefix@kubernetescrd,{{ .Release.Namespace }}-authentik-forwarded-proto@kubernetescrd
+    traefik.ingress.kubernetes.io/router.middlewares: {{ .Release.Namespace }}-authentik-forwarded-proto@kubernetescrd
     {{- else if eq .Values.ingress.className "nginx" }}
-    nginx.ingress.kubernetes.io/rewrite-target: /$2
     nginx.ingress.kubernetes.io/proxy-buffer-size: "16k"
     {{- end }}
     {{- with .Values.ingress.annotations }}
@@ -206,16 +205,13 @@ spec:
     - host: {{ .Values.ingress.host | quote }}
       http:
         paths:
-          {{- if eq .Values.ingress.className "nginx" }}
-          - path: /api/auth/idp(/|$)(.*)
-            pathType: ImplementationSpecific
-            backend:
-              service:
-                name: authentik-server
-                port:
-                  number: 9000
-          {{- else }}
-          - path: /api/auth/idp
+          # Route Authentik's OWN native root paths under the app host (NO prefix,
+          # NO strip). Authentik ignores X-Forwarded-Prefix, so it builds absolute
+          # OIDC discovery/authorize URLs at these root paths using the forwarded
+          # Host (app.fuzefront.com) — which must therefore be routable here.
+          # These prefixes don't overlap the app's /api, /apps, /socket.io, / routes.
+          {{- range $p := list "/application" "/if" "/source" "/flows" "/ws" "/-" "/outpost.goauthentik.io" "/static/dist" "/static/authentik" }}
+          - path: {{ $p }}
             pathType: Prefix
             backend:
               service:

--- a/deploy/helm/fuzefront/values-prod.yaml
+++ b/deploy/helm/fuzefront/values-prod.yaml
@@ -256,11 +256,14 @@ authentik:
   bootstrapEmail: admin@fuzefront.com
   oidc:
     enabled: true
-    # App-hosted, reverse-proxied issuer. The /api/auth/idp prefix is stripped by
-    # the Traefik middleware before reaching authentik-server; X-Forwarded-Prefix
-    # keeps Authentik's discovery URLs under this path. The FuzeFront OAuth
-    # callback (redirectUri) is already app-hosted and unchanged.
-    issuerUrl: "https://app.fuzefront.com/api/auth/idp/application/o/fuzefront/"
+    # App-hosted, reverse-proxied issuer at Authentik's NATIVE root path. Authentik
+    # ignores X-Forwarded-Prefix, so it advertises discovery/authorize URLs at
+    # /application/o/... (using the forwarded Host app.fuzefront.com); the app
+    # Ingress routes those native Authentik paths (/application,/if,/source,...)
+    # straight to authentik-server (no prefix, no strip), so the browser stays on
+    # app.fuzefront.com and never sees the IdP host. Callback (redirectUri) is the
+    # FuzeFront security-service route, unchanged.
+    issuerUrl: "https://app.fuzefront.com/application/o/fuzefront/"
     redirectUri: "https://app.fuzefront.com/api/auth/oidc/callback"
     # No split-DNS in prod: real public DNS + a real Let's Encrypt cert mean the
     # backend reaches Authentik over the internet without a hostAlias or a custom


### PR DESCRIPTION
## Prod incident fix (chart-only, deploys via Argo)

**Root cause:** #247's reverse-proxy stripped `/api/auth/idp` and relied on `X-Forwarded-Prefix`, but **Authentik ignores it**. Live-probe proof: OIDC discovery advertised `authorization_endpoint: https://app.fuzefront.com/application/o/authorize/` — right host (no `auth.fuzefront.com` leak, boundary intact) but no `/api/auth/idp` prefix, so the path 404'd → browser authorize redirect failed → **prod login broke**.

**Fix:** route Authentik's native root paths (`/application`,`/if`,`/source`,`/flows`,`/ws`,`/-`,`/outpost.goauthentik.io`,`/static/dist`,`/static/authentik`) straight to `authentik-server` under `app.fuzefront.com` (no strip); issuer → `https://app.fuzefront.com/application/o/fuzefront/`. `helm template` renders clean; no collision with app `/api`,`/apps`,`/socket.io`,`/` routes.

**Verify post-merge (Argo auto-syncs):** `curl -s https://app.fuzefront.com/application/o/fuzefront/.well-known/openid-configuration` → `authorization_endpoint` should be a **routable** `https://app.fuzefront.com/application/o/authorize/`.

**Follow-up (not this PR):** Google Cloud Console must have `https://app.fuzefront.com/source/oauth/callback/google/` as an authorized redirect URI for Google social login; `release.yml` still isn't building images (blocks deploying the new #253 backend / #250 frontend).

🤖 Generated with [Claude Code](https://claude.com/claude-code)