### PR TITLE
fix(authn): Google sign-in goes direct to Google + repair auth e2e drift from the Security API cutover

### DIFF
--- a/backend/security/src/providers/authentik/AuthentikIdentityProvider.ts
+++ b/backend/security/src/providers/authentik/AuthentikIdentityProvider.ts
@@ -249,20 +249,23 @@ export class AuthentikIdentityProvider implements IdentityProvider {
     const authorize = new URL(url)
     const authorizePath = `${idpProxyPrefix()}${authorize.pathname}${authorize.search}`
 
-    // Launch the Google SOURCE directly rather than sending the browser to the
-    // generic authorize endpoint. Authorize requires an authenticated session,
-    // so with no session it falls back to the brand's authentication flow and
-    // renders Authentik's identification page (`/if/flow/...`) with a "Google"
-    // button — the user gets stranded on the IdP's own UI.
+    // Launch the provider's SOURCE directly rather than sending the browser to
+    // the generic authorize endpoint. Authorize requires an authenticated
+    // session, so with none it falls back to the brand's authentication flow
+    // and renders the IdP's identification page (`/if/flow/...`) with a social
+    // button — stranding the user on the provider's own UI.
     //
-    // The source-redirect view instead 302s straight to accounts.google.com.
-    // Google returns to /source/oauth/callback/google/, the source flow runs
+    // The source-redirect view instead 302s straight to the social provider.
+    // It returns to /source/oauth/callback/<provider>/, the source flow runs
     // (auto stages: silent enrollment first time, login when returning) and
     // establishes the session, then `next` sends the browser to authorize,
     // which now issues the code silently. Same cookie/state/PKCE round-trip —
     // this only inserts one hop ahead of authorize, so no `/if/flow/` renders.
+    //
+    // The source slug tracks `provider` (guarded to `google` above) so widening
+    // that guard cannot silently route a new provider through Google's source.
     const redirectUrl =
-      `${idpProxyPrefix()}/source/oauth/login/google/` +
+      `${idpProxyPrefix()}/source/oauth/login/${provider}/` +
       `?next=${encodeURIComponent(authorizePath)}`
 
     this.socialStates.set(state, {

--- a/backend/security/src/providers/authentik/AuthentikIdentityProvider.ts
+++ b/backend/security/src/providers/authentik/AuthentikIdentityProvider.ts
@@ -247,7 +247,23 @@ export class AuthentikIdentityProvider implements IdentityProvider {
     // Rewrite the absolute internal authorize URL to a SAME-HOST path under the
     // IdP reverse-proxy prefix, so the browser never sees the internal host.
     const authorize = new URL(url)
-    const redirectUrl = `${idpProxyPrefix()}${authorize.pathname}${authorize.search}`
+    const authorizePath = `${idpProxyPrefix()}${authorize.pathname}${authorize.search}`
+
+    // Launch the Google SOURCE directly rather than sending the browser to the
+    // generic authorize endpoint. Authorize requires an authenticated session,
+    // so with no session it falls back to the brand's authentication flow and
+    // renders Authentik's identification page (`/if/flow/...`) with a "Google"
+    // button — the user gets stranded on the IdP's own UI.
+    //
+    // The source-redirect view instead 302s straight to accounts.google.com.
+    // Google returns to /source/oauth/callback/google/, the source flow runs
+    // (auto stages: silent enrollment first time, login when returning) and
+    // establishes the session, then `next` sends the browser to authorize,
+    // which now issues the code silently. Same cookie/state/PKCE round-trip —
+    // this only inserts one hop ahead of authorize, so no `/if/flow/` renders.
+    const redirectUrl =
+      `${idpProxyPrefix()}/source/oauth/login/google/` +
+      `?next=${encodeURIComponent(authorizePath)}`
 
     this.socialStates.set(state, {
       codeVerifier,

--- a/backend/security/tests/authentik-provider.test.ts
+++ b/backend/security/tests/authentik-provider.test.ts
@@ -140,29 +140,41 @@ describe('passwordLogin', () => {
 })
 
 describe('social login boundary', () => {
-  it('rewrites the authorize URL to the same-host IdP proxy prefix when one is set', async () => {
+  it('launches the Google source (not authorize) under the same-host IdP proxy prefix when one is set', async () => {
     const p = newProvider()
     const { redirectUrl, state, codeVerifier } = await p.startSocialLogin('google', '/home')
-    expect(redirectUrl.startsWith('/api/auth/idp/application/o/authorize/')).toBe(true)
+    // Must hit the source-redirect view — that 302s straight to Google. Going
+    // to authorize with no session renders Authentik's `/if/flow/` UI instead.
+    expect(redirectUrl.startsWith('/api/auth/idp/source/oauth/login/google/')).toBe(true)
     expect(redirectUrl).not.toMatch(/auth\.internal\.example/)
+    // authorize is carried as the post-login `next`, not as the destination.
+    const next = new URLSearchParams(redirectUrl.split('?')[1]).get('next')
+    expect(next?.startsWith('/api/auth/idp/application/o/authorize/')).toBe(true)
     expect(state).toBeTruthy()
     // codeVerifier is surfaced so the route can set the oidc_cv cookie.
     expect(codeVerifier).toBe('cv')
   })
 
-  it('defaults to a NATIVE same-host authorize path (empty prefix, matching #256 ingress)', async () => {
+  it('defaults to a NATIVE same-host source path (empty prefix, matching #256 ingress)', async () => {
     const saved = process.env.SECURITY_IDP_PROXY_PREFIX
     delete process.env.SECURITY_IDP_PROXY_PREFIX
     try {
       const p = newProvider()
       const { redirectUrl } = await p.startSocialLogin('google', '/home')
       // Native path, no /api/auth/idp prefix, no double slash, no internal host.
-      expect(redirectUrl.startsWith('/application/o/authorize/')).toBe(true)
+      expect(redirectUrl.startsWith('/source/oauth/login/google/')).toBe(true)
       expect(redirectUrl.startsWith('//')).toBe(false)
       expect(redirectUrl).not.toMatch(/auth\.internal\.example/)
+      const next = new URLSearchParams(redirectUrl.split('?')[1]).get('next')
+      expect(next?.startsWith('/application/o/authorize/')).toBe(true)
     } finally {
       if (saved !== undefined) process.env.SECURITY_IDP_PROXY_PREFIX = saved
     }
+  })
+
+  it('never sends the browser to the Authentik flow UI (/if/)', async () => {
+    const { redirectUrl } = await newProvider().startSocialLogin('google', '/home')
+    expect(redirectUrl).not.toMatch(/\/if\//)
   })
   it('rejects an absolute redirectTo (open-redirect guard)', async () => {
     await expect(newProvider().startSocialLogin('google', 'https://evil.com')).rejects.toBeInstanceOf(InvalidInputError)

--- a/deploy/helm/fuzefront/authentik/blueprints/source-google.yaml
+++ b/deploy/helm/fuzefront/authentik/blueprints/source-google.yaml
@@ -8,8 +8,14 @@
 # (APIs & Services → Credentials → OAuth 2.0 Client ID, type: Web application)
 # and add the following Authorized redirect URIs to the matching Google OAuth client:
 #
-#   Production client:  https://auth.fuzefront.com/source/oauth/callback/google/
+#   Production client:  https://app.fuzefront.com/source/oauth/callback/google/
 #   Dev tunnel client:  https://auth-dev.fuzefront.com/source/oauth/callback/google/
+#
+# The production callback is on the APP host, not a dedicated IdP host: the
+# public auth.fuzefront.com ingress was removed so the browser only ever sees
+# app.fuzefront.com + accounts.google.com. There is no settable callback field
+# on an oauthsource — Authentik derives callback_url at runtime from the request
+# Host + X-Forwarded-Proto, which the IdP ingress pins to https/app.fuzefront.com.
 #
 # Use TWO SEPARATE Google OAuth clients — one for production, one for the dev
 # tunnel. Never share credentials between them. The dev client is used by

--- a/frontend/e2e/post-prod/live-smoke.spec.ts
+++ b/frontend/e2e/post-prod/live-smoke.spec.ts
@@ -7,12 +7,12 @@ import { test, expect, type Page, type ConsoleMessage } from '@playwright/test'
  * Verifies the acceptance-criteria critical journey on the real deployment:
  *   1. The Module-Federation SHELL serves (root 200, correct title).
  *   2. Core API health is up.
- *   3. The backend advertises OIDC as configured (/api/auth/method) — this is
- *      the flag that hides the local form, so it is asserted explicitly.
+ *   3. The Security API advertises the expected capabilities
+ *      (/api/v1/security/methods) — a non-empty `social` array is what renders
+ *      the Google button, so it is asserted explicitly.
  *   4. /login shows the NATIVE credentials form (email/password verified
- *      against Authentik server-side — no redirect) plus a "Sign in with
- *      Google" button (federated through Authentik). The old "Sign in with
- *      Authentik" redirect button is gone.
+ *      server-side by the identity provider — no redirect) plus a "Sign in with
+ *      Google" button. The old "Sign in with Authentik" redirect button is gone.
  *   5. Clicking "Sign in with Google" hands off into the OIDC flow.
  *   6. The auth backend is routable.
  *   7. The dashboard renders for an authenticated user and Module-Federation
@@ -25,9 +25,10 @@ import { test, expect, type Page, type ConsoleMessage } from '@playwright/test'
  *      IdP was never configured".
  *
  * The authenticated journey (test 7) obtains its session via the API
- * (POST /api/auth/login) rather than the UI: the local form is intentionally
- * absent from the UI, and driving real Google/Authentik credentials through a
- * synthetic check is brittle + a security liability. The API path remains as
+ * (POST /api/v1/security/session) rather than the UI: driving real Google
+ * credentials through a synthetic check is brittle + a security liability.
+ * This is the same endpoint the SPA uses, so it still fails if sign-in
+ * genuinely breaks. The API path remains as
  * the platform's machine/break-glass authentication.
  *
  * Credentials come from env so we never hard-code secrets in the repo:
@@ -73,15 +74,19 @@ test.describe('FuzeFront live post-prod smoke', () => {
     expect(body?.database?.status, 'platform DB connection').toBe('connected')
   })
 
-  test('3. backend advertises OIDC as configured (Authentik is the identity authority)', async ({ request }) => {
-    const resp = await request.get('/api/auth/method')
-    expect(resp.status(), '/api/auth/method status').toBe(200)
+  test('3. Security API advertises the expected auth capabilities in prod', async ({ request }) => {
+    // The SPA reads the provider-agnostic Security API, not the deprecated
+    // /api/auth shim — smoke the surface prod actually serves to browsers.
+    const resp = await request.get('/api/v1/security/methods')
+    expect(resp.status(), '/api/v1/security/methods status').toBe(200)
     const body = await resp.json()
     expect(
-      body.oidcConfigured,
-      'oidcConfigured must be true in prod — false would re-expose the local fallback form'
-    ).toBe(true)
-    expect(body.defaultMethod).toBe('oidc')
+      body.social,
+      'social login must be advertised in prod — an empty array hides the Google button'
+    ).toContain('google')
+    expect(body.password, 'password sign-in must be advertised in prod').toBe(true)
+    // Boundary: prod must never leak the identity/authz vendor to a browser.
+    expect(JSON.stringify(body)).not.toMatch(/authentik|permit/i)
   })
 
   test('4. /login offers the native credentials form + Google (no Authentik redirect button)', async ({ page }) => {
@@ -138,17 +143,20 @@ test.describe('FuzeFront live post-prod smoke', () => {
   test('7. authenticated dashboard + Module-Federation apps load', async ({ page, request }) => {
     const { consoleErrors, pageErrors, failedRequests } = attachErrorCollectors(page)
 
-    // Authenticate via the API (machine/break-glass path). The UI no longer
-    // renders a local form — human sign-in is Authentik/Google only — so the
-    // synthetic check mints its session directly and injects the token.
-    const loginResp = await request.post('/api/auth/login', {
+    // Authenticate via the Security API (machine/break-glass path) — the same
+    // surface the SPA uses, so this smoke fails if real sign-in is broken.
+    const loginResp = await request.post('/api/v1/security/session', {
       data: { email: EMAIL, password: PASSWORD },
     })
     expect(
       loginResp.status(),
-      `POST /api/auth/login -> ${loginResp.status()} (401/403 = creds rejected: POST_PROD_EMAIL/POST_PROD_PASSWORD not provisioned in prod; 5xx = backend error)`
+      `POST /api/v1/security/session -> ${loginResp.status()} (401/403 = creds rejected: POST_PROD_EMAIL/POST_PROD_PASSWORD not provisioned in prod; 5xx = backend error)`
     ).toBe(200)
     const loginBody = await loginResp.json()
+    expect(
+      loginBody.status,
+      'break-glass account must not require MFA step-up, or this synthetic cannot sign in'
+    ).not.toBe('mfa_required')
     const token: string = loginBody.token
     expect(token, 'API login returned a token').toBeTruthy()
 

--- a/frontend/tests/auth-simple.spec.ts
+++ b/frontend/tests/auth-simple.spec.ts
@@ -14,9 +14,16 @@ test.describe('Authentication - Simple', () => {
     await page.fill('input[type="email"]', 'admin@fuzefront.dev')
     await page.fill('input[type="password"]', 'admin123')
 
-    // Wait for login response and submit
+    // Wait for login response and submit.
+    // The SPA logs in via the provider-agnostic Security API (POST
+    // /api/v1/security/session), not the deprecated /api/auth/login. Match the
+    // METHOD too — GET /session ("me") hits the same URL and would otherwise
+    // satisfy this wait before the login round-trip completes.
     const responsePromise = page.waitForResponse(
-      response => response.url().includes('/api/auth/login') && response.status() === 200,
+      response =>
+        response.url().includes('/api/v1/security/session') &&
+        response.request().method() === 'POST' &&
+        response.status() === 200,
       { timeout: 15000 }
     )
 

--- a/frontend/tests/clock-load.spec.ts
+++ b/frontend/tests/clock-load.spec.ts
@@ -28,8 +28,13 @@ test('Clock mounts from the launcher at runtime', async ({ page }) => {
   await page.fill('input[type="email"]', 'admin@fuzefront.dev')
   await page.fill('input[type="password"]', 'admin123')
   await Promise.all([
+    // Login goes through the Security API (POST /api/v1/security/session);
+    // match the method so GET /session ("me") cannot satisfy the wait early.
     page.waitForResponse(
-      r => r.url().includes('/api/auth/login') && r.status() === 200
+      r =>
+        r.url().includes('/api/v1/security/session') &&
+        r.request().method() === 'POST' &&
+        r.status() === 200
     ),
     page.click('button[type="submit"]'),
   ])

--- a/frontend/tests/federated-apps-register-activate.frontend.spec.ts
+++ b/frontend/tests/federated-apps-register-activate.frontend.spec.ts
@@ -19,7 +19,7 @@ import { test, expect, type Page } from '@playwright/test'
  * DETERMINISM: the full live stack (Postgres + backend + Authentik + Permit +
  * a real Module-Federation remote) is not runnable in this sandbox, so this
  * spec MOCKS the contract surface via Playwright request interception:
- *   - auth   (/api/auth/user)          → an authenticated admin
+ *   - auth   (/api/v1/security/session) → an authenticated admin
  *   - orgs   (/api/organizations)      → a personal org (opens the provisioning gate)
  *   - registry (/api/v1/app-registry/*)→ stateful list/register/activate
  *
@@ -79,8 +79,10 @@ function activatedApp(): Record<string, unknown> {
  * AND activated, exactly like the real lifecycle.
  */
 async function installMocks(page: Page) {
-  // Authenticated as a provisioned admin (AuthWrapper -> GET /api/auth/user).
-  await page.route('**/api/auth/user', route =>
+  // Authenticated as a provisioned admin. The shell resolves "me" from the
+  // provider-agnostic Security API (GET /api/v1/security/session), not the
+  // deprecated /api/auth/user shim.
+  await page.route('**/api/v1/security/session', route =>
     route.fulfill({
       status: 200,
       contentType: 'application/json',

--- a/frontend/tests/google-signin.spec.ts
+++ b/frontend/tests/google-signin.spec.ts
@@ -3,21 +3,26 @@
  *
  * FRONTEND COMPONENT TESTS (mock-based) — NOT an end-to-end integration test.
  *
- * All backend/Authentik calls are intercepted with page.route() so these tests
- * do NOT require a live Authentik instance or Google OAuth credentials. They test
- * ONLY the frontend's rendering and routing logic in isolation.
+ * All backend calls are intercepted with page.route() so these tests do NOT
+ * require a live identity provider or Google OAuth credentials. They test ONLY
+ * the frontend's rendering and routing logic in isolation.
+ *
+ * The SPA talks exclusively to FuzeFront's own provider-agnostic Security API
+ * (`/api/v1/security/*`) — it never names or calls a vendor — so these mocks
+ * intercept that surface, not the deprecated `/api/auth/*` compatibility layer.
  *
  * For the real end-to-end integration test that exercises every layer —
- * frontend → backend OIDC login → Authentik → token exchange → JWT — see:
- *   tests/oidc-plumbing.e2e.spec.ts   (local Authentik user, runs on every PR)
+ * frontend → Security API → identity provider → token exchange → JWT — see:
+ *   tests/oidc-plumbing.e2e.spec.ts   (local provider user, runs on every PR)
  *   tests/google-oauth-e2e.spec.ts    (real Google OAuth, requires CI secrets)
  *
  * What these mock tests cover:
- *   1. Login page shows / hides the OIDC button based on /api/auth/method response
- *   2. Click → loginWithOIDC() → browser navigates to GET /api/auth/oidc/login
- *      (intercepted — does NOT hit the real backend or Authentik)
- *   3. After Authentik auth, backend redirects frontend to /?code=<hex>
- *   4. LoginPage.handleOIDCCallback() reads ?code=, POSTs /api/auth/token-exchange
+ *   1. Login page shows / hides the Google button based on the `social` array
+ *      returned by GET /api/v1/security/methods
+ *   2. Click → startSocialLogin() → browser navigates to
+ *      GET /api/v1/security/social/google/start (intercepted — never hits Google)
+ *   3. After provider auth, the backend redirects the frontend to /?code=<hex>
+ *   4. handleAuthCallback() reads ?code=, POSTs /api/v1/security/session/exchange
  *   5. App navigates to /dashboard on success
  *   6. Error path: ?error= shows an error on the login page
  */
@@ -33,15 +38,19 @@ async function setupCommonMocks(page: Parameters<Parameters<typeof test>[1]>[0],
     route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ status: 'ok' }) })
   )
 
-  // Auth method discovery endpoint
-  await page.route('**/api/auth/method', route =>
+  // Auth capability discovery. The SPA reads the provider-agnostic Security API
+  // (`GET /api/v1/security/methods`), which returns a neutral descriptor — a
+  // non-empty `social` array is what enables the Google button; the legacy
+  // vendor-flavoured `oidcConfigured` boolean is gone.
+  await page.route('**/api/v1/security/methods', route =>
     route.fulfill({
       status: 200,
       contentType: 'application/json',
       body: JSON.stringify({
-        methods: oidcConfigured ? ['local', 'oidc'] : ['local'],
-        oidcConfigured,
-        defaultMethod: oidcConfigured ? 'oidc' : 'local',
+        password: true,
+        social: oidcConfigured ? ['google'] : [],
+        mfa: { enabled: true, types: ['totp', 'sms', 'email'] },
+        verification: { email: true, sms: true },
       }),
     })
   )
@@ -80,28 +89,28 @@ test.describe('OIDC / Google Sign-In — pre-production E2E', () => {
   })
 
   /**
-   * 3. Clicking "Sign in with Authentik" navigates the browser to /api/auth/oidc/login.
-   *    We intercept that route to prevent a real redirect to Authentik.
+   * 3. Clicking "Sign in with Google" navigates the browser to the Security API's
+   *    social-start endpoint. We intercept it to prevent a real redirect out.
    */
-  test('clicking "Sign in with Authentik" issues a request to /api/auth/oidc/login', async ({ page }) => {
+  test('clicking "Sign in with Google" issues a request to /api/v1/security/social/google/start', async ({ page }) => {
     await setupCommonMocks(page, true)
 
-    // Intercept the OIDC login initiation endpoint.  The real backend would
-    // redirect here to Authentik; we short-circuit to keep the test self-contained.
-    let oidcLoginRequested = false
-    await page.route('**/api/auth/oidc/login', route => {
-      oidcLoginRequested = true
+    // Intercept the server-brokered social-login initiation endpoint. The real
+    // backend 302s from here toward Google; we short-circuit to stay self-contained.
+    let socialStartRequested = false
+    await page.route('**/api/v1/security/social/google/start', route => {
+      socialStartRequested = true
       // Fulfill with a 200 so the browser doesn't chase a real 302.
-      route.fulfill({ status: 200, body: 'Intercepted — redirecting to Authentik…' })
+      route.fulfill({ status: 200, body: 'Intercepted — redirecting to Google…' })
     })
 
     await page.goto('/')
-    await page.getByRole('button', { name: /sign in with authentik/i }).click()
+    await page.getByRole('button', { name: /sign in with google/i }).click()
 
     // Give the navigation a moment to reach our route handler.
     await page.waitForTimeout(1500)
 
-    expect(oidcLoginRequested).toBe(true)
+    expect(socialStartRequested).toBe(true)
   })
 
   /**
@@ -136,17 +145,24 @@ test.describe('OIDC / Google Sign-In — pre-production E2E', () => {
     // (Playwright evaluates routes in reverse-registration order).
     await setupCommonMocks(page, true)
 
-    // Token exchange: frontend POSTs the code → backend returns JWT.
-    await page.route('**/api/auth/token-exchange', route =>
+    // Token exchange: frontend POSTs the opaque code to the Security API
+    // (`POST /api/v1/security/session/exchange`) → returns a SessionResult.
+    await page.route('**/api/v1/security/session/exchange', route =>
       route.fulfill({
         status: 200,
         contentType: 'application/json',
-        body: JSON.stringify({ token: 'e2e-test-jwt', sessionId: 'e2e-session-1' }),
+        body: JSON.stringify({
+          status: 'authenticated',
+          token: 'e2e-test-jwt',
+          sessionId: 'e2e-session-1',
+          user: { id: 'u-1', email: 'e2e@fuzefront.dev', firstName: 'E2E', lastName: 'User', roles: ['user'] },
+        }),
       })
     )
 
-    // User lookup: frontend GETs /api/auth/user after storing the token.
-    await page.route('**/api/auth/user', route =>
+    // User lookup ("me"): frontend GETs the Security API session after storing
+    // the token. Exact path — `/session/exchange` above keeps its own route.
+    await page.route('**/api/v1/security/session', route =>
       route.fulfill({
         status: 200,
         contentType: 'application/json',

--- a/frontend/tests/mobile-layout.spec.ts
+++ b/frontend/tests/mobile-layout.spec.ts
@@ -18,8 +18,13 @@ test.describe('Mobile layout', () => {
     await page.fill('input[type="email"]', 'admin@fuzefront.dev')
     await page.fill('input[type="password"]', 'admin123')
     await Promise.all([
+      // Login goes through the Security API (POST /api/v1/security/session);
+      // match the method so GET /session ("me") cannot satisfy the wait early.
       page.waitForResponse(
-        r => r.url().includes('/api/auth/login') && r.status() === 200,
+        r =>
+          r.url().includes('/api/v1/security/session') &&
+          r.request().method() === 'POST' &&
+          r.status() === 200,
         { timeout: 15000 }
       ),
       page.click('button[type="submit"]'),

--- a/frontend/tests/oidc-plumbing.e2e.spec.ts
+++ b/frontend/tests/oidc-plumbing.e2e.spec.ts
@@ -57,12 +57,58 @@ test.describe('OIDC plumbing — full stack (local Authentik user)', () => {
   })
 
   // ── 2. Backend health + OIDC configured ────────────────────────────────
-  test('backend reports oidcConfigured:true', async ({ request }) => {
+  // NOTE: /api/auth/* is the DEPRECATED compatibility layer, kept mounted for
+  // one release. It is still asserted here so we notice if the shim breaks —
+  // but the SPA and all consumers use /api/v1/security/* (covered in 2c/2d).
+  test('backend reports oidcConfigured:true (deprecated /api/auth shim)', async ({ request }) => {
     const resp = await request.get(`${BACKEND_URL}/api/auth/method`)
     expect(resp.ok()).toBeTruthy()
     const body = await resp.json()
     expect(body.oidcConfigured).toBe(true)
     expect(body.methods).toContain('oidc')
+  })
+
+  // ── 2c. Security API capability descriptor (the surface the SPA reads) ──
+  // Provider-neutral by contract: a vendor name must never appear here.
+  test('Security API advertises neutral capabilities incl. Google social', async ({ request }) => {
+    const resp = await request.get(`${BACKEND_URL}/api/v1/security/methods`)
+    expect(resp.ok(), `GET /api/v1/security/methods -> ${resp.status()}`).toBeTruthy()
+    const body = await resp.json()
+    expect(body.password).toBe(true)
+    expect(body.social).toContain('google')
+    expect(body.mfa?.enabled).toBe(true)
+    // Boundary: the descriptor must not leak the identity provider.
+    expect(JSON.stringify(body)).not.toMatch(/authentik|permit/i)
+  })
+
+  // ── 2d. Password sign-in through the Security API (what the SPA calls) ──
+  test('Security API password sign-in returns a platform JWT session', async ({ request }) => {
+    const resp = await request.post(`${BACKEND_URL}/api/v1/security/session`, {
+      data: { email: E2E_USER_EMAIL, password: E2E_USER_PASSWORD },
+    })
+    expect(
+      resp.status(),
+      `POST /api/v1/security/session -> ${resp.status()}: ${await resp.text().catch(() => '')}`
+    ).toBe(200)
+    const body = await resp.json()
+    // Either an authenticated session, or an mfa_required challenge if the
+    // account has step-up enabled — both are contract-valid; only the
+    // authenticated branch carries a token.
+    if (body.status === 'mfa_required') {
+      expect(body.challengeId ?? body.mfaToken ?? body.token).toBeTruthy()
+      return
+    }
+    expect(body.token, 'platform JWT returned').toBeTruthy()
+    expect(body.token.split('.')).toHaveLength(3)
+    expect(body.sessionId).toBeTruthy()
+    expect(body.user?.email?.toLowerCase()).toBe(E2E_USER_EMAIL.toLowerCase())
+  })
+
+  test('Security API rejects a wrong password with 401', async ({ request }) => {
+    const resp = await request.post(`${BACKEND_URL}/api/v1/security/session`, {
+      data: { email: E2E_USER_EMAIL, password: 'definitely-not-the-password' },
+    })
+    expect(resp.status()).toBe(401)
   })
 
   // ── 2b. Server-side password sign-in (flow-executor, no redirect) ───────

--- a/frontend/tests/pages/login-page.ts
+++ b/frontend/tests/pages/login-page.ts
@@ -34,8 +34,13 @@ export class LoginPage {
     await this.page.waitForLoadState('networkidle')
     
     // Click submit and wait for the request
+    // Login goes through the Security API (POST /api/v1/security/session);
+    // match the method so GET /session ("me") cannot satisfy the wait early.
     const responsePromise = this.page.waitForResponse(
-      response => response.url().includes('/api/auth/login') && response.status() !== 0,
+      response =>
+        response.url().includes('/api/v1/security/session') &&
+        response.request().method() === 'POST' &&
+        response.status() !== 0,
       { timeout: 10000 }
     )
     


### PR DESCRIPTION
Two AuthN correctness fixes this session owns. Both stem from the Security API cutover.

## 1. Google sign-in got stuck on Authentik's UI
`startSocialLogin` 302'd to the generic OIDC **authorize** endpoint. Authorize requires a session; with none, Authentik falls back to the brand's auth flow and renders its **identification page** (`/if/flow/...`) with a "Google" button — the IdP's own UI, leaking across our boundary.

**Fix:** launch the Google **source** directly — `/source/oauth/login/google/?next=<authorize>`. That view 302s **straight to `accounts.google.com`**; after the callback the source flow runs (silent enrollment first time, login when returning), then `next` resumes authorize, which issues the code silently. Same cookie/state/PKCE round-trip — one hop inserted ahead of authorize, so **no `/if/flow/` ever renders**. Adds a regression assertion that the redirect never matches `/if/`.

This unblocks devops dropping `/if` from the IdP ingress.

## 2. The auth e2e suite was testing endpoints we deleted
`E2E (sign-in)` has been **red on master since the cutover** — not flake, and not something to wave off as "pre-existing". The SPA moved to `/api/v1/security/*` (`POST /session`, `GET /methods`, `/social/google/start`, `/session/exchange`) but the tests still waited on `/api/auth/login` and mocked `/api/auth/method`. The frontend never calls those anymore, so `waitForResponse` hung until timeout.

Repointed: `auth-simple`, `clock-load`, `mobile-layout`, `pages/login-page`, `google-signin`, `federated-apps-register-activate`, and the post-prod `live-smoke`. Where login is awaited, the **HTTP method is matched too** — `GET /session` ("me") shares the URL and would otherwise satisfy the wait before login completed.

**Also adds the coverage that was missing:** `oidc-plumbing` only exercised the deprecated `/api/auth` shim and had **zero** coverage of the surface the SPA and consumers actually use. It now asserts the capability descriptor, password sign-in, wrong-password 401, and a **boundary check that no response leaks `authentik`/`permit`**. The shim assertions stay — it's still mounted for one release.

## Verification
CI is the gate (local install hangs on this Windows box). The proof is `E2E (sign-in)` going **green on this PR** having been red on master.

`hold` + no `auto-merge` — master is deploy-on-push; merge in a deploy window. Does not touch `package-lock.json`.

Co-Authored-By: Claude