### PR TITLE
fix(authn): flow-executor over in-cluster DNS + raise client timeout

### DIFF
--- a/deploy/helm/fuzefront/templates/security.yaml
+++ b/deploy/helm/fuzefront/templates/security.yaml
@@ -111,6 +111,13 @@ spec:
               value: {{ .Values.authentik.oidc.issuerUrl | quote }}
             - name: AUTHENTIK_REDIRECT_URI
               value: {{ .Values.authentik.oidc.redirectUri | quote }}
+            # Server-side base for Authentik's flow-executor (password + enrollment
+            # driver). Points at the IN-CLUSTER service so the multi-hop flow does
+            # NOT hairpin out to the app host via Cloudflare (which took 17-34s and
+            # blew the client timeout). The external issuer/redirect above stay for
+            # the browser + the `iss` claim.
+            - name: AUTHENTIK_BASE_URL
+              value: {{ .Values.authentik.oidc.internalUrl | default "http://authentik-server:9000" | quote }}
             # Admin token for server-side Authentik REST (M2M client provisioning).
             # Reuses the akadmin bootstrap token (see authentik-m2m-provisioning).
             - name: AUTHENTIK_ADMIN_TOKEN

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -59,7 +59,10 @@ const api = axios.create({
   headers: {
     'Content-Type': 'application/json',
   },
-  timeout: 10000, // 10 second timeout
+  // Server-brokered sign-in/up drive the identity provider's flow-executor +
+  // OIDC exchange server-side (several hops); allow headroom so a legitimate
+  // login isn't cut off. The provider itself is reached over fast in-cluster DNS.
+  timeout: 30000, // 30 second timeout
 })
 
 // Add request timing and enhanced logging


### PR DESCRIPTION
Login took 17-34s (server-side flow-executor hairpinned out to app.fuzefront.com via Cloudflare per hop) and blew the SPA's 10s axios timeout. Point AUTHENTIK_BASE_URL at authentik-server:9000 (in-cluster, sub-100ms) and raise the client timeout to 30s. The env change is chart-only (fast/reversible); the timeout needs the frontend image. Caught by the headed demo.