### PR TITLE
fix(security): derive /methods capabilities from config instead of hard-coding them

### DIFF
--- a/backend/security/src/providers/authentik/AuthentikIdentityProvider.ts
+++ b/backend/security/src/providers/authentik/AuthentikIdentityProvider.ts
@@ -123,7 +123,7 @@ const EMAIL_VERIFY_TTL_MS = 30 * 60_000
  * — so signup/local dev/prod-without-SMTP never strands a user on an
  * undeliverable challenge. Provider-neutral: no vendor is named.
  */
-function emailVerificationEnabled(): boolean {
+export function emailVerificationEnabled(): boolean {
   return (
     process.env.REQUIRE_EMAIL_VERIFICATION === 'true' &&
     !!(process.env.EMAIL_SERVICE_URL && process.env.EMAIL_SERVICE_URL.trim())

--- a/backend/security/src/routes/security.ts
+++ b/backend/security/src/routes/security.ts
@@ -16,6 +16,7 @@ import {
   ConflictError,
   InvalidInputError,
   UnauthorizedError,
+  emailVerificationEnabled,
 } from '../providers/authentik/AuthentikIdentityProvider'
 import { appBaseUrl } from '../providers/authentik/config'
 import type { BrokeredSession, BrokeredUser } from '../providers/IdentityProvider'
@@ -206,14 +207,44 @@ router.post('/signup', async (req: Request, res: Response) => {
 })
 
 // ── Capabilities ──────────────────────────────────────────────────────────
+/**
+ * The SMS transport is a two-condition gate like email's: an SMS path only
+ * exists when the family sms-service is reachable by Service DNS. Without
+ * `SMS_SERVICE_URL` the dispatcher has nowhere to send, so any SMS factor or
+ * phone-verification challenge would be minted but never delivered.
+ * Provider-neutral: no vendor is named.
+ */
+function smsTransportConfigured(): boolean {
+  return !!(process.env.SMS_SERVICE_URL && process.env.SMS_SERVICE_URL.trim())
+}
+
+/**
+ * Neutral capability descriptor, DERIVED from actual configuration.
+ *
+ * This descriptor is a promise the UI renders affordances from: every `true`
+ * here becomes a flow a user can start. Over-reporting is therefore worse than
+ * under-reporting — an unconfigured transport advertised as available dead-ends
+ * the user mid-way through securing their account. So each field reports only
+ * what can actually complete end-to-end, and anything unconfigured is reported
+ * as absent rather than assumed.
+ */
 router.get('/methods', (_req: Request, res: Response) => {
-  // Neutral capability descriptor. Provider config decides what is enabled.
   const social: Array<'google'> = process.env.SECURITY_SOCIAL_GOOGLE === 'false' ? [] : ['google']
+
+  const emailAvailable = emailVerificationEnabled()
+  const smsAvailable = smsTransportConfigured()
+
+  // `totp` is self-contained (shared secret + local clock), so it is always
+  // available; `sms`/`email` require their transport to be configured.
+  const mfaTypes: Array<'totp' | 'sms' | 'email'> = ['totp']
+  if (smsAvailable) mfaTypes.push('sms')
+  if (emailAvailable) mfaTypes.push('email')
+
   res.status(200).json({
     password: true,
     social,
-    mfa: { enabled: true, types: ['totp', 'sms', 'email'] },
-    verification: { email: true, sms: true },
+    mfa: { enabled: mfaTypes.length > 0, types: mfaTypes },
+    verification: { email: emailAvailable, sms: smsAvailable },
   })
 })
 

--- a/backend/security/tests/security-routes.test.ts
+++ b/backend/security/tests/security-routes.test.ts
@@ -159,16 +159,85 @@ describe('POST /signup', () => {
 })
 
 describe('GET /methods', () => {
-  it('returns the neutral capability descriptor (no vendor names)', async () => {
-    const res = await request(makeApp(fakeProvider())).get('/api/v1/security/methods')
+  // The descriptor is derived from process.env, so each case owns a clean slate.
+  const CAP_VARS = ['SMS_SERVICE_URL', 'EMAIL_SERVICE_URL', 'REQUIRE_EMAIL_VERIFICATION', 'SECURITY_SOCIAL_GOOGLE']
+  let saved: Record<string, string | undefined>
+
+  beforeEach(() => {
+    saved = Object.fromEntries(CAP_VARS.map(k => [k, process.env[k]]))
+    for (const k of CAP_VARS) delete process.env[k]
+  })
+  afterEach(() => {
+    for (const k of CAP_VARS) {
+      if (saved[k] === undefined) delete process.env[k]
+      else process.env[k] = saved[k] as string
+    }
+  })
+
+  const methods = () => request(makeApp(fakeProvider())).get('/api/v1/security/methods')
+
+  it('nothing configured: only totp; email/sms verification reported OFF', async () => {
+    const res = await methods()
     expect(res.status).toBe(200)
     expect(res.body).toMatchObject({
       password: true,
-      social: ['google'],
-      mfa: { enabled: true, types: ['totp', 'sms', 'email'] },
-      verification: { email: true, sms: true },
+      mfa: { enabled: true, types: ['totp'] },
+      verification: { email: false, sms: false },
     })
+  })
+
+  it('SMS_SERVICE_URL configured: sms factor + sms verification appear', async () => {
+    process.env.SMS_SERVICE_URL = 'http://sms-service:3000'
+    const res = await methods()
+    expect(res.body.mfa.types).toEqual(['totp', 'sms'])
+    expect(res.body.verification.sms).toBe(true)
+    expect(res.body.verification.email).toBe(false)
+  })
+
+  it('blank SMS_SERVICE_URL is not "configured"', async () => {
+    process.env.SMS_SERVICE_URL = '   '
+    const res = await methods()
+    expect(res.body.mfa.types).toEqual(['totp'])
+    expect(res.body.verification.sms).toBe(false)
+  })
+
+  it('email verification enabled (both conditions): email factor + email verification appear', async () => {
+    process.env.REQUIRE_EMAIL_VERIFICATION = 'true'
+    process.env.EMAIL_SERVICE_URL = 'http://email-service:3000'
+    const res = await methods()
+    expect(res.body.mfa.types).toEqual(['totp', 'email'])
+    expect(res.body.verification.email).toBe(true)
+  })
+
+  it('email transport without the switch stays OFF (degrade mode is not a capability)', async () => {
+    process.env.EMAIL_SERVICE_URL = 'http://email-service:3000'
+    const res = await methods()
+    expect(res.body.mfa.types).toEqual(['totp'])
+    expect(res.body.verification.email).toBe(false)
+  })
+
+  it('the switch without a transport stays OFF', async () => {
+    process.env.REQUIRE_EMAIL_VERIFICATION = 'true'
+    const res = await methods()
+    expect(res.body.verification.email).toBe(false)
+  })
+
+  it('everything configured: all three factors', async () => {
+    process.env.SMS_SERVICE_URL = 'http://sms-service:3000'
+    process.env.REQUIRE_EMAIL_VERIFICATION = 'true'
+    process.env.EMAIL_SERVICE_URL = 'http://email-service:3000'
+    const res = await methods()
+    expect(res.body.mfa).toEqual({ enabled: true, types: ['totp', 'sms', 'email'] })
+    expect(res.body.verification).toEqual({ email: true, sms: true })
+  })
+
+  it('stays neutral (no vendor names) and honours the social switch', async () => {
+    const res = await methods()
+    expect(res.body.social).toEqual(['google'])
     expect(JSON.stringify(res.body).toLowerCase()).not.toMatch(/authentik/)
+
+    process.env.SECURITY_SOCIAL_GOOGLE = 'false'
+    expect((await methods()).body.social).toEqual([])
   })
 })
 


### PR DESCRIPTION
`GET /api/v1/security/methods` returns **hard-coded** `mfa:{enabled:true,types:[totp,sms,email]}` and `verification:{email:true,sms:true}`. I verified against live prod — it returns exactly that, and **none of it is true**:

- No `SMS_SERVICE_URL`, no `TWILIO_*`, and `smsService.image.tag: ""` → the SMS service **is not deployed**. Phone 2FA cannot complete.
- No `REQUIRE_EMAIL_VERIFICATION`, no `EMAIL_SERVICE_URL` → email verification silently runs in **degrade mode (auto-verify)**. Effectively OFF.

The SPA renders affordances from this descriptor, so today it **offers users flows that physically cannot work**. Over-promising is worse than under-promising: the UI offers it, the user commits, and it dead-ends — at the exact moment they're trying to secure their account.

Now derived from config (reusing the existing `emailVerificationEnabled()` gate; following the `SECURITY_SOCIAL_GOOGLE` pattern already there). Shape unchanged, provider-neutral — a truthfulness fix, not a contract change.

**⚠️ UNVERIFIED — plan mode froze the agent before `tsc`/`jest` ran.** Also flagged by the author: the replaced test asserted the hard-coded values and so would have **defended the bug**; and an unexamined `backend/security/tests/security-api/` may contain another such test. **Treat "the tests pass" as an open question.** CI is the gate.

`hold` — deploy-on-push; ruleset requires 1 approving review.

Co-Authored-By: Claude