### PR TITLE
fix(e2e): run the security-service in the compose stack + route /api/v1/security

### DIFF
--- a/deploy/e2e/nginx.e2e.conf
+++ b/deploy/e2e/nginx.e2e.conf
@@ -93,10 +93,29 @@ http {
             try_files $uri =404;
         }
 
-        # E2E: all /api/* routes to the single backend container.
+        # The SPA signs in through the provider-agnostic Security API, served
+        # ONLY by the security container (the monolith does not mount it). This
+        # location MUST stay above the /api/ catch-all — nginx prefers the
+        # longest matching prefix, but the intent is easy to break by reordering.
+        # Mirrors the prod Ingress: /api/v1/security → fuzefront-security:3002.
+        location /api/v1/security/ {
+            add_header X-Frame-Options "SAMEORIGIN" always;
+            add_header X-Content-Type-Options "nosniff" always;
+            add_header X-XSS-Protection "1; mode=block" always;
+            add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+            proxy_pass http://security:3002;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_read_timeout 86400;
+        }
+
+        # E2E: every OTHER /api/* route goes to the single monolith container.
         # Production nginx.conf splits across fuzefront-security/applications/backend
-        # (K8s service names that don't exist in docker-compose). This conf
-        # consolidates them all to backend:3001 for the self-contained E2E stack.
+        # (K8s service names that don't exist in docker-compose); this conf
+        # consolidates the rest to backend:3001 for the self-contained E2E stack.
         location /api/ {
             add_header X-Frame-Options "SAMEORIGIN" always;
             add_header X-Content-Type-Options "nosniff" always;

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -267,10 +267,16 @@ services:
       AUTHENTIK_BASE_URL: http://authentik-server:9000
       # Native IdP paths — no reverse-proxy prefix (matches the prod ingress).
       SECURITY_IDP_PROXY_PREFIX: ''
-      # Browser-facing social callback, on the APP origin: nginx routes
-      # /api/v1/security/ → this service. Path from
-      # providers/authentik/config.ts socialCallbackPath().
-      AUTHENTIK_REDIRECT_URI: http://localhost:4173/api/v1/security/social/callback
+      # MUST be a redirect_uri registered on the OIDC provider (matching_mode:
+      # strict), or Authentik rejects the authorize call and password login
+      # fails — password sign-in is a full authorize→code→exchange, not just a
+      # flow-executor call. It does NOT need to be browser-reachable: the server
+      # follows that 302 itself and lifts `code` out of the Location header.
+      # So we reuse the shared, registered /api/auth/oidc/callback — exactly what
+      # prod's security service does (values.authentik.oidc.redirectUri points at
+      # https://app.fuzefront.com/api/auth/oidc/callback). The registered set
+      # lives in authentik/blueprints/provider-oidc.yaml.
+      AUTHENTIK_REDIRECT_URI: http://localhost:3001/api/auth/oidc/callback
     networks:
       - e2e
     depends_on:

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -284,6 +284,15 @@ services:
         condition: service_healthy
       authentik-server:
         condition: service_started
+      # Serialise migrations. This service runs the SAME 001-009 chain against
+      # the SAME `knex_migrations` table as the monolith (see
+      # backend/security/src/index.ts). Started concurrently, the two race for
+      # the migration lock and one dies — which is exactly what happened when
+      # this container was first added: `backend exited (1)` took the whole
+      # stack down with it. Waiting for backend to be healthy means the chain is
+      # already applied and this service's run is a no-op.
+      backend:
+        condition: service_healthy
     healthcheck:
       test: ['CMD', 'wget', '-q', '--spider', 'http://localhost:3002/health']
       interval: 10s

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -228,6 +228,63 @@ services:
       retries: 6
       start_period: 30s
 
+  # ── Security service ──────────────────────────────────────────────────────
+  # The SPA signs in through the provider-agnostic Security API
+  # (/api/v1/security/*), which ONLY this service serves — the monolith `backend`
+  # above mounts /api/auth, /api/apps, /api/organizations, /api/v1/app-registry
+  # and nothing else. Without this container the SPA's login POST 404s, so the
+  # sign-in e2e times out waiting for a response that can never arrive. nginx
+  # (see deploy/e2e/nginx.e2e.conf) path-routes /api/v1/security/ here, mirroring
+  # the prod Ingress which sends /api/v1/security → fuzefront-security.
+  security:
+    build:
+      context: .
+      dockerfile: backend/security/Dockerfile
+    ports:
+      - '3002:3002'
+    environment:
+      NODE_ENV: production
+      USE_POSTGRES: 'true'
+      DB_HOST: postgres
+      DB_PORT: '5432'
+      DB_NAME: fuzefront_platform
+      DB_USER: e2e
+      DB_PASSWORD: e2e_pass
+      # Must match the monolith: both mint/validate the same platform JWT.
+      JWT_SECRET: e2e-jwt-secret-not-for-prod
+      PORT: '3002'
+      FRONTEND_URL: http://localhost:4173
+      PERMIT_API_KEY: ci-noop
+      PERMIT_PDP_URL: http://localhost:7766
+      # Password sign-in is brokered SERVER-side through Authentik's
+      # flow-executor (no browser redirect), so these are required even for the
+      # plain email/password e2e — not just the social flow.
+      AUTHENTIK_CLIENT_ID: fuzefront-oidc-client
+      AUTHENTIK_CLIENT_SECRET: ${AUTHENTIK_OIDC_CLIENT_SECRET:-e2e-oidc-client-secret}
+      AUTHENTIK_ISSUER_URL: ${AUTHENTIK_ISSUER_URL:-http://authentik-server:9000/application/o/fuzefront/}
+      # Server-side calls (flow-executor, token, userinfo, jwks) go over the
+      # compose network rather than back out through a published port.
+      AUTHENTIK_BASE_URL: http://authentik-server:9000
+      # Native IdP paths — no reverse-proxy prefix (matches the prod ingress).
+      SECURITY_IDP_PROXY_PREFIX: ''
+      # Browser-facing social callback, on the APP origin: nginx routes
+      # /api/v1/security/ → this service. Path from
+      # providers/authentik/config.ts socialCallbackPath().
+      AUTHENTIK_REDIRECT_URI: http://localhost:4173/api/v1/security/social/callback
+    networks:
+      - e2e
+    depends_on:
+      postgres:
+        condition: service_healthy
+      authentik-server:
+        condition: service_started
+    healthcheck:
+      test: ['CMD', 'wget', '-q', '--spider', 'http://localhost:3002/health']
+      interval: 10s
+      timeout: 5s
+      retries: 6
+      start_period: 30s
+
   # ── Frontend ──────────────────────────────────────────────────────────────
   # Built from repo root (Dockerfile requires workspace context for @fuzefront/* aliases).
   frontend:
@@ -253,4 +310,8 @@ services:
       - e2e
     depends_on:
       backend:
+        condition: service_healthy
+      # nginx resolves upstreams at startup, so it fails to boot if `security`
+      # is not up yet — and without it the SPA cannot sign in at all.
+      security:
         condition: service_healthy


### PR DESCRIPTION
## The gap

The SPA was migrated onto the provider-agnostic Security API (`/api/v1/security/*`), served **only** by `backend/security`. But **no e2e stack ran that service.** This compose builds `backend/Dockerfile` — the **monolith**, which mounts `/api/auth`, `/api/apps`, `/api/organizations`, `/api/v1/app-registry` and *not* `/api/v1/security`. So in CI the SPA's login POST 404s and the sign-in e2e times out waiting for a response that can never arrive.

**The security service — which now serves all SPA auth — has had zero e2e coverage since the cutover.** That is why `E2E (sign-in)` has been red on master since then, and red on *every* PR since, including [#278](https://github.com/izzywdev/FuzeFront/pull/278) which touches only a shell script and markdown. A docs-and-script PR cannot break sign-in — that's the tell. It was never flake, and "pre-existing" was never a reason to wave it off.

**Prod was never affected**: the k8s Ingress routes `/api/v1/security` → `fuzefront-security` ahead of nginx, which is why real sign-in works.

## The fix
- Adds the **`security` service** to `docker-compose.e2e.yml` — with Authentik + DB env, because password sign-in is brokered **server-side through the flow-executor**, so Authentik is required even for the plain email/password path (not just social).
- Routes **`/api/v1/security/` → `security:3002`** in `deploy/e2e/nginx.e2e.conf`, above the `/api/` catch-all — mirroring the prod Ingress.
- `frontend` now `depends_on` it: nginx resolves upstreams at startup and **refuses to boot** on an unresolvable one (confirmed while testing: `host not found in upstream "security"`).

## Verified (actually run, not asserted)
```
docker compose -f docker-compose.e2e.yml config   → PARSE OK; services: …, security
nginx -t (upstreams host-mapped)                  → syntax is ok, test is successful
```

## Scope
Foundation only. **Not** included: `.github/workflows/e2e.yml` (the sign-in workflow hand-starts the monolith with no Authentik — separate piece), the oidc-plumbing spec base URLs, and `frontend/nginx.conf` parity. `hold` + no `auto-merge` — master is deploy-on-push.

Co-Authored-By: Claude