### PR TITLE
feat(ui): FuzeFront rebrand + logo, /signup mode, Loading-vs-Creating workspace box

### DIFF
--- a/frontend/src/__tests__/LoginPage.google-signin.test.tsx
+++ b/frontend/src/__tests__/LoginPage.google-signin.test.tsx
@@ -35,7 +35,7 @@ import type { AuthMethods } from '@fuzefront/security-client'
 // ── Hoisted mocks (processed before imports) ──────────────────────────────
 
 // PNG asset — jsdom cannot load real images; return a stable string.
-vi.mock('../assets/FrontFuseLogo.png', () => ({ default: 'mock-logo.png' }))
+vi.mock('../assets/FuzeFrontLogo.svg', () => ({ default: 'mock-logo.png' }))
 
 // LanguageContext — LoginPage calls useLanguage(). Echo translation keys so
 // t('signUp') returns 'signUp', making button text predictable in assertions.

--- a/frontend/src/assets/FuzeFrontLogo.svg
+++ b/frontend/src/assets/FuzeFrontLogo.svg
@@ -1,0 +1,17 @@
+<svg width="160" height="40" viewBox="0 0 160 40" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="FuzeFront">
+  <defs>
+    <linearGradient id="ffSeam" x1="0" y1="0" x2="40" y2="40" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#7c5cff"/>
+      <stop offset="1" stop-color="#22d3ee"/>
+    </linearGradient>
+  </defs>
+  <!-- Fuse-seam mark: two panels split by a diagonal seam -->
+  <rect x="2" y="4" width="32" height="32" rx="8" fill="url(#ffSeam)"/>
+  <path d="M12 30 L24 10" stroke="#0b1020" stroke-width="2.5" stroke-linecap="round"/>
+  <circle cx="12" cy="30" r="2.6" fill="#0b1020"/>
+  <circle cx="24" cy="10" r="2.6" fill="#0b1020"/>
+  <!-- Wordmark: Fuze (accent) + Front -->
+  <text x="44" y="27" font-family="'Inter','Segoe UI',system-ui,sans-serif" font-size="20" font-weight="700" letter-spacing="-0.5">
+    <tspan fill="url(#ffSeam)">Fuze</tspan><tspan fill="currentColor">Front</tspan>
+  </text>
+</svg>

--- a/frontend/src/components/TopBar.tsx
+++ b/frontend/src/components/TopBar.tsx
@@ -4,7 +4,7 @@ import { LanguageSelector, useT } from '@fuzefront/i18n'
 import AppSelector from './AppSelector'
 import UserMenu from './UserMenu'
 import { OrganizationSelector } from './OrganizationSelector'
-import FrontFuseLogo from '../assets/FrontFuseLogo.png'
+import FuzeFrontLogo from '../assets/FuzeFrontLogo.svg'
 
 interface TopBarProps {
   onMenuToggle?: () => void
@@ -35,7 +35,7 @@ function TopBar({ onMenuToggle }: TopBarProps) {
         style={{ display: 'flex', alignItems: 'center', gap: '10px' }}
       >
         <img
-          src={FrontFuseLogo}
+          src={FuzeFrontLogo}
           alt="FuzeFront"
           style={{ height: '28px', width: 'auto' }}
         />

--- a/frontend/src/components/WorkspaceProvisioningGate.tsx
+++ b/frontend/src/components/WorkspaceProvisioningGate.tsx
@@ -155,6 +155,10 @@ export function WorkspaceProvisioningGate({
   }
 
   if (gateState === 'checking' || gateState === 'provisioning') {
+    // First-timers have their workspace CREATED (provisioning); returning users
+    // already have one and we're just LOADING it (checking). Distinct copy so an
+    // existing user doesn't see "Creating your workspace".
+    const isCreating = gateState === 'provisioning'
     return (
       <div
         style={{
@@ -165,7 +169,13 @@ export function WorkspaceProvisioningGate({
           background: 'var(--bg-primary)',
         }}
       >
-        <ProvisioningCard state="loading" />
+        <ProvisioningCard
+          state="loading"
+          title={isCreating ? undefined : 'Loading your workspace…'}
+          description={
+            isCreating ? undefined : 'Getting your workspace ready…'
+          }
+        />
       </div>
     )
   }

--- a/frontend/src/contexts/LanguageContext.tsx
+++ b/frontend/src/contexts/LanguageContext.tsx
@@ -11,7 +11,7 @@ interface LanguageContextType {
 const translations = {
   en: {
     // Top bar
-    appHub: 'FrontFuse',
+    appHub: 'FuzeFront',
     switchToLight: 'Switch to light mode',
     switchToDark: 'Switch to dark mode',
 
@@ -24,7 +24,7 @@ const translations = {
     portal: 'Portal',
     appMenu: 'App Menu',
     logout: 'Logout',
-    frontFuse: 'FrontFuse',
+    frontFuse: 'FuzeFront',
 
     // User menu
     profile: 'Profile',
@@ -43,12 +43,12 @@ const translations = {
 
     // Dashboard
     welcome: 'Welcome',
-    welcomeMessage: 'Welcome to FrontFuse',
+    welcomeMessage: 'Welcome to FuzeFront',
     myApps: 'My Applications',
     recentActivity: 'Recent Activity',
 
     // Auth
-    welcomeToAppHub: 'Welcome to FrontFuse',
+    welcomeToAppHub: 'Welcome to FuzeFront',
     signInMessage: 'Sign in to access your microfrontend platform',
     email: 'Email',
     password: 'Password',
@@ -86,7 +86,7 @@ const translations = {
 
     // New additions
     addApp: 'Add Application',
-    welcomeToFrontFuse: 'Welcome to FrontFuse',
+    welcomeToFrontFuse: 'Welcome to FuzeFront',
     login: 'Login',
     loginButton: 'Login',
 
@@ -110,7 +110,7 @@ const translations = {
   },
   he: {
     // Top bar
-    appHub: 'FrontFuse',
+    appHub: 'FuzeFront',
     switchToLight: 'עבור למצב בהיר',
     switchToDark: 'עבור למצב כהה',
 
@@ -123,7 +123,7 @@ const translations = {
     portal: 'פורטל',
     appMenu: 'תפריט אפליקציות',
     logout: 'התנתק',
-    frontFuse: 'FrontFuse',
+    frontFuse: 'FuzeFront',
 
     // User menu
     profile: 'פרופיל',
@@ -142,12 +142,12 @@ const translations = {
 
     // Dashboard
     welcome: 'ברוך הבא',
-    welcomeMessage: 'ברוך הבא ל-FrontFuse',
+    welcomeMessage: 'ברוך הבא ל-FuzeFront',
     myApps: 'האפליקציות שלי',
     recentActivity: 'פעילות אחרונה',
 
     // Auth
-    welcomeToAppHub: 'ברוכים הבאים ל-FrontFuse',
+    welcomeToAppHub: 'ברוכים הבאים ל-FuzeFront',
     signInMessage: 'היכנס כדי לגשת לפלטפורמת המיקרו-פרונטאנד שלך',
     email: 'אימייל',
     password: 'סיסמה',
@@ -185,7 +185,7 @@ const translations = {
 
     // New additions
     addApp: 'הוסף אפליקציה',
-    welcomeToFrontFuse: 'ברוך הבא ל-FrontFuse',
+    welcomeToFrontFuse: 'ברוך הבא ל-FuzeFront',
     login: 'התחבר',
     loginButton: 'התחבר',
 

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -4,7 +4,7 @@ import { useCurrentUser } from '../lib/shared'
 import { authAPI } from '../services/api'
 import type { AuthMethods, SessionResult } from '../services/api'
 import { Button, Input, Alert, SeamDivider } from '@fuzefront/design-system'
-import FrontFuseLogo from '../assets/FrontFuseLogo.png'
+import FuzeFrontLogo from '../assets/FuzeFrontLogo.svg'
 
 // Official Google "G" mark palette — these exact values are mandated by
 // Google's brand identity guidelines for third-party sign-in buttons and must
@@ -35,7 +35,10 @@ type FormMode = 'signin' | 'signup'
 
 function LoginPage() {
   const { t } = useLanguage()
-  const [mode, setMode] = useState<FormMode>('signin')
+  // Open in sign-up mode when the user arrived at /signup; sign-in otherwise.
+  const [mode, setMode] = useState<FormMode>(
+    window.location.pathname.includes('signup') ? 'signup' : 'signin'
+  )
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [firstName, setFirstName] = useState('')
@@ -199,11 +202,11 @@ function LoginPage() {
         }}
       >
         <img
-          src={FrontFuseLogo}
-          alt="FrontFuse"
+          src={FuzeFrontLogo}
+          alt="FuzeFront"
           style={{ height: '48px', width: 'auto', marginRight: 'var(--space-3, 12px)' }}
         />
-        <h2 style={{ margin: 0 }}>Welcome to FrontFuse</h2>
+        <h2 style={{ margin: 0 }}>Welcome to FuzeFront</h2>
       </div>
       <p style={{ color: 'var(--text-secondary)' }}>
         {mode === 'signin'


### PR DESCRIPTION
- Rebrand FrontFuse→FuzeFront across the login page + top bar + i18n app-name values, with a new fuse-seam wordmark logo (SVG).
- `/signup` now opens the form in **signup** mode (was always sign-in) — fixes the 'create account' flow.
- Workspace gate: first-timers (provisioning) see **Creating your workspace**; returning users (checking) see **Loading your workspace**.

Needs a frontend image rebuild (release.yml dispatch).