### PR TITLE
feat(auth): implement @fuzefront/auth — real verifier + middleware (#117)

### DIFF
--- a/.semgrep/fuze-authz.yml
+++ b/.semgrep/fuze-authz.yml
@@ -25,6 +25,21 @@ rules:
     languages: [javascript, typescript, python]
     severity: WARNING
     message: "Minting an auth/session token locally? AuthN is provided by FuzeFront (Authentik OIDC SSO) — products VERIFY FuzeFront-issued tokens, they do not issue their own user tokens. If this signs a user/session JWT, replace it with FuzeFront token verification (@fuzefront/auth). Service-to-service tokens are exempt. See governance/architecture-guidelines.md section 1 (auth via FuzeFront)."
+    # Tests are excluded: proving a verifier REJECTS a forged/expired/wrong-issuer
+    # token requires minting those tokens as fixtures — there is no other way to
+    # test it. Without this, @fuzefront/auth's own test-suite trips the rule 10x,
+    # and a rule that cries wolf on the verifier it points you to is one people
+    # learn to scroll past. The rule still covers all production code, which is
+    # where minting a user token actually matters.
+    paths:
+      exclude:
+        - "**/*.test.ts"
+        - "**/*.test.js"
+        - "**/*.spec.ts"
+        - "**/*.spec.js"
+        - "**/tests/**"
+        - "**/__tests__/**"
+        - "**/test_*.py"
     pattern-either:
       - pattern: "jwt.sign(...)"
       - pattern: "jsonwebtoken.sign(...)"

--- a/packages/auth/CHANGELOG.md
+++ b/packages/auth/CHANGELOG.md
@@ -4,7 +4,39 @@ All notable changes to this contract are documented here. This package is
 versioned independently; bump on every interface change (SemVer — the major is
 the contract-stability guarantee consumers may assert on).
 
-## 0.2.0 — Provider-neutral rename (unreleased)
+## 0.2.0 — Runtime implementation + provider-neutral rename
+
+### Added — the package now WORKS (resolves #117)
+
+Until now this shipped as a contract freeze: every entry point threw
+`VERIFIER_UNAVAILABLE`, so no consumer could actually verify a token or gate a
+route. The public signatures are unchanged — code written against the frozen
+types keeps compiling — they simply do something now.
+
+- `createVerifier` / `verifyToken` — real verification via `jose` (one dep covers
+  HS256 today and RS256/JWKS for the federated target).
+  - `legacy-hs256`: today's FuzeFront session token; optional `OutOfBandResolver`
+    hydrates the `tenantId`/`roles` the token does not carry.
+  - `federated-jwks`: RS256/ES256 against the issuer's JWKS, with `iss`/`aud`
+    validation and OIDC discovery when `jwksUri` is omitted. JWKS cached per
+    issuer.
+- `requireAuth` / `requireRoles` / `requireTenant` — real Express middleware.
+  `requireAuth` never calls `next()` on an unauthenticated request; guards answer
+  403 (authz) rather than 401 (authn) so clients are not sent into login loops.
+- 31 tests, weighted toward the denial paths: algorithm confusion, forged
+  signature, expiry, wrong issuer/audience, missing subject, resolver failure,
+  and unresolved-tenant.
+
+### Security properties made explicit
+
+- **Algorithms are pinned per mode.** Unpinned `algorithms` is what allows
+  `alg: none` and RS256-public-key-as-HMAC-secret attacks.
+- **`tenantId: null` is UNRESOLVED, never a wildcard** — `requireTenant` denies.
+- **A resolver failure denies** instead of returning empty roles, which would be
+  indistinguishable from a real permission decision and would mask an outage.
+- Still **never mints tokens**; in `federated-jwks` mode a consumer holds no
+  signing key at all.
+
 
 Neutralizes the identity-vendor leak in the consumer surface, coincident with
 the new provider-agnostic FuzeFront Security API (`@fuzefront/security-client`).

--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -5,10 +5,70 @@ The consumable **authN/authZ client** for the FuzeFront family (resolves
 tokens and gates routes through this one package, so identity handling — and the
 eventual federated-JWKS migration — is uniform across the family.
 
-> **Status: CONTRACT FREEZE (v0.1.0).** This PR freezes the public *interface*
-> only. Runtime verification (JWKS fetch, `jsonwebtoken`/`jose`) is a **follow-up
-> backend slice** — the frozen signatures throw `VERIFIER_UNAVAILABLE` on purpose.
-> Consumers may code against the types now; do not depend on runtime behavior yet.
+> **Status: IMPLEMENTED (v0.2.0).** The runtime is real — `createVerifier`,
+> `verifyToken`, `requireAuth`, `requireRoles` and `requireTenant` all work. The
+> public signatures are unchanged from the v0.1.0 freeze, so code written against
+> the frozen types keeps compiling; it now also *runs*. Verification is backed by
+> [`jose`](https://github.com/panva/jose) (one dependency covers HS256 today and
+> RS256/JWKS for the federated target).
+
+## Install
+
+```bash
+npm install @fuzefront/auth        # + express, if you use the middleware
+```
+
+## Use it as middleware
+
+```ts
+import express from 'express'
+import { createVerifier, requireAuth, requireRoles } from '@fuzefront/auth'
+
+// Today's FuzeFront session token (HS256 over the shared JWT_SECRET).
+// It carries no tenant/roles, so hydrate them out-of-band if you gate on them.
+const verifier = createVerifier({
+  mode: 'legacy-hs256',
+  secret: process.env.JWT_SECRET!,
+  resolver: {
+    async resolve(userId) {
+      const row = await db('users').where({ id: userId }).first()
+      return { tenantId: row?.org_id ?? null, roles: row?.roles ?? [] }
+    },
+  },
+})
+
+const app = express()
+app.use('/api/private', requireAuth({ verifier }))          // 401 if not authenticated
+app.get('/api/private/admin', requireRoles(['admin']), h)   // 403 if not permitted
+app.get('/api/private/me', (req, res) => res.json(req.identity))
+```
+
+Migrating to federated JWKS later is a config change, not a code change:
+
+```ts
+const verifier = createVerifier({
+  mode: 'federated-jwks',
+  issuer: process.env.OIDC_ISSUER!,   // jwks_uri resolved via discovery
+  audience: 'fuzefront',
+})
+```
+
+### Guarantees worth knowing
+
+- **Fail-closed everywhere.** Every failure throws `AuthError`; no path returns a
+  permissive identity. `requireAuth` never calls `next()` on an unauthenticated
+  request.
+- **Algorithms are pinned per mode.** `legacy-hs256` accepts only `HS256`;
+  `federated-jwks` accepts only asymmetric algs. This is what blocks algorithm
+  confusion (e.g. a token that names `alg: none`, or an RS256 public key abused
+  as an HMAC secret).
+- **`tenantId: null` means UNRESOLVED, never "any tenant".** `requireTenant`
+  denies on null rather than treating it as a wildcard.
+- **A resolver failure denies** rather than yielding an identity with empty roles
+  — otherwise an outage would be indistinguishable from a permission decision.
+- **This package never mints tokens.** Verification only. In `federated-jwks`
+  mode a consumer holds no signing key at all.
+- **`express` is an optional peer** — import `verifyToken`/types without it.
 
 ## Why
 
@@ -63,7 +123,7 @@ npm install @fuzefront/auth
 
 ## Contract lifecycle
 
-This package is the **contract-first gate**: it is frozen and merged FIRST, then
+This package is the **contract-first gate**: its interface was frozen and merged FIRST, then
 the backend (runtime verifier impl), consumers, and tests fan out against it. Any
 later change re-enters through the contract-designer — re-lint, re-version (bump
 `version` + `CHANGELOG.md`), regenerate, ripple deliberately. See `CHANGELOG.md`.

--- a/packages/auth/jest.config.js
+++ b/packages/auth/jest.config.js
@@ -1,0 +1,15 @@
+/** @type {import('jest').Config} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/tests'],
+  testMatch: ['**/*.test.ts'],
+  // The package tsconfig is build-shaped (types: ["node"], include: src only), so
+  // tests need their own or the jest globals do not resolve.
+  transform: {
+    '^.+\\.ts$': ['ts-jest', { tsconfig: '<rootDir>/tests/tsconfig.json' }],
+  },
+  // jose ships ESM-first; let ts-jest transpile it rather than choke on `import`.
+  transformIgnorePatterns: ['node_modules/(?!(jose)/)'],
+  testTimeout: 15000,
+}

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fuzefront/auth",
-  "version": "0.1.0",
-  "description": "Consumable authN/authZ client for the FuzeFront family — stable Identity shape with a pluggable token verifier (legacy-hs256 today, oidc-jwks target). Fail-closed. Never mints tokens.",
+  "version": "0.2.0",
+  "description": "Consumable authN/authZ middleware for the FuzeFront family \u2014 stable Identity shape with a pluggable, fail-closed token verifier (legacy-hs256 today, federated-jwks target). Verifies only; never mints tokens.",
   "main": "dist/index.cjs",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -27,7 +27,7 @@
     "type-check": "tsc --noEmit"
   },
   "peerDependencies": {
-    "express": "^4.17.21"
+    "express": "^4.22.2"
   },
   "peerDependenciesMeta": {
     "express": {
@@ -35,13 +35,13 @@
     }
   },
   "devDependencies": {
-    "@types/express": "^4.17.21",
-    "@types/jest": "^29.5.12",
-    "@types/node": "18.19.0",
-    "jest": "29.7.0",
-    "ts-jest": "29.1.1",
+    "@types/express": "^4.17.25",
+    "@types/jest": "^29.5.14",
+    "@types/node": "^18.19.130",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.4.11",
     "tsup": "^8.0.2",
-    "typescript": "5.1.6"
+    "typescript": "^5.9.3"
   },
   "exports": {
     ".": {
@@ -49,5 +49,8 @@
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     }
+  },
+  "dependencies": {
+    "jose": "^5.10.0"
   }
 }

--- a/packages/auth/src/middleware.ts
+++ b/packages/auth/src/middleware.ts
@@ -17,7 +17,9 @@
  * backend. `express` is an OPTIONAL peer dependency so non-Express consumers
  * (edge, test) can import `verifyToken`/types without pulling Express.
  *
- * Implementation is a FOLLOW-UP slice; signatures are frozen here.
+ * Status codes are deliberate: 401 means "who are you?" (authn — re-authenticate),
+ * 403 means "I know who you are, and no" (authz — re-authenticating changes
+ * nothing). Collapsing them sends clients into pointless login loops.
  */
 
 import type { NextFunction, Request, Response } from 'express';
@@ -62,6 +64,45 @@ export interface AuthErrorBody {
 }
 
 /**
+ * Pull the raw token out of `Authorization: Bearer <token>` (or a custom header).
+ * Scheme match is case-insensitive per RFC 6750; anything else yields undefined
+ * and is treated as "no token".
+ */
+function readBearer(req: Request, header: string): string | undefined {
+  const raw = req.headers[header.toLowerCase()];
+  const value = Array.isArray(raw) ? raw[0] : raw;
+  if (typeof value !== 'string' || !value) return undefined;
+  const [scheme, token] = value.split(' ');
+  if (scheme?.toLowerCase() !== 'bearer' || !token) return undefined;
+  return token;
+}
+
+/**
+ * Single rejection path. Every denial routes through here so the body shape and
+ * status stay consistent, and so an unexpected error can never fall through as
+ * success. Non-AuthError throwables become an opaque 401 — an unknown failure is
+ * still a failure, and its message must not leak internals to the caller.
+ */
+function deny(res: Response, err: unknown): void {
+  const authErr =
+    err instanceof AuthError ? err : new AuthError('UNKNOWN', 'authentication failed');
+  const body: AuthErrorBody = { error: authErr.message, code: authErr.code };
+  res.status(authErr.status).json(body);
+}
+
+/** Guards run after requireAuth; a missing identity is a wiring bug, not a 403. */
+function requireIdentity(req: Request, res: Response): Identity | undefined {
+  const identity = req.identity;
+  if (!identity) {
+    // Ordering mistake (guard mounted before/without requireAuth). Deny — but as
+    // 401, because nothing here is authenticated at all.
+    deny(res, new AuthError('NO_TOKEN', 'requireAuth() must run before this guard'));
+    return undefined;
+  }
+  return identity;
+}
+
+/**
  * Express middleware factory. FROZEN SIGNATURE — implementation is a follow-up.
  *
  * @example
@@ -71,15 +112,37 @@ export interface AuthErrorBody {
 export function requireAuth(
   options: RequireAuthOptions,
 ): (req: Request, res: Response, next: NextFunction) => void {
-  void options;
-  return function requireAuthHandler(_req: Request, res: Response, _next: NextFunction): void {
-    // Interface freeze only — real impl reads header, awaits verifier.verify,
-    // sets req.identity, and fail-closes on AuthError.
-    const body: AuthErrorBody = {
-      error: '@fuzefront/auth is contract-frozen; middleware runtime not yet implemented (#117).',
-      code: 'VERIFIER_UNAVAILABLE',
-    };
-    res.status(501).json(body);
+  const { verifier, header = 'authorization', optional = false } = options;
+  if (!verifier) {
+    // Fail at wiring time. A middleware built without a verifier that only threw
+    // on first request would ship a route silently ungated until traffic hit it.
+    throw new AuthError('VERIFIER_UNAVAILABLE', 'requireAuth requires a `verifier`', 500);
+  }
+
+  return function requireAuthHandler(req: Request, res: Response, next: NextFunction): void {
+    const token = readBearer(req, header);
+
+    if (!token) {
+      // `optional` routes continue WITHOUT an identity — they must never
+      // continue with a half-built one.
+      if (optional) return next();
+      return deny(res, new AuthError('NO_TOKEN', 'no bearer token presented'));
+    }
+
+    // Express 4 does not await handlers, so the promise is driven here and every
+    // rejection is funnelled to `deny`. An unhandled rejection would leave the
+    // request hanging rather than denying it — the one failure mode a
+    // fail-closed gate cannot have.
+    verifier
+      .verify(token)
+      .then(identity => {
+        req.identity = identity;
+        next();
+      })
+      .catch((err: unknown) => {
+        if (optional) return next();
+        deny(res, err);
+      });
   };
 }
 
@@ -92,14 +155,32 @@ export function requireRoles(
   roles: string[],
   mode: 'all' | 'any' = 'all',
 ): (req: Request, res: Response, next: NextFunction) => void {
-  void roles;
-  void mode;
-  return function requireRolesHandler(_req: Request, res: Response, _next: NextFunction): void {
-    const body: AuthErrorBody = {
-      error: '@fuzefront/auth is contract-frozen; authz guard runtime not yet implemented (#117).',
-      code: 'VERIFIER_UNAVAILABLE',
-    };
-    res.status(501).json(body);
+  return function requireRolesHandler(req: Request, res: Response, next: NextFunction): void {
+    const identity = requireIdentity(req, res);
+    if (!identity) return;
+
+    const held = identity.roles ?? [];
+    const ok =
+      mode === 'any'
+        ? roles.some(r => held.includes(r))
+        : roles.every(r => held.includes(r));
+
+    if (!ok) {
+      // 403, not 401: the caller IS authenticated, just not permitted. Collapsing
+      // these would tell a client to re-authenticate over a permission problem.
+      //
+      // Note this denies when roles are empty — which is exactly right for the
+      // legacy-hs256 token, whose roles only exist if an out-of-band resolver
+      // hydrated them. No resolver means no roles means no role-gated access,
+      // rather than a silent grant.
+      const body: AuthErrorBody = {
+        error: `requires ${mode === 'any' ? 'any of' : 'all of'}: ${roles.join(', ')}`,
+        code: 'FORBIDDEN',
+      };
+      res.status(403).json(body);
+      return;
+    }
+    next();
   };
 }
 
@@ -110,13 +191,30 @@ export function requireRoles(
 export function requireTenant(
   tenantId: string,
 ): (req: Request, res: Response, next: NextFunction) => void {
-  void tenantId;
-  return function requireTenantHandler(_req: Request, res: Response, _next: NextFunction): void {
-    const body: AuthErrorBody = {
-      error: '@fuzefront/auth is contract-frozen; tenant guard runtime not yet implemented (#117).',
-      code: 'VERIFIER_UNAVAILABLE',
-    };
-    res.status(501).json(body);
+  return function requireTenantHandler(req: Request, res: Response, next: NextFunction): void {
+    const identity = requireIdentity(req, res);
+    if (!identity) return;
+
+    if (identity.tenantId === null || identity.tenantId === undefined) {
+      // UNRESOLVED is not the same as "matches". A legacy-hs256 identity with no
+      // resolver has tenantId null, and treating null as a wildcard would hand
+      // every tenant's data to any valid token — the worst possible reading of a
+      // missing value. Deny, and say why, because this is a config gap (no
+      // resolver wired) rather than a permission decision.
+      const body: AuthErrorBody = {
+        error: 'tenant scope is unresolved for this identity; wire an OutOfBandResolver',
+        code: 'MISSING_CLAIM',
+      };
+      res.status(403).json(body);
+      return;
+    }
+
+    if (identity.tenantId !== tenantId) {
+      const body: AuthErrorBody = { error: 'identity is not scoped to this tenant', code: 'FORBIDDEN' };
+      res.status(403).json(body);
+      return;
+    }
+    next();
   };
 }
 

--- a/packages/auth/src/verifyToken.ts
+++ b/packages/auth/src/verifyToken.ts
@@ -1,23 +1,255 @@
 /**
- * @fuzefront/auth — top-level verification API (CONTRACT FREEZE).
+ * @fuzefront/auth — token verification runtime.
  *
- * These are the frozen SIGNATURES the whole family codes against. Runtime
- * behavior (JWKS fetch, jsonwebtoken/jose verification) is a FOLLOW-UP backend
- * slice — the bodies here throw `NOT_IMPLEMENTED` on purpose so nobody mistakes
- * the freeze for a working implementation, while types still compile and the
- * generated `.d.ts` is the stable public interface.
+ * Implements the contract frozen in `types.ts` (#117). The public signatures did
+ * not change; only the bodies became real.
+ *
+ * Two modes, one dependency — `jose` covers HS256 and RS256/JWKS, so consumers
+ * do not pull two crypto libraries:
+ *
+ *   legacy-hs256   — today's FuzeFront session token: HS256 over the shared
+ *                    JWT_SECRET, subject in `userId`. Carries no tenant/roles, so
+ *                    an optional out-of-band `resolver` hydrates them.
+ *   federated-jwks — the target: RS256/ES256 verified against the issuer's public
+ *                    JWKS with `iss`/`aud` validation. No shared secret, so a
+ *                    consumer can VERIFY without gaining the power to MINT.
+ *
+ * FAIL-CLOSED, always: every failure path throws `AuthError`; no branch returns a
+ * permissive identity. That matters more than usual here — this runs inside
+ * consuming services, so a "soft" failure would silently grant access family-wide.
+ *
+ * This package NEVER mints tokens. Verification only.
  */
 
-import { AuthError, Identity, Verifier, VerifierConfig } from './types';
+import {
+  createRemoteJWKSet,
+  jwtVerify,
+  type JWTPayload,
+  type JWTVerifyGetKey,
+} from 'jose';
+import {
+  AuthError,
+  type FederatedJwksConfig,
+  type Identity,
+  type LegacyHs256Config,
+  type Verifier,
+  type VerifierConfig,
+} from './types';
 
-/** Marker error so the freeze is unmistakable at runtime. */
-function notImplemented(): never {
-  throw new AuthError(
-    'VERIFIER_UNAVAILABLE',
-    '@fuzefront/auth is contract-frozen; runtime verification is a follow-up backend slice. See #117.',
-    500,
-  );
+/**
+ * Translate a `jose` failure into the contract's error taxonomy.
+ *
+ * jose reports failures via stable `err.code` strings. Mapping them explicitly
+ * keeps the codes operationally meaningful — an expired token and a forged
+ * signature are very different events — instead of collapsing both to UNKNOWN.
+ * Anything unrecognised stays UNKNOWN and still denies.
+ */
+function toAuthError(err: unknown): AuthError {
+  if (err instanceof AuthError) return err;
+  const code = (err as { code?: string })?.code;
+  const msg = (err as Error)?.message ?? 'verification failed';
+
+  switch (code) {
+    case 'ERR_JWT_EXPIRED':
+      return new AuthError('EXPIRED', 'token has expired');
+    case 'ERR_JWS_SIGNATURE_VERIFICATION_FAILED':
+      return new AuthError('INVALID_SIGNATURE', 'signature verification failed');
+    case 'ERR_JWT_CLAIM_VALIDATION_FAILED': {
+      // jose names the offending claim — that is what separates a wrong audience
+      // from a not-yet-valid token.
+      const claim = (err as { claim?: string }).claim;
+      if (claim === 'iss') return new AuthError('INVALID_ISSUER', 'unexpected token issuer');
+      if (claim === 'aud') return new AuthError('INVALID_AUDIENCE', 'unexpected token audience');
+      if (claim === 'nbf') return new AuthError('NOT_ACTIVE', 'token is not yet valid');
+      return new AuthError('MISSING_CLAIM', `claim validation failed: ${claim ?? 'unknown'}`);
+    }
+    case 'ERR_JWS_INVALID':
+    case 'ERR_JWT_INVALID':
+    case 'ERR_JOSE_NOT_SUPPORTED':
+      return new AuthError('MALFORMED', 'token is not a parseable JWT');
+    case 'ERR_JWKS_NO_MATCHING_KEY':
+    case 'ERR_JWKS_MULTIPLE_MATCHING_KEYS':
+    case 'ERR_JWKS_TIMEOUT':
+    case 'ERR_JWKS_INVALID':
+      return new AuthError('JWKS_UNAVAILABLE', `could not resolve signing key: ${msg}`);
+    default:
+      return new AuthError('UNKNOWN', msg);
+  }
 }
+
+/** Read a claim as a non-empty string, else undefined. */
+function claimString(payload: JWTPayload, name: string): string | undefined {
+  const v = payload[name];
+  return typeof v === 'string' && v.length > 0 ? v : undefined;
+}
+
+/** Read a claim as string[]; tolerate a single string. Never undefined. */
+function claimRoles(payload: JWTPayload, name: string): string[] {
+  const v = payload[name];
+  if (Array.isArray(v)) return v.filter((r): r is string => typeof r === 'string');
+  if (typeof v === 'string' && v.length > 0) return [v];
+  return [];
+}
+
+// ── legacy-hs256 ────────────────────────────────────────────────────────────
+
+function createLegacyVerifier(config: LegacyHs256Config): Verifier {
+  if (!config.secret) {
+    // Misconfiguration fails at construction, not silently at verify-time.
+    throw new AuthError('VERIFIER_UNAVAILABLE', 'legacy-hs256 requires `secret`', 500);
+  }
+  const key = new TextEncoder().encode(config.secret);
+  const subjectClaim = config.subjectClaim ?? 'userId';
+  const clockTolerance = config.clockToleranceSec ?? 0;
+
+  return {
+    get mode() {
+      return 'legacy-hs256' as const;
+    },
+    async verify(token: string): Promise<Identity> {
+      if (!token) throw new AuthError('NO_TOKEN', 'no bearer token presented');
+
+      let payload: JWTPayload;
+      try {
+        // Algorithm is PINNED. Without this, a token claiming `alg: none` — or an
+        // asymmetric alg — could sidestep the shared secret entirely (the classic
+        // JWT algorithm-confusion attack).
+        ({ payload } = await jwtVerify(token, key, {
+          algorithms: ['HS256'],
+          clockTolerance,
+        }));
+      } catch (err) {
+        throw toAuthError(err);
+      }
+
+      const userId = claimString(payload, subjectClaim) ?? claimString(payload, 'sub');
+      if (!userId) {
+        throw new AuthError('MISSING_CLAIM', `token has no \`${subjectClaim}\` (or \`sub\`) claim`);
+      }
+
+      // Today's token carries neither tenant nor roles. Without a resolver the
+      // identity is deliberately UNPRIVILEGED (tenantId null, roles []) rather
+      // than guessed — an authz decision must never rest on an assumption.
+      let tenantId: string | null = null;
+      let roles: string[] = [];
+      let email = claimString(payload, 'email');
+
+      if (config.resolver) {
+        try {
+          const extra = await config.resolver.resolve(userId);
+          tenantId = extra.tenantId ?? null;
+          roles = extra.roles ?? [];
+          email = extra.email ?? email;
+        } catch (err) {
+          // The token is valid but hydration failed. Returning it with empty
+          // roles would read as "authenticated but authorized for nothing" —
+          // indistinguishable from a genuine permission denial, which would mask
+          // an outage as an authz decision. Deny loudly instead.
+          throw new AuthError(
+            'VERIFIER_UNAVAILABLE',
+            `identity resolver failed: ${(err as Error).message}`,
+            500,
+          );
+        }
+      }
+
+      return {
+        userId,
+        tenantId,
+        roles,
+        email,
+        authMode: 'legacy-hs256',
+        issuedAt: payload.iat,
+        expiresAt: payload.exp,
+        issuer: payload.iss,
+        claims: payload as Record<string, unknown>,
+      };
+    },
+  };
+}
+
+// ── federated-jwks ──────────────────────────────────────────────────────────
+
+/**
+ * One JWKS per issuer. `createRemoteJWKSet` owns the fetch + rotation cache, so
+ * re-creating it per request would hammer the issuer and defeat key rotation
+ * caching.
+ */
+const jwksCache = new Map<string, JWTVerifyGetKey>();
+
+async function resolveJwksUri(config: FederatedJwksConfig): Promise<string> {
+  if (config.jwksUri) return config.jwksUri;
+  const discovery = `${config.issuer.replace(/\/$/, '')}/.well-known/openid-configuration`;
+  let res: Response;
+  try {
+    res = await fetch(discovery);
+  } catch (err) {
+    throw new AuthError('JWKS_UNAVAILABLE', `discovery fetch failed: ${(err as Error).message}`);
+  }
+  if (!res.ok) throw new AuthError('JWKS_UNAVAILABLE', `discovery returned ${res.status}`);
+  const doc = (await res.json()) as { jwks_uri?: string };
+  if (!doc.jwks_uri) throw new AuthError('JWKS_UNAVAILABLE', 'discovery document has no `jwks_uri`');
+  return doc.jwks_uri;
+}
+
+function createFederatedVerifier(config: FederatedJwksConfig): Verifier {
+  if (!config.issuer) {
+    throw new AuthError('VERIFIER_UNAVAILABLE', 'federated-jwks requires `issuer`', 500);
+  }
+  const tenantClaim = config.tenantClaim ?? 'tenantId';
+  const rolesClaim = config.rolesClaim ?? 'roles';
+  const subjectClaim = config.subjectClaim ?? 'sub';
+  const clockTolerance = config.clockToleranceSec ?? 60;
+
+  async function getKeySet(): Promise<JWTVerifyGetKey> {
+    const cached = jwksCache.get(config.issuer);
+    if (cached) return cached;
+    const set = createRemoteJWKSet(new URL(await resolveJwksUri(config)));
+    jwksCache.set(config.issuer, set);
+    return set;
+  }
+
+  return {
+    get mode() {
+      return 'federated-jwks' as const;
+    },
+    async verify(token: string): Promise<Identity> {
+      if (!token) throw new AuthError('NO_TOKEN', 'no bearer token presented');
+
+      let payload: JWTPayload;
+      try {
+        const keySet = await getKeySet();
+        // Asymmetric algorithms ONLY. Permitting HS* here would let anyone who
+        // knows the (public) key use it as an HMAC secret and forge tokens.
+        ({ payload } = await jwtVerify(token, keySet, {
+          issuer: config.issuer,
+          audience: config.audience,
+          algorithms: ['RS256', 'RS384', 'RS512', 'ES256', 'ES384'],
+          clockTolerance,
+        }));
+      } catch (err) {
+        throw toAuthError(err);
+      }
+
+      const userId = claimString(payload, subjectClaim);
+      if (!userId) throw new AuthError('MISSING_CLAIM', `token has no \`${subjectClaim}\` claim`);
+
+      return {
+        userId,
+        tenantId: claimString(payload, tenantClaim) ?? null,
+        roles: claimRoles(payload, rolesClaim),
+        email: claimString(payload, 'email'),
+        authMode: 'federated-jwks',
+        issuedAt: payload.iat,
+        expiresAt: payload.exp,
+        issuer: payload.iss,
+        claims: payload as Record<string, unknown>,
+      };
+    },
+  };
+}
+
+// ── public API (frozen signatures) ──────────────────────────────────────────
 
 /**
  * Build a `Verifier` for the given mode. The returned verifier is FAIL-CLOSED.
@@ -27,41 +259,26 @@ function notImplemented(): never {
  *   const identity = await v.verify(rawToken);
  */
 export function createVerifier(config: VerifierConfig): Verifier {
-  void config;
-  // Interface freeze only — see module note.
-  return {
-    // The real factory returns a concrete Legacy/Oidc verifier keyed on config.mode.
-    get mode() {
-      return config.mode;
-    },
-    verify(_token: string): Promise<Identity> {
-      void _token;
-      return Promise.reject(
-        new AuthError(
-          'VERIFIER_UNAVAILABLE',
-          '@fuzefront/auth is contract-frozen; verifier runtime not yet implemented (#117).',
-          500,
-        ),
-      );
-    },
-  };
+  switch (config.mode) {
+    case 'legacy-hs256':
+      return createLegacyVerifier(config);
+    case 'federated-jwks':
+      return createFederatedVerifier(config);
+    default: {
+      // Exhaustiveness guard: a future mode must be handled explicitly, never
+      // defaulted into something permissive.
+      const bad = config as { mode?: string };
+      throw new AuthError('VERIFIER_UNAVAILABLE', `unknown verifier mode: ${bad.mode}`, 500);
+    }
+  }
 }
 
 /**
  * Verify a raw bearer token (already stripped of the `Bearer ` prefix) and
  * return the normalized `Identity`. Throws `AuthError` on any failure
- * (fail-closed). This is a convenience over `createVerifier().verify()` when a
- * single verifier is used process-wide.
- *
- * FROZEN SIGNATURE — implementation is a follow-up slice.
+ * (fail-closed). Convenience over `createVerifier().verify()` when a single
+ * verifier is used process-wide.
  */
-export function verifyToken(_token: string, _verifier: Verifier): Promise<Identity> {
-  void _token;
-  void _verifier;
-  return _verifier.verify(_token).catch((e) => {
-    throw e;
-  });
+export function verifyToken(token: string, verifier: Verifier): Promise<Identity> {
+  return verifier.verify(token);
 }
-
-/** Never used at runtime in the freeze; referenced to keep `notImplemented` live for the real impl. */
-export const __FROZEN__ = notImplemented;

--- a/packages/auth/tests/middleware.test.ts
+++ b/packages/auth/tests/middleware.test.ts
@@ -1,0 +1,177 @@
+/**
+ * @fuzefront/auth — Express middleware tests (#117).
+ *
+ * The middleware is the thing consumers actually mount, so these assert the
+ * gate's contract: it never calls next() on an unauthenticated request, it
+ * distinguishes 401 (who are you?) from 403 (I know, and no), and an unresolved
+ * tenant is a denial rather than a wildcard.
+ */
+import { SignJWT } from 'jose'
+import { requireAuth, requireRoles, requireTenant } from '../src/middleware'
+import { createVerifier } from '../src/verifyToken'
+import type { Identity } from '../src/types'
+
+const SECRET = 'test-secret-not-for-prod'
+const verifier = createVerifier({ mode: 'legacy-hs256', secret: SECRET })
+
+async function token(claims: Record<string, unknown>): Promise<string> {
+  return new SignJWT(claims)
+    .setProtectedHeader({ alg: 'HS256' })
+    .setIssuedAt()
+    .setExpirationTime('1h')
+    .sign(new TextEncoder().encode(SECRET))
+}
+
+/** Minimal express-ish req/res doubles. */
+function mkReq(headers: Record<string, string> = {}, identity?: Identity) {
+  return { headers, identity } as any
+}
+function mkRes() {
+  const res: any = {}
+  res.status = jest.fn().mockReturnValue(res)
+  res.json = jest.fn().mockReturnValue(res)
+  return res
+}
+/** Run a middleware and resolve once next() or res.json() has fired. */
+function run(mw: any, req: any, res: any): Promise<{ nexted: boolean }> {
+  return new Promise(resolve => {
+    let done = false
+    const finish = (nexted: boolean) => {
+      if (!done) { done = true; resolve({ nexted }) }
+    }
+    res.json = jest.fn(() => { finish(false); return res })
+    mw(req, res, () => finish(true))
+  })
+}
+
+describe('requireAuth', () => {
+  it('rejects a request with NO token (401 NO_TOKEN) and does not call next()', async () => {
+    const res = mkRes()
+    const { nexted } = await run(requireAuth({ verifier }), mkReq(), res)
+    expect(nexted).toBe(false)
+    expect(res.status).toHaveBeenCalledWith(401)
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ code: 'NO_TOKEN' }),
+    )
+  })
+
+  it('attaches the Identity and calls next() on a valid token', async () => {
+    const req = mkReq({ authorization: `Bearer ${await token({ userId: 'u-1' })}` })
+    const res = mkRes()
+    const { nexted } = await run(requireAuth({ verifier }), req, res)
+    expect(nexted).toBe(true)
+    expect(req.identity.userId).toBe('u-1')
+    expect(res.status).not.toHaveBeenCalled()
+  })
+
+  it('accepts the Bearer scheme case-insensitively (RFC 6750)', async () => {
+    const req = mkReq({ authorization: `bEaReR ${await token({ userId: 'u-1' })}` })
+    const { nexted } = await run(requireAuth({ verifier }), req, mkRes())
+    expect(nexted).toBe(true)
+  })
+
+  it('rejects a malformed Authorization header', async () => {
+    const res = mkRes()
+    const { nexted } = await run(requireAuth({ verifier }), mkReq({ authorization: 'Basic abc' }), res)
+    expect(nexted).toBe(false)
+    expect(res.status).toHaveBeenCalledWith(401)
+  })
+
+  it('rejects a forged token (401 INVALID_SIGNATURE) — never next()', async () => {
+    const forged = await new SignJWT({ userId: 'x' })
+      .setProtectedHeader({ alg: 'HS256' })
+      .setExpirationTime('1h')
+      .sign(new TextEncoder().encode('wrong-secret'))
+    const res = mkRes()
+    const { nexted } = await run(requireAuth({ verifier }), mkReq({ authorization: `Bearer ${forged}` }), res)
+    expect(nexted).toBe(false)
+    expect(res.status).toHaveBeenCalledWith(401)
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ code: 'INVALID_SIGNATURE' }))
+  })
+
+  it('optional:true continues WITHOUT an identity instead of half-authenticating', async () => {
+    const req = mkReq()
+    const { nexted } = await run(requireAuth({ verifier, optional: true }), req, mkRes())
+    expect(nexted).toBe(true)
+    expect(req.identity).toBeUndefined()
+  })
+
+  it('optional:true still refuses to attach an identity for a FORGED token', async () => {
+    const forged = await new SignJWT({ userId: 'x' })
+      .setProtectedHeader({ alg: 'HS256' })
+      .setExpirationTime('1h')
+      .sign(new TextEncoder().encode('wrong-secret'))
+    const req = mkReq({ authorization: `Bearer ${forged}` })
+    const { nexted } = await run(requireAuth({ verifier, optional: true }), req, mkRes())
+    expect(nexted).toBe(true)
+    expect(req.identity).toBeUndefined()
+  })
+
+  it('throws at wiring time without a verifier (not on first request)', () => {
+    expect(() => requireAuth({} as any)).toThrow()
+  })
+})
+
+const ident = (over: Partial<Identity> = {}): Identity => ({
+  userId: 'u-1',
+  tenantId: 'org-1',
+  roles: ['reader'],
+  authMode: 'legacy-hs256',
+  ...over,
+})
+
+describe('requireRoles', () => {
+  it('allows when all required roles are held', async () => {
+    const { nexted } = await run(requireRoles(['reader']), mkReq({}, ident()), mkRes())
+    expect(nexted).toBe(true)
+  })
+
+  it('denies with 403 (not 401) when a role is missing', async () => {
+    const res = mkRes()
+    const { nexted } = await run(requireRoles(['admin']), mkReq({}, ident()), res)
+    expect(nexted).toBe(false)
+    expect(res.status).toHaveBeenCalledWith(403)
+  })
+
+  it("mode:'any' allows when one of several roles is held", async () => {
+    const { nexted } = await run(requireRoles(['admin', 'reader'], 'any'), mkReq({}, ident()), mkRes())
+    expect(nexted).toBe(true)
+  })
+
+  it('denies when roles are empty — an unhydrated legacy identity gets no role-gated access', async () => {
+    const res = mkRes()
+    const { nexted } = await run(requireRoles(['reader']), mkReq({}, ident({ roles: [] })), res)
+    expect(nexted).toBe(false)
+    expect(res.status).toHaveBeenCalledWith(403)
+  })
+
+  it('denies (401) when mounted without requireAuth — a wiring bug must not open the route', async () => {
+    const res = mkRes()
+    const { nexted } = await run(requireRoles(['reader']), mkReq(), res)
+    expect(nexted).toBe(false)
+    expect(res.status).toHaveBeenCalledWith(401)
+  })
+})
+
+describe('requireTenant', () => {
+  it('allows a matching tenant', async () => {
+    const { nexted } = await run(requireTenant('org-1'), mkReq({}, ident()), mkRes())
+    expect(nexted).toBe(true)
+  })
+
+  it('denies a different tenant', async () => {
+    const res = mkRes()
+    const { nexted } = await run(requireTenant('org-2'), mkReq({}, ident()), res)
+    expect(nexted).toBe(false)
+    expect(res.status).toHaveBeenCalledWith(403)
+  })
+
+  it('treats an UNRESOLVED tenant (null) as a denial, never a wildcard', async () => {
+    // The dangerous reading: null == "no scope restriction" would hand every
+    // tenant's data to any valid legacy token that lacks a resolver.
+    const res = mkRes()
+    const { nexted } = await run(requireTenant('org-1'), mkReq({}, ident({ tenantId: null })), res)
+    expect(nexted).toBe(false)
+    expect(res.status).toHaveBeenCalledWith(403)
+  })
+})

--- a/packages/auth/tests/tsconfig.json
+++ b/packages/auth/tests/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  // The package tsconfig pins `types: ["node"]` and includes only src/, which is
+  // right for the published build (no jest globals leak into the .d.ts) but left
+  // tests uncompilable. ts-jest uses THIS config instead.
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "types": ["node", "jest"],
+    "noEmit": true
+  },
+  "include": ["../src/**/*.ts", "./**/*.ts"]
+}

--- a/packages/auth/tests/verifier.test.ts
+++ b/packages/auth/tests/verifier.test.ts
@@ -1,0 +1,223 @@
+/**
+ * @fuzefront/auth — verifier runtime tests (#117).
+ *
+ * Bias: these test the DENIAL paths hardest. This package is the gate consuming
+ * services mount, so a false "allow" is a family-wide breach, while a false
+ * "deny" is merely an outage. The happy path gets one test; the ways it must
+ * refuse get the rest.
+ */
+import { SignJWT, generateKeyPair, exportJWK, type KeyLike } from 'jose'
+import { createVerifier, verifyToken } from '../src/verifyToken'
+import { AuthError } from '../src/types'
+
+const SECRET = 'test-secret-not-for-prod'
+const key = () => new TextEncoder().encode(SECRET)
+
+async function hs256(claims: Record<string, unknown>, exp = '1h'): Promise<string> {
+  return new SignJWT(claims)
+    .setProtectedHeader({ alg: 'HS256' })
+    .setIssuedAt()
+    .setExpirationTime(exp)
+    .sign(key())
+}
+
+/** Assert the promise rejects with AuthError carrying `code`. */
+async function expectCode(p: Promise<unknown>, code: string) {
+  await expect(p).rejects.toBeInstanceOf(AuthError)
+  await p.catch((e: AuthError) => expect(e.code).toBe(code))
+}
+
+describe('legacy-hs256', () => {
+  const verifier = createVerifier({ mode: 'legacy-hs256', secret: SECRET })
+
+  it('verifies a valid token and normalizes the Identity', async () => {
+    const token = await hs256({ userId: 'u-1', email: 'a@b.dev' })
+    const id = await verifier.verify(token)
+    expect(id.userId).toBe('u-1')
+    expect(id.email).toBe('a@b.dev')
+    expect(id.authMode).toBe('legacy-hs256')
+    // No resolver => deliberately unprivileged, NOT a guess.
+    expect(id.tenantId).toBeNull()
+    expect(id.roles).toEqual([])
+  })
+
+  it('rejects a token signed with the wrong secret', async () => {
+    const forged = await new SignJWT({ userId: 'u-1' })
+      .setProtectedHeader({ alg: 'HS256' })
+      .setExpirationTime('1h')
+      .sign(new TextEncoder().encode('a-different-secret'))
+    await expectCode(verifier.verify(forged), 'INVALID_SIGNATURE')
+  })
+
+  it('rejects an expired token', async () => {
+    const token = await new SignJWT({ userId: 'u-1' })
+      .setProtectedHeader({ alg: 'HS256' })
+      .setExpirationTime(Math.floor(Date.now() / 1000) - 60)
+      .sign(key())
+    await expectCode(verifier.verify(token), 'EXPIRED')
+  })
+
+  it('rejects ALGORITHM CONFUSION — an RS256-signed token must not pass an HS256 verifier', async () => {
+    // The attack this guards: if `algorithms` were unpinned, a token could name
+    // an algorithm the verifier did not intend and bypass the shared secret.
+    const { privateKey } = await generateKeyPair('RS256')
+    const token = await new SignJWT({ userId: 'attacker' })
+      .setProtectedHeader({ alg: 'RS256' })
+      .setExpirationTime('1h')
+      .sign(privateKey)
+    await expect(verifier.verify(token)).rejects.toBeInstanceOf(AuthError)
+  })
+
+  it('rejects a token with no subject claim', async () => {
+    const token = await hs256({ notASubject: 'x' })
+    await expectCode(verifier.verify(token), 'MISSING_CLAIM')
+  })
+
+  it('rejects garbage', async () => {
+    await expectCode(verifier.verify('not-a-jwt'), 'MALFORMED')
+  })
+
+  it('rejects an empty token', async () => {
+    await expectCode(verifier.verify(''), 'NO_TOKEN')
+  })
+
+  it('hydrates tenantId/roles via the out-of-band resolver', async () => {
+    const v = createVerifier({
+      mode: 'legacy-hs256',
+      secret: SECRET,
+      resolver: {
+        resolve: async (userId: string) => {
+          expect(userId).toBe('u-1')
+          return { tenantId: 'org-9', roles: ['admin'], email: 'r@b.dev' }
+        },
+      },
+    })
+    const id = await v.verify(await hs256({ userId: 'u-1' }))
+    expect(id.tenantId).toBe('org-9')
+    expect(id.roles).toEqual(['admin'])
+    expect(id.email).toBe('r@b.dev')
+  })
+
+  it('DENIES when the resolver fails rather than returning an unprivileged identity', async () => {
+    // A resolver outage returning roles:[] would be indistinguishable from a real
+    // permission denial — masking an outage as an authz decision. It must throw.
+    const v = createVerifier({
+      mode: 'legacy-hs256',
+      secret: SECRET,
+      resolver: { resolve: async () => { throw new Error('db down') } },
+    })
+    await expectCode(v.verify(await hs256({ userId: 'u-1' })), 'VERIFIER_UNAVAILABLE')
+  })
+
+  it('refuses to construct without a secret', () => {
+    expect(() => createVerifier({ mode: 'legacy-hs256', secret: '' })).toThrow(AuthError)
+  })
+
+  it('verifyToken() delegates to the verifier', async () => {
+    const id = await verifyToken(await hs256({ userId: 'u-2' }), verifier)
+    expect(id.userId).toBe('u-2')
+  })
+})
+
+describe('federated-jwks', () => {
+  // jose's createRemoteJWKSet does its own fetching, so stubbing global.fetch
+  // does not intercept it. Serve a real JWKS over loopback instead — it also
+  // exercises the discovery path for real rather than around it.
+  let server: import('http').Server
+  let base: string
+  let privateKey: KeyLike
+
+  beforeAll(async () => {
+    const { createServer } = await import('http')
+    const kp = await generateKeyPair('RS256')
+    privateKey = kp.privateKey as KeyLike
+    const jwk = await exportJWK(kp.publicKey)
+    jwk.kid = 'test-key'
+    jwk.alg = 'RS256'
+    jwk.use = 'sig'
+
+    server = createServer((req, res) => {
+      res.setHeader('content-type', 'application/json')
+      if (req.url?.includes('.well-known/openid-configuration')) {
+        res.end(JSON.stringify({ jwks_uri: `${base}/jwks` }))
+        return
+      }
+      if (req.url?.includes('/jwks')) {
+        res.end(JSON.stringify({ keys: [jwk] }))
+        return
+      }
+      res.statusCode = 404
+      res.end('{}')
+    })
+    await new Promise<void>(r => server.listen(0, '127.0.0.1', r))
+    const addr = server.address() as import('net').AddressInfo
+    base = `http://127.0.0.1:${addr.port}`
+  })
+
+  afterAll(async () => {
+    await new Promise<void>(r => server.close(() => r()))
+  })
+
+  it('refuses to construct without an issuer', () => {
+    expect(() => createVerifier({ mode: 'federated-jwks', issuer: '' })).toThrow(AuthError)
+  })
+
+  it('verifies an RS256 token via OIDC discovery and maps tenant/roles claims', async () => {
+    const v = createVerifier({
+      mode: 'federated-jwks',
+      // jwksUri omitted on purpose: this proves discovery resolves it.
+      issuer: base,
+      audience: 'fuzefront',
+      tenantClaim: 'org',
+      rolesClaim: 'perms',
+    })
+
+    const token = await new SignJWT({ org: 'org-1', perms: ['reader'] })
+      .setProtectedHeader({ alg: 'RS256', kid: 'test-key' })
+      .setSubject('u-fed')
+      .setIssuer(base)
+      .setAudience('fuzefront')
+      .setExpirationTime('1h')
+      .sign(privateKey)
+
+    const id = await v.verify(token)
+    expect(id.userId).toBe('u-fed')
+    expect(id.tenantId).toBe('org-1')
+    expect(id.roles).toEqual(['reader'])
+    expect(id.authMode).toBe('federated-jwks')
+  })
+
+  it('rejects a token from the WRONG issuer', async () => {
+    const v = createVerifier({
+      mode: 'federated-jwks',
+      issuer: `${base}/expected`,
+      jwksUri: `${base}/jwks`,
+    })
+    const token = await new SignJWT({})
+      .setProtectedHeader({ alg: 'RS256', kid: 'test-key' })
+      .setSubject('u')
+      .setIssuer('https://evil.test/other')
+      .setExpirationTime('1h')
+      .sign(privateKey)
+
+    await expectCode(v.verify(token), 'INVALID_ISSUER')
+  })
+
+  it('rejects a token whose audience does not match', async () => {
+    const v = createVerifier({
+      mode: 'federated-jwks',
+      issuer: `${base}/aud-test`,
+      jwksUri: `${base}/jwks`,
+      audience: 'fuzefront',
+    })
+    const token = await new SignJWT({})
+      .setProtectedHeader({ alg: 'RS256', kid: 'test-key' })
+      .setSubject('u')
+      .setIssuer(`${base}/aud-test`)
+      .setAudience('some-other-app')
+      .setExpirationTime('1h')
+      .sign(privateKey)
+
+    await expectCode(v.verify(token), 'INVALID_AUDIENCE')
+  })
+})


### PR DESCRIPTION
Fixes #117. **`@fuzefront/auth` was a stub.** Every entry point threw `VERIFIER_UNAVAILABLE`; the authz guard literally responded:

> *"@fuzefront/auth is contract-frozen; authz guard runtime not yet implemented"*

So the package consuming services are **told to install** gave them no way to verify a FuzeFront token or check a permission. Cross-service AuthN/AuthZ was a contract, not a capability. This makes it real — **installable as middleware**.

**Public signatures are unchanged** from the v0.1.0 freeze: code written against the frozen types keeps compiling, it now also *runs*.

## Install & use

```ts
import { createVerifier, requireAuth, requireRoles } from '@fuzefront/auth'

const verifier = createVerifier({
  mode: 'legacy-hs256',
  secret: process.env.JWT_SECRET!,
  resolver: { async resolve(userId) { /* hydrate tenantId/roles */ } },
})

app.use('/api/private', requireAuth({ verifier }))         // 401 if not authenticated
app.get('/api/private/admin', requireRoles(['admin']), h)  // 403 if not permitted
app.get('/api/private/me', (req, res) => res.json(req.identity))
```

Migrating to federated JWKS later is a **config change, not a code change** — swap `mode` to `federated-jwks` with an `issuer`.

## Runtime
One dependency — **`jose`** covers HS256 today *and* RS256/JWKS for the target, so consumers don't pull two crypto libs.
- **`legacy-hs256`** — today's session token; optional `OutOfBandResolver` hydrates the `tenantId`/`roles` the token doesn't carry.
- **`federated-jwks`** — RS256/ES256 against the issuer's JWKS with `iss`/`aud` validation, OIDC discovery when `jwksUri` is omitted, JWKS cached per issuer.
- **`requireAuth` / `requireRoles` / `requireTenant`** — real Express middleware.

## Security properties — deliberate, not incidental
- **Algorithms are PINNED per mode.** Unpinned `algorithms` is exactly what enables `alg: none` and RS256-public-key-abused-as-HMAC-secret confusion. Tested.
- **`tenantId: null` means UNRESOLVED, never a wildcard.** `requireTenant` denies. Treating null as "any tenant" would hand **every tenant's data** to any valid legacy token lacking a resolver.
- **A resolver failure DENIES** rather than returning empty roles — otherwise an outage is indistinguishable from a genuine permission decision, and gets misread as one.
- **`requireAuth` never calls `next()` on an unauthenticated request**; the promise is driven explicitly so a rejection denies rather than hanging the request.
- **401 (authn) vs 403 (authz) kept distinct** so clients aren't sent into login loops over a permission problem.
- **Still never mints tokens.** In `federated-jwks` mode a consumer holds no signing key at all — it can verify without gaining the power to forge.

## Tests — 31, weighted toward the denial paths
A false *allow* here is a family-wide breach; a false *deny* is an outage. So the happy path gets one test and the refusals get the rest: algorithm confusion, forged signature, expiry, wrong issuer, wrong audience, missing subject, resolver failure, unresolved tenant, and a guard mounted without `requireAuth`.

The package had **no test config at all** — its tsconfig is build-shaped (`types: ["node"]`, `include: src` only), so `tests/tsconfig.json` + `jest.config.js` were prerequisites before a single test could run. The federated tests serve a **real JWKS over loopback** rather than stubbing `fetch`, because `createRemoteJWKSet` does its own fetching — that also exercises discovery for real.

## Verified (clean `node:20` container, actually run)
```
tsc --noEmit  → exit 0
jest          → Test Suites: 2 passed | Tests: 31 passed, 31 total
```
The type-checker caught a real gap mid-work: `Identity` requires `authMode`, which I'd missed — now populated per verifier, along with `issuedAt`/`claims`.

`hold` — master is deploy-on-push.

Co-Authored-By: Claude