### PR TITLE
feat(authn): reconcile backend for sign-up + Google (Phase 1)

### DIFF
--- a/backend/security/src/providers/IdentityProvider.ts
+++ b/backend/security/src/providers/IdentityProvider.ts
@@ -76,6 +76,13 @@ export interface SocialLoginStart {
   redirectUrl: string;
   /** Opaque anti-forgery state the callback must echo. */
   state: string;
+  /**
+   * PKCE code_verifier for this authorize request. The route persists it in an
+   * HttpOnly cookie so the (replica-agnostic) OIDC callback can complete the
+   * token exchange — the social handshake transits the registered OIDC
+   * redirect_uri (`/api/auth/oidc/callback`), which reads this cookie.
+   */
+  codeVerifier: string;
 }
 
 export interface SocialCallbackInput {

--- a/backend/security/src/providers/authentik/AuthentikIdentityProvider.ts
+++ b/backend/security/src/providers/authentik/AuthentikIdentityProvider.ts
@@ -24,7 +24,8 @@ import { db as defaultDb } from '../../config/database'
 import { oidcService as defaultOidc } from '../../services/oidc'
 import { authentikPasswordLogin as defaultPasswordLogin } from '../../services/authentikPassword'
 import { runInternalProvision } from '../../services/organizationProvisioning'
-import { defaultEventPublisher } from '../../services/eventPublisher'
+import { authentikSignup as defaultSignup, EnrollmentConflictError } from '../../services/authentikPassword'
+import { putBrokerCode, takeBrokerCode } from '../../services/brokerCodes'
 import type {
   IdentityProvider,
   BrokeredSession,
@@ -96,10 +97,6 @@ export class UnauthorizedError extends Error {
 
 type Db = typeof defaultDb
 
-interface PendingCode {
-  session: BrokeredSession
-  expiresAt: number
-}
 interface SocialState {
   codeVerifier: string
   redirectTo: string
@@ -117,6 +114,8 @@ export interface AuthentikProviderDeps {
   db: Db
   oidc: typeof defaultOidc
   passwordLoginFn: (email: string, password: string) => Promise<BrokeredUser>
+  /** Drives Authentik enrollment + OIDC sync; returns the synced user projection. */
+  signupFn: (input: SignupInput) => Promise<BrokeredUser>
   notifications: NotificationClient
   now: () => number
   /** Injected M2M provisioning (defaults to the absorbed machine-identity module). */
@@ -141,13 +140,13 @@ export class AuthentikIdentityProvider implements IdentityProvider {
   private db: Db
   private oidc: typeof defaultOidc
   private passwordLoginFn: (email: string, password: string) => Promise<BrokeredUser>
+  private signupFn: (input: SignupInput) => Promise<BrokeredUser>
   private notifications: NotificationClient
   private now: () => number
   private provisionM2MFn?: (name: string, scopes: string[]) => Promise<M2MClient>
   private issueM2MFn?: (input: M2MTokenInput) => Promise<M2MToken>
   private introspectM2MFn?: (token: string) => Promise<TokenIntrospection>
 
-  private pendingCodes = new Map<string, PendingCode>()
   private socialStates = new Map<string, SocialState>()
   private mfaChallenges = new Map<string, MfaChallenge>()
 
@@ -158,6 +157,17 @@ export class AuthentikIdentityProvider implements IdentityProvider {
       deps.passwordLoginFn ??
       (async (email, password) => {
         const user = await defaultPasswordLogin(email, password)
+        return { ...user, roles: user.roles ?? [] } as BrokeredUser
+      })
+    this.signupFn =
+      deps.signupFn ??
+      (async (input) => {
+        const user = await defaultSignup({
+          email: input.email,
+          password: input.password,
+          firstName: input.firstName,
+          lastName: input.lastName,
+        })
         return { ...user, roles: user.roles ?? [] } as BrokeredUser
       })
     this.notifications = deps.notifications ?? new HttpNotificationClient()
@@ -244,7 +254,9 @@ export class AuthentikIdentityProvider implements IdentityProvider {
       redirectTo,
       expiresAt: this.now() + 10 * 60_000,
     })
-    return { redirectUrl, state }
+    // codeVerifier is handed back so the route can persist it in an HttpOnly
+    // cookie (`oidc_cv`) for the replica-agnostic OIDC callback.
+    return { redirectUrl, state, codeVerifier }
   }
 
   async brokerCallback(input: SocialCallbackInput): Promise<SocialCallbackResult> {
@@ -265,87 +277,54 @@ export class AuthentikIdentityProvider implements IdentityProvider {
     // in the URL). Social sign-in does not re-gate MFA at the browser hop.
     const session = await this.mintSession(user)
     const code = crypto.randomBytes(32).toString('hex')
-    this.pendingCodes.set(code, { session, expiresAt: this.now() + CODE_TTL_MS })
+    // Shared store: a code minted here OR by the legacy /api/auth/oidc/callback
+    // is redeemable by the SPA's /api/v1/security/session/exchange.
+    putBrokerCode(code, {
+      token: session.token,
+      sessionId: session.sessionId,
+      user: session.user,
+      expiresAt: this.now() + CODE_TTL_MS,
+    })
     return { code, redirectTo: st.redirectTo || '/' }
   }
 
   async exchangeCode(code: string): Promise<BrokeredSession> {
-    const pending = this.pendingCodes.get(code)
-    if (!pending || pending.expiresAt < this.now()) {
-      this.pendingCodes.delete(code)
+    const entry = takeBrokerCode(code, this.now())
+    if (!entry) {
       throw new UnauthorizedError('invalid or expired code')
     }
-    this.pendingCodes.delete(code) // single-use
-    return pending.session
+    return { token: entry.token, sessionId: entry.sessionId, user: entry.user }
   }
 
-  // ── Signup (server-brokered) ──────────────────────────────────────────────
+  // ── Signup (server-brokered against Authentik enrollment) ─────────────────
+  //
+  // The account is created in AUTHENTIK (the sole identity authority) by driving
+  // its self-service enrollment flow server-side; the flow's final user-login
+  // stage auto-authenticates the new user, so the OIDC code exchange runs and
+  // the local `users` row is created as a SYNCED PROJECTION via the SAME
+  // syncUserToDatabase path login uses (which also writes the identity.user.created
+  // outbox row + event). There is NO local bcrypt user — that split-brain (a
+  // local user Authentik never knew about, thus unable to log in) is the bug this
+  // replaces.
   async signup(input: SignupInput): Promise<BrokeredSession> {
     if (!input?.email || !input?.password) {
       throw new InvalidInputError('email and password are required')
     }
-    const bcrypt = await import('bcryptjs')
+    // Fast-path conflict on the synced projection (cheap; the enrollment flow is
+    // also authoritative and maps its own "already exists" to ConflictError).
     const existing = await this.db('users').where('email', input.email).first()
     if (existing) throw new ConflictError()
 
-    const id = uuidv4()
-    const passwordHash = await bcrypt.hash(input.password, 10)
-    const correlationId = `identity-${id}`
-    const row = {
-      id,
-      email: input.email,
-      password_hash: passwordHash,
-      first_name: input.firstName ?? null,
-      last_name: input.lastName ?? null,
-      roles: JSON.stringify(['user']),
-      created_at: new Date(),
-      updated_at: new Date(),
-    }
-    await this.db.transaction(async (trx: any) => {
-      await trx('users').insert(row)
-      await trx('event_outbox').insert({
-        id: uuidv4(),
-        topic: 'identity.user.created',
-        payload: JSON.stringify({
-          userId: id,
-          email: input.email,
-          firstName: input.firstName,
-          lastName: input.lastName,
-          intent: 'signup',
-          tenantName: input.tenantName,
-        }),
-        correlation_id: correlationId,
-        status: 'pending',
-        attempts: 0,
-      })
-    })
-    // Best-effort publish; the outbox row is the durable record.
+    let user: BrokeredUser
     try {
-      await defaultEventPublisher.publishIdentityUserCreated(
-        {
-          userId: id,
-          email: input.email,
-          firstName: input.firstName,
-          lastName: input.lastName,
-          intent: 'signup',
-        },
-        correlationId
-      )
-      await this.db('event_outbox')
-        .where({ correlation_id: correlationId })
-        .update({ status: 'sent', attempts: 1, sent_at: new Date() })
-    } catch (pubErr) {
-      console.error('⚠️ identity.user.created publish failed (outbox retains it):', pubErr)
+      user = await this.signupFn(input)
+    } catch (err) {
+      if (err instanceof EnrollmentConflictError) throw new ConflictError()
+      throw err
     }
-
-    const user: BrokeredUser = {
-      id,
-      email: input.email,
-      firstName: input.firstName,
-      lastName: input.lastName,
-      roles: ['user'],
-    }
-    return this.mintSession(user)
+    // Gate through MFA step-up if the (rare, freshly-enrolled) account already
+    // has active factors — otherwise mint the session directly.
+    return this.sessionOrChallenge(user)
   }
 
   // ── Identity / session inspection ─────────────────────────────────────────

--- a/backend/security/src/providers/authentik/config.ts
+++ b/backend/security/src/providers/authentik/config.ts
@@ -12,13 +12,23 @@ export function appBaseUrl(): string {
 
 /**
  * The internal IdP reverse-proxy prefix. The browser is ALWAYS sent to a
- * same-host path under this prefix (devops reverse-proxies it to the internal
- * authentik-server ClusterIP), so the browser never sees an internal identity
- * host. Configurable; defaults to the coordinated same-host prefix.
+ * same-host path (optionally under this prefix), so the browser never sees an
+ * internal identity host.
+ *
+ * DEFAULT is now EMPTY (""): PR #256 removed the `/api/auth/idp` ingress path and
+ * routes Authentik's NATIVE paths (`/application`, `/if`, `/flows`, `/source`,
+ * `/ws`, `/-`, …) directly under app.fuzefront.com with NO prefix. So the
+ * authorize URL must be a bare native same-host path
+ * (`/application/o/authorize/…`) which #256 routes to the internal
+ * authentik-server. Set `SECURITY_IDP_PROXY_PREFIX` only if a deployment
+ * re-introduces a reverse-proxy prefix.
  */
 export function idpProxyPrefix(): string {
-  const raw = process.env.SECURITY_IDP_PROXY_PREFIX || '/api/auth/idp'
-  return '/' + raw.replace(/^\/+|\/+$/g, '')
+  const raw = process.env.SECURITY_IDP_PROXY_PREFIX ?? ''
+  const trimmed = raw.replace(/^\/+|\/+$/g, '')
+  // Empty → no prefix at all (native paths), NOT a bare "/" (which would
+  // produce a "//application/…" double-slash when concatenated with pathname).
+  return trimmed ? '/' + trimmed : ''
 }
 
 /** Same-origin social-callback path (where the internal IdP returns the browser). */

--- a/backend/security/src/routes/auth.ts
+++ b/backend/security/src/routes/auth.ts
@@ -15,11 +15,10 @@ import {
   UnsupportedFlowStageError,
 } from '../services/authentikPassword'
 import { runInternalProvision } from '../services/organizationProvisioning'
+import { putBrokerCode, takeBrokerCode, sweepBrokerCodes } from '../services/brokerCodes'
 
 
 const CODE_TTL_MS = 60_000
-interface PendingCode { token: string; sessionId: string; expiresAt: number }
-const pendingCodes = new Map<string, PendingCode>()
 
 // Use the configured frontend base URL for all redirects so that exchange codes
 // ride HTTPS in production rather than a hardcoded http:// origin.
@@ -27,14 +26,7 @@ const FRONTEND_BASE = (process.env.FRONTEND_URL || 'http://fuzefront.dev.local')
 
 // Periodic sweep: remove never-redeemed codes that have passed their TTL.
 // .unref() prevents this interval from keeping the process alive in tests.
-setInterval(() => {
-  const now = Date.now()
-  for (const [key, value] of pendingCodes) {
-    if (value.expiresAt < now) {
-      pendingCodes.delete(key)
-    }
-  }
-}, CODE_TTL_MS).unref()
+setInterval(() => sweepBrokerCodes(), CODE_TTL_MS).unref()
 
 const router = express.Router()
 
@@ -721,7 +713,14 @@ router.get('/oidc/callback', async (req, res) => {
     // Issue a short-lived opaque exchange code instead of putting the bearer token in the URL
     // (avoids token leakage via referrer headers, server logs, and browser history).
     const exchangeCode = crypto.randomBytes(32).toString('hex')
-    pendingCodes.set(exchangeCode, { token, sessionId, expiresAt: Date.now() + CODE_TTL_MS })
+    // Shared store: redeemable by BOTH /api/auth/token-exchange and the
+    // provider-agnostic /api/v1/security/session/exchange (which social login uses).
+    putBrokerCode(exchangeCode, {
+      token,
+      sessionId,
+      user: { id: user.id, email: user.email, firstName: user.firstName, lastName: user.lastName, roles: user.roles },
+      expiresAt: Date.now() + CODE_TTL_MS,
+    })
     res.redirect(`${FRONTEND_BASE}/?code=${exchangeCode}`)
 
   } catch (error) {
@@ -804,13 +803,10 @@ router.post('/token-exchange', async (req, res) => {
   if (!code || typeof code !== 'string') {
     return res.status(400).json({ error: 'code required' })
   }
-  const pending = pendingCodes.get(code)
-  if (!pending || Date.now() > pending.expiresAt) {
-    pendingCodes.delete(code)  // clean up expired entry if present
+  const pending = takeBrokerCode(code)
+  if (!pending) {
     return res.status(401).json({ error: 'invalid or expired code' })
   }
-  // Single-use: delete immediately
-  pendingCodes.delete(code)
   return res.json({ token: pending.token, sessionId: pending.sessionId })
 })
 

--- a/backend/security/src/routes/security.ts
+++ b/backend/security/src/routes/security.ts
@@ -151,10 +151,17 @@ router.post('/session/exchange', async (req: Request, res: Response) => {
 router.get('/social/:provider/start', async (req: Request, res: Response) => {
   try {
     const redirectTo = typeof req.query.redirectTo === 'string' ? req.query.redirectTo : '/'
-    const { redirectUrl, state } = await getIdentityProvider().startSocialLogin(req.params.provider, redirectTo)
-    // Persist anti-forgery state (+ desired return path) in an HttpOnly cookie
-    // so the callback is replica-agnostic.
+    const { redirectUrl, state, codeVerifier } = await getIdentityProvider().startSocialLogin(req.params.provider, redirectTo)
+    // The authorize URL's redirect_uri is the OIDC client's registered callback
+    // (`/api/auth/oidc/callback`), so the browser returns THERE after Google
+    // consent. That handler is replica-agnostic via the oidc_state + oidc_cv
+    // cookies — set them here (same names/semantics as /api/auth/oidc/login) so
+    // the exchange completes and mints the shared opaque ?code= the SPA redeems
+    // at /api/v1/security/session/exchange. `sec_social_state` is retained for
+    // the (non-default) brokerCallback path.
     res.setHeader('Set-Cookie', [
+      `oidc_state=${state}; HttpOnly; Secure; SameSite=Lax; Max-Age=600; Path=/`,
+      `oidc_cv=${codeVerifier}; HttpOnly; Secure; SameSite=Lax; Max-Age=600; Path=/`,
       `sec_social_state=${state}; HttpOnly; Secure; SameSite=Lax; Max-Age=600; Path=/`,
     ])
     res.redirect(302, redirectUrl)

--- a/backend/security/src/services/authentikPassword.ts
+++ b/backend/security/src/services/authentikPassword.ts
@@ -47,7 +47,7 @@ export class UnsupportedFlowStageError extends Error {
 }
 
 /** Minimal cookie jar for the short-lived per-login Authentik session. */
-class CookieJar {
+export class CookieJar {
   private cookies = new Map<string, string>()
 
   absorb(res: { headers: Headers }): void {
@@ -81,7 +81,7 @@ class CookieJar {
   }
 }
 
-function authentikBaseUrl(): string {
+export function authentikBaseUrl(): string {
   if (process.env.AUTHENTIK_BASE_URL) {
     return process.env.AUTHENTIK_BASE_URL.replace(/\/$/, '')
   }
@@ -95,14 +95,18 @@ function authFlowSlug(): string {
   return process.env.AUTHENTIK_AUTH_FLOW_SLUG || 'default-authentication-flow'
 }
 
-function redirectUri(): string {
+export function redirectUri(): string {
   return (
     process.env.AUTHENTIK_REDIRECT_URI ||
     'http://fuzefront.dev.local/api/auth/oidc/callback'
   )
 }
 
-interface FlowChallenge {
+function enrollmentFlowSlug(): string {
+  return process.env.AUTHENTIK_ENROLLMENT_FLOW_SLUG || 'fuzefront-enrollment'
+}
+
+export interface FlowChallenge {
   component?: string
   type?: string
   to?: string
@@ -111,7 +115,7 @@ interface FlowChallenge {
   [key: string]: unknown
 }
 
-async function flowRequest(
+export async function flowRequest(
   base: string,
   slug: string,
   jar: CookieJar,
@@ -264,7 +268,21 @@ export async function authentikPasswordLogin(
     }
   }
 
-  // ── Complete OIDC code+PKCE with the authenticated session ────────────────
+  // Complete OIDC code+PKCE with the now-authenticated Authentik session.
+  return completeOidcWithSession(base, jar)
+}
+
+/**
+ * Drive the OIDC authorize→code exchange using an ALREADY-AUTHENTICATED
+ * Authentik session (the cookie jar). Shared by both server-side password login
+ * and server-side signup (enrollment auto-logs the new user in, establishing the
+ * same session). Token exchange + user sync is identical to the redirect
+ * callback path — Authentik stays the SOLE identity authority.
+ */
+export async function completeOidcWithSession(
+  base: string,
+  jar: CookieJar
+): Promise<User> {
   const state = generators.state()
   const { url: authorizeUrl, codeVerifier } = oidcService.generateAuthUrl(state)
   const target = redirectUri()
@@ -326,4 +344,113 @@ export async function authentikPasswordLogin(
 
   // Token exchange + user sync — identical to the redirect callback path.
   return oidcService.handleCallback(code, returnedState || state, codeVerifier)
+}
+
+/** Thrown when an account already exists for the email (signup conflict). */
+export class EnrollmentConflictError extends Error {
+  constructor(message = 'An account with that email already exists') {
+    super(message)
+    this.name = 'EnrollmentConflictError'
+  }
+}
+
+export interface AuthentikSignupInput {
+  email: string
+  password: string
+  firstName?: string
+  lastName?: string
+  username?: string
+}
+
+/**
+ * Create the account in AUTHENTIK by driving the self-service enrollment flow
+ * server-side (same CookieJar + flow-executor driver as password login), then
+ * complete the OIDC code exchange — the enrollment flow's final user-login
+ * stage establishes an authenticated session, so the freshly-created user is
+ * synced into the platform DB via the SAME `syncUserToDatabase` path login
+ * uses. Authentik is the sole identity store; no local bcrypt user is written.
+ *
+ * The blueprint flow (deploy/helm/.../authentik/blueprints/flow-enrollment.yaml)
+ * has a single prompt stage (email/username/password/password_repeat/tos) then
+ * a user-write + user-login stage. Only that shape is driven; any other stage
+ * (e.g. an email-verification stage) fails closed as unsupported server-side.
+ */
+export async function authentikSignup(input: AuthentikSignupInput): Promise<User> {
+  if (!oidcService.isConfigured() || !oidcService.isInitialized()) {
+    throw new AuthentikUnavailableError('OIDC is not configured/initialized')
+  }
+  if (!input.email || !input.password) {
+    throw new InvalidCredentialsError('email and password are required')
+  }
+
+  const base = authentikBaseUrl()
+  const slug = enrollmentFlowSlug()
+  const jar = new CookieJar()
+
+  // Derive a username from the local-part when the caller did not supply one.
+  const username =
+    input.username || input.email.split('@')[0].replace(/[^a-zA-Z0-9_.-]/g, '') || input.email
+
+  let challenge = await flowRequest(base, slug, jar)
+  const MAX_STEPS = 8
+  let enrolled = false
+
+  for (let step = 0; step < MAX_STEPS; step++) {
+    const component = challenge.component || challenge.type || ''
+
+    if (component === 'xak-flow-redirect') {
+      enrolled = true
+      break
+    }
+
+    if (component === 'ak-stage-prompt') {
+      // The enrollment prompt collects all fields at once. Include name fields
+      // and the ToS acceptance; Authentik ignores unknown fields.
+      const body: Record<string, unknown> = {
+        component,
+        email: input.email,
+        username,
+        password: input.password,
+        password_repeat: input.password,
+        tos_accepted: true,
+      }
+      if (input.firstName || input.lastName) {
+        body.name = [input.firstName, input.lastName].filter(Boolean).join(' ')
+      }
+      challenge = await flowRequest(base, slug, jar, body)
+    } else if (component === 'ak-stage-user-login' || component === 'ak-stage-user-write') {
+      // Non-interactive stages that occasionally surface a challenge — re-POST
+      // the bare component to advance.
+      challenge = await flowRequest(base, slug, jar, { component })
+    } else if (component === 'ak-stage-access-denied') {
+      throw new EnrollmentConflictError()
+    } else {
+      // Captcha, email-verification, MFA-enroll, consent … not driveable here.
+      throw new UnsupportedFlowStageError(component || 'unknown')
+    }
+
+    if (challengeHasCredentialErrors(challenge)) {
+      // Distinguish "already exists" from a password-policy rejection.
+      const errs = challenge.response_errors || {}
+      const flat = JSON.stringify(errs).toLowerCase()
+      if (
+        errs.email ||
+        errs.username ||
+        /already|exist|taken|unique/.test(flat)
+      ) {
+        throw new EnrollmentConflictError()
+      }
+      throw new InvalidCredentialsError(
+        'Enrollment rejected: ' + flat.slice(0, 200)
+      )
+    }
+  }
+
+  if (!enrolled) {
+    const last = challenge.component || challenge.type || 'unknown'
+    throw new UnsupportedFlowStageError(last)
+  }
+
+  // Enrollment auto-logged-in → complete OIDC + sync via the shared path.
+  return completeOidcWithSession(base, jar)
 }

--- a/backend/security/src/services/brokerCodes.ts
+++ b/backend/security/src/services/brokerCodes.ts
@@ -1,0 +1,49 @@
+/**
+ * Shared single-use opaque broker-code store.
+ *
+ * The browser OIDC completion (`/api/auth/oidc/callback`) mints a short-lived
+ * opaque `?code=` instead of putting a bearer token in the URL. The SPA then
+ * exchanges it. Historically two SEPARATE in-memory maps existed:
+ *   - routes/auth.ts               (redeemed by POST /api/auth/token-exchange)
+ *   - AuthentikIdentityProvider    (redeemed by POST /api/v1/security/session/exchange)
+ *
+ * The provider-agnostic Security API SPA exchanges via
+ * `/api/v1/security/session/exchange`, but social login now transits the LEGACY
+ * `/api/auth/oidc/callback` (the OIDC client's registered redirect_uri). With
+ * two maps the code minted by the callback was unredeemable by the new
+ * endpoint. This module is the SINGLE store both paths use, so a code minted by
+ * either callback is redeemable by either exchange endpoint.
+ *
+ * In-memory + single-use + short TTL; a code is redeemed at most once.
+ */
+import type { BrokeredUser } from '../providers/IdentityProvider'
+
+export interface BrokerCodeEntry {
+  token: string
+  sessionId: string
+  /** Full user projection carried through so redemption needs no DB read. */
+  user: BrokeredUser
+  expiresAt: number
+}
+
+const store = new Map<string, BrokerCodeEntry>()
+
+export function putBrokerCode(code: string, entry: BrokerCodeEntry): void {
+  store.set(code, entry)
+}
+
+/** Redeem a code exactly once; returns null when unknown/expired. */
+export function takeBrokerCode(code: string, now = Date.now()): BrokerCodeEntry | null {
+  const entry = store.get(code)
+  if (!entry) return null
+  store.delete(code) // single-use
+  if (entry.expiresAt < now) return null
+  return entry
+}
+
+/** Sweep never-redeemed expired codes. */
+export function sweepBrokerCodes(now = Date.now()): void {
+  for (const [code, entry] of store) {
+    if (entry.expiresAt < now) store.delete(code)
+  }
+}

--- a/backend/security/tests/authentik-provider.test.ts
+++ b/backend/security/tests/authentik-provider.test.ts
@@ -101,6 +101,14 @@ function newProvider(db = makeFakeDb(), overrides: any = {}) {
     oidc: fakeOidc,
     notifications,
     passwordLoginFn: jest.fn().mockResolvedValue({ id: 'u1', email: 'u@e.com', roles: ['user'] }),
+    // Default signupFn simulates Authentik enrollment + OIDC sync: the synced
+    // projection row is inserted into the (fake) users table, mirroring the real
+    // syncUserToDatabase path. Provider.signup then mints the session.
+    signupFn: jest.fn().mockImplementation(async (input: any) => {
+      const id = 'newuser-1'
+      await db('users').insert({ id, email: input.email, first_name: input.firstName, last_name: input.lastName, roles: JSON.stringify(['user']) })
+      return { id, email: input.email, firstName: input.firstName, lastName: input.lastName, roles: ['user'] }
+    }),
     ...overrides,
   })
 }
@@ -132,12 +140,29 @@ describe('passwordLogin', () => {
 })
 
 describe('social login boundary', () => {
-  it('rewrites the authorize URL to the same-host IdP proxy prefix', async () => {
+  it('rewrites the authorize URL to the same-host IdP proxy prefix when one is set', async () => {
     const p = newProvider()
-    const { redirectUrl, state } = await p.startSocialLogin('google', '/home')
+    const { redirectUrl, state, codeVerifier } = await p.startSocialLogin('google', '/home')
     expect(redirectUrl.startsWith('/api/auth/idp/application/o/authorize/')).toBe(true)
     expect(redirectUrl).not.toMatch(/auth\.internal\.example/)
     expect(state).toBeTruthy()
+    // codeVerifier is surfaced so the route can set the oidc_cv cookie.
+    expect(codeVerifier).toBe('cv')
+  })
+
+  it('defaults to a NATIVE same-host authorize path (empty prefix, matching #256 ingress)', async () => {
+    const saved = process.env.SECURITY_IDP_PROXY_PREFIX
+    delete process.env.SECURITY_IDP_PROXY_PREFIX
+    try {
+      const p = newProvider()
+      const { redirectUrl } = await p.startSocialLogin('google', '/home')
+      // Native path, no /api/auth/idp prefix, no double slash, no internal host.
+      expect(redirectUrl.startsWith('/application/o/authorize/')).toBe(true)
+      expect(redirectUrl.startsWith('//')).toBe(false)
+      expect(redirectUrl).not.toMatch(/auth\.internal\.example/)
+    } finally {
+      if (saved !== undefined) process.env.SECURITY_IDP_PROXY_PREFIX = saved
+    }
   })
   it('rejects an absolute redirectTo (open-redirect guard)', async () => {
     await expect(newProvider().startSocialLogin('google', 'https://evil.com')).rejects.toBeInstanceOf(InvalidInputError)
@@ -161,14 +186,43 @@ describe('social login boundary', () => {
 })
 
 describe('signup', () => {
-  it('creates a user + session and rejects a duplicate email with ConflictError', async () => {
+  it('delegates to Authentik enrollment (signupFn) then mints a session; no local bcrypt user', async () => {
     const db = makeFakeDb()
-    const p = newProvider(db)
+    const signupFn = jest.fn().mockImplementation(async (input: any) => {
+      // Simulate the synced projection the OIDC callback would create.
+      await db('users').insert({ id: 'ak-1', email: input.email, first_name: input.firstName, roles: JSON.stringify(['user']) })
+      return { id: 'ak-1', email: input.email, firstName: input.firstName, roles: ['user'] }
+    })
+    const p = newProvider(db, { signupFn })
     const s = await p.signup({ email: 'new@e.com', password: 'pw', firstName: 'N' })
     expect(s.token).toBeTruthy()
+    expect(s.user.id).toBe('ak-1')
+    expect(signupFn).toHaveBeenCalledWith(expect.objectContaining({ email: 'new@e.com', password: 'pw' }))
+    // The user row is a synced projection — NOT a locally-hashed bcrypt insert.
     expect(db.__tables.users.length).toBe(1)
-    expect(db.__tables.event_outbox.length).toBe(1)
-    await expect(p.signup({ email: 'new@e.com', password: 'pw' })).rejects.toBeInstanceOf(ConflictError)
+    expect(db.__tables.users[0].password_hash).toBeUndefined()
+    expect(db.__tables.sessions.length).toBe(1)
+  })
+
+  it('rejects a duplicate email (existing projection) with ConflictError, without calling enrollment', async () => {
+    const db = makeFakeDb()
+    db.__tables.users.push({ id: 'u1', email: 'dup@e.com', roles: '["user"]' })
+    const signupFn = jest.fn()
+    const p = newProvider(db, { signupFn })
+    await expect(p.signup({ email: 'dup@e.com', password: 'pw' })).rejects.toBeInstanceOf(ConflictError)
+    expect(signupFn).not.toHaveBeenCalled()
+  })
+
+  it('maps an Authentik EnrollmentConflictError to ConflictError', async () => {
+    const { EnrollmentConflictError } = require('../src/services/authentikPassword')
+    const db = makeFakeDb()
+    const signupFn = jest.fn().mockRejectedValue(new EnrollmentConflictError())
+    const p = newProvider(db, { signupFn })
+    await expect(p.signup({ email: 'x@e.com', password: 'pw' })).rejects.toBeInstanceOf(ConflictError)
+  })
+
+  it('rejects missing credentials with InvalidInputError', async () => {
+    await expect(newProvider().signup({ email: '', password: '' } as any)).rejects.toBeInstanceOf(InvalidInputError)
   })
 })
 

--- a/backend/security/tests/authentik-signup.test.ts
+++ b/backend/security/tests/authentik-signup.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Unit tests for server-side Authentik ENROLLMENT signup
+ * (services/authentikPassword.ts → authentikSignup).
+ *
+ * The enrollment flow-executor conversation and the authorize redirect are
+ * simulated by mocking global.fetch — no network. OIDC pieces (authorize URL,
+ * token exchange / user sync) are mocked at the oidcService boundary, exactly
+ * like the password-login test. The point: signup drives AUTHENTIK enrollment
+ * (no local bcrypt user) then completes the SAME OIDC sync as login.
+ */
+jest.mock('../src/services/oidc', () => ({
+  oidcService: {
+    isConfigured: jest.fn().mockReturnValue(true),
+    isInitialized: jest.fn().mockReturnValue(true),
+    generateAuthUrl: jest.fn().mockReturnValue({
+      url: 'http://auth.example.test/application/o/authorize/?client_id=x&state=st',
+      codeVerifier: 'test-code-verifier',
+    }),
+    handleCallback: jest.fn().mockResolvedValue({
+      id: 'new-user-1',
+      email: 'signup@test.local',
+      firstName: 'New',
+      lastName: 'User',
+      roles: ['user'],
+    }),
+  },
+}))
+
+import {
+  authentikSignup,
+  EnrollmentConflictError,
+  UnsupportedFlowStageError,
+  InvalidCredentialsError,
+} from '../src/services/authentikPassword'
+import { oidcService } from '../src/services/oidc'
+
+const REDIRECT_URI = 'http://fuzefront.test.local/api/auth/oidc/callback'
+
+function mkRes(opts: { status?: number; json?: unknown; setCookies?: string[]; location?: string }) {
+  const headerMap = new Map<string, string>()
+  if (opts.location) headerMap.set('location', opts.location)
+  if (opts.json !== undefined) headerMap.set('content-type', 'application/json')
+  return {
+    ok: (opts.status ?? 200) >= 200 && (opts.status ?? 200) < 300,
+    status: opts.status ?? 200,
+    headers: {
+      get: (name: string) => headerMap.get(name.toLowerCase()) ?? null,
+      getSetCookie: () => opts.setCookies ?? [],
+    },
+    json: async () => opts.json ?? {},
+    text: async () => JSON.stringify(opts.json ?? ''),
+  } as unknown as Response
+}
+
+describe('authentikSignup()', () => {
+  const savedEnv = { ...process.env }
+  let fetchMock: jest.Mock
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    process.env.AUTHENTIK_ISSUER_URL = 'http://auth.example.test/application/o/fuzefront/'
+    process.env.AUTHENTIK_REDIRECT_URI = REDIRECT_URI
+    delete process.env.AUTHENTIK_BASE_URL
+    delete process.env.AUTHENTIK_ENROLLMENT_FLOW_SLUG
+    ;(oidcService.isConfigured as jest.Mock).mockReturnValue(true)
+    ;(oidcService.isInitialized as jest.Mock).mockReturnValue(true)
+    fetchMock = jest.fn()
+    ;(global as any).fetch = fetchMock
+  })
+
+  afterAll(() => {
+    process.env = savedEnv
+  })
+
+  it('drives the prompt stage then completes OIDC sync (no local bcrypt user)', async () => {
+    fetchMock
+      // 1. GET enrollment flow → prompt stage (+ CSRF cookie)
+      .mockResolvedValueOnce(
+        mkRes({ json: { component: 'ak-stage-prompt' }, setCookies: ['authentik_csrf=csrf-tok; Path=/'] })
+      )
+      // 2. POST prompt → flow complete (auto user-write + user-login)
+      .mockResolvedValueOnce(
+        mkRes({ json: { component: 'xak-flow-redirect', to: '/' }, setCookies: ['authentik_session=sess-1; Path=/'] })
+      )
+      // 3. GET authorize → 302 to our callback with the code
+      .mockResolvedValueOnce(mkRes({ status: 302, location: `${REDIRECT_URI}?code=the-code&state=st` }))
+
+    const user = await authentikSignup({ email: 'signup@test.local', password: 'Sup3rSecret!!', firstName: 'New', lastName: 'User' })
+
+    expect(user.email).toBe('signup@test.local')
+    expect(oidcService.handleCallback).toHaveBeenCalledWith('the-code', 'st', 'test-code-verifier')
+
+    // The prompt POST carried the enrollment fields + CSRF + hit the enrollment slug.
+    const [promptUrl, promptInit] = fetchMock.mock.calls[1]
+    expect(promptUrl).toContain('/api/v3/flows/executor/fuzefront-enrollment/')
+    const body = JSON.parse(promptInit.body)
+    expect(body).toMatchObject({
+      component: 'ak-stage-prompt',
+      email: 'signup@test.local',
+      password: 'Sup3rSecret!!',
+      password_repeat: 'Sup3rSecret!!',
+    })
+    expect(body.username).toBeTruthy()
+    expect(promptInit.headers['X-CSRFToken']).toBe('csrf-tok')
+  })
+
+  it('maps an "already exists" response_error to EnrollmentConflictError', async () => {
+    fetchMock
+      .mockResolvedValueOnce(mkRes({ json: { component: 'ak-stage-prompt' } }))
+      .mockResolvedValueOnce(
+        mkRes({ json: { component: 'ak-stage-prompt', response_errors: { username: [{ string: 'User with this username already exists.', code: 'unique' }] } } })
+      )
+
+    await expect(
+      authentikSignup({ email: 'dup@test.local', password: 'Sup3rSecret!!' })
+    ).rejects.toBeInstanceOf(EnrollmentConflictError)
+    expect(oidcService.handleCallback).not.toHaveBeenCalled()
+  })
+
+  it('maps a password-policy rejection to InvalidCredentialsError (not a conflict)', async () => {
+    fetchMock
+      .mockResolvedValueOnce(mkRes({ json: { component: 'ak-stage-prompt' } }))
+      .mockResolvedValueOnce(
+        mkRes({ json: { component: 'ak-stage-prompt', response_errors: { password: [{ string: 'Password too short', code: 'invalid' }] } } })
+      )
+
+    await expect(
+      authentikSignup({ email: 'weak@test.local', password: 'x' })
+    ).rejects.toBeInstanceOf(InvalidCredentialsError)
+  })
+
+  it('fails closed on an unsupported stage (e.g. captcha / email-verify)', async () => {
+    fetchMock.mockResolvedValueOnce(mkRes({ json: { component: 'ak-stage-captcha' } }))
+
+    await expect(
+      authentikSignup({ email: 'bot@test.local', password: 'Sup3rSecret!!' })
+    ).rejects.toBeInstanceOf(UnsupportedFlowStageError)
+  })
+})

--- a/deploy/helm/fuzefront/templates/security.yaml
+++ b/deploy/helm/fuzefront/templates/security.yaml
@@ -111,6 +111,20 @@ spec:
               value: {{ .Values.authentik.oidc.issuerUrl | quote }}
             - name: AUTHENTIK_REDIRECT_URI
               value: {{ .Values.authentik.oidc.redirectUri | quote }}
+            # Admin token for server-side Authentik REST (M2M client provisioning).
+            # Reuses the akadmin bootstrap token (see authentik-m2m-provisioning).
+            - name: AUTHENTIK_ADMIN_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "fuzefront.secretName" . }}
+                  key: AUTHENTIK_BOOTSTRAP_TOKEN
+            # Enrollment flow slug driven server-side by signup() (blueprint: flow-enrollment.yaml).
+            - name: AUTHENTIK_ENROLLMENT_FLOW_SLUG
+              value: {{ .Values.authentik.oidc.enrollmentFlowSlug | default "fuzefront-enrollment" | quote }}
+            # Empty prefix: PR #256 routes Authentik's NATIVE paths under app.fuzefront.com
+            # (no /api/auth/idp prefix). Pin it so the authorize URL stays a bare native path.
+            - name: SECURITY_IDP_PROXY_PREFIX
+              value: {{ .Values.authentik.oidc.idpProxyPrefix | default "" | quote }}
             {{- if .Values.authentik.oidc.caConfigMap }}
             - name: NODE_EXTRA_CA_CERTS
               value: /etc/fuzefront-ca/ca.crt


### PR DESCRIPTION
## Phase 1 — make sign-up (A) + Google (B) actually work on the new backend

Reconciles three gaps found after #253/#256 merged (salvaged + finished after the original agent hung on a local npm install):

**A — sign-up split-brain fixed:** `AuthentikIdentityProvider.signup()` no longer writes a local bcrypt orphan; it now drives **Authentik enrollment server-side** (mirrors the `authentikPassword.ts` flow-executor broker against the `fuzefront-enrollment` blueprint) so the user exists in Authentik and can log in. Local `users` becomes a synced projection.

**B — social reconciled with #256:** `idpProxyPrefix()` now defaults to `""` so authorize URLs use Authentik's **native paths** (`/application/o/authorize/…`) that #256 routes under `app.fuzefront.com` (the old `/api/auth/idp` prefix was removed). Broker-code exchange moved to a dedicated `brokerCodes.ts` store.

**C — env wired:** `AUTHENTIK_ADMIN_TOKEN` (M2M), `AUTHENTIK_ENROLLMENT_FLOW_SLUG`, `SECURITY_IDP_PROXY_PREFIX=""` on the security Deployment.

Build/tests run in CI (local npm install hangs on this Windows host). `helm template` renders clean.

**Deploy note:** this must ship **with frontend #250**, and only via a **staggered** `release.yml` dispatch — not auto-deployed. Google also needs the app-hosted callback registered in the Google console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)