### PR TITLE
fix(nginx): route /api/v1/security to the security-service (parity + landmine)

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -111,7 +111,34 @@ http {
         # catch-all below. Used for in-pod / port-forward scenarios; the ingress
         # does the same path routing upstream of nginx.
 
-        # Security-service: auth + organizations.
+        # Security-service: the provider-agnostic Security API. This is the
+        # surface the SPA and all consumers use (/api/v1/security/{session,
+        # methods,social,mfa,verify,authz,tenants,...}). It was missing here
+        # while /api/auth/ and /api/organizations/ were routed, so it fell
+        # through to the /api/ catch-all and reached fuzefront-backend — the
+        # MONOLITH, which does not serve it, i.e. a 404 on every auth call.
+        #
+        # Not currently live: the ingress routes /api/v1/security straight to
+        # fuzefront-security ahead of nginx, so prod is unaffected today. This
+        # closes the gap for in-pod / port-forward use and, more importantly,
+        # removes a landmine — any ingress change that let /api/* reach this pod
+        # would silently break all authentication. The identical omission in the
+        # e2e nginx is exactly what made sign-in untestable there.
+        location /api/v1/security/ {
+            add_header X-Frame-Options "SAMEORIGIN" always;
+            add_header X-Content-Type-Options "nosniff" always;
+            add_header X-XSS-Protection "1; mode=block" always;
+            add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+            proxy_pass http://fuzefront-security:3002;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_read_timeout 86400;
+        }
+
+        # Security-service: deprecated /api/auth shim + organizations.
         location /api/auth/ {
             add_header X-Frame-Options "SAMEORIGIN" always;
             add_header X-Content-Type-Options "nosniff" always;


### PR DESCRIPTION
**Piece C.** `frontend/nginx.conf` routes `/api/auth/` and `/api/organizations/` to `fuzefront-security` — but had **no location for `/api/v1/security/`**, the surface the SPA and every consumer actually use.

So it fell through to the `/api/` catch-all and reached **`fuzefront-backend`** — the monolith, which doesn't serve it. A **404 on every auth call**.

## Is it live?
**No** — the k8s Ingress routes `/api/v1/security` straight to `fuzefront-security` ahead of nginx, so prod is unaffected today. I verified that before writing this.

## Then why fix it
1. **It's a landmine.** Any ingress change that let `/api/*` reach this pod would silently break **all** authentication — no error, just 404s on login.
2. **It's not hypothetical.** The *identical* omission in `deploy/e2e/nginx.e2e.conf` is exactly what made sign-in untestable in CI — the same missing route has already cost us once, in the stack where nothing was routing it.
3. **Parity.** Routing the deprecated `/api/auth/` shim to the security service while *not* routing its real API is the kind of inconsistency that reads as intentional and gets copied.

## Verified
`nginx -t` (upstreams host-mapped) → **syntax is ok, test is successful**.

`hold` + no `auto-merge` — master is deploy-on-push. Independent of the other auth PRs; safe to merge on its own.

Co-Authored-By: Claude