### PR TITLE
fix(security): enforce session revocation on the request path

### DIFF
--- a/backend/core/src/middleware/auth.ts
+++ b/backend/core/src/middleware/auth.ts
@@ -26,25 +26,62 @@ export const authenticateToken = async (
   try {
     const decoded = jwt.verify(token, process.env.JWT_SECRET!) as {
       userId: string
+      sessionId?: string
     }
 
-    const userRow = await db('users')
-      .select(
-        'id',
-        'email',
-        'first_name',
-        'last_name',
-        'default_app_id',
-        'roles'
-      )
-      .where('id', decoded.userId)
-      .first()
+    // Revocation is enforced HERE, on the request path, or it does not exist.
+    //
+    // The session JWT is stateless HS256, so signature validity alone says
+    // nothing about whether the session still lives. `logout()` and any
+    // device-revoke delete the `sessions` row — but until this check existed,
+    // nothing on the request path read that table, so a "logged out" token kept
+    // authenticating every route until `exp` (up to 24h). Revocation was
+    // enforced only by GET /session ("me"), i.e. effectively nowhere.
+    //
+    // Run in parallel with the user load: this is a PK lookup, so the added
+    // cost is one concurrent round-trip, not a serial one.
+    const [userRow, session] = await Promise.all([
+      db('users')
+        .select(
+          'id',
+          'email',
+          'first_name',
+          'last_name',
+          'default_app_id',
+          'roles'
+        )
+        .where('id', decoded.userId)
+        .first(),
+      decoded.sessionId
+        ? db('sessions').select('id', 'expires_at').where('id', decoded.sessionId).first()
+        : Promise.resolve(undefined),
+    ])
 
     if (!userRow) {
       console.log(`❌ [${requestId}] User not found in database:`, {
         userId: decoded.userId,
       })
       return res.status(401).json({ error: 'User not found' })
+    }
+
+    if (decoded.sessionId) {
+      if (!session) {
+        // Signed-out, device-revoked, or reaped. Deny.
+        console.log(`❌ [${requestId}] Session revoked`, { sessionId: decoded.sessionId })
+        return res.status(401).json({ error: 'Session revoked' })
+      }
+      if (session.expires_at && new Date(session.expires_at).getTime() < Date.now()) {
+        console.log(`❌ [${requestId}] Session expired`, { sessionId: decoded.sessionId })
+        return res.status(401).json({ error: 'Session expired' })
+      }
+    } else {
+      // Every current mint site includes `sessionId`, so absence means a token
+      // issued by an older build. Those age out with the 24h TTL; allowing them
+      // keeps this deploy from signing everyone out mid-session. Not a new
+      // weakness — an attacker cannot strip the claim without the signing key,
+      // and holding that key lets them mint anything anyway.
+      // TODO: once a release has fully rolled (>24h), make this branch a 401.
+      console.warn(`⚠️ [${requestId}] Session token has no sessionId — pre-rollout token, revocation cannot be enforced`)
     }
 
     const user: User = {


### PR DESCRIPTION
## Logging out did not log you out

`logout()` deletes the `sessions` row, and `getUserInfo()` checks it — its comment even says *"Session must still exist (revocation is authoritative)"*. But **`authenticateToken` in `@fuzefront/core` — the middleware every API route actually uses — never read that table.**

I verified it: zero references to `sessions` in the request-validation path.

**Consequence:** after logout, the token kept authenticating **every API route until `exp`** (up to 24h). Revocation was enforced on `GET /session` ("me") and nowhere else. The only real kill-switch on a session was deleting the user row.

The same hole makes **"manage devices" cosmetic** — revoking a device deletes the row and reports success while that device's token keeps working. We were about to ship exactly that feature.

## Why it has to be here
The session JWT is stateless HS256. Signature validity says nothing about whether the session still lives — so it must be checked on the request path. There is no other enforcement point.

## The change
Loads the user and the session **concurrently** (`Promise.all`). Both are PK lookups and the middleware **already** hit the DB for the user, so the cost is one extra *concurrent* round-trip, not a serial one — no added wall-clock in the common case.

- session row gone → **401 `Session revoked`**
- past `expires_at` → **401 `Session expired`**

## Backward compatibility (deliberate)
Tokens **without** a `sessionId` are still accepted, with a warning. All four current mint sites include the claim (verified), so absence means a token from an older build; those age out with the 24h TTL. This avoids signing every live user out on deploy. It is not a new weakness — an attacker cannot strip the claim without the signing key, and with that key they could mint anything. `TODO` marks it to become a 401 once a release has fully rolled.

## Does it actually ship?
Yes — I checked, because `backend/core/dist` is **committed**: the Dockerfile runs `cd backend/core && npm run build`, so the image compiles from `src`. The committed `dist` is a stale artifact.

**Worth flagging separately:** jest maps `@fuzefront/core` → the committed `dist`, while Docker builds from `src`. Unit tests can therefore pass against stale code while the image ships something different. That trap deserves its own fix.

`hold` — master is deploy-on-push; merge in a window.

Co-Authored-By: Claude