### PR TITLE
fix(authn): route /api/v3 (Authentik flow-executor) to authentik-server

### DIFF
--- a/deploy/helm/fuzefront/templates/ingress.yaml
+++ b/deploy/helm/fuzefront/templates/ingress.yaml
@@ -210,7 +210,12 @@ spec:
           # OIDC discovery/authorize URLs at these root paths using the forwarded
           # Host (app.fuzefront.com) — which must therefore be routable here.
           # These prefixes don't overlap the app's /api, /apps, /socket.io, / routes.
-          {{- range $p := list "/application" "/if" "/source" "/flows" "/ws" "/-" "/outpost.goauthentik.io" "/static/dist" "/static/authentik" }}
+          {{- /* /api/v3 = Authentik's flow-executor + REST API, called BOTH by the
+                 login-page SPA (browser) AND server-side by the security-service
+                 (password/enrollment flow driver). Must route to authentik-server,
+                 or flow-executor calls hit FuzeFront's /api and fail with
+                 PROVIDER_UNAVAILABLE. Does not collide with FuzeFront's /api/v1/*. */ -}}
+          {{- range $p := list "/application" "/if" "/source" "/flows" "/ws" "/-" "/outpost.goauthentik.io" "/api/v3" "/static/dist" "/static/authentik" }}
           - path: {{ $p }}
             pathType: Prefix
             backend:


### PR DESCRIPTION
Follow-up to #256. The security-service + login SPA call Authentik's flow-executor at `/api/v3/flows/executor/...` to drive password + enrollment; #256 missed routing `/api/v3`, so those calls hit FuzeFront's `/api` → `PROVIDER_UNAVAILABLE` (signup + login 401, caught by the headed Playwright demo). Routes `/api/v3` to `authentik-server`. Chart-only; deploys via Argo. No collision with `/api/v1/*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)