### PR TITLE
fix(authn): expect internal iss for in-cluster OIDC (completes the fast-login fix)

### DIFF
--- a/backend/security/src/services/oidc.ts
+++ b/backend/security/src/services/oidc.ts
@@ -54,6 +54,12 @@ class OIDCService {
         };
         effectiveIssuer = new Issuer({
           ...issuer.metadata,
+          // Authentik derives `iss` from the request host even in per_provider
+          // mode, so a token fetched from authentik-server:9000 carries
+          // iss=http://authentik-server:9000/... — expect exactly that. The
+          // browser-facing FuzeFront session token is separately HS256-minted, so
+          // this internal `iss` never leaves the server.
+          issuer: toInternal(issuer.metadata.issuer) as string,
           token_endpoint: toInternal(issuer.metadata.token_endpoint),
           userinfo_endpoint: toInternal(issuer.metadata.userinfo_endpoint),
           jwks_uri: toInternal(issuer.metadata.jwks_uri),


### PR DESCRIPTION
Follow-up to #265: Authentik stamps iss from the request host even in per_provider mode, so the in-cluster token carried iss=authentik-server:9000 and openid-client rejected it (all 401). Expect the internal iss (the FuzeFront session token is separately HS256-minted). Completes the fast (<2s) + reliable login fix.