### PR TITLE
ci(security): make @fuzefront/security-client publishable + installable now (izzywdev alias)

### DIFF
--- a/.github/workflows/security-packages-publish.yml
+++ b/.github/workflows/security-packages-publish.yml
@@ -1,0 +1,65 @@
+# Publish the security client to GitHub Packages under the @izzywdev scope.
+#
+# GitHub Packages requires the npm scope to match the repository owner, so the
+# canonical @fuzefront/security-client name cannot publish until the org transfer
+# completes (see packages-publish.yml, which stays the long-term path and no-ops
+# until then). Consuming apps (FuzeSocial, Mendys) need the security client TODAY,
+# so this workflow publishes the same build under an owner-scoped alias name:
+#
+#   @fuzefront/security-client -> @izzywdev/fuzefront-security-client
+#
+# Consumers install via an npm alias so their imports keep the canonical name:
+#
+#   "@fuzefront/security-client": "npm:@izzywdev/fuzefront-security-client@^0.1.0"
+#
+# Once the org transfer lands and packages-publish.yml activates, consumers drop
+# the alias and this workflow is deleted. Publishing is idempotent: a version that
+# already exists in the registry is skipped, not overwritten. No git push / tag is
+# made, so master's required_signatures protection is never involved.
+name: Publish security client (alias scope)
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [master]
+    paths:
+      - 'packages/security/**'
+
+concurrency:
+  group: security-packages-publish
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    if: github.repository_owner == 'izzywdev'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        with:
+          node-version: '20.x'
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@izzywdev'
+
+      - name: Build security client
+        working-directory: packages/security
+        run: |
+          npm install --workspaces=false --no-audit --no-fund
+          npm run build
+
+      - name: Publish @izzywdev/fuzefront-security-client
+        working-directory: packages/security
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION=$(npm pkg get version | tr -d '"')
+          npm pkg set name=@izzywdev/fuzefront-security-client
+          if npm view "@izzywdev/fuzefront-security-client@${VERSION}" version --registry=https://npm.pkg.github.com >/dev/null 2>&1; then
+            echo "@izzywdev/fuzefront-security-client@${VERSION} already published — skipping."
+          else
+            npm publish --registry=https://npm.pkg.github.com
+          fi

--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "version": "1.0.0",
   "npmClient": "npm",
-  "packages": ["backend", "frontend", "shared", "sdk", "task-manager-app", "services/email-service", "services/sms-service", "services/provisioning-service", "services/chat-service", "packages/chat-client", "packages/chat-ui", "packages/identity-ui", "design-system", "packages/i18n", "packages/i18n-translate", "packages/feature-flags"],
+  "packages": ["backend", "frontend", "shared", "sdk", "task-manager-app", "services/email-service", "services/sms-service", "services/provisioning-service", "services/chat-service", "packages/chat-client", "packages/chat-ui", "packages/identity-ui", "design-system", "packages/i18n", "packages/i18n-translate", "packages/feature-flags", "packages/security"],
   "command": {
     "version": {
       "allowBranch": ["main", "master", "develop"],

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "packages/i18n",
     "packages/i18n-translate",
     "packages/feature-flags",
+    "packages/security",
     "design-system",
     "services/email-service"
   ],


### PR DESCRIPTION
## What
Makes `@fuzefront/security-client` (`packages/security/`) actually publishable and installable so FuzeSocial / Mendys can reintegrate through it.

## Changes
- Add `packages/security` to **`lerna.json` `packages[]`** and to the **root `workspaces`** (it was in neither, so lerna change-detection + workspace tooling never saw it).
- Add **`.github/workflows/security-packages-publish.yml`** — mirrors the proven `chat-packages-publish.yml`: on push to `master` touching `packages/security/**`, builds the tsup output and publishes to GitHub Packages, idempotently (skips an already-published version). No git push / tag, so master's `required_signatures` is never involved.

## The scope-vs-owner constraint (important)
GitHub Packages ties the npm **scope to the repo owner**. Under the current **`izzywdev`** account, `@fuzefront/*` **cannot** publish (403) — which is exactly why `packages-publish.yml` is gated to `github.repository_owner == 'fuzefront'` and no-ops today. The finding's suggested "flip that gate to izzywdev and keep the `@fuzefront` scope" would make `lerna publish` 403 on every `@fuzefront/*` package on every master push, so that gate is intentionally left unchanged as the long-term org-transfer path.

Instead we follow the repo's already-established workaround (used for chat packages): publish under the **owner-scoped alias** `@izzywdev/fuzefront-security-client`. Consumers install via an npm alias so their imports keep the canonical name:

```jsonc
// consumer package.json
"@fuzefront/security-client": "npm:@izzywdev/fuzefront-security-client@^0.1.0"
```
with a scoped `.npmrc`:
```
@izzywdev:registry=https://npm.pkg.github.com
//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}
```
Once the org transfer lands and `packages-publish.yml` activates, consumers drop the alias and this workflow is deleted.

## Signatures / tags
The alias workflow does **no** `git commit`/`git push`/tag — it only `npm publish`es — so master's `required_signatures` protection is not touched (unlike a `lerna publish` version-bump-and-push, which would be rejected on signed-master).

🤖 Generated with [Claude Code](https://claude.com/claude-code)