### PR TITLE
fix(authn): users.id must be a uuid, not the OIDC sub (email)

### DIFF
--- a/backend/security/src/services/oidc.ts
+++ b/backend/security/src/services/oidc.ts
@@ -131,9 +131,12 @@ class OIDCService {
 
         console.log(`✅ Updated existing user: ${email}`);
       } else {
-        // Create new user
+        // Create new user. The local `id` is ALWAYS a generated uuid — never the
+        // OIDC `sub`, which Authentik sets to the email/username (not a uuid) and
+        // which would fail the uuid-typed `id` column. Email is the natural key we
+        // match on (above), so a fresh uuid is safe and stable per-account.
         const newUser = {
-          id: userinfo.sub || require('uuid').v4(),
+          id: require('uuid').v4(),
           email: email,
           first_name: firstName,
           last_name: lastName,


### PR DESCRIPTION
syncUserToDatabase wrote `id = userinfo.sub` (Authentik's sub = email) into the uuid `id` column → new-user insert threw `invalid input syntax for type uuid` → signup + first-login 401. Always generate a uuid; email stays the match key. Caught by the headed Playwright demo. Needs a security-service image rebuild (release.yml dispatch).