### PR TITLE
feat(security): email verification during registration

### DIFF
--- a/backend/security/src/providers/authentik/AuthentikIdentityProvider.ts
+++ b/backend/security/src/providers/authentik/AuthentikIdentityProvider.ts
@@ -110,6 +110,26 @@ interface MfaChallenge {
 const CHALLENGE_TTL_MS = 5 * 60_000
 const EMAIL_VERIFY_TTL_MS = 30 * 60_000
 
+/**
+ * Registration-time email verification is a two-condition gate, kept a release
+ * flag (default OFF) until prod SMTP is wired:
+ *
+ *   - `REQUIRE_EMAIL_VERIFICATION` (default `false`) is the release/kill switch.
+ *   - `EMAIL_SERVICE_URL` must be configured (the family email-service reachable
+ *     by Service DNS) for a real message to be deliverable.
+ *
+ * When BOTH hold, verification is REQUIRED: we mint a link token + OTP and
+ * dispatch it. Otherwise we GRACEFULLY DEGRADE — auto-verify the address and log
+ * — so signup/local dev/prod-without-SMTP never strands a user on an
+ * undeliverable challenge. Provider-neutral: no vendor is named.
+ */
+function emailVerificationEnabled(): boolean {
+  return (
+    process.env.REQUIRE_EMAIL_VERIFICATION === 'true' &&
+    !!(process.env.EMAIL_SERVICE_URL && process.env.EMAIL_SERVICE_URL.trim())
+  )
+}
+
 export interface AuthentikProviderDeps {
   db: Db
   oidc: typeof defaultOidc
@@ -322,9 +342,53 @@ export class AuthentikIdentityProvider implements IdentityProvider {
       if (err instanceof EnrollmentConflictError) throw new ConflictError()
       throw err
     }
+    // Kick off contact-ownership verification for the freshly-enrolled address.
+    // Best-effort: a delivery/transport failure must NOT fail the signup — the
+    // user can re-request via /verify/email/start. In degrade mode this simply
+    // auto-verifies + logs. Uses the user id directly (no bearer needed yet).
+    try {
+      await this.startEmailVerificationForUser(user.id, user.email)
+    } catch (err) {
+      console.error(
+        `[security] signup email-verification dispatch failed for ${maskContact(
+          user.email,
+        )}:`,
+        (err as Error).message,
+      )
+    }
+
     // Gate through MFA step-up if the (rare, freshly-enrolled) account already
     // has active factors — otherwise mint the session directly.
     return this.sessionOrChallenge(user)
+  }
+
+  /**
+   * Internal variant of startEmailVerification keyed by a known user id (used at
+   * signup, before any bearer exists). Honours the same degrade gate.
+   */
+  private async startEmailVerificationForUser(userId: string, email: string): Promise<void> {
+    if (!email) return
+    if (!emailVerificationEnabled()) {
+      await this.db('users').where({ id: userId }).update({ email_verified: true })
+      console.warn(
+        `[security] email verification degraded at signup (auto-verified ${maskContact(
+          email,
+        )}); set REQUIRE_EMAIL_VERIFICATION=true + EMAIL_SERVICE_URL to enforce.`,
+      )
+      return
+    }
+    const linkToken = crypto.randomBytes(32).toString('hex')
+    const code = ('' + crypto.randomInt(0, 1_000_000)).padStart(6, '0')
+    await this.db('email_verifications').insert({
+      id: uuidv4(),
+      user_id: userId,
+      email,
+      token_hash: sha256(linkToken),
+      code_hash: sha256(code),
+      expires_at: new Date(this.now() + EMAIL_VERIFY_TTL_MS),
+      consumed: false,
+    })
+    await this.notifications.sendEmailVerification(email, linkToken, code)
   }
 
   // ── Identity / session inspection ─────────────────────────────────────────
@@ -586,6 +650,22 @@ export class AuthentikIdentityProvider implements IdentityProvider {
       target = target || user.email
     }
     if (!target) throw new InvalidInputError('email is required')
+
+    // Degrade mode: verification not required (flag off) or no email-service
+    // wired — auto-verify the local projection and log. Never strand the user on
+    // an undeliverable challenge.
+    if (!emailVerificationEnabled()) {
+      if (userId) {
+        await this.db('users').where({ id: userId }).update({ email_verified: true })
+      }
+      console.warn(
+        `[security] email verification degraded (auto-verified ${maskContact(
+          target,
+        )}); set REQUIRE_EMAIL_VERIFICATION=true + EMAIL_SERVICE_URL to enforce.`,
+      )
+      return
+    }
+
     const linkToken = crypto.randomBytes(32).toString('hex')
     const code = ('' + crypto.randomInt(0, 1_000_000)).padStart(6, '0')
     await this.db('email_verifications').insert({

--- a/backend/security/src/providers/authentik/AuthentikIdentityProvider.ts
+++ b/backend/security/src/providers/authentik/AuthentikIdentityProvider.ts
@@ -349,10 +349,12 @@ export class AuthentikIdentityProvider implements IdentityProvider {
     try {
       await this.startEmailVerificationForUser(user.id, user.email)
     } catch (err) {
+      // Constant format string + args: the email is attacker-chosen, so
+      // interpolating it INTO the format string lets a `%s` in an address forge
+      // log output (console.* applies util.format specifiers to the first arg).
       console.error(
-        `[security] signup email-verification dispatch failed for ${maskContact(
-          user.email,
-        )}:`,
+        '[security] signup email-verification dispatch failed for %s: %s',
+        maskContact(user.email),
         (err as Error).message,
       )
     }
@@ -655,13 +657,26 @@ export class AuthentikIdentityProvider implements IdentityProvider {
     // wired — auto-verify the local projection and log. Never strand the user on
     // an undeliverable challenge.
     if (!emailVerificationEnabled()) {
-      if (userId) {
-        await this.db('users').where({ id: userId }).update({ email_verified: true })
-      }
+      // Resolve by EMAIL when there is no token: the signup path calls this with
+      // an address and no session, so `userId` is null there. Gating the update
+      // on `userId` meant that path updated NOTHING while still logging
+      // "auto-verified" — the account stayed unverified and the log said
+      // otherwise. Harmless while the flag is off, but it strands exactly those
+      // accounts the moment REQUIRE_EMAIL_VERIFICATION is switched on.
+      const updated = userId
+        ? await this.db('users').where({ id: userId }).update({ email_verified: true })
+        : await this.db('users').where({ email: target }).update({ email_verified: true })
+
+      // Log what actually happened. `updated === 0` is legitimate (the user row
+      // may not be synced yet mid-signup) but it must not read as success.
       console.warn(
-        `[security] email verification degraded (auto-verified ${maskContact(
-          target,
-        )}); set REQUIRE_EMAIL_VERIFICATION=true + EMAIL_SERVICE_URL to enforce.`,
+        updated
+          ? `[security] email verification degraded (auto-verified ${maskContact(
+              target,
+            )}); set REQUIRE_EMAIL_VERIFICATION=true + EMAIL_SERVICE_URL to enforce.`
+          : `[security] email verification degraded and NO user row matched ${maskContact(
+              target,
+            )} — left unverified; it will be promoted on first login via the OIDC email_verified claim.`,
       )
       return
     }

--- a/backend/security/src/services/oidc.ts
+++ b/backend/security/src/services/oidc.ts
@@ -156,7 +156,16 @@ class OIDCService {
     // The enrollment email-verify stage (or a verified social login) sets the
     // standard OIDC `email_verified` claim; we only ever flip FALSE->TRUE here so
     // a stale/absent claim never un-verifies an already-verified account.
-    const emailVerifiedClaim = userinfo.email_verified === true;
+    //
+    // Accept the STRING "true" as well as the boolean. The OIDC spec types this
+    // as a boolean, but real providers emit `"true"` — and this claim passes
+    // through from the upstream social provider (e.g. Google) as well as from our
+    // own IdP, so we cannot assume one encoding. A strict `=== true` silently
+    // treats a genuinely-verified account as unverified forever: it never gets
+    // promoted on login, and the moment REQUIRE_EMAIL_VERIFICATION is switched on
+    // that user is locked out of an account they did verify.
+    const emailVerifiedClaim =
+      userinfo.email_verified === true || userinfo.email_verified === 'true';
 
     try {
       // Check if user exists

--- a/backend/security/src/services/oidc.ts
+++ b/backend/security/src/services/oidc.ts
@@ -152,18 +152,26 @@ class OIDCService {
     const email = userinfo.email;
     const firstName = userinfo.given_name || userinfo.name?.split(' ')[0] || 'User';
     const lastName = userinfo.family_name || userinfo.name?.split(' ').slice(1).join(' ') || '';
+    // Project the provider's email-verification assertion into our local column.
+    // The enrollment email-verify stage (or a verified social login) sets the
+    // standard OIDC `email_verified` claim; we only ever flip FALSE->TRUE here so
+    // a stale/absent claim never un-verifies an already-verified account.
+    const emailVerifiedClaim = userinfo.email_verified === true;
 
     try {
       // Check if user exists
       let userRow = await db('users').where('email', email).first();
 
       if (userRow) {
-        // Update existing user
+        // Update existing user. Only ever promote email_verified FALSE->TRUE.
         await db('users')
           .where('id', userRow.id)
           .update({
             first_name: firstName,
             last_name: lastName,
+            ...(emailVerifiedClaim && !userRow.email_verified
+              ? { email_verified: true }
+              : {}),
             updated_at: new Date(),
           });
 
@@ -179,6 +187,7 @@ class OIDCService {
           first_name: firstName,
           last_name: lastName,
           roles: JSON.stringify(['user']), // Default role
+          email_verified: emailVerifiedClaim,
           created_at: new Date(),
           updated_at: new Date(),
         };


### PR DESCRIPTION
Resumes the interrupted backend-engineer. Email-verify during signup: challenge via email-service, POST /verify/email, email_verified projection, degrade flag when SMTP absent. **Non-draft + `hold`** (deploy-on-push). CI validates; gate-frontend-build may be red until lockfile #270. Co-Authored-By: Claude