### PR TITLE
feat(security): provider-agnostic AuthZ (/authz, /tenants) wrapping Permit

### DIFF
--- a/backend/security/src/index.ts
+++ b/backend/security/src/index.ts
@@ -15,6 +15,7 @@ import path from 'path'
 
 import authRoutes from './routes/auth'
 import securityRoutes from './routes/security'
+import authzRoutes from './routes/authz'
 import organizationsRoutes from './routes/organizations'
 import invitationsRoutes from './routes/invitations'
 import internalRoutes from './routes/internal'
@@ -35,6 +36,9 @@ const startTime = Date.now()
 
 // Provider-agnostic Security API (AuthN surface). New consumers use this.
 app.use('/api/v1/security', securityRoutes)
+// Provider-agnostic Security API (AuthZ surface) — /authz/* + /tenants/*,
+// implemented purely against the AuthorizationProvider contract (Permit hidden).
+app.use('/api/v1/security', authzRoutes)
 // Domain routes (identical paths to the monolith). These remain the working,
 // prod-tested `/api/auth/*` surface; they are the DEPRECATED compatibility
 // layer that the SPA migrates OFF onto `/api/v1/security/*`. Converting them

--- a/backend/security/src/providers/authzFactory.ts
+++ b/backend/security/src/providers/authzFactory.ts
@@ -1,0 +1,34 @@
+/**
+ * Authorization provider factory — env-driven selection of the concrete
+ * `AuthorizationProvider`. Mirrors `factory.ts` for identity.
+ *
+ * The `/api/v1/security/authz` + `/tenants` routes and `requirePermission`
+ * middleware call `getAuthorizationProvider()` and never name a vendor.
+ * Swapping engines is a one-line change here (or an env flip once a second
+ * provider exists). Today only the Permit-backed implementation exists;
+ * `SECURITY_AUTHORIZATION_PROVIDER` selects it (default `permit`).
+ */
+import type { AuthorizationProvider } from './AuthorizationProvider'
+import { PermitAuthorizationProvider } from './permit/PermitAuthorizationProvider'
+
+let singleton: AuthorizationProvider | null = null
+
+export function getAuthorizationProvider(): AuthorizationProvider {
+  if (singleton) return singleton
+  const selected = (
+    process.env.SECURITY_AUTHORIZATION_PROVIDER || 'permit'
+  ).toLowerCase()
+  switch (selected) {
+    case 'permit':
+      singleton = new PermitAuthorizationProvider()
+      break
+    default:
+      throw new Error(`Unknown SECURITY_AUTHORIZATION_PROVIDER: ${selected}`)
+  }
+  return singleton
+}
+
+/** Test seam: inject a provider (e.g. a mock) and reset between tests. */
+export function setAuthorizationProvider(p: AuthorizationProvider | null): void {
+  singleton = p
+}

--- a/backend/security/src/providers/permit/PermitAuthorizationProvider.ts
+++ b/backend/security/src/providers/permit/PermitAuthorizationProvider.ts
@@ -1,0 +1,262 @@
+/**
+ * PermitAuthorizationProvider — the first concrete `AuthorizationProvider`.
+ *
+ * Wraps Permit.io (the policy/ReBAC engine) behind FuzeFront's neutral AuthZ
+ * swap contract. This file is the ONLY place the vendor is named; every route,
+ * middleware, and consumer path talks to the `AuthorizationProvider` interface,
+ * so the engine is swappable without any consumer change.
+ *
+ * It reuses the existing, battle-tested `utils/permit/*` helpers (already
+ * fail-closed and CI-no-op aware) so no logic is discarded — this class is the
+ * neutral surface over them.
+ *
+ * Fail-closed everywhere: `check`/`bulkCheck` return `false` on any error; the
+ * read helpers return empty; writes surface a thrown error only for genuine
+ * caller mistakes (never silently "allow").
+ */
+import type {
+  AuthorizationProvider,
+  AuthzQuery,
+  Grant,
+  GrantQuery,
+  GrantRequest,
+  GrantRevokeRequest,
+  Member,
+  MemberCreate,
+  Page,
+  PageParams,
+  Role,
+  Tenant,
+  TenantCreate,
+} from '../AuthorizationProvider'
+import permit from '../../config/permit'
+import {
+  checkPermission,
+  bulkCheckPermissions,
+  getUserPermissions,
+} from '../../utils/permit/permission-check'
+import {
+  assignRoleInPermit,
+  unassignRoleInPermit,
+  getUserRoleAssignments,
+  getTenantRoleAssignments,
+} from '../../utils/permit/role-assignment'
+import {
+  getTenantFromPermit,
+  listTenantsFromPermit,
+} from '../../utils/permit/tenant-management'
+
+/** Compose the Permit resource-instance key `type:key` (ReBAC scope). */
+function resourceInstance(
+  resource?: { type: string; key?: string }
+): string | undefined {
+  if (!resource?.key) return undefined
+  return `${resource.type}:${resource.key}`
+}
+
+/** Single, unpaginated page (Permit's list APIs are not cursor-native here). */
+function singlePage<T>(items: T[]): Page<T> {
+  return { items, page: { nextCursor: null, hasMore: false, total: items.length } }
+}
+
+/** Best-effort map of an unknown Permit role-assignment row → its role key. */
+function roleKeyOf(a: any): string | undefined {
+  return a?.role ?? a?.role_key ?? undefined
+}
+
+export class PermitAuthorizationProvider implements AuthorizationProvider {
+  // ── Decisions (read-side, already fail-closed in the helpers) ──
+
+  async check(query: AuthzQuery): Promise<boolean> {
+    return checkPermission({
+      user: query.subject,
+      action: query.action,
+      resource: {
+        type: query.resource.type,
+        tenant: query.tenant,
+        key: query.resource.key,
+      },
+      context: query.context as Record<string, any> | undefined,
+    })
+  }
+
+  async bulkCheck(queries: AuthzQuery[]): Promise<boolean[]> {
+    if (queries.length === 0) return []
+    return bulkCheckPermissions(
+      queries.map(q => ({
+        user: q.subject,
+        action: q.action,
+        resource: { type: q.resource.type, tenant: q.tenant, key: q.resource.key },
+        context: q.context as Record<string, any> | undefined,
+      }))
+    )
+  }
+
+  async getPermissions(subject: string, tenant: string): Promise<string[]> {
+    const raw = (await getUserPermissions(subject, tenant)) as
+      | Record<string, { permissions?: string[] }>
+      | Record<string, string[]>
+      | undefined
+    if (!raw) return []
+    // Permit keys the result by tenant; each entry is either a bare string[]
+    // of `resource:action`, or an object exposing `.permissions`.
+    const out = new Set<string>()
+    for (const value of Object.values(raw)) {
+      const perms = Array.isArray(value) ? value : value?.permissions
+      for (const p of perms ?? []) out.add(p)
+    }
+    return [...out]
+  }
+
+  // ── Grants (write-side) ──
+
+  async grant(req: GrantRequest): Promise<Grant> {
+    const ok = await assignRoleInPermit({
+      user: req.subject,
+      role: req.role,
+      tenant: req.tenant,
+      resource_instance: resourceInstance(req.resource),
+    })
+    if (!ok) throw new Error('grant failed')
+    return {
+      id: `${req.tenant}:${req.subject}:${req.role}`,
+      subject: req.subject,
+      tenant: req.tenant,
+      role: req.role,
+      permission: req.permission,
+      resource: req.resource,
+    }
+  }
+
+  async revoke(req: GrantRevokeRequest): Promise<void> {
+    // Support the identity-tuple form (Permit unassigns by user+role+tenant).
+    // A grantId of the `tenant:subject:role` shape is decomposed if present.
+    let subject = req.subject
+    let tenant = req.tenant
+    let role = req.role
+    if (req.grantId && (!subject || !tenant || !role)) {
+      const [gTenant, gSubject, gRole] = req.grantId.split(':')
+      subject = subject ?? gSubject
+      tenant = tenant ?? gTenant
+      role = role ?? gRole
+    }
+    if (!subject || !tenant || !role) {
+      throw new Error('revoke requires grantId or subject+tenant+role')
+    }
+    // Idempotent: the helper returns false (not throws) if the assignment is
+    // already gone, which we treat as success.
+    await unassignRoleInPermit({ user: subject, role, tenant })
+  }
+
+  async listGrants(query: GrantQuery): Promise<Page<Grant>> {
+    const rows = (await getUserRoleAssignments(query.subject, query.tenant)) as any[]
+    const grants: Grant[] = (rows ?? [])
+      .map(r => {
+        const role = roleKeyOf(r)
+        if (!role) return null
+        return {
+          id: `${query.tenant}:${query.subject}:${role}`,
+          subject: query.subject,
+          tenant: query.tenant,
+          role,
+        } as Grant
+      })
+      .filter((g): g is Grant => g !== null)
+    return singlePage(grants)
+  }
+
+  // ── Tenants / membership / roles ──
+
+  async listTenants(_caller: string, _params: PageParams): Promise<Page<Tenant>> {
+    const raw = (await listTenantsFromPermit()) as any
+    const rows: any[] = Array.isArray(raw) ? raw : (raw?.data ?? [])
+    const tenants: Tenant[] = rows.map(t => ({
+      id: t.key ?? t.id,
+      name: t.name ?? t.key,
+      slug: t.attributes?.slug ?? t.slug,
+    }))
+    return singlePage(tenants)
+  }
+
+  async createTenant(input: TenantCreate): Promise<Tenant> {
+    const key = input.slug || input.name.toLowerCase().replace(/[^a-z0-9]+/g, '-')
+    await permit.api.tenants.create({
+      key,
+      name: input.name,
+      attributes: input.slug ? { slug: input.slug } : undefined,
+    })
+    return { id: key, name: input.name, slug: input.slug }
+  }
+
+  async getTenant(tenantId: string): Promise<Tenant | null> {
+    const t = (await getTenantFromPermit(tenantId)) as any
+    if (!t) return null
+    return {
+      id: t.key ?? t.id ?? tenantId,
+      name: t.name ?? tenantId,
+      slug: t.attributes?.slug ?? t.slug,
+    }
+  }
+
+  async listMembers(tenantId: string, _params: PageParams): Promise<Page<Member>> {
+    const rows = (await getTenantRoleAssignments(tenantId)) as any[]
+    // Collapse a user's multiple role rows into one Member with all roles.
+    const byUser = new Map<string, Member>()
+    for (const r of rows ?? []) {
+      const userId = r.user ?? r.user_id
+      const role = roleKeyOf(r)
+      if (!userId) continue
+      const existing = byUser.get(userId)
+      if (existing) {
+        if (role && !existing.roles.includes(role)) existing.roles.push(role)
+      } else {
+        byUser.set(userId, { userId, email: r.user_email, roles: role ? [role] : [] })
+      }
+    }
+    return singlePage([...byUser.values()])
+  }
+
+  async addMember(tenantId: string, input: MemberCreate): Promise<Member> {
+    const userId = input.userId
+    if (!userId) throw new Error('addMember requires userId')
+    const roles = input.roles?.length ? input.roles : ['viewer']
+    for (const role of roles) {
+      const ok = await assignRoleInPermit({ user: userId, role, tenant: tenantId })
+      if (!ok) throw new Error(`failed to assign role ${role}`)
+    }
+    return { userId, email: input.email, roles }
+  }
+
+  async removeMember(tenantId: string, userId: string): Promise<void> {
+    const rows = (await getUserRoleAssignments(userId, tenantId)) as any[]
+    for (const r of rows ?? []) {
+      const role = roleKeyOf(r)
+      if (role) await unassignRoleInPermit({ user: userId, role, tenant: tenantId })
+    }
+  }
+
+  async listRoles(_tenantId: string): Promise<Role[]> {
+    try {
+      const raw = (await permit.api.roles.list()) as any
+      const rows: any[] = Array.isArray(raw) ? raw : (raw?.data ?? [])
+      return rows.map(r => ({ key: r.key, name: r.name }))
+    } catch (err) {
+      console.error('listRoles failed (returning empty catalogue):', err)
+      return []
+    }
+  }
+
+  async assignRoles(
+    tenantId: string,
+    userId: string,
+    roles: string[]
+  ): Promise<Member> {
+    // Replace: drop existing assignments, then apply the requested set.
+    await this.removeMember(tenantId, userId)
+    for (const role of roles) {
+      const ok = await assignRoleInPermit({ user: userId, role, tenant: tenantId })
+      if (!ok) throw new Error(`failed to assign role ${role}`)
+    }
+    return { userId, roles }
+  }
+}

--- a/backend/security/src/routes/authz.ts
+++ b/backend/security/src/routes/authz.ts
@@ -1,0 +1,232 @@
+/**
+ * FuzeFront Security API — AuthZ surface under `/api/v1/security`.
+ *
+ * `/authz/*` (decisions + grants) and `/tenants/*` (tenant/member/role
+ * management), implemented PURELY against the neutral `AuthorizationProvider`
+ * contract (via the env-driven factory) — no vendor is named here. Request /
+ * response shapes match the frozen OpenAPI (`packages/security/openapi.yaml`)
+ * and the generated `@fuzefront/security-client` types. Fail-closed throughout:
+ * every route requires a valid caller identity, and decision endpoints deny on
+ * any provider error (the provider itself returns `false`, never throws-allow).
+ */
+import express, { Request, Response } from 'express'
+import { getIdentityProvider } from '../providers/factory'
+import { getAuthorizationProvider } from '../providers/authzFactory'
+import type { AuthzQuery } from '../providers/AuthorizationProvider'
+
+const router = express.Router()
+
+function bearer(req: Request): string | null {
+  const h = req.headers['authorization']
+  if (!h || Array.isArray(h)) return null
+  const [scheme, token] = h.split(' ')
+  return scheme?.toLowerCase() === 'bearer' && token ? token : null
+}
+
+/** Resolve the caller from the bearer token, or null (→ 401). */
+async function caller(req: Request): Promise<{ id: string } | null> {
+  const token = bearer(req)
+  if (!token) return null
+  try {
+    const { user } = await getIdentityProvider().getUserInfo(token)
+    return user?.id ? { id: user.id } : null
+  } catch {
+    return null
+  }
+}
+
+function unauthorized(res: Response): void {
+  res.status(401).json({ error: 'Authentication required', code: 'AUTH_REQUIRED' })
+}
+
+/** Coerce a request-body query into the neutral AuthzQuery (subject defaults to caller). */
+function toQuery(body: any, callerId: string): AuthzQuery | null {
+  if (!body || typeof body !== 'object') return null
+  const resource = body.resource
+  if (!resource?.type || !body.action || !body.tenant) return null
+  return {
+    subject: body.subject || callerId,
+    tenant: String(body.tenant),
+    resource: { type: String(resource.type), key: resource.key ? String(resource.key) : undefined },
+    action: String(body.action),
+    context: body.context,
+  }
+}
+
+// ── Decisions ─────────────────────────────────────────────────────────────
+
+router.post('/authz/check', async (req: Request, res: Response) => {
+  const c = await caller(req)
+  if (!c) return unauthorized(res)
+  const q = toQuery(req.body, c.id)
+  if (!q) return res.status(400).json({ error: 'Malformed query', code: 'MALFORMED' })
+  const allow = await getAuthorizationProvider().check(q)
+  res.status(200).json({ allow })
+})
+
+router.post('/authz/bulk-check', async (req: Request, res: Response) => {
+  const c = await caller(req)
+  if (!c) return unauthorized(res)
+  const raw = Array.isArray(req.body?.queries) ? req.body.queries : null
+  if (!raw) return res.status(400).json({ error: 'Malformed queries', code: 'MALFORMED' })
+  const queries: AuthzQuery[] = []
+  for (const item of raw) {
+    const q = toQuery(item, c.id)
+    if (!q) return res.status(400).json({ error: 'Malformed query in batch', code: 'MALFORMED' })
+    queries.push(q)
+  }
+  const results = await getAuthorizationProvider().bulkCheck(queries)
+  res.status(200).json({ results })
+})
+
+router.get('/authz/permissions', async (req: Request, res: Response) => {
+  const c = await caller(req)
+  if (!c) return unauthorized(res)
+  const tenant = String(req.query.tenant || '')
+  if (!tenant) return res.status(400).json({ error: 'tenant is required', code: 'MALFORMED' })
+  const subject = req.query.subject ? String(req.query.subject) : c.id
+  const permissions = await getAuthorizationProvider().getPermissions(subject, tenant)
+  res.status(200).json({ permissions })
+})
+
+// ── Grants ────────────────────────────────────────────────────────────────
+
+router.post('/authz/grants', async (req: Request, res: Response) => {
+  const c = await caller(req)
+  if (!c) return unauthorized(res)
+  const b = req.body || {}
+  if (!b.subject || !b.tenant || !b.role) {
+    return res.status(400).json({ error: 'subject, tenant and role are required', code: 'MALFORMED' })
+  }
+  try {
+    const grant = await getAuthorizationProvider().grant({
+      subject: String(b.subject),
+      tenant: String(b.tenant),
+      role: String(b.role),
+      permission: b.permission,
+      resource: b.resource,
+    })
+    res.status(201).json(grant)
+  } catch (err) {
+    res.status(502).json({ error: 'grant failed', code: 'PROVIDER_ERROR' })
+  }
+})
+
+router.delete('/authz/grants', async (req: Request, res: Response) => {
+  const c = await caller(req)
+  if (!c) return unauthorized(res)
+  const b = req.body || {}
+  if (!b.grantId && !(b.subject && b.tenant && b.role)) {
+    return res.status(400).json({ error: 'grantId or subject+tenant+role required', code: 'MALFORMED' })
+  }
+  try {
+    await getAuthorizationProvider().revoke(b)
+    res.status(204).end()
+  } catch (err) {
+    res.status(400).json({ error: (err as Error).message, code: 'MALFORMED' })
+  }
+})
+
+router.get('/authz/grants', async (req: Request, res: Response) => {
+  const c = await caller(req)
+  if (!c) return unauthorized(res)
+  const subject = req.query.subject ? String(req.query.subject) : c.id
+  const tenant = String(req.query.tenant || '')
+  if (!tenant) return res.status(400).json({ error: 'tenant is required', code: 'MALFORMED' })
+  const page = await getAuthorizationProvider().listGrants({
+    subject,
+    tenant,
+    limit: req.query.limit ? Number(req.query.limit) : undefined,
+    cursor: req.query.cursor ? String(req.query.cursor) : undefined,
+  })
+  res.status(200).json(page)
+})
+
+// ── Tenants / members / roles ───────────────────────────────────────────────
+
+router.get('/tenants', async (req: Request, res: Response) => {
+  const c = await caller(req)
+  if (!c) return unauthorized(res)
+  const page = await getAuthorizationProvider().listTenants(c.id, {
+    limit: req.query.limit ? Number(req.query.limit) : undefined,
+    cursor: req.query.cursor ? String(req.query.cursor) : undefined,
+  })
+  res.status(200).json(page)
+})
+
+router.post('/tenants', async (req: Request, res: Response) => {
+  const c = await caller(req)
+  if (!c) return unauthorized(res)
+  if (!req.body?.name) return res.status(400).json({ error: 'name is required', code: 'MALFORMED' })
+  try {
+    const tenant = await getAuthorizationProvider().createTenant({
+      name: String(req.body.name),
+      slug: req.body.slug ? String(req.body.slug) : undefined,
+    })
+    res.status(201).json(tenant)
+  } catch (err) {
+    res.status(502).json({ error: 'createTenant failed', code: 'PROVIDER_ERROR' })
+  }
+})
+
+router.get('/tenants/:id', async (req: Request, res: Response) => {
+  const c = await caller(req)
+  if (!c) return unauthorized(res)
+  const tenant = await getAuthorizationProvider().getTenant(req.params.id)
+  if (!tenant) return res.status(404).json({ error: 'Tenant not found', code: 'NOT_FOUND' })
+  res.status(200).json(tenant)
+})
+
+router.get('/tenants/:id/members', async (req: Request, res: Response) => {
+  const c = await caller(req)
+  if (!c) return unauthorized(res)
+  const page = await getAuthorizationProvider().listMembers(req.params.id, {
+    limit: req.query.limit ? Number(req.query.limit) : undefined,
+    cursor: req.query.cursor ? String(req.query.cursor) : undefined,
+  })
+  res.status(200).json(page)
+})
+
+router.post('/tenants/:id/members', async (req: Request, res: Response) => {
+  const c = await caller(req)
+  if (!c) return unauthorized(res)
+  try {
+    const member = await getAuthorizationProvider().addMember(req.params.id, {
+      userId: req.body?.userId,
+      email: req.body?.email,
+      roles: req.body?.roles,
+    })
+    res.status(201).json(member)
+  } catch (err) {
+    res.status(400).json({ error: (err as Error).message, code: 'MALFORMED' })
+  }
+})
+
+router.delete('/tenants/:id/members/:userId', async (req: Request, res: Response) => {
+  const c = await caller(req)
+  if (!c) return unauthorized(res)
+  await getAuthorizationProvider().removeMember(req.params.id, req.params.userId)
+  res.status(204).end()
+})
+
+router.get('/tenants/:id/roles', async (req: Request, res: Response) => {
+  const c = await caller(req)
+  if (!c) return unauthorized(res)
+  const roles = await getAuthorizationProvider().listRoles(req.params.id)
+  res.status(200).json({ roles })
+})
+
+router.put('/tenants/:id/members/:userId/roles', async (req: Request, res: Response) => {
+  const c = await caller(req)
+  if (!c) return unauthorized(res)
+  const roles = Array.isArray(req.body?.roles) ? req.body.roles.map(String) : null
+  if (!roles) return res.status(400).json({ error: 'roles[] is required', code: 'MALFORMED' })
+  try {
+    const member = await getAuthorizationProvider().assignRoles(req.params.id, req.params.userId, roles)
+    res.status(200).json(member)
+  } catch (err) {
+    res.status(400).json({ error: (err as Error).message, code: 'MALFORMED' })
+  }
+})
+
+export default router

--- a/backend/security/tests/authz-provider.test.ts
+++ b/backend/security/tests/authz-provider.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Unit tests for the AuthZ swap contract.
+ *
+ * Two things are proven here, both WITHOUT any network / real Permit:
+ *  1. Swappability — a mock `AuthorizationProvider` injected via the factory is
+ *     returned by `getAuthorizationProvider()`, so routes/middleware bind to the
+ *     interface, never to a vendor.
+ *  2. Fail-closed mapping — `PermitAuthorizationProvider` (running against the
+ *     CI no-op Permit client, which resolves every call to `undefined`) never
+ *     "allows" on missing data: decisions are falsy, list/read paths return
+ *     empty, and bulkCheck is index-aligned.
+ */
+process.env.NODE_ENV = 'test'
+process.env.PERMIT_API_KEY = 'ci-no-real-permit-calls'
+
+import {
+  getAuthorizationProvider,
+  setAuthorizationProvider,
+} from '../src/providers/authzFactory'
+import { PermitAuthorizationProvider } from '../src/providers/permit/PermitAuthorizationProvider'
+import type {
+  AuthorizationProvider,
+  AuthzQuery,
+} from '../src/providers/AuthorizationProvider'
+
+const q = (over: Partial<AuthzQuery> = {}): AuthzQuery => ({
+  subject: 'user-1',
+  tenant: 'tenant-1',
+  resource: { type: 'App' },
+  action: 'read',
+  ...over,
+})
+
+describe('authorization provider swap contract', () => {
+  afterEach(() => setAuthorizationProvider(null))
+
+  it('returns an injected mock provider (proves the interface is swappable)', async () => {
+    const calls: AuthzQuery[] = []
+    const mock: AuthorizationProvider = {
+      check: async query => {
+        calls.push(query)
+        return true
+      },
+      bulkCheck: async queries => queries.map(() => true),
+      getPermissions: async () => ['App:read'],
+      grant: async () => ({ id: 'g1', subject: 'u', tenant: 't', role: 'r' }),
+      revoke: async () => {},
+      listGrants: async () => ({ items: [], page: { nextCursor: null, hasMore: false } }),
+      listTenants: async () => ({ items: [], page: { nextCursor: null, hasMore: false } }),
+      createTenant: async input => ({ id: 't1', name: input.name }),
+      getTenant: async () => null,
+      listMembers: async () => ({ items: [], page: { nextCursor: null, hasMore: false } }),
+      addMember: async (_t, input) => ({ userId: input.userId!, roles: input.roles ?? [] }),
+      removeMember: async () => {},
+      listRoles: async () => [{ key: 'admin' }],
+      assignRoles: async (_t, userId, roles) => ({ userId, roles }),
+    }
+    setAuthorizationProvider(mock)
+
+    const provider = getAuthorizationProvider()
+    expect(provider).toBe(mock)
+    await expect(provider.check(q())).resolves.toBe(true)
+    expect(calls).toHaveLength(1)
+    expect(calls[0].subject).toBe('user-1')
+  })
+
+  it('defaults to the Permit-backed provider when none injected', () => {
+    setAuthorizationProvider(null)
+    expect(getAuthorizationProvider()).toBeInstanceOf(PermitAuthorizationProvider)
+  })
+})
+
+describe('PermitAuthorizationProvider fail-closed mapping', () => {
+  const provider = new PermitAuthorizationProvider()
+
+  it('does not allow when the engine returns no decision', async () => {
+    // No-op Permit resolves check() to undefined — must be falsy, never true.
+    await expect(provider.check(q())).resolves.toBeFalsy()
+  })
+
+  it('bulkCheck([]) short-circuits to []', async () => {
+    await expect(provider.bulkCheck([])).resolves.toEqual([])
+  })
+
+  it('bulkCheck stays index-aligned and never allows on empty data', async () => {
+    const results = await provider.bulkCheck([q(), q({ action: 'write' })])
+    expect(results).toHaveLength(2)
+    expect(results.every(r => r !== true)).toBe(true)
+  })
+
+  it('getPermissions tolerates an empty/undefined engine result', async () => {
+    await expect(provider.getPermissions('user-1', 'tenant-1')).resolves.toEqual([])
+  })
+
+  it('listGrants / listTenants / listMembers return empty single pages', async () => {
+    const grants = await provider.listGrants({ subject: 'u', tenant: 't' })
+    expect(grants.items).toEqual([])
+    expect(grants.page.hasMore).toBe(false)
+
+    const tenants = await provider.listTenants('u', {})
+    expect(tenants.items).toEqual([])
+
+    const members = await provider.listMembers('t', {})
+    expect(members.items).toEqual([])
+  })
+
+  it('revoke requires an identifiable grant', async () => {
+    await expect(provider.revoke({})).rejects.toThrow()
+    // identity-tuple form is accepted (idempotent no-op under the mock)
+    await expect(
+      provider.revoke({ subject: 'u', tenant: 't', role: 'admin' })
+    ).resolves.toBeUndefined()
+  })
+})


### PR DESCRIPTION
Implements the **AuthZ slice** of the FuzeFront Security API against the frozen `AuthorizationProvider` contract (#243). Resumes the cloud AuthZ agent whose unpushed work was lost when the shared weekly usage pool was exhausted.

## What
- `providers/permit/PermitAuthorizationProvider.ts` — first concrete impl; **wraps Permit** via the existing `utils/permit/*` helpers (already fail-closed + CI no-op aware). Permit is named **only** in this file.
- `providers/authzFactory.ts` — env-driven `getAuthorizationProvider()` (`SECURITY_AUTHORIZATION_PROVIDER`, default `permit`) + `setAuthorizationProvider` test seam.
- `routes/authz.ts` — mounts under `/api/v1/security`: `POST /authz/check`, `POST /authz/bulk-check`, `GET /authz/permissions`, `GET/POST/DELETE /authz/grants`, `/tenants` CRUD, `/tenants/:id/members`, `/tenants/:id/roles`. Every route requires a valid caller (bearer → `getUserInfo`); decisions fail-closed.
- `tests/authz-provider.test.ts` — proves interface **swappability** (injected mock) and **fail-closed** mapping (no allow on empty engine data).

## Why draft + `hold`
`master` is **deploy-on-push**. This is intentionally NOT `auto-merge` — hold for a deploy window; the orchestrator/owner merges. Local `npm install` hangs on this Windows worktree, so **CI is the typecheck/test gate** — promote out of draft once CI is green and it's a good deploy window.

## Out of scope
Contract amendment (separate branch), UI, e2e, deploy env wiring.

Co-Authored-By: Claude