### PR TITLE
docs(consumers): integrate via the Security API + @fuzefront/security-client, not Authentik/Permit

### DIFF
--- a/docs/consumers/authn-authz-integration.md
+++ b/docs/consumers/authn-authz-integration.md
@@ -1,258 +1,303 @@
-# Multi-product authN/authZ integration
+# AuthN + AuthZ integration for consumer products
 
 How a **consumer product** (a product built on the FuzeFront platform — e.g.
-**FuzeMarket**) onboards its own **authentication** (Authentik OIDC) and
-**authorization** (Permit.io) policy, scoped to FuzeFront's multi-tenant org
-model.
+**FuzeMarket**) authenticates its users and authorizes their actions **through
+the FuzeFront Security API**, without ever talking to an identity or policy
+vendor directly.
 
 > Audience: platform engineers extending FuzeFront, and product teams onboarding
-> a new consumer product. For the step-by-step consumer recipe see
+> a new consumer product. For the step-by-step recipe see
 > [`onboarding-authn-authz.md`](./onboarding-authn-authz.md).
+
+---
+
+## The only two things a consumer knows
+
+1. **The FuzeFront Security API** — a stable, same-origin HTTP surface under
+   **`/api/v1/security/*`**. The source of truth is the OpenAPI contract at
+   [`packages/security/openapi.yaml`](../../packages/security/openapi.yaml).
+2. **The `@fuzefront/security-client` package** — the generated TypeScript types
+   for that contract (including the stable `Identity` shape). Install it from
+   GitHub Packages (see the onboarding guide) and import its types.
+
+That is the entire integration seam. A consumer never sees, names, or configures
+an identity provider, an authorization engine, a JWKS endpoint, or any vendor
+SDK. Those are **swappable server-side implementations** hidden behind the
+Security API's internal adapters (`IdentityProvider`, `AuthorizationProvider`).
+FuzeFront can switch or blend providers for features or cost with **zero**
+consumer change.
+
+**Naming rule (strict):** no vendor/product name appears in any consumer-facing
+path, type, field, config key, URL, or doc. Open-standard protocol terms
+(OIDC/OAuth2/JWKS/PKCE) may appear only where they name a genuine wire protocol
+the browser transits — never as a thing you integrate against.
 
 ---
 
 ## TL;DR
 
-- A consumer product registers via its **App Manifest** (the federated-app
-  registration contract). The manifest gains two new sections: **`auth`**
-  (authN) and **`authz`** (authZ policy).
-- **AuthN**: the platform provisions a **per-product Authentik OIDC application/
-  client** from the manifest `auth` section (redirect URIs, scopes, claims).
-  Identity is one shared Authentik; products trust the same issuer.
-- **AuthZ**: the product declares its OWN resources/actions/roles with **bare
-  keys** (`Listing`, `seller`). The platform **namespaces** them
-  (`fuzemarket.Listing`, `fuzemarket.seller`) and **merges** them into the
-  Permit environment schema. Two products can't collide.
-- **Org model**: authZ is **per-tenant** (one Permit tenant per org), with a
-  **ReBAC hierarchy** where **FuzeOne is the root/parent tenant** and FuzeOne
-  staff manage child (customer) tenants by derivation.
+- **AuthN** — sign users in/up and manage their session entirely through
+  `/api/v1/security/*` (`/session`, `/signup`, `/social/{provider}/start`,
+  `/session/exchange`, `/methods`). For social login the user's browser only
+  ever transits `app.fuzefront.com` and, briefly, the social provider's own
+  consent host (e.g. `accounts.google.com`) — never a FuzeFront-internal
+  identity host.
+- **Identity** — every authenticated caller resolves to the stable, normalized
+  **`Identity`** (`{ userId, tenantId, roles, authMode, … }`) from
+  `@fuzefront/security-client`. It is **invariant across token-format
+  migrations**, so your code never parses raw JWTs or fetches JWKS. Read
+  "who am I" from `GET /api/v1/security/session`.
+- **AuthZ** — ask the platform for decisions with
+  `POST /api/v1/security/authz/check` (single) or `/authz/bulk-check`, list
+  effective `/authz/permissions`, and manage tenants/members/roles/grants under
+  `/authz/grants` and `/tenants/*`. Never call a policy SDK.
+- **Fail-closed everywhere** — any verification, provider, or transport error
+  yields a denial (401/403) or an explicit error body, never a permissive
+  fallback. `authz/check` returns `{ allow: false }` on any error.
 
 ---
 
 ## 1. Architecture
 
 ```
-                         ┌──────────────────────────────────────────┐
-                         │              FuzeFront platform            │
-                         │                                            │
-   Product registers     │   App Manifest                             │
-   (App Manifest) ──────►│   ├─ auth   { oidc: {...} }  ──┐           │
-                         │   └─ authz  { product, resources, roles }  │
-                         │                               │  │         │
-                         │      provisioning             │  │         │
-                         │      ┌────────────────────────┘  │         │
-                         │      ▼                            ▼         │
-                         │  Authentik (OIDC)           Permit.io       │
-                         │  per-product application    env schema      │
-                         │  + client                   (merged,        │
-                         │                              namespaced)    │
-                         └──────┬──────────────────────────┬──────────┘
-                                │ id_token / userinfo       │ check()/assign()
-                                ▼                            ▼
-                         ┌──────────────────────────────────────────┐
-                         │      Consumer product runtime (FuzeMarket) │
-                         │  - logs users in via shared Authentik OIDC │
-                         │  - checks fuzemarket.Listing:update etc.   │
-                         └──────────────────────────────────────────┘
+   Consumer product (e.g. FuzeMarket)
+   ─ browser SPA ─┐                        ┌───────────────────────────────────┐
+                  │  same-origin HTTPS      │        FuzeFront platform          │
+                  ▼                        │                                    │
+        /api/v1/security/*  ──────────────►│   FuzeFront Security API           │
+        (@fuzefront/security-client types) │   (packages/security/openapi.yaml) │
+                  ▲                        │        │                           │
+   ─ product API ─┘                        │        ▼   internal adapters       │
+        Bearer <token>                     │   IdentityProvider  AuthorizationProvider
+        authz/check ─────────────────────►│   (identity engine) (policy engine)  │
+                                           │        ▲                ▲            │
+                                           │   swappable, vendor-hidden           │
+                                           └───────────────────────────────────┘
 ```
 
-- **AuthN** = **Authentik OIDC** (`backend/src/services/oidc.ts`; Helm
-  `authentik` block in `deploy/helm/fuzefront/values-prod.yaml`). One Authentik
-  instance, one issuer; each product is its own OIDC *application + client*.
-- **AuthZ** = **Permit.io**, per-tenant (one Permit tenant per org). Base
-  platform schema in `backend/security/src/permit/schema.ts` (mirrored to
-  `backend/src/permit/schema.ts`), synced by
-  `backend/src/permit/sync-permit-schema.ts`, checked via
-  `backend/src/utils/permit/permission-check.ts` and (for product resources)
-  `backend/src/utils/permit/product-authz.ts`.
+- The consumer SPA and the consumer's own API both speak **only** to
+  `/api/v1/security/*` on the same origin (`app.fuzefront.com` in prod; local
+  TLS locally). Never hard-code an absolute API host — the base is same-origin so
+  it works identically local and prod.
+- Every request carries `Authorization: Bearer <token>` where the token is a
+  **FuzeFront-minted** session or M2M token. Consumers depend on the normalized
+  `Identity`, never on the raw claims inside the token.
+- The identity engine and the authorization engine live behind server-side
+  adapters. Their vendor identity is a server-only implementation detail.
 
 ---
 
-## 2. End-to-end flow
+## 2. AuthN — authenticate through the Security API
 
-1. **Register** — the product publishes its App Manifest with `auth` + `authz`.
-2. **Declare policy** — `authz` lists the product's resources/actions/roles with
-   bare keys. `auth.oidc` lists redirect URIs, scopes, claim mapping.
-3. **Platform provisions**:
-   - **AuthN**: creates/updates an Authentik **application + OIDC provider** for
-     the product (client_id/secret, redirect URIs, scopes). Secrets land in a
-     k8s Secret the product consumes.
-   - **AuthZ**: validates + **namespaces** the product policy and **merges** it
-     into the Permit environment schema, then runs the idempotent sync
-     (`syncPermitSchemaWithProducts`).
-4. **Product consumes at runtime**:
-   - **AuthN**: redirect users to the shared Authentik issuer with the product's
-     client; trust `id_token`/`userinfo` (same `sub` across products).
-   - **AuthZ**: assign product roles to users
-     (`assignProductRole(user, 'fuzemarket', 'seller', orgId)`) and check
-     (`checkProductPermission(user, 'fuzemarket', 'Listing', 'update', orgId)`).
+The consumer never runs an OIDC code flow itself and never redirects users to an
+identity host. It calls the Security API; the platform brokers everything.
 
----
+### 2.1 Capability discovery — `GET /api/v1/security/methods`
 
-## 3. AuthN — per-product Authentik OIDC client
-
-One Authentik, one issuer, **one OIDC application/client per product**. The
-manifest drives provisioning:
+Returns the neutral `AuthMethods` descriptor so the UI can render the right
+affordances (password form, which social buttons, whether MFA / contact
+verification are enabled) **without knowing any provider**:
 
 ```jsonc
-// App Manifest — auth section
-"auth": {
-  "oidc": {
-    "applicationSlug": "fuzemarket",          // Authentik application + provider slug
-    "redirectUris": [
-      "https://market.fuzefront.com/api/auth/oidc/callback"
-    ],
-    "scopes": ["openid", "email", "profile"],  // default platform scopes
-    "claims": {                                 // claim → product field mapping
-      "sub": "userId",
-      "email": "email",
-      "groups": "roles"
-    }
-  }
+{
+  "password": true,
+  "social": ["google"],
+  "mfa": { "enabled": true, "types": ["totp", "sms", "email"] },
+  "verification": { "email": true, "sms": true }
 }
 ```
 
-**Trust model**
+This replaces the legacy vendor-specific `oidcConfigured` boolean.
 
-- All products trust the **same Authentik issuer** (`AUTHENTIK_ISSUER_URL`). The
-  `sub` claim is a stable, cross-product user id — the same person is the same
-  `sub` in FuzeFront and in FuzeMarket. This is what lets a Permit role
-  assignment made by the platform apply to the product's checks.
-- Each product gets its **own client_id/client_secret** and its **own redirect
-  URIs** so tokens are scoped and revocable per product. Secrets are delivered
-  as k8s Secrets (SealedSecrets in prod), never embedded in the manifest.
-- The platform shell remains the canonical session holder; products may either
-  reuse the shell session (same-origin) or run their own OIDC code-flow against
-  the shared issuer with their client. Authorization is **always** re-checked
-  against Permit at the product API — a valid token is necessary but not
-  sufficient.
+### 2.2 Password login — `POST /api/v1/security/session`
 
-Provisioning the Authentik application/provider from the manifest is an
-operations step (Authentik blueprint or API); the manifest is the declarative
-source. See the onboarding guide for the exact blueprint fields.
+Body `{ email, password }`. Returns a **`SessionResult`** — a discriminated union
+on `status`:
+
+- `{ status: "authenticated", token, sessionId?, user }` — session established.
+- `{ status: "mfa_required", challengeId, factors[] }` — the account has MFA;
+  complete step-up via `POST /mfa/challenge` then `POST /mfa/verify` (which
+  returns the authenticated `LoginResponse`).
+
+Always narrow on `status` before reading variant fields. Bad credentials
+fail-closed with `401`.
+
+### 2.3 Social login — server-brokered, no internal host exposed
+
+1. Send the browser to `GET /api/v1/security/social/{provider}/start`
+   (`provider` = `google` today; extensible). Optional same-origin `redirectTo`.
+   The platform 302-redirects to the provider's own consent host.
+2. The provider returns to `GET /api/v1/security/social/callback`. The platform
+   completes the handshake, provisions/links the user, mints a **single-use
+   opaque `code`**, and 302-redirects back to the app with `?code=<opaque>`.
+   **No token is ever placed in the URL.**
+3. The SPA calls `POST /api/v1/security/session/exchange` with `{ code }` and
+   gets a `SessionResult` (which may itself be an `mfa_required` challenge).
+
+The browser only ever transits `app.fuzefront.com` and the social provider's
+consent host. No FuzeFront-internal identity host is visible or named.
+
+### 2.4 Signup — `POST /api/v1/security/signup`
+
+Body `{ email, password, firstName?, lastName?, tenantName? }`. The user sees
+only FuzeFront-branded UI — never a provider's raw enrollment page. On success a
+session is established (`201` → `LoginResponse`). `409` if the email exists.
+
+### 2.5 Session lifecycle
+
+- `GET /api/v1/security/session` → `SessionInfo { identity, user }` — the current
+  identity ("me"). This is the authoritative source of any out-of-band
+  role/tenant hydration.
+- `DELETE /api/v1/security/session` — logout; revokes the presented token
+  (idempotent, `204`).
+
+### 2.6 MFA and contact verification (provider-agnostic)
+
+- **MFA** (`/mfa/*`): enroll/list/activate/remove factors, regenerate
+  recovery codes, and the login step-up pair `/mfa/challenge` + `/mfa/verify`.
+  Consumers see only neutral factor `type` values (`totp`/`sms`/`email`, with
+  `webauthn` reserved) — never a provider name.
+- **Contact verification** (`/verify/*`): email + phone ownership verification,
+  distinct from MFA login step-up; `GET /verify/status` returns
+  `{ emailVerified, phoneVerified, phone? }`.
+
+### 2.7 Machine-to-machine tokens
+
+- `POST /api/v1/security/tokens` — issue a FuzeFront-owned M2M token
+  (client-credentials style) for a provisioned service client.
+- `POST /api/v1/security/tokens/introspect` — introspect it; fail-closed
+  (`{ active: false }` for unknown/expired).
 
 ---
 
-## 4. AuthZ — per-product policy declaration & merge
+## 3. Identity — the stable keystone
 
-### 4.1 Declaration schema (`ProductPolicy`)
-
-A product submits **bare** keys; the platform namespaces them. Type:
-`backend/src/permit/product-policy.ts`.
+Every authenticated caller resolves to the normalized `Identity` from
+`@fuzefront/security-client`:
 
 ```ts
-interface ProductPolicy {
-  product: string            // namespace key, lowercase [a-z0-9-], e.g. 'fuzemarket'
-  name?: string              // display prefix, e.g. 'FuzeMarket'
-  resources: { key; name; actions: Record<string,{name}> }[]
-  roles:     { key; name; permissions: string[] }[]   // 'Listing:create' (bare)
+import type { Identity } from '@fuzefront/security-client'
+
+// Identity = {
+//   userId: string            // stable subject id — always present
+//   tenantId: string | null   // tenant/org scope; null when unresolved (legacy mode)
+//   roles: string[]           // always an array; [] means "no roles known"
+//   email?: string
+//   authMode: 'legacy-hs256' | 'federated-jwks'
+//   issuedAt?, expiresAt?, issuer?
+// }
+```
+
+- **Verify tokens via the platform, not by hand.** Do not parse the JWT, do not
+  fetch a JWKS, do not trust raw claims. Present the token to the Security API
+  (e.g. `GET /session`, or `/tokens/introspect` for M2M) and consume the
+  resulting `Identity`.
+- **`Identity` is invariant across the token-format migration** (`authMode`
+  moves `legacy-hs256` → `federated-jwks`). Your integration does not change when
+  the underlying token format does.
+- **`tenantId` may be `null`** in legacy token mode when the tenant is not yet
+  resolved. Consumers **fail-closed** on tenant-scoped authorization when it is
+  null — never default it to a tenant.
+- The `userId` is the same stable subject across the whole family, so a role or
+  grant the platform assigns applies to your product's checks for the same user.
+
+The contract version is exported as `SECURITY_CONTRACT_VERSION` (currently
+`0.3.0`); consumers may assert on the major.
+
+---
+
+## 4. AuthZ — decisions through the Security API
+
+> **Delivery status:** AuthN is shipped first (it closes the acute vendor-leak).
+> The AuthZ surface below (`/authz/*`, `/tenants/*`) is **frozen in the contract**
+> and generated into the client, but its endpoints are **not yet live** in the
+> Security service. Build against the contract/client types now; the endpoints
+> light up in the AuthZ rollout that follows AuthN. Treat any AuthZ call as
+> "coming" until then and gate it behind your own flag.
+
+A grant/role assignment is a rollout convenience — the **authoritative** answer
+to "may this subject do this?" is always `POST /authz/check`, never the presence
+of a role record and never a local cache.
+
+### 4.1 Check a single decision — `POST /api/v1/security/authz/check`
+
+```jsonc
+// request (AuthzCheckRequest)
+{
+  "subject": "<userId>",
+  "tenant":  "<tenantId>",
+  "resource": { "type": "Listing", "key": "listing-123" },  // key optional (ReBAC instance)
+  "action":  "update",
+  "context": { }                                            // optional
 }
+// response (AuthzDecision)
+{ "allow": true }
 ```
 
-Worked example: `backend/src/permit/products/fuzemarket.policy.ts` — resources
-`Listing`/`Order`/`Cart`, roles `seller`/`buyer`/`market-admin`.
+Fail-closed: any provider/transport error returns `{ allow: false }`.
 
-### 4.2 Namespacing (collision avoidance)
+### 4.2 Bulk + effective permissions
 
-Every product key is prefixed with `<product>.` (the separator `PRODUCT_NS_SEP`,
-a `.`). So `Listing` → **`fuzemarket.Listing`**, role `seller` →
-**`fuzemarket.seller`**, and permission `Listing:create` →
-**`fuzemarket.Listing:create`**. The `.` never collides with the `:` that
-separates a resource key from its action in a permission string.
+- `POST /api/v1/security/authz/bulk-check` — ordered `checks[]` (≤ 200) →
+  `decisions[]` index-aligned with the request.
+- `GET /api/v1/security/authz/permissions?subject&tenant` → `PermissionSet`
+  (`{ subject, tenant, permissions: ["resource:action", …] }`) — the effective,
+  bounded permission set for one subject in one tenant.
 
-Two products that both define a `Listing` resource and a `seller` role never
-collide: `fuzemarket.Listing` vs `fuzeshop.Listing`.
+### 4.3 Grants (write side) — `/api/v1/security/authz/grants`
 
-### 4.3 Merge & sync
+- `POST` — grant a `role` (and/or explicit `permission`) to a `subject` within a
+  `tenant`. Omit `resource` for a **tenant-wide (RBAC)** grant; include
+  `resource: { type, key }` to scope to a **specific resource instance (ReBAC)**.
+  Returns the created `Grant`.
+- `DELETE` — revoke by `{ grantId }` **or** by the identity tuple
+  `{ subject, tenant, role, resource? }` (supply one form). Idempotent (`204`
+  even if absent).
+- `GET ?subject&tenant` — list a subject's grants (cursor-paginated `GrantPage`,
+  because ReBAC grants across many resource instances are potentially unbounded).
 
-`mergeProductPolicy(base, ...policies)` is a **pure** function that returns the
-base platform schema with the namespaced product resources/roles appended; it
-throws `ProductPolicyError` on a re-used product namespace. `buildEnvSchema(...)`
-is the base + products convenience wrapper.
+### 4.4 Tenants, members, roles — `/api/v1/security/tenants/*`
 
-`syncPermitSchemaWithProducts(permit, [fuzemarketPolicy])` builds the merged
-schema and runs the existing **idempotent** get-or-(create|update) sync. Running
-it for one product never disturbs another product's namespace.
+Neutralized authorization primitives for multi-tenant org management:
 
-### 4.4 Runtime checks & role assignment
-
-Product resources are checked/assigned with namespacing handled for you
-(`backend/src/utils/permit/product-authz.ts`):
-
-```ts
-// is this user allowed to update this listing in org `orgId`?
-await checkProductPermission(userId, 'fuzemarket', 'Listing', 'update', orgId, listingId)
-
-// make a user a seller in org `orgId`
-await assignProductRole(userId, 'fuzemarket', 'seller', orgId)
-
-// express route guard
-router.patch('/listings/:id',
-  requireProductPermission('fuzemarket', 'Listing', 'update',
-    req => req.organizationId, req => req.params.id),
-  handler)
-```
-
-Permit checks **fail safe** (deny on PDP error), matching the platform's
-existing `checkPermission`.
-
----
-
-## 5. ReBAC org hierarchy — FuzeOne is the root
-
-AuthZ is **per-tenant** (one Permit tenant per org). On top of that, the
-`Organization` resource declares a **ReBAC** parent→child hierarchy so **FuzeOne
-staff manage all child (customer) tenants** without a per-tenant assignment.
-
-In the base schema (`schema.ts`), the `Organization` resource gains:
-
-```ts
-relations: { parent: 'Organization' },     // a child org points at its parent
-roles: {
-  'org-admin': {                            // resource-instance-scoped ReBAC role
-    permissions: ['create','read','update','delete','manage'],
-    granted_to: { users_with_role: [
-      { role: 'org-admin', on_resource: 'Organization', linked_by_relation: 'parent' }
-    ] },
-  },
-}
-```
-
-Read it as: *a user who is `org-admin` on a **parent** Organization instance is
-**granted** `org-admin` on every **child** instance via the `parent` relation* —
-transitively down the whole tree. Grant a FuzeOne staff member `org-admin` on
-the **FuzeOne root org** and they administer every customer org beneath it.
-
-**Provisioning** (`backend/src/utils/permit/resource-instances.ts`):
-
-- `setOrganizationParent(childOrgId, parentOrgId)` — records the `parent`
-  relationship tuple between two Organization instances (idempotent). Customer
-  orgs are created with `parent = FuzeOne root org`.
-- `assignOrgAdminRebac(userId, organizationId)` — grants `org-admin` on a
-  specific Organization instance (use the FuzeOne root for platform staff).
-
-The existing flat tenant roles (`admin`/`editor`/`viewer`, mapped from
-membership in `role-assignment.ts`) are unchanged and additive — they govern
-in-tenant membership; the ReBAC `org-admin` governs cross-tenant staff reach.
-
-> The org `type: 'platform'` (see `Organization` in
-> `backend/src/types/shared.ts`) marks the FuzeOne root; customer orgs are
-> `type: 'organization'` with `parent_id` set to the root.
-
----
-
-## 6. Files
-
-| Concern | File |
+| Operation | Endpoint |
 | --- | --- |
-| Base platform schema + ReBAC | `backend/src/permit/schema.ts` (mirror: `backend/security/src/permit/schema.ts`) |
-| Product policy types + merge | `backend/src/permit/product-policy.ts` (mirror under `backend/security`) |
-| Schema sync (+ product merge) | `backend/src/permit/sync-permit-schema.ts` |
-| FuzeMarket sample policy | `backend/src/permit/products/fuzemarket.policy.ts` |
-| Runtime product checks/roles | `backend/src/utils/permit/product-authz.ts` |
-| ReBAC org provisioning | `backend/src/utils/permit/resource-instances.ts` |
-| AuthN (OIDC) | `backend/src/services/oidc.ts`, Helm `authentik` block |
-| Tests | `backend/tests/product-policy.test.ts` |
+| List / create tenants | `GET` / `POST /tenants` (list is cursor-paginated) |
+| Get a tenant | `GET /tenants/{tenantId}` |
+| List / add members | `GET` / `POST /tenants/{tenantId}/members` (list paginated) |
+| Remove a member | `DELETE /tenants/{tenantId}/members/{userId}` |
+| List roles (bounded catalogue) | `GET /tenants/{tenantId}/roles` |
+| Replace a member's roles | `PUT /tenants/{tenantId}/members/{userId}/roles` |
 
-> `backend/src/permit/*` and `backend/security/src/permit/*` are kept
-> **byte-identical** (the security microservice owns the sync job). Edit both.
+Authorization is **per-tenant**: a role in tenant A does not grant it in tenant
+B. Assign per tenant.
+
+---
+
+## 5. Cross-product session handoff — coming
+
+A within-product opaque-`code` exchange exists today for social login
+(`/social/callback` → `/session/exchange`, §2.3). A **cross-product** one-time
+handoff — where a user already signed in to one Fuze product lands
+pre-authenticated in another without re-login — is **not yet available**. When it
+ships it will reuse the same opaque single-use-`code` + `/session/exchange`
+pattern (no token in the URL). Do not build against it until it is in the
+contract; treat it as a future capability.
+
+---
+
+## 6. What lives where
+
+| Concern | Location (source of truth) |
+| --- | --- |
+| Contract (all paths + schemas) | `packages/security/openapi.yaml` |
+| Generated + stable client types | `@fuzefront/security-client` (`packages/security/src/`) |
+| `Identity`, `AuthMode`, `AuthMethods`, `Grant`, … | `packages/security/src/types.ts` |
+| Contract version | `SECURITY_CONTRACT_VERSION` (`0.3.0`) |
+
+Everything else — which identity engine, which policy engine, JWKS, provider
+config — is server-side and **out of the consumer's contract**. If you find
+yourself needing a vendor name to integrate, that is a bug in the integration,
+not a missing doc.
+</content>
+</invoke>

--- a/docs/consumers/onboarding-authn-authz.md
+++ b/docs/consumers/onboarding-authn-authz.md
@@ -1,9 +1,12 @@
-# Consumer onboarding: authN + authZ (FuzeMarket worked example)
+# Consumer onboarding: authN + authZ (step-by-step)
 
-Step-by-step recipe for onboarding a **consumer product** to FuzeFront's
-authentication (Authentik OIDC) and authorization (Permit.io). The running
-example is **FuzeMarket**: a marketplace product with resources
-`Listing`/`Order`/`Cart` and roles `seller`/`buyer`/`market-admin`.
+A recipe for wiring a **consumer product** to FuzeFront authentication and
+authorization. You integrate against exactly two things — the **FuzeFront
+Security API** (`/api/v1/security/*`) and the **`@fuzefront/security-client`**
+types. You never touch an identity or policy vendor.
+
+The running example is **FuzeMarket**: a marketplace product with resources like
+`Listing`/`Order`/`Cart` and roles like `seller`/`buyer`/`market-admin`.
 
 For the architecture and trust model, read
 [`authn-authz-integration.md`](./authn-authz-integration.md) first.
@@ -12,165 +15,254 @@ For the architecture and trust model, read
 
 ## Prerequisites
 
-- Your product is (or will be) registered with the platform via an **App
-  Manifest** (the federated-app registration contract).
-- You have a product key: a lowercase `[a-z0-9-]` slug, e.g. `fuzemarket`. This
-  is your **namespace** for every Permit resource/role and your Authentik
-  application slug.
+- Your product is served **same-origin** with the platform (under
+  `app.fuzefront.com` in prod, or local TLS in dev), so `/api/v1/security/*`
+  resolves without a cross-origin base URL. Never hard-code an absolute API host.
+- You can read a GitHub Packages token to install a private `@fuzefront/*`
+  package (below).
 
 ---
 
-## Step 1 — Declare your `auth` section (authN)
+## Step 0 — Install `@fuzefront/security-client`
 
-Add an `auth.oidc` block to your App Manifest:
+The client is published **privately** to GitHub Packages under the `@fuzefront`
+scope (`access: restricted`). Add a scoped `.npmrc` (do **not** commit a token —
+use an env var / CI secret):
 
-```jsonc
-"auth": {
-  "oidc": {
-    "applicationSlug": "fuzemarket",
-    "redirectUris": [
-      "https://market.fuzefront.com/api/auth/oidc/callback"
-    ],
-    "scopes": ["openid", "email", "profile"],
-    "claims": { "sub": "userId", "email": "email", "groups": "roles" }
+```ini
+# .npmrc
+@fuzefront:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}
+```
+
+```bash
+npm install @fuzefront/security-client
+```
+
+```ts
+import type {
+  Identity,
+  AuthMethods,
+  SessionResult,
+  SECURITY_CONTRACT_VERSION,
+} from '@fuzefront/security-client'
+// generated request/response shapes:
+import type { components } from '@fuzefront/security-client'
+type LoginResponse = components['schemas']['LoginResponse']
+type AuthzCheckRequest = components['schemas']['AuthzCheckRequest']
+```
+
+> **The package is types-only.** It ships the OpenAPI-generated TypeScript types
+> and the stable hand-authored contract types (the `Identity` keystone). There is
+> no `client.login()` / `createClient()` — you call the same-origin Security API
+> with your own `fetch`/HTTP layer and let these types make contract drift a
+> compile error. (A non-TS consumer just calls the HTTP API directly using
+> [`packages/security/openapi.yaml`](../../packages/security/openapi.yaml) as the
+> reference.)
+
+---
+
+## Step 1 — Discover capabilities and render the sign-in UI
+
+Call `GET /api/v1/security/methods` and render affordances from the neutral
+`AuthMethods` descriptor — never assume a provider:
+
+```ts
+const methods: AuthMethods = await fetch('/api/v1/security/methods').then(r => r.json())
+// methods.password        → show the email/password form
+// methods.social          → e.g. ["google"] → render those buttons
+// methods.mfa.enabled      → be ready for an mfa_required SessionResult
+// methods.verification     → whether email/SMS ownership verification is offered
+```
+
+---
+
+## Step 2 — Sign users in / up
+
+### Password login
+
+```ts
+const res: SessionResult = await fetch('/api/v1/security/session', {
+  method: 'POST',
+  headers: { 'content-type': 'application/json' },
+  body: JSON.stringify({ email, password }),
+}).then(r => r.json())
+
+if (res.status === 'authenticated') {
+  saveToken(res.token)              // FuzeFront-minted session token
+} else {
+  // res.status === 'mfa_required'
+  await completeMfa(res.challengeId, res.factors)  // /mfa/challenge → /mfa/verify
+}
+```
+
+### Social login (server-brokered)
+
+1. Navigate the browser to `GET /api/v1/security/social/google/start`
+   (optionally `?redirectTo=/some/app/path`, same-origin only).
+2. The platform brokers the provider handshake and returns the browser to your
+   app with a single-use `?code=…` (never a token in the URL).
+3. Exchange it:
+
+```ts
+const res: SessionResult = await fetch('/api/v1/security/session/exchange', {
+  method: 'POST',
+  headers: { 'content-type': 'application/json' },
+  body: JSON.stringify({ code }),
+}).then(r => r.json())
+// same authenticated | mfa_required handling as above
+```
+
+The browser only ever sees `app.fuzefront.com` and the provider's own consent
+host — no internal identity host.
+
+### Signup
+
+```ts
+await fetch('/api/v1/security/signup', {
+  method: 'POST',
+  headers: { 'content-type': 'application/json' },
+  body: JSON.stringify({ email, password, firstName, lastName, tenantName }),
+}) // 201 → LoginResponse (session established); 409 if the email exists
+```
+
+> A valid token **authenticates**; it does **not** authorize. Always re-check
+> permissions at your API (Step 4).
+
+---
+
+## Step 3 — Read "who am I" (Identity)
+
+On every authenticated request, resolve the caller to the stable `Identity` via
+the platform — do not parse the JWT or fetch a JWKS yourself:
+
+```ts
+const { identity, user } = await fetch('/api/v1/security/session', {
+  headers: { authorization: `Bearer ${token}` },
+}).then(r => r.json())
+
+// identity: Identity
+//   identity.userId    → stable subject id (use this as the user id everywhere)
+//   identity.tenantId  → tenant/org scope, or null if unresolved
+//   identity.roles     → string[]
+```
+
+- Use `identity.userId` as the canonical user id — do **not** invent your own.
+- If `identity.tenantId` is `null`, **fail closed** on any tenant-scoped
+  authorization; never guess a tenant.
+- `identity.authMode` (`legacy-hs256` → `federated-jwks`) is informational; your
+  code stays the same across the migration because `Identity` is invariant.
+
+For M2M callers, introspect the token instead:
+`POST /api/v1/security/tokens/introspect` with `{ token }` → fail-closed
+`{ active, subject, tenantId, scope, expiresAt }`.
+
+---
+
+## Step 4 — Authorize actions
+
+> **Status:** the AuthZ endpoints below are **frozen in the contract** and
+> generated into the client, but are **not yet live** in the Security service —
+> AuthN ships first, AuthZ follows. Type your integration against them now and
+> gate the calls behind your own feature flag until the AuthZ rollout lands.
+
+Ask the platform for the decision — never a local role cache and never a policy
+SDK. `authz/check` is authoritative and fail-closed (`{ allow: false }` on any
+error):
+
+```ts
+async function may(subject: string, tenant: string,
+                   resourceType: string, action: string, key?: string) {
+  const body: AuthzCheckRequest = {
+    subject, tenant, resource: { type: resourceType, key }, action,
   }
+  const { allow } = await fetch('/api/v1/security/authz/check', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', authorization: `Bearer ${token}` },
+    body: JSON.stringify(body),
+  }).then(r => r.json())
+  return allow
 }
+
+// guard a route
+app.patch('/listings/:id', async (req, res) => {
+  if (!(await may(req.identity.userId, req.identity.tenantId!, 'Listing', 'update', req.params.id))) {
+    return res.status(403).json({ error: 'forbidden', code: 'FORBIDDEN' })
+  }
+  // …
+})
 ```
 
-The platform provisions a **per-product Authentik application + OIDC provider**
-from this. You receive:
+Batch checks with `POST /api/v1/security/authz/bulk-check` (≤ 200, index-aligned
+decisions); read a subject's effective permissions with
+`GET /api/v1/security/authz/permissions?subject&tenant`.
 
-- `AUTHENTIK_ISSUER_URL` — shared issuer (same for all products).
-- `AUTHENTIK_CLIENT_ID` / `AUTHENTIK_CLIENT_SECRET` — **your** client, delivered
-  as a k8s Secret (SealedSecret in prod). Never commit these.
-- `AUTHENTIK_REDIRECT_URI` — one of your declared redirect URIs.
+Expected FuzeMarket outcomes once AuthZ is live:
 
-At runtime, run the OIDC code flow against the shared issuer with your client
-(mirror `backend/src/services/oidc.ts`). The `sub` claim is the **same user id**
-the platform uses for Permit role assignments — do not invent your own user ids.
-
-> A valid token authenticates; it does **not** authorize. Always re-check
-> permissions against Permit at your API (Step 4).
-
----
-
-## Step 2 — Write your `ProductPolicy` (authZ declaration)
-
-Declare resources/actions/roles with **bare** keys (no `fuzemarket.` prefix —
-the platform adds it). This is the FuzeMarket policy
-(`backend/src/permit/products/fuzemarket.policy.ts`):
-
-```ts
-export const fuzemarketPolicy: ProductPolicy = {
-  product: 'fuzemarket',
-  name: 'FuzeMarket',
-  resources: [
-    { key: 'Listing', name: 'Listing',
-      actions: { create:{name:'Create'}, read:{name:'Read'}, update:{name:'Update'},
-                 delete:{name:'Delete'}, publish:{name:'Publish'} } },
-    { key: 'Order', name: 'Order',
-      actions: { create:{name:'Create'}, read:{name:'Read'}, update:{name:'Update'},
-                 cancel:{name:'Cancel'}, refund:{name:'Refund'} } },
-    { key: 'Cart', name: 'Cart',
-      actions: { read:{name:'Read'}, add_item:{name:'Add Item'},
-                 remove_item:{name:'Remove Item'}, checkout:{name:'Checkout'} } },
-  ],
-  roles: [
-    { key: 'seller', name: 'Seller',
-      permissions: ['Listing:create','Listing:read','Listing:update','Listing:delete',
-                    'Listing:publish','Order:read','Order:update','Order:refund'] },
-    { key: 'buyer', name: 'Buyer',
-      permissions: ['Listing:read','Cart:read','Cart:add_item','Cart:remove_item',
-                    'Cart:checkout','Order:create','Order:read','Order:cancel'] },
-    { key: 'market-admin', name: 'Market Admin',
-      permissions: [/* full control of Listing/Order/Cart */] },
-  ],
-}
-```
-
-Rules enforced by `validateProductPolicy()`:
-
-- `product` must match `^[a-z][a-z0-9-]{1,30}[a-z0-9]$`.
-- Resource/role keys must be unique and match `^[A-Za-z][A-Za-z0-9_-]*$`.
-- Every permission `Resource:action` must reference a resource **and** action
-  you declared. Typos fail fast at sync time, not at runtime.
-
----
-
-## Step 3 — Merge & sync into Permit
-
-The platform validates, **namespaces**, and merges your policy into the Permit
-environment schema, then runs the idempotent sync:
-
-```ts
-import { syncPermitSchemaWithProducts } from './permit/sync-permit-schema'
-import { fuzemarketPolicy } from './permit/products/fuzemarket.policy'
-import permit from './config/permit'
-
-await syncPermitSchemaWithProducts(permit, [fuzemarketPolicy])
-```
-
-After sync, Permit has (alongside the platform's own resources/roles):
-
-| Bare | In Permit |
-| --- | --- |
-| resource `Listing` | `fuzemarket.Listing` |
-| role `seller` | `fuzemarket.seller` |
-| permission `Listing:create` | `fuzemarket.Listing:create` |
-
-Re-running sync is safe and only touches **your** namespace.
-
----
-
-## Step 4 — Assign roles & check permissions at runtime
-
-Use the helpers in `backend/src/utils/permit/product-authz.ts` — they namespace
-for you, so you pass bare names:
-
-```ts
-// onboard a user as a seller within an org (tenant)
-await assignProductRole(userId, 'fuzemarket', 'seller', orgId)
-
-// guard an API route
-router.patch('/listings/:id',
-  requireProductPermission('fuzemarket', 'Listing', 'update',
-    req => req.organizationId,           // tenant
-    req => req.params.id),               // resource instance
-  updateListingHandler)
-
-// or check inline
-if (!(await checkProductPermission(userId, 'fuzemarket', 'Listing', 'publish', orgId, listingId))) {
-  return res.status(403).json({ error: 'forbidden' })
-}
-```
-
-Expected outcomes for FuzeMarket:
-
-- a `buyer` calling `Listing:create` or `Listing:publish` → **denied**.
-- a `seller` calling `Listing:publish` → **allowed**.
+- a `buyer` calling `Listing:update` → **denied**.
+- a `seller` calling `Listing:update` on their listing → **allowed**.
 - a `market-admin` calling `Order:refund` → **allowed**.
 
 ---
 
-## Step 5 — Multi-tenant & the FuzeOne hierarchy
+## Step 5 — Manage tenants, members, roles, and grants
 
-- Authorization is **per-tenant**: a user's `fuzemarket.seller` role in org A
-  does **not** grant it in org B. Assign per org.
-- **FuzeOne staff** who hold the ReBAC `org-admin` role on the **FuzeOne root
-  org** automatically administer **child** orgs (see §5 of the integration doc).
-  Your product gets this for free via the org hierarchy — you don't model it.
-- When the platform creates a customer org it calls
-  `setOrganizationParent(childOrgId, fuzeOneRootOrgId)` so the derivation
-  applies. Your product never sets parents itself.
+Assign roles and manage org membership through the API (again, contract-frozen /
+AuthZ-rollout gated):
+
+```ts
+// make a user a seller in a tenant (tenant-wide RBAC grant)
+await fetch('/api/v1/security/authz/grants', {
+  method: 'POST',
+  headers: { 'content-type': 'application/json', authorization: `Bearer ${token}` },
+  body: JSON.stringify({ subject: userId, tenant: tenantId, role: 'seller' }),
+})
+
+// scope a grant to one resource instance (ReBAC)
+await fetch('/api/v1/security/authz/grants', {
+  method: 'POST',
+  headers: { 'content-type': 'application/json', authorization: `Bearer ${token}` },
+  body: JSON.stringify({
+    subject: userId, tenant: tenantId, role: 'editor',
+    resource: { type: 'Listing', key: 'listing-123' },
+  }),
+})
+```
+
+- Tenants: `GET`/`POST /api/v1/security/tenants`, `GET /tenants/{tenantId}`.
+- Members: `GET`/`POST /tenants/{tenantId}/members`,
+  `DELETE /tenants/{tenantId}/members/{userId}`,
+  `PUT /tenants/{tenantId}/members/{userId}/roles`.
+- Roles catalogue: `GET /tenants/{tenantId}/roles`.
+- Revoke a grant: `DELETE /authz/grants` by `{ grantId }` or the identity tuple
+  (idempotent).
+
+Authorization is **per-tenant** — a role in one tenant does not carry to another.
+Grants are convenience; `authz/check` (Step 4) stays the source of truth.
+
+---
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| `401` on `/session` GET | Missing/expired token | Send `Authorization: Bearer <token>`; re-login on expiry. |
+| `authz/check` always `{ allow: false }` | Fail-closed on error, or the AuthZ rollout isn't live yet | Confirm the AuthZ endpoints are enabled; check `subject`/`tenant`/`resource.type`/`action` are all set. |
+| `identity.tenantId` is `null` | Legacy token mode, tenant unresolved | Fail closed on tenant-scoped authz; do not default a tenant. |
+| Social login loops / no `code` | Absolute or cross-origin `redirectTo` | Use a **same-origin, app-relative** `redirectTo`; absolute URLs are rejected. |
+| `npm install` 401/403 for `@fuzefront/*` | Missing scoped `.npmrc` / token | Add the `@fuzefront:registry` line + a valid `GITHUB_TOKEN`. |
+| Tempted to parse the JWT / fetch JWKS | Wrong layer | Resolve identity via `GET /session` (or `/tokens/introspect`); consume `Identity`. |
 
 ---
 
 ## Checklist
 
-- [ ] Product key chosen (`[a-z0-9-]`), used for both Authentik slug and authZ namespace.
-- [ ] `auth.oidc` block in the App Manifest; client secret delivered as a k8s Secret.
-- [ ] `ProductPolicy` written with bare keys; passes `validateProductPolicy`.
-- [ ] `syncPermitSchemaWithProducts` wired into your provisioning/onboarding job.
-- [ ] Runtime routes guarded with `requireProductPermission` / `checkProductPermission`.
-- [ ] Role assignment on user onboarding via `assignProductRole`.
-- [ ] Verified deny/allow for at least one buyer-vs-seller-vs-admin case.
+- [ ] `@fuzefront/security-client` installed via a scoped `.npmrc` (token not committed).
+- [ ] Same-origin `/api/v1/security/*` reachable (no absolute API host hard-coded).
+- [ ] Sign-in UI rendered from `GET /methods` (no provider assumptions).
+- [ ] Login/signup handles the `authenticated` **and** `mfa_required` `SessionResult`.
+- [ ] Identity resolved via `GET /session` — no raw JWT/JWKS parsing.
+- [ ] `tenantId === null` fails closed on tenant-scoped authz.
+- [ ] Every protected action re-checked via `POST /authz/check` (AuthZ-rollout gated).
+- [ ] Roles/grants managed via `/authz/grants` + `/tenants/*`, not a vendor SDK.
+</content>

--- a/docs/guides/BUILDING_ON_FUZEFRONT.md
+++ b/docs/guides/BUILDING_ON_FUZEFRONT.md
@@ -2,8 +2,8 @@
 
 How a downstream product runs **on top of** the FuzeFront platform: register a
 micro-frontend into the host shell, consume the shared `@fuzefront/*` packages,
-sign users in via Authentik OIDC SSO, authorize with Permit scopes, and call the
-platform API.
+sign users in and authorize them through the **FuzeFront Security API**, and call
+the platform API.
 
 FuzeFront is a **Module-Federation host shell** ("runtime fabric"): a dark-default
 dashboard that discovers, mounts, and fuses remote micro-frontends ("apps") into
@@ -111,48 +111,56 @@ constant together.
 
 ---
 
-## 3. Authentik OIDC SSO
+## 3. Authentication (Security API)
 
-Identity is owned by **Authentik** (`auth.fuzefront.com` in prod). The platform
-backend brokers OIDC; your product gets SSO by sending users through the shell's
-auth, or by registering your own OIDC client in Authentik.
+Sign users in through the **FuzeFront Security API** (`/api/v1/security/*`,
+same-origin) and the `@fuzefront/security-client` types — never a vendor SDK or
+identity host. The platform brokers everything server-side; the browser only ever
+transits `app.fuzefront.com` and (for social login) the social provider's own
+consent host.
 
-Backend OIDC endpoints:
+Consumer AuthN endpoints:
 
-- `GET /api/auth/oidc/login` — starts the Authorization Code flow (redirects to
-  Authentik).
-- `GET /api/auth/oidc/callback` — exchange + session; the backend issues a JWT.
-- `POST /api/auth/login` — local JWT login (dev / non-SSO).
+- `GET /api/v1/security/methods` — capability descriptor (which sign-in methods
+  are available); replaces the legacy `oidcConfigured` boolean.
+- `POST /api/v1/security/session` — password login → `SessionResult`
+  (`authenticated` or `mfa_required`).
+- `GET /api/v1/security/social/{provider}/start` → provider consent →
+  `GET /api/v1/security/social/callback` returns a single-use `?code=`, which you
+  exchange at `POST /api/v1/security/session/exchange` (no token in the URL).
+- `POST /api/v1/security/signup` — server-brokered account creation.
+- `GET /api/v1/security/session` — the current stable `Identity` ("me");
+  `DELETE /api/v1/security/session` — logout.
 
-Prod OIDC config (from `values-prod.yaml`):
-
-- issuer: `https://auth.fuzefront.com/application/o/fuzefront/`
-- redirect: `https://app.fuzefront.com/api/auth/oidc/callback`
-- cookie domain: `fuzefront.com` (session shared across `*.fuzefront.com`)
-
-To SSO your own subdomain product, register an OIDC provider/application in
-Authentik with your redirect URI, and validate the issued JWT against the same
-issuer. Keep your cookie/JWT audience consistent so the shared session works
-across the apex.
+Resolve every caller to the stable `Identity`
+(`{ userId, tenantId, roles, authMode, … }`) via the Security API — **do not**
+parse the JWT or fetch a JWKS. `Identity` is invariant across the token-format
+migration. See
+[`docs/consumers/onboarding-authn-authz.md`](../consumers/onboarding-authn-authz.md)
+for the step-by-step recipe.
 
 ---
 
-## 4. Permit scopes (authorization)
+## 4. Authorization (Security API)
 
-Authorization is policy-based via **Permit.io** (a PDP runs in-cluster;
-`permit.enabled: true` in prod). The backend gates routes with a
-`requirePermission(resource, action)` middleware; the SDK degrades gracefully if
-no PDP is reachable (permission-gated routes deny).
+Authorize actions by asking the Security API for a decision — never a local role
+cache or a policy SDK. `POST /api/v1/security/authz/check` is authoritative and
+fail-closed (`{ allow: false }` on any error):
 
-To authorize your product's actions:
+1. `POST /api/v1/security/authz/check` with
+   `{ subject, tenant, resource: { type, key? }, action }` → `{ allow }`.
+   Batch with `/authz/bulk-check`; read effective grants with
+   `/authz/permissions?subject&tenant`.
+2. Manage roles/membership via `/authz/grants` (tenant-wide RBAC or
+   resource-scoped ReBAC) and `/tenants/*`.
+3. Multi-tenant: authorization is isolated **per tenant**; a role in one tenant
+   does not carry to another. If `identity.tenantId` is `null`, fail closed.
 
-1. Model your resources/actions/roles in the Permit schema (the chart's
-   `permit-schema-sync` Job applies the FuzeFront schema on upgrade; extend it
-   for your resources).
-2. Call the platform API with a JWT; the backend resolves the user + org context
-   and checks the PDP.
-3. Multi-tenant: permissions are isolated per **organization**; pass/inherit the
-   org context so checks are scoped to the right tenant.
+> **Status:** AuthN is live; the AuthZ endpoints (`/authz/*`, `/tenants/*`) are
+> contract-frozen and generated into the client but not yet wired in the Security
+> service — build against them now and gate behind a flag until the AuthZ rollout
+> lands. Full detail:
+> [`docs/consumers/authn-authz-integration.md`](../consumers/authn-authz-integration.md).
 
 ---
 
@@ -162,7 +170,8 @@ To authorize your product's actions:
   nginx proxies `/api` + `/socket.io` to the backend Services. The browser API
   base defaults to same-origin — never hardcode `http://…` (mixed-content under
   TLS).
-- **Auth**: `Authorization: Bearer <jwt>` from OIDC or local login.
+- **Auth**: `Authorization: Bearer <token>` — a FuzeFront-minted session or M2M
+  token from the Security API (§3). Consume the normalized `Identity`, not raw claims.
 - **Health**: `GET /api/health` → `{ status, database, ... }` (used by the prod
   smoke check).
 - **Client**: prefer `@izzywdev/fuzefront-api-client` over hand-rolled fetch — it

--- a/docs/planning/epics/EPIC-05-multi-product-authn-authz.md
+++ b/docs/planning/epics/EPIC-05-multi-product-authn-authz.md
@@ -53,12 +53,22 @@ domain: Identity / Security
 - Replacing Permit — authz stays Permit; this extends the schema-merge + ReBAC.
 
 ### 🏗️ High-Level Architecture Notes
-> AuthN = Authentik OIDC (per `values-prod.yaml` `authentik` block). AuthZ = Permit.io. Namespaced
-> per-product resource keys avoid collisions. `sync-permit-schema.ts` is extended to merge a product's
-> submitted policy into the env. ReBAC: FuzeOne is the root/parent tenant; FuzeOne staff manage child
-> customer tenants (parent→child derivation). The manifest `auth` section (from #107) is the integration
-> seam — consumer authn/authz plugs into the federated-app manifest. Tests cover schema-merge + a sample
+> **The integration seam for consumers is the FuzeFront Security API (`/api/v1/security/*`, contract
+> `packages/security/openapi.yaml`) and the `@fuzefront/security-client` types — NOT any vendor.** Consumers
+> authenticate via `/session`, `/signup`, `/social/{provider}/start`, `/session/exchange`, `/methods` and
+> authorize via `/authz/check` + `/authz/grants` + `/tenants/*`, always resolving to the stable `Identity`.
+> The identity engine and the authorization engine are swappable server-side implementations hidden behind
+> the `IdentityProvider` / `AuthorizationProvider` adapters — their vendor names never appear in any
+> consumer-facing surface. Internally: namespaced per-product resource keys avoid collisions;
+> `sync-permit-schema.ts` merges a product's submitted policy into the policy env; ReBAC makes FuzeOne the
+> root/parent tenant so FuzeOne staff manage child customer tenants (parent→child derivation). The manifest
+> `auth`/`authz` sections (from #107) remain the declarative provisioning input, but the runtime consumer
+> contract is the Security API, not the manifest or a vendor SDK. Tests cover schema-merge + a sample
 > FuzeMarket policy.
+>
+> **Status note:** AuthN is shipped first behind `/api/v1/security/*`; the AuthZ endpoints (`/authz/*`,
+> `/tenants/*`) are contract-frozen and generated into the client but not yet wired in the Security
+> service — the consumer docs mark them "coming".
 
 ### 📊 Success Metrics
 | Metric | Current Baseline | Target |
@@ -105,9 +115,13 @@ domain: Identity / Security
 > the ReBAC hierarchy** so that **I understand how my product gets SSO + authz before any code is written**.
 
 #### 📌 Background & Context
-This design doc is the gate: it defines register → declare auth+authz policy → platform provisions OIDC
-client + merges Permit resources/roles → product consumes authn+authz at runtime, plus the FuzeOne-root
-ReBAC hierarchy. Subsequent stories implement against it.
+This design doc is the gate: it defines how a consumer integrates **through the FuzeFront Security API
+(`/api/v1/security/*`) and `@fuzefront/security-client`** — capability discovery + sign-in/up + session
+(AuthN) and `authz/check` + grants + tenant/role management (AuthZ), all resolving to the stable
+`Identity`, with the identity/authorization engines hidden behind server-side adapters. It also covers the
+internal provisioning (manifest `auth`/`authz` → per-product policy merge) and the FuzeOne-root ReBAC
+hierarchy. Subsequent stories implement against it. (Delivered as `docs/consumers/authn-authz-integration.md`
++ `docs/consumers/onboarding-authn-authz.md`.)
 
 #### ✅ Acceptance Criteria
 1. **Given** the requirements **When** the doc is authored at `docs/consumers/authn-authz-integration.md` **Then** it covers the full register→provision→consume flow and the ReBAC FuzeOne-root hierarchy.


### PR DESCRIPTION
## What

Rewrites FuzeFront's consumer onboarding / integration docs so downstream products integrate **only** through the provider-agnostic FuzeFront **Security API** (`/api/v1/security/*`) and the **`@fuzefront/security-client`** types — never against Authentik/Permit directly. Enforces the strict naming rule: no `authentik`/`permit` in any consumer-facing guidance (they are hidden server-side implementations behind the `IdentityProvider`/`AuthorizationProvider` adapters).

## Files

- `docs/consumers/authn-authz-integration.md` — architecture/trust model rewritten around the Security API + client. AuthN (session/social/signup/methods, MFA, contact verify, M2M tokens), stable `Identity`, AuthZ (`authz/check`/bulk/permissions/grants + tenants/members/roles).
- `docs/consumers/onboarding-authn-authz.md` — step-by-step recipe: install from GitHub Packages via scoped `.npmrc`, discover `/methods`, sign in/up, resolve `Identity` via `/session` (no raw JWT/JWKS), authorize via `/authz/check`, manage grants/tenants. Troubleshooting + checklist.
- `docs/guides/BUILDING_ON_FUZEFRONT.md` — auth sections (3 & 4) rerouted from Authentik OIDC / Permit scopes to the Security API.
- `docs/planning/epics/EPIC-05-multi-product-authn-authz.md` — reframes the consumer seam as the Security API + client (vendor engines hidden behind adapters); manifest remains provisioning input, not the runtime consumer contract.

## Accuracy / verification

Every claim cross-checked against source, not aspiration:
- Endpoints/schemas ← `packages/security/openapi.yaml` (v0.3.0).
- `Identity`/`AuthMode`/`AuthMethods`/`Grant`, types-only client (no client class), install/publish config ← `packages/security/src/{types,index}.ts`, `package.json`, `README.md`.
- **AuthZ marked "contract-frozen, not yet live"**: verified `backend/security/src/routes/security.ts` mounts only AuthN/MFA/verify/tokens routes; the file header states `/authz/*` + `/tenants/*` are a later stream.
- **Cross-product one-time-code handoff** marked "coming" (not invented) — only the within-product social `code`→`/session/exchange` exchange exists today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)