### PR TITLE
fix(deps): register packages/security in root lockfile (unblocks gate-frontend-build)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24028,6 +24028,19 @@
         "uuid": "9.0.1"
       }
     },
+    "services/email-service/node_modules/@types/express": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
+      "integrity": "sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.33",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
     "services/email-service/node_modules/@types/node": {
       "version": "18.19.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "packages/i18n",
         "packages/i18n-translate",
         "packages/feature-flags",
+        "packages/security",
         "design-system",
         "services/email-service"
       ],
@@ -559,27 +560,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "billing-client/node_modules/openapi-typescript": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/openapi-typescript/-/openapi-typescript-7.13.0.tgz",
-      "integrity": "sha512-EFP392gcqXS7ntPvbhBzbF8TyBA+baIYEm791Hy5YkjDYKTnk/Tn5OQeKm5BIZvJihpp8Zzr4hzx0Irde1LNGQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@redocly/openapi-core": "^1.34.6",
-        "ansi-colors": "^4.1.3",
-        "change-case": "^5.4.4",
-        "parse-json": "^8.3.0",
-        "supports-color": "^10.2.2",
-        "yargs-parser": "^21.1.1"
-      },
-      "bin": {
-        "openapi-typescript": "bin/cli.js"
-      },
-      "peerDependencies": {
-        "typescript": "^5.x"
       }
     },
     "billing-client/node_modules/rimraf": {
@@ -2237,6 +2217,10 @@
     },
     "node_modules/@fuzefront/identity-ui": {
       "resolved": "packages/identity-ui",
+      "link": true
+    },
+    "node_modules/@fuzefront/security-client": {
+      "resolved": "packages/security",
       "link": true
     },
     "node_modules/@fuzefront/security-service": {
@@ -15262,6 +15246,27 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/openapi-typescript": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/openapi-typescript/-/openapi-typescript-7.13.0.tgz",
+      "integrity": "sha512-EFP392gcqXS7ntPvbhBzbF8TyBA+baIYEm791Hy5YkjDYKTnk/Tn5OQeKm5BIZvJihpp8Zzr4hzx0Irde1LNGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@redocly/openapi-core": "^1.34.6",
+        "ansi-colors": "^4.1.3",
+        "change-case": "^5.4.4",
+        "parse-json": "^8.3.0",
+        "supports-color": "^10.2.2",
+        "yargs-parser": "^21.1.1"
+      },
+      "bin": {
+        "openapi-typescript": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "typescript": "^5.x"
+      }
+    },
     "node_modules/openid-client": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.7.1.tgz",
@@ -23962,6 +23967,41 @@
         }
       }
     },
+    "packages/security": {
+      "name": "@fuzefront/security-client",
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/node": "18.19.0",
+        "openapi-typescript": "^7.4.0",
+        "tsup": "^8.0.2",
+        "typescript": "5.1.6"
+      }
+    },
+    "packages/security/node_modules/@types/node": {
+      "version": "18.19.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.0.tgz",
+      "integrity": "sha512-667KNhaD7U29mT5wf+TZUnrzPrlL2GNQ5N0BMjO2oNULhBxX0/FKCkm6JMu0Jh7Z+1LwUlR21ekd7KhIboNFNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "packages/security/node_modules/typescript": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "services/email-service": {
       "name": "@fuzefront/email-service",
       "version": "1.0.0",
@@ -23986,19 +24026,6 @@
         "ts-node": "10.9.2",
         "typescript": "5.1.6",
         "uuid": "9.0.1"
-      }
-    },
-    "services/email-service/node_modules/@types/express": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
-      "integrity": "sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/body-parser": "*",
-        "@types/express-serve-static-core": "^4.17.33",
-        "@types/qs": "*",
-        "@types/serve-static": "*"
       }
     },
     "services/email-service/node_modules/@types/node": {


### PR DESCRIPTION
## Problem
`packages/security` was added as a workspace in root `package.json` but is missing from `package-lock.json`, so `gate-frontend-build` (npm ci) is red on every PR.

## Fix
Regenerated the root lockfile so the `packages/security` workspace is registered. Only `package-lock.json` changed (+ .gitignore for the isolated cache dir).

## Verify
- `npm ci` resolves from clean (security workspace present, 5 references).

🤖 Generated with [Claude Code](https://claude.com/claude-code)