### PR TITLE
feat(security): password reset flow (request/confirm + session revocation)

### DIFF
--- a/backend/security/src/migrations/013_create_password_resets.ts
+++ b/backend/security/src/migrations/013_create_password_resets.ts
@@ -1,0 +1,45 @@
+import { Knex } from 'knex'
+
+/**
+ * Migration 013 — self-service password-reset tokens.
+ *
+ * Backs `POST /api/v1/security/session/password/reset-request` and
+ * `/session/password/reset-confirm`. Provider-neutral: the row records only the
+ * local user projection + the reset challenge; the credential itself lives in
+ * the identity store, never here (no local password column, by design).
+ *
+ * Only the SHA-256 hex of the single-use token is stored — the raw token exists
+ * solely in the dispatched message, so a DB read cannot reset an account.
+ *
+ * Idempotent (hasTable guard) so it runs alongside the existing 001-012 chain
+ * against the shared knex_migrations table.
+ */
+export async function up(knex: Knex): Promise<void> {
+  if (!(await knex.schema.hasTable('password_resets'))) {
+    await knex.schema.createTable('password_resets', table => {
+      table.uuid('id').primary().defaultTo(knex.raw('gen_random_uuid()'))
+      table
+        .uuid('user_id')
+        .notNullable()
+        .references('id')
+        .inTable('users')
+        .onDelete('CASCADE')
+      // The address the reset was dispatched to (audit; may differ from a later
+      // change of the user's primary email).
+      table.string('email', 255).notNullable()
+      // SHA-256 hex of the single-use reset token. Never the raw token.
+      table.string('token_hash', 64).notNullable()
+      table.timestamp('expires_at').notNullable()
+      table.boolean('consumed').notNullable().defaultTo(false)
+      table.timestamp('created_at').defaultTo(knex.fn.now())
+      // Lookup is always by token_hash; unique so a hash collision/replay cannot
+      // yield two live challenges.
+      table.unique(['token_hash'])
+      table.index(['user_id'])
+    })
+  }
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.dropTableIfExists('password_resets')
+}

--- a/backend/security/src/providers/IdentityProvider.ts
+++ b/backend/security/src/providers/IdentityProvider.ts
@@ -259,6 +259,23 @@ export interface IdentityProvider {
   /** Verify a login-step-up challenge; on success returns an authenticated session. */
   verifyMfa(challengeId: string, factorId: string, code: string): Promise<BrokeredSession>;
 
+  // ── Self-service password reset ──
+
+  /**
+   * Begin a self-service password reset for `email`. NEVER reveals whether the
+   * address maps to an account — resolves silently and always fulfils, so the
+   * caller can answer an unconditional 202 (no user enumeration).
+   */
+  requestPasswordReset(email: string): Promise<void>;
+
+  /**
+   * Complete a password reset with the single-use token from the dispatched
+   * message. Sets the credential in the identity store and revokes every
+   * existing session for the account. Fail-closed on an unknown/expired/consumed
+   * token.
+   */
+  confirmPasswordReset(token: string, newPassword: string): Promise<void>;
+
   // ── Contact-ownership verification (distinct from MFA login step-up) ──
 
   /** Send an email verification link/code (current user, or a signup-scoped address). */

--- a/backend/security/src/providers/authentik/AuthentikIdentityProvider.ts
+++ b/backend/security/src/providers/authentik/AuthentikIdentityProvider.ts
@@ -24,7 +24,11 @@ import { db as defaultDb } from '../../config/database'
 import { oidcService as defaultOidc } from '../../services/oidc'
 import { authentikPasswordLogin as defaultPasswordLogin } from '../../services/authentikPassword'
 import { runInternalProvision } from '../../services/organizationProvisioning'
-import { authentikSignup as defaultSignup, EnrollmentConflictError } from '../../services/authentikPassword'
+import {
+  authentikSignup as defaultSignup,
+  EnrollmentConflictError,
+  authentikSetPassword as defaultSetPassword,
+} from '../../services/authentikPassword'
 import { putBrokerCode, takeBrokerCode } from '../../services/brokerCodes'
 import type {
   IdentityProvider,
@@ -109,6 +113,19 @@ interface MfaChallenge {
 
 const CHALLENGE_TTL_MS = 5 * 60_000
 const EMAIL_VERIFY_TTL_MS = 30 * 60_000
+/** Reset tokens are short-lived — they are a credential-change capability. */
+const PASSWORD_RESET_TTL_MS = 30 * 60_000
+
+/**
+ * Password reset needs only a deliverable email channel — unlike registration
+ * verification it has no release flag, because a reset is always user-initiated
+ * and never blocks signup. With no `EMAIL_SERVICE_URL` we GRACEFULLY DEGRADE:
+ * mint nothing, log, and still resolve, so the route's unconditional 202 holds
+ * and no user is stranded on an undeliverable token.
+ */
+function passwordResetEnabled(): boolean {
+  return !!(process.env.EMAIL_SERVICE_URL && process.env.EMAIL_SERVICE_URL.trim())
+}
 
 /**
  * Registration-time email verification is a two-condition gate, kept a release
@@ -138,6 +155,8 @@ export interface AuthentikProviderDeps {
   signupFn: (input: SignupInput) => Promise<BrokeredUser>
   notifications: NotificationClient
   now: () => number
+  /** Sets the credential in the identity store (never a local hash). */
+  setPasswordFn: (email: string, newPassword: string) => Promise<void>
   /** Injected M2M provisioning (defaults to the absorbed machine-identity module). */
   provisionM2M?: (name: string, scopes: string[]) => Promise<M2MClient>
   issueM2M?: (input: M2MTokenInput) => Promise<M2MToken>
@@ -163,6 +182,7 @@ export class AuthentikIdentityProvider implements IdentityProvider {
   private signupFn: (input: SignupInput) => Promise<BrokeredUser>
   private notifications: NotificationClient
   private now: () => number
+  private setPasswordFn: (email: string, newPassword: string) => Promise<void>
   private provisionM2MFn?: (name: string, scopes: string[]) => Promise<M2MClient>
   private issueM2MFn?: (input: M2MTokenInput) => Promise<M2MToken>
   private introspectM2MFn?: (token: string) => Promise<TokenIntrospection>
@@ -192,6 +212,7 @@ export class AuthentikIdentityProvider implements IdentityProvider {
       })
     this.notifications = deps.notifications ?? new HttpNotificationClient()
     this.now = deps.now ?? (() => Date.now())
+    this.setPasswordFn = deps.setPasswordFn ?? defaultSetPassword
     this.provisionM2MFn = deps.provisionM2M
     this.issueM2MFn = deps.issueM2M
     this.introspectM2MFn = deps.introspectM2M
@@ -659,6 +680,108 @@ export class AuthentikIdentityProvider implements IdentityProvider {
     this.mfaChallenges.delete(challengeId)
     const user = await this.loadUser(ch.userId)
     return this.mintSession(user)
+  }
+
+  // ── Self-service password reset ───────────────────────────────────────────
+  /**
+   * Begin a reset. Unconditionally resolves — an unknown address, a disabled
+   * email channel, and a real dispatch are INDISTINGUISHABLE to the caller, so
+   * the route's 202 leaks nothing about account existence.
+   */
+  async requestPasswordReset(email: string): Promise<void> {
+    if (!email || typeof email !== 'string') {
+      throw new InvalidInputError('email is required')
+    }
+
+    // Degrade mode: no email channel wired — a reset token would be
+    // undeliverable, so mint nothing and log. Still resolves (no enumeration).
+    if (!passwordResetEnabled()) {
+      console.warn(
+        `[security] password reset requested for ${maskContact(email)} but no email ` +
+          'channel is configured — nothing dispatched. Set EMAIL_SERVICE_URL to enable.'
+      )
+      return
+    }
+
+    const user = await this.db('users').whereRaw('LOWER(email) = ?', [email.toLowerCase()]).first()
+    if (!user) {
+      // Unknown address: do the same nothing, tell the caller the same nothing.
+      console.warn(
+        `[security] password reset requested for unknown address ${maskContact(email)} — no-op.`
+      )
+      return
+    }
+
+    // Invalidate any outstanding challenge for this user, so a reset request
+    // supersedes its predecessors rather than leaving several live tokens.
+    await this.db('password_resets')
+      .where({ user_id: user.id, consumed: false })
+      .update({ consumed: true })
+
+    const resetToken = crypto.randomBytes(32).toString('hex')
+    await this.db('password_resets').insert({
+      id: uuidv4(),
+      user_id: user.id,
+      email: user.email,
+      token_hash: sha256(resetToken),
+      expires_at: new Date(this.now() + PASSWORD_RESET_TTL_MS),
+      consumed: false,
+    })
+
+    try {
+      await this.notifications.sendPasswordReset(user.email, resetToken)
+    } catch (err) {
+      // Dispatch failure must not become an enumeration oracle (a 5xx for real
+      // accounts only). Burn the token and resolve; the user can retry.
+      await this.db('password_resets')
+        .where({ token_hash: sha256(resetToken) })
+        .update({ consumed: true })
+      console.error(
+        `[security] password reset dispatch failed for ${maskContact(user.email)}:`,
+        err
+      )
+    }
+  }
+
+  /**
+   * Complete a reset: validate the single-use token, set the credential in the
+   * identity store, consume the token, then REVOKE EVERY SESSION for the account
+   * — a password reset must not leave a pre-reset session alive (that is the
+   * whole point when the reset follows a compromise).
+   */
+  async confirmPasswordReset(token: string, newPassword: string): Promise<void> {
+    if (!token || typeof token !== 'string') {
+      throw new InvalidInputError('token is required')
+    }
+    if (!newPassword || typeof newPassword !== 'string') {
+      throw new InvalidInputError('newPassword is required')
+    }
+
+    const row = await this.db('password_resets')
+      .where({ token_hash: sha256(token), consumed: false })
+      .first()
+    // Unknown, already-consumed, and expired all fail identically.
+    if (!row || new Date(row.expires_at).getTime() < this.now()) {
+      throw new InvalidInputError('invalid or expired reset token')
+    }
+
+    const user = await this.db('users').where({ id: row.user_id }).first()
+    if (!user) throw new InvalidInputError('invalid or expired reset token')
+
+    // Set the credential in the identity store FIRST. If this throws (policy
+    // rejection / store unavailable) the token stays live so a valid retry with
+    // a compliant password still works.
+    await this.setPasswordFn(user.email, newPassword)
+
+    await this.db('password_resets').where({ id: row.id }).update({ consumed: true })
+
+    // Revoke all sessions. `authenticateToken` enforces the sessions table, so
+    // deleting these genuinely signs the account out everywhere.
+    const revoked = await this.db('sessions').where({ user_id: user.id }).del()
+    console.warn(
+      `[security] password reset completed for ${maskContact(user.email)}; ` +
+        `revoked ${revoked} session(s).`
+    )
   }
 
   // ── Contact-ownership verification ────────────────────────────────────────

--- a/backend/security/src/providers/authentik/notifications.ts
+++ b/backend/security/src/providers/authentik/notifications.ts
@@ -16,6 +16,8 @@ export interface NotificationClient {
   checkSmsOtp(phone: string, code: string): Promise<boolean>
   /** Send an email verification message (link or code) to an address. */
   sendEmailVerification(email: string, token: string, code: string): Promise<void>
+  /** Send a self-service password-reset message carrying the single-use token. */
+  sendPasswordReset(email: string, token: string): Promise<void>
 }
 
 function smsServiceBase(): string {
@@ -112,6 +114,23 @@ export class HttpNotificationClient implements NotificationClient {
         to: email,
         template: 'verify-email',
         data: { token, code },
+      },
+      emailServiceToken()
+    )
+    if (!res.ok) {
+      throw new Error(`email-service /send returned HTTP ${res.status}`)
+    }
+  }
+
+  async sendPasswordReset(email: string, token: string): Promise<void> {
+    // Same `email.requested` intent as verification, different template. The raw
+    // token leaves the service ONLY here — the DB holds just its SHA-256.
+    const res = await postJson(
+      `${emailServiceBase()}/send`,
+      {
+        to: email,
+        template: 'password-reset',
+        data: { token },
       },
       emailServiceToken()
     )

--- a/backend/security/src/routes/security.ts
+++ b/backend/security/src/routes/security.ts
@@ -146,6 +146,53 @@ router.post('/session/exchange', async (req: Request, res: Response) => {
   }
 })
 
+// ── Self-service password reset ────────────────────────────────────────────
+// POST /v1/security/session/password/reset-request — ALWAYS 202
+router.post('/session/password/reset-request', async (req: Request, res: Response) => {
+  try {
+    if (!req.body?.email || typeof req.body.email !== 'string') {
+      // Only a MALFORMED body earns a 400; a well-formed unknown address does
+      // not — that distinction is the whole no-enumeration guarantee.
+      res.status(400).json({ error: 'email is required', code: 'MALFORMED' })
+      return
+    }
+    await getIdentityProvider().requestPasswordReset(req.body.email)
+  } catch (err) {
+    // Never surface a provider failure here: a 5xx for real accounts and a 202
+    // for unknown ones would be an enumeration oracle. Log and answer 202.
+    console.error('[security] password reset request failed:', err)
+  }
+  res.status(202).end()
+})
+
+// POST /v1/security/session/password/reset-confirm
+router.post('/session/password/reset-confirm', async (req: Request, res: Response) => {
+  try {
+    if (!req.body?.token || typeof req.body.token !== 'string') {
+      throw new InvalidInputError('token is required')
+    }
+    if (!req.body?.newPassword || typeof req.body.newPassword !== 'string') {
+      throw new InvalidInputError('newPassword is required')
+    }
+    await getIdentityProvider().confirmPasswordReset(req.body.token, req.body.newPassword)
+    res.status(200).json({ reset: true })
+  } catch (err) {
+    // Per contract this surface is 400-or-200: an invalid/expired/consumed token
+    // and a policy-rejected password are all fail-closed 400s.
+    const name = (err as Error)?.name
+    if (name === 'PasswordPolicyError') {
+      res.status(400).json({ error: (err as Error).message, code: 'MALFORMED' })
+      return
+    }
+    if (err instanceof InvalidInputError) {
+      res.status(400).json({ error: err.message, code: 'MALFORMED' })
+      return
+    }
+    console.error('[security] password reset confirm failed:', err)
+    res.status(400).json({ error: 'Password reset failed', code: 'MALFORMED' })
+  }
+})
+
 // ── Social login (server-brokered) ─────────────────────────────────────────
 // GET /v1/security/social/{provider}/start — 302 to the provider via same-host IdP path
 router.get('/social/:provider/start', async (req: Request, res: Response) => {

--- a/backend/security/src/services/authentikPassword.ts
+++ b/backend/security/src/services/authentikPassword.ts
@@ -454,3 +454,107 @@ export async function authentikSignup(input: AuthentikSignupInput): Promise<User
   // Enrollment auto-logged-in → complete OIDC + sync via the shared path.
   return completeOidcWithSession(base, jar)
 }
+
+/** Thrown when the identity store has no account for the address. */
+export class AuthentikUserNotFoundError extends Error {
+  constructor(message = 'No identity-store account for that address') {
+    super(message)
+    this.name = 'AuthentikUserNotFoundError'
+  }
+}
+
+/** Thrown when the new password is rejected by the identity store's policy. */
+export class PasswordPolicyError extends Error {
+  constructor(message = 'Password does not meet the password policy') {
+    super(message)
+    this.name = 'PasswordPolicyError'
+  }
+}
+
+function authentikAdminToken(): string {
+  const token = process.env.AUTHENTIK_ADMIN_TOKEN
+  if (!token) {
+    throw new AuthentikUnavailableError(
+      'AUTHENTIK_ADMIN_TOKEN is required to set an account password'
+    )
+  }
+  return token
+}
+
+/**
+ * Set an account's password IN THE IDENTITY STORE (Authentik) via the Admin API.
+ *
+ * Authentik is the sole credential store — FuzeFront never writes a local
+ * password hash, so a reset MUST land here or it has not happened. Resolves the
+ * account by email (`GET /api/v3/core/users/?email=`) then drives
+ * `POST /api/v3/core/users/{pk}/set_password/`.
+ *
+ * Fail-closed: an unresolvable account, a policy rejection, or any transport
+ * error throws — a caller never treats a non-2xx as "reset".
+ */
+export async function authentikSetPassword(
+  email: string,
+  newPassword: string
+): Promise<void> {
+  if (!email || !newPassword) {
+    throw new InvalidCredentialsError('email and newPassword are required')
+  }
+  const base = authentikBaseUrl()
+  const headers = {
+    Authorization: `Bearer ${authentikAdminToken()}`,
+    'Content-Type': 'application/json',
+    Accept: 'application/json',
+  }
+
+  let lookup: Response
+  try {
+    lookup = await fetch(
+      `${base}/api/v3/core/users/?email=${encodeURIComponent(email)}`,
+      { headers }
+    )
+  } catch (err) {
+    throw new AuthentikUnavailableError(
+      `identity-store lookup failed: ${(err as Error).message}`
+    )
+  }
+  if (!lookup.ok) {
+    throw new AuthentikUnavailableError(
+      `identity-store user lookup returned HTTP ${lookup.status}`
+    )
+  }
+  const body = (await lookup.json().catch(() => ({}))) as {
+    results?: Array<{ pk: number | string; email?: string }>
+  }
+  // Match the address exactly (case-insensitively): the query is a filter, not
+  // an exact-match guarantee, and resetting the WRONG account is unacceptable.
+  const match = (body.results || []).find(
+    u => (u.email || '').toLowerCase() === email.toLowerCase()
+  )
+  if (!match) throw new AuthentikUserNotFoundError()
+
+  let res: Response
+  try {
+    res = await fetch(`${base}/api/v3/core/users/${match.pk}/set_password/`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ password: newPassword }),
+    })
+  } catch (err) {
+    throw new AuthentikUnavailableError(
+      `identity-store set_password failed: ${(err as Error).message}`
+    )
+  }
+  // 400 is the password-policy rejection; surface it distinctly so the API can
+  // answer 400 rather than a generic failure.
+  if (res.status === 400) {
+    const text = await res.text().catch(() => '')
+    throw new PasswordPolicyError(
+      text ? `Password rejected by policy: ${text}` : undefined
+    )
+  }
+  if (!res.ok) {
+    throw new AuthentikUnavailableError(
+      `identity-store set_password returned HTTP ${res.status}`
+    )
+  }
+}

--- a/backend/security/tests/authentik-provider.test.ts
+++ b/backend/security/tests/authentik-provider.test.ts
@@ -79,6 +79,7 @@ const notifications: NotificationClient = {
   sendSmsOtp: jest.fn().mockResolvedValue(undefined),
   checkSmsOtp: jest.fn().mockResolvedValue(true),
   sendEmailVerification: jest.fn().mockResolvedValue(undefined),
+  sendPasswordReset: jest.fn().mockResolvedValue(undefined),
 }
 
 jest.mock('../src/services/organizationProvisioning', () => ({

--- a/backend/security/tests/password-reset.test.ts
+++ b/backend/security/tests/password-reset.test.ts
@@ -1,0 +1,408 @@
+/**
+ * Unit tests for the self-service password-reset flow.
+ *
+ * Covers the provider logic (token minting/validation, identity-store password
+ * set, session revocation) and the route contract (unconditional 202, no user
+ * enumeration). Uses the same in-memory knex-like fake + injected deps as the
+ * sibling provider tests — no network, no DB.
+ *
+ * The security-critical invariants asserted here:
+ *   - an unknown email is INDISTINGUISHABLE from a known one (always 202)
+ *   - only the SHA-256 of the token is ever persisted
+ *   - expired / consumed / wrong tokens all fail closed
+ *   - a completed reset revokes EVERY existing session for the account
+ *   - the credential is set in the identity store, never stored locally
+ */
+import crypto from 'crypto'
+import express from 'express'
+import request from 'supertest'
+import { AuthentikIdentityProvider } from '../src/providers/authentik/AuthentikIdentityProvider'
+import type { NotificationClient } from '../src/providers/authentik/notifications'
+
+process.env.JWT_SECRET = 'test-secret'
+// A deliverable email channel — the enabled path. The degrade path clears this.
+process.env.EMAIL_SERVICE_URL = 'http://email-service:3000'
+
+jest.mock('../src/services/organizationProvisioning', () => ({
+  runInternalProvision: jest.fn().mockResolvedValue(undefined),
+}))
+jest.mock('../src/services/eventPublisher', () => ({
+  defaultEventPublisher: { publishIdentityUserCreated: jest.fn().mockResolvedValue(undefined) },
+}))
+
+const sha256 = (v: string) => crypto.createHash('sha256').update(v).digest('hex')
+
+// ── Minimal in-memory knex-like fake (adds whereRaw for the email lookup) ────
+function matches(row: any, cond: any, val?: any): boolean {
+  if (typeof cond === 'string') return row[cond] === val
+  return Object.entries(cond).every(([k, v]) => row[k] === v)
+}
+function makeFakeDb() {
+  const tables: Record<string, any[]> = {
+    users: [],
+    sessions: [],
+    password_resets: [],
+    mfa_factors: [],
+  }
+  function qb(table: string) {
+    let filter = (_r: any) => true
+    const api: any = {
+      where(cond: any, val?: any) {
+        const prev = filter
+        filter = (r: any) => prev(r) && matches(r, cond, val)
+        return api
+      },
+      andWhere(cond: any, val?: any) {
+        return api.where(cond, val)
+      },
+      // Only the `LOWER(email) = ?` shape the provider issues is modelled.
+      whereRaw(_sql: string, bindings: any[]) {
+        const prev = filter
+        const want = String(bindings[0]).toLowerCase()
+        filter = (r: any) => prev(r) && String(r.email || '').toLowerCase() === want
+        return api
+      },
+      async first() {
+        return tables[table].find(filter)
+      },
+      select() {
+        return tables[table].filter(filter)
+      },
+      async insert(rows: any) {
+        const arr = Array.isArray(rows) ? rows : [rows]
+        tables[table].push(...arr.map(r => ({ ...r })))
+        return []
+      },
+      async update(patch: any) {
+        let n = 0
+        for (const r of tables[table]) if (filter(r)) { Object.assign(r, patch); n++ }
+        return n
+      },
+      async del() {
+        const before = tables[table].length
+        tables[table] = tables[table].filter(r => !filter(r))
+        return before - tables[table].length
+      },
+      then(resolve: any) {
+        return Promise.resolve(tables[table].filter(filter)).then(resolve)
+      },
+    }
+    return api
+  }
+  const db: any = (table: string) => qb(table)
+  db.__tables = tables
+  return db
+}
+
+function makeNotifications(): NotificationClient & { sendPasswordReset: jest.Mock } {
+  return {
+    sendSmsOtp: jest.fn().mockResolvedValue(undefined),
+    checkSmsOtp: jest.fn().mockResolvedValue(true),
+    sendEmailVerification: jest.fn().mockResolvedValue(undefined),
+    sendPasswordReset: jest.fn().mockResolvedValue(undefined),
+  } as any
+}
+
+function newProvider(db: any, overrides: any = {}) {
+  return new AuthentikIdentityProvider({
+    db,
+    notifications: overrides.notifications ?? makeNotifications(),
+    setPasswordFn: overrides.setPasswordFn ?? jest.fn().mockResolvedValue(undefined),
+    now: overrides.now ?? (() => Date.now()),
+    ...overrides,
+  })
+}
+
+function seedUser(db: any, email = 'user@example.com', id = 'u1') {
+  db.__tables.users.push({ id, email, first_name: 'A', last_name: 'B', roles: JSON.stringify(['user']) })
+  return id
+}
+
+/** The raw token as the user would receive it — captured from the dispatch. */
+function dispatchedToken(notifications: any): string {
+  expect(notifications.sendPasswordReset).toHaveBeenCalled()
+  return notifications.sendPasswordReset.mock.calls[0][1]
+}
+
+describe('requestPasswordReset', () => {
+  it('mints a hashed, expiring token and dispatches the raw one to the user', async () => {
+    const db = makeFakeDb()
+    seedUser(db)
+    const notifications = makeNotifications()
+    const provider = newProvider(db, { notifications })
+
+    await provider.requestPasswordReset('user@example.com')
+
+    const rows = db.__tables.password_resets
+    expect(rows).toHaveLength(1)
+    expect(rows[0].user_id).toBe('u1')
+    expect(rows[0].consumed).toBe(false)
+    expect(new Date(rows[0].expires_at).getTime()).toBeGreaterThan(Date.now())
+
+    // The RAW token must never be persisted — only its sha256.
+    const raw = dispatchedToken(notifications)
+    expect(rows[0].token_hash).toBe(sha256(raw))
+    expect(JSON.stringify(rows)).not.toContain(raw)
+  })
+
+  it('resolves silently for an unknown email and mints nothing (no enumeration)', async () => {
+    const db = makeFakeDb()
+    seedUser(db)
+    const notifications = makeNotifications()
+    const provider = newProvider(db, { notifications })
+
+    await expect(provider.requestPasswordReset('nobody@example.com')).resolves.toBeUndefined()
+
+    expect(db.__tables.password_resets).toHaveLength(0)
+    expect(notifications.sendPasswordReset).not.toHaveBeenCalled()
+  })
+
+  it('resolves email case-insensitively', async () => {
+    const db = makeFakeDb()
+    seedUser(db, 'User@Example.com')
+    const provider = newProvider(db)
+
+    await provider.requestPasswordReset('user@example.COM')
+
+    expect(db.__tables.password_resets).toHaveLength(1)
+  })
+
+  it('supersedes an outstanding challenge so only one token stays live', async () => {
+    const db = makeFakeDb()
+    seedUser(db)
+    const provider = newProvider(db)
+
+    await provider.requestPasswordReset('user@example.com')
+    await provider.requestPasswordReset('user@example.com')
+
+    const live = db.__tables.password_resets.filter((r: any) => !r.consumed)
+    expect(db.__tables.password_resets).toHaveLength(2)
+    expect(live).toHaveLength(1)
+  })
+
+  it('gracefully degrades (mints nothing, still resolves) when no email channel is wired', async () => {
+    const prev = process.env.EMAIL_SERVICE_URL
+    delete process.env.EMAIL_SERVICE_URL
+    try {
+      const db = makeFakeDb()
+      seedUser(db)
+      const notifications = makeNotifications()
+      const provider = newProvider(db, { notifications })
+
+      await expect(provider.requestPasswordReset('user@example.com')).resolves.toBeUndefined()
+
+      expect(db.__tables.password_resets).toHaveLength(0)
+      expect(notifications.sendPasswordReset).not.toHaveBeenCalled()
+    } finally {
+      process.env.EMAIL_SERVICE_URL = prev
+    }
+  })
+
+  it('burns the token and still resolves when dispatch fails (no enumeration oracle)', async () => {
+    const db = makeFakeDb()
+    seedUser(db)
+    const notifications = makeNotifications()
+    notifications.sendPasswordReset.mockRejectedValue(new Error('email-service down'))
+    const provider = newProvider(db, { notifications })
+
+    await expect(provider.requestPasswordReset('user@example.com')).resolves.toBeUndefined()
+
+    expect(db.__tables.password_resets.every((r: any) => r.consumed)).toBe(true)
+  })
+})
+
+describe('confirmPasswordReset', () => {
+  it('happy path: sets the password in the identity store, consumes the token, revokes sessions', async () => {
+    const db = makeFakeDb()
+    seedUser(db)
+    db.__tables.sessions.push(
+      { id: 's1', user_id: 'u1' },
+      { id: 's2', user_id: 'u1' },
+      { id: 'other', user_id: 'u2' } // another user's session must survive
+    )
+    const notifications = makeNotifications()
+    const setPasswordFn = jest.fn().mockResolvedValue(undefined)
+    const provider = newProvider(db, { notifications, setPasswordFn })
+
+    await provider.requestPasswordReset('user@example.com')
+    const raw = dispatchedToken(notifications)
+
+    await expect(provider.confirmPasswordReset(raw, 'N3wPassw0rd!')).resolves.toBeUndefined()
+
+    // Credential set in the identity store — NOT stored locally.
+    expect(setPasswordFn).toHaveBeenCalledWith('user@example.com', 'N3wPassw0rd!')
+    expect(JSON.stringify(db.__tables.users)).not.toContain('N3wPassw0rd!')
+
+    expect(db.__tables.password_resets[0].consumed).toBe(true)
+
+    // Every session for THIS user is gone; the other user's is untouched.
+    expect(db.__tables.sessions.filter((s: any) => s.user_id === 'u1')).toHaveLength(0)
+    expect(db.__tables.sessions.filter((s: any) => s.user_id === 'u2')).toHaveLength(1)
+  })
+
+  it('rejects an expired token and leaves sessions intact', async () => {
+    const db = makeFakeDb()
+    seedUser(db)
+    db.__tables.sessions.push({ id: 's1', user_id: 'u1' })
+    const notifications = makeNotifications()
+    let clock = Date.now()
+    const setPasswordFn = jest.fn().mockResolvedValue(undefined)
+    const provider = newProvider(db, { notifications, setPasswordFn, now: () => clock })
+
+    await provider.requestPasswordReset('user@example.com')
+    const raw = dispatchedToken(notifications)
+
+    clock += 31 * 60_000 // past the 30-minute TTL
+
+    await expect(provider.confirmPasswordReset(raw, 'N3wPassw0rd!')).rejects.toThrow(
+      /invalid or expired/i
+    )
+    expect(setPasswordFn).not.toHaveBeenCalled()
+    expect(db.__tables.sessions).toHaveLength(1)
+  })
+
+  it('rejects a reused (already consumed) token', async () => {
+    const db = makeFakeDb()
+    seedUser(db)
+    const notifications = makeNotifications()
+    const setPasswordFn = jest.fn().mockResolvedValue(undefined)
+    const provider = newProvider(db, { notifications, setPasswordFn })
+
+    await provider.requestPasswordReset('user@example.com')
+    const raw = dispatchedToken(notifications)
+
+    await provider.confirmPasswordReset(raw, 'FirstPassw0rd!')
+    expect(setPasswordFn).toHaveBeenCalledTimes(1)
+
+    // Single-use: the second presentation must fail closed.
+    await expect(provider.confirmPasswordReset(raw, 'SecondPassw0rd!')).rejects.toThrow(
+      /invalid or expired/i
+    )
+    expect(setPasswordFn).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects a wrong/unknown token', async () => {
+    const db = makeFakeDb()
+    seedUser(db)
+    const setPasswordFn = jest.fn().mockResolvedValue(undefined)
+    const provider = newProvider(db, { setPasswordFn })
+
+    await provider.requestPasswordReset('user@example.com')
+
+    await expect(
+      provider.confirmPasswordReset('deadbeef'.repeat(8), 'N3wPassw0rd!')
+    ).rejects.toThrow(/invalid or expired/i)
+    expect(setPasswordFn).not.toHaveBeenCalled()
+  })
+
+  it('keeps the token live when the identity store rejects the password', async () => {
+    const db = makeFakeDb()
+    seedUser(db)
+    const notifications = makeNotifications()
+    const policyError = Object.assign(new Error('too weak'), { name: 'PasswordPolicyError' })
+    const setPasswordFn = jest.fn().mockRejectedValueOnce(policyError).mockResolvedValue(undefined)
+    const provider = newProvider(db, { notifications, setPasswordFn })
+
+    await provider.requestPasswordReset('user@example.com')
+    const raw = dispatchedToken(notifications)
+
+    await expect(provider.confirmPasswordReset(raw, 'weak')).rejects.toThrow('too weak')
+    // Not consumed — a compliant retry with the same token must still work.
+    expect(db.__tables.password_resets[0].consumed).toBe(false)
+
+    await expect(provider.confirmPasswordReset(raw, 'N3wPassw0rd!')).resolves.toBeUndefined()
+    expect(db.__tables.password_resets[0].consumed).toBe(true)
+  })
+
+  it('requires both token and newPassword', async () => {
+    const provider = newProvider(makeFakeDb())
+    await expect(provider.confirmPasswordReset('', 'x')).rejects.toThrow(/token is required/)
+    await expect(provider.confirmPasswordReset('t', '')).rejects.toThrow(/newPassword is required/)
+  })
+})
+
+// ── Route contract ──────────────────────────────────────────────────────────
+describe('password-reset routes', () => {
+  const provider = {
+    requestPasswordReset: jest.fn().mockResolvedValue(undefined),
+    confirmPasswordReset: jest.fn().mockResolvedValue(undefined),
+  }
+
+  function app() {
+    jest.doMock('../src/providers/factory', () => ({ getIdentityProvider: () => provider }))
+    const a = express()
+    a.use(express.json())
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    a.use('/v1/security', require('../src/routes/security').default)
+    return a
+  }
+
+  beforeEach(() => {
+    jest.resetModules()
+    provider.requestPasswordReset.mockReset().mockResolvedValue(undefined)
+    provider.confirmPasswordReset.mockReset().mockResolvedValue(undefined)
+  })
+
+  it('reset-request returns 202 for a known email', async () => {
+    await request(app())
+      .post('/v1/security/session/password/reset-request')
+      .send({ email: 'user@example.com' })
+      .expect(202)
+  })
+
+  it('reset-request returns the SAME 202 for an unknown email (no enumeration)', async () => {
+    const known = await request(app())
+      .post('/v1/security/session/password/reset-request')
+      .send({ email: 'user@example.com' })
+    const unknown = await request(app())
+      .post('/v1/security/session/password/reset-request')
+      .send({ email: 'nobody@example.com' })
+
+    expect(unknown.status).toBe(202)
+    expect(unknown.status).toBe(known.status)
+    expect(unknown.text).toBe(known.text)
+  })
+
+  it('reset-request still returns 202 when the provider throws (no oracle)', async () => {
+    provider.requestPasswordReset.mockRejectedValue(new Error('store down'))
+    await request(app())
+      .post('/v1/security/session/password/reset-request')
+      .send({ email: 'user@example.com' })
+      .expect(202)
+  })
+
+  it('reset-request 400s only on a malformed body', async () => {
+    await request(app()).post('/v1/security/session/password/reset-request').send({}).expect(400)
+  })
+
+  it('reset-confirm returns { reset: true } on success', async () => {
+    const res = await request(app())
+      .post('/v1/security/session/password/reset-confirm')
+      .send({ token: 'tok', newPassword: 'N3wPassw0rd!' })
+      .expect(200)
+    expect(res.body).toEqual({ reset: true })
+  })
+
+  it('reset-confirm 400s on an invalid token', async () => {
+    const { InvalidInputError } = require('../src/providers/authentik/AuthentikIdentityProvider')
+    provider.confirmPasswordReset.mockRejectedValue(new InvalidInputError('invalid or expired reset token'))
+    await request(app())
+      .post('/v1/security/session/password/reset-confirm')
+      .send({ token: 'bad', newPassword: 'N3wPassw0rd!' })
+      .expect(400)
+  })
+
+  it('reset-confirm 400s on a missing field', async () => {
+    await request(app())
+      .post('/v1/security/session/password/reset-confirm')
+      .send({ token: 'tok' })
+      .expect(400)
+  })
+
+  it('never names the identity vendor in a response', async () => {
+    const res = await request(app())
+      .post('/v1/security/session/password/reset-confirm')
+      .send({ token: 'tok', newPassword: 'N3wPassw0rd!' })
+    expect(JSON.stringify(res.body).toLowerCase()).not.toContain('authentik')
+  })
+})


### PR DESCRIPTION
Implements `POST /session/password/reset-request` and `/session/password/reset-confirm` — in the frozen contract (#273) but **404 in production**; never implemented.

**⚠️ UNVERIFIED — `tsc` and `jest` have never run against this.** The authoring agent's isolated-cache `npm install` timed out twice, then plan mode froze it. **19 tests exist and have executed zero times.** CI is the gate here; do not read this PR as a claim that it works.

## Design
- Reset token: sha256-hashed at rest, single-use, 30-min TTL, idempotent migration (`013_create_password_resets`).
- Password is set **in Authentik** via the Admin API — **no bcrypt, no local password row.** Authentik remains the credential store.
- **All sessions revoked on reset.** Now that #282 makes `authenticateToken` enforce the `sessions` table, deleting those rows genuinely logs the attacker out — a reset that left old sessions alive would be theatre.
- Resolves the target by email then **re-matches exactly (case-insensitively)**, because Authentik's `?email=` is a *filter*, not an exact match — resetting the wrong account would be unacceptable.

## Three decisions worth scrutinising
1. **No enumeration oracle**: unknown email, unwired email channel, *and* dispatch failure all return an identical **202**. The route deliberately swallows provider throws — a 5xx for real accounts only would itself leak existence. Only a malformed body 400s.
2. **Confirm ordering**: set password → consume token → revoke sessions. A store/policy rejection leaves the token live so a compliant retry works.
3. Degrades + logs when the email channel is unwired (mirrors `emailVerificationEnabled()`), rather than stranding the user.

`hold` — deploy-on-push; ruleset requires 1 approving review.

Co-Authored-By: Claude