### PR TITLE
feat(security): manage-devices (sessions) + social link/unlink + set-password

### DIFF
--- a/backend/security/src/migrations/013_sessions_device_and_password_state.ts
+++ b/backend/security/src/migrations/013_sessions_device_and_password_state.ts
@@ -1,0 +1,80 @@
+import { Knex } from 'knex'
+
+/**
+ * Manage-devices + sign-in-method state.
+ *
+ * 1. `sessions` gains the device telemetry the `GET /v1/security/sessions`
+ *    contract returns (`ip`, `user_agent`, `last_seen_at`). These are recorded
+ *    at mint time; the user-agent is parsed into device/browser/os at READ time
+ *    (storing the raw string keeps the parser improvable without a backfill).
+ *
+ * 2. `users` gains a TRI-STATE `has_password` projection:
+ *      true    — we know a password sign-in method exists (we set/enrolled it)
+ *      false   — we know there is none (social-only account)
+ *      NULL    — UNKNOWN (legacy row predating this column)
+ *
+ *    Why a projection at all: the identity store never exposes password state
+ *    over its API (password writes are blueprint-only and `has_usable_password`
+ *    is not serialized), so there is NO read path to ask it. This column is the
+ *    only available truth, maintained at the points we control (enrollment and
+ *    set-password).
+ *
+ *    NULL is deliberately NOT defaulted to true/false — a wrong guess is unsafe
+ *    in BOTH directions (guessing true can strand a social-only user with no way
+ *    to sign in after unlinking; guessing false silently permits overwriting a
+ *    real password). Unknown is resolved fail-closed per-operation instead:
+ *    unlink treats NULL as "no password" (refuses, 409), set-password treats it
+ *    as "may set" — so an unknown account converges to a known state safely.
+ *
+ * Idempotent: every add is guarded by hasColumn, so a re-run is a no-op.
+ */
+export async function up(knex: Knex): Promise<void> {
+  const hasIp = await knex.schema.hasColumn('sessions', 'ip')
+  const hasUa = await knex.schema.hasColumn('sessions', 'user_agent')
+  const hasSeen = await knex.schema.hasColumn('sessions', 'last_seen_at')
+
+  if (!hasIp || !hasUa || !hasSeen) {
+    await knex.schema.alterTable('sessions', table => {
+      // `ip` is a plain string, not `inet`: it holds whatever the proxy chain
+      // reported (may be IPv4, IPv6, or absent) and is display-only.
+      if (!hasIp) table.string('ip').nullable()
+      if (!hasUa) table.text('user_agent').nullable()
+      if (!hasSeen) table.timestamp('last_seen_at').nullable()
+    })
+  }
+
+  // Backfill last_seen_at for pre-existing sessions so the device list has a
+  // sensible ordering key immediately; created_at is the best known activity.
+  if (!hasSeen) {
+    await knex('sessions').whereNull('last_seen_at').update({
+      last_seen_at: knex.ref('created_at'),
+    })
+  }
+
+  const hasPwd = await knex.schema.hasColumn('users', 'has_password')
+  if (!hasPwd) {
+    await knex.schema.alterTable('users', table => {
+      // Intentionally nullable with NO default — NULL means "unknown".
+      table.boolean('has_password').nullable()
+    })
+  }
+}
+
+export async function down(knex: Knex): Promise<void> {
+  const hasIp = await knex.schema.hasColumn('sessions', 'ip')
+  const hasUa = await knex.schema.hasColumn('sessions', 'user_agent')
+  const hasSeen = await knex.schema.hasColumn('sessions', 'last_seen_at')
+  if (hasIp || hasUa || hasSeen) {
+    await knex.schema.alterTable('sessions', table => {
+      if (hasIp) table.dropColumn('ip')
+      if (hasUa) table.dropColumn('user_agent')
+      if (hasSeen) table.dropColumn('last_seen_at')
+    })
+  }
+  const hasPwd = await knex.schema.hasColumn('users', 'has_password')
+  if (hasPwd) {
+    await knex.schema.alterTable('users', table => {
+      table.dropColumn('has_password')
+    })
+  }
+}

--- a/backend/security/src/providers/IdentityProvider.ts
+++ b/backend/security/src/providers/IdentityProvider.ts
@@ -98,10 +98,17 @@ export interface SocialCallbackInput {
  * the browser to. No token is ever placed in the redirect URL.
  */
 export interface SocialCallbackResult {
-  /** FuzeFront-minted single-use opaque code. */
+  /**
+   * FuzeFront-minted single-use opaque code. Empty for a LINK handshake, which
+   * attaches a provider to an already-signed-in account and mints no session.
+   */
   code: string;
   /** Same-origin app path to redirect the browser back to. */
   redirectTo: string;
+  /** True when this callback completed a LINK (not a sign-in) handshake. */
+  linked?: boolean;
+  /** For a link handshake, the neutral provider slug that was linked. */
+  provider?: string;
 }
 
 export interface M2MClientProvisionInput {
@@ -194,6 +201,72 @@ export interface VerificationStatus {
   phone?: string;
 }
 
+// ── Manage devices (platform sessions) ──
+
+/**
+ * One active platform session, as shown in "manage devices" (mirrors the API
+ * `SessionDevice` schema).
+ *
+ * `device`/`browser`/`os`/`ip`/`geo` are best-effort DISPLAY hints derived from
+ * what was recorded when the session was minted — they help a human recognise a
+ * session and are never inputs to an authorization decision. Any of them may be
+ * null.
+ *
+ * The platform session is the browser-facing truth: these are FuzeFront's own
+ * sessions, NOT any vendor's session objects.
+ */
+export interface SessionDevice {
+  /** Session id; pass to `revokeSession`. */
+  id: string;
+  device?: string | null;
+  browser?: string | null;
+  os?: string | null;
+  ip?: string | null;
+  geo?: string | null;
+  /** Epoch millis of the session's most recent observed activity. */
+  lastSeenAt?: number;
+  /** True for the session that made the request. */
+  current: boolean;
+}
+
+/** Context recorded when a session is minted, for the device list. */
+export interface SessionContext {
+  ip?: string | null;
+  userAgent?: string | null;
+}
+
+// ── Account sign-in connections (social links + password) ──
+
+/** A linked social sign-in connection (mirrors the API `SocialConnection`). */
+export interface SocialConnection {
+  /** Neutral provider slug (e.g. `google`) — never a vendor/IdP name. */
+  provider: string;
+  /** Epoch millis when the provider was linked. */
+  linkedAt?: number;
+}
+
+/**
+ * The account's sign-in methods (mirrors the API `IdentityConnections`).
+ *
+ * `hasPassword` is false when a password is known-absent OR unknown — callers
+ * must treat it as "no password proven", which is the fail-closed reading for
+ * the last-sign-in-method guard.
+ */
+export interface IdentityConnections {
+  providers: SocialConnection[];
+  hasPassword: boolean;
+}
+
+/** The outcome of beginning a social-LINK handshake for a signed-in user. */
+export interface SocialLinkStart {
+  /** Same-host URL to navigate the browser to. Never an internal identity host. */
+  redirectUrl: string;
+  /** Opaque anti-forgery state the callback must echo. */
+  state: string;
+  /** PKCE code_verifier, persisted by the route in an HttpOnly cookie. */
+  codeVerifier: string;
+}
+
 /**
  * The AuthN swap contract. Shaped from the current server-brokered behavior in
  * `backend/security/src/routes/auth.ts` (`/oidc/password` :520, `/oidc/login`
@@ -201,20 +274,23 @@ export interface VerificationStatus {
  * `services/*`. Providers are swappable behind it.
  */
 export interface IdentityProvider {
-  /** Password login (server-brokered). Rejects on bad credentials. */
-  passwordLogin(input: PasswordLoginInput): Promise<BrokeredSession>;
+  /**
+   * Password login (server-brokered). Rejects on bad credentials.
+   * `ctx` records the device/IP the session was minted from, for manage-devices.
+   */
+  passwordLogin(input: PasswordLoginInput, ctx?: SessionContext): Promise<BrokeredSession>;
 
   /** Begin a social login; returns where to 302 the browser + anti-forgery state. */
   startSocialLogin(provider: string, redirectTo?: string): Promise<SocialLoginStart>;
 
   /** Complete the social handshake; returns a single-use opaque code + return path. */
-  brokerCallback(input: SocialCallbackInput): Promise<SocialCallbackResult>;
+  brokerCallback(input: SocialCallbackInput, ctx?: SessionContext): Promise<SocialCallbackResult>;
 
   /** Exchange a single-use opaque code for a session. Rejects on unknown/expired code. */
   exchangeCode(code: string): Promise<BrokeredSession>;
 
   /** Server-brokered account creation. Rejects with CONFLICT if the email exists. */
-  signup(input: SignupInput): Promise<BrokeredSession>;
+  signup(input: SignupInput, ctx?: SessionContext): Promise<BrokeredSession>;
 
   /** Normalized identity + user for a presented session token ("me"). */
   getUserInfo(token: string): Promise<{ identity: NormalizedIdentity; user: BrokeredUser }>;
@@ -257,7 +333,12 @@ export interface IdentityProvider {
   challengeMfa(challengeId: string, factorId: string): Promise<MfaChallengeAck>;
 
   /** Verify a login-step-up challenge; on success returns an authenticated session. */
-  verifyMfa(challengeId: string, factorId: string, code: string): Promise<BrokeredSession>;
+  verifyMfa(
+    challengeId: string,
+    factorId: string,
+    code: string,
+    ctx?: SessionContext
+  ): Promise<BrokeredSession>;
 
   // ── Contact-ownership verification (distinct from MFA login step-up) ──
 
@@ -275,4 +356,46 @@ export interface IdentityProvider {
 
   /** Current contact-verification status for the user. */
   getVerificationStatus(token: string): Promise<VerificationStatus>;
+
+  // ── Manage devices (platform sessions) ──
+  //
+  // These operate on FuzeFront's OWN session store — the source of truth that
+  // `authenticateToken` enforces — so revocation is REAL: a revoked session's
+  // token stops authenticating immediately. A vendor's own session objects are
+  // never exposed here; that would leak the provider across the boundary.
+
+  /** List the user's active sessions, flagging the caller's own. Bounded per user. */
+  listSessions(token: string): Promise<SessionDevice[]>;
+
+  /** Revoke one session belonging to the caller. Idempotent. */
+  revokeSession(token: string, sessionId: string): Promise<void>;
+
+  /** Revoke every session for the caller EXCEPT the one presenting `token`. Idempotent. */
+  revokeOtherSessions(token: string): Promise<void>;
+
+  // ── Account sign-in connections ──
+
+  /** The account's linked social providers + whether a password method exists. */
+  getIdentityConnections(token: string): Promise<IdentityConnections>;
+
+  /**
+   * Begin linking a social provider to the ALREADY-SIGNED-IN account.
+   * Rejects with CONFLICT when the provider is already linked.
+   */
+  startSocialLink(token: string, provider: string): Promise<SocialLinkStart>;
+
+  /**
+   * Unlink a social provider. Fail-closed: rejects with CONFLICT when it would
+   * leave the account with NO sign-in method (no password AND no other social)
+   * — an account must always retain at least one way back in.
+   */
+  unlinkSocial(token: string, provider: string): Promise<IdentityConnections>;
+
+  /**
+   * Set a password on an account that has none (e.g. social-only). Rejects with
+   * CONFLICT when a password sign-in method already exists — changing an
+   * existing password goes through the reset flow. The password is set in the
+   * identity store; FuzeFront never stores one.
+   */
+  setPassword(token: string, newPassword: string): Promise<IdentityConnections>;
 }

--- a/backend/security/src/providers/authentik/AuthentikIdentityProvider.ts
+++ b/backend/security/src/providers/authentik/AuthentikIdentityProvider.ts
@@ -47,7 +47,20 @@ import type {
   MfaEnrollResult,
   MfaChallengeAck,
   VerificationStatus,
+  SessionContext,
+  SessionDevice,
+  SocialConnection,
+  IdentityConnections,
+  SocialLinkStart,
 } from '../IdentityProvider'
+import {
+  findUserPk,
+  listOAuthConnections,
+  deleteOAuthConnection,
+  setUserPassword,
+  PasswordPolicyError,
+} from './accountApi'
+import { parseUserAgent } from './userAgent'
 import {
   HttpNotificationClient,
   type NotificationClient,
@@ -95,6 +108,20 @@ export class UnauthorizedError extends Error {
   }
 }
 
+/**
+ * Thrown when an addressed resource does not exist for the CALLER (maps to 404).
+ *
+ * Only used where the contract specifies 404 and the existence of the resource
+ * is not itself sensitive — e.g. unlinking a provider the account has not
+ * linked. Never used to distinguish another account's resources.
+ */
+export class NotFoundError extends Error {
+  constructor(message = 'Not found') {
+    super(message)
+    this.name = 'NotFoundError'
+  }
+}
+
 type Db = typeof defaultDb
 
 interface SocialState {
@@ -106,6 +133,25 @@ interface MfaChallenge {
   userId: string
   expiresAt: number
 }
+/** An in-flight LINK handshake, bound to the account that started it. */
+interface SocialLinkState {
+  codeVerifier: string
+  /** The signed-in account the provider will be attached to. */
+  userId: string
+  /** That account's email at start — the identity the callback must return. */
+  email: string
+  provider: string
+  redirectTo: string
+  expiresAt: number
+}
+
+/**
+ * The social providers FuzeFront exposes. Neutral slugs; they happen to match
+ * the identity store's source slugs, which is why `startSocialLogin` can build a
+ * source path from one — so this guard is also what stops a new provider being
+ * silently routed through another's source.
+ */
+const SUPPORTED_SOCIAL_PROVIDERS = new Set(['google'])
 
 const CHALLENGE_TTL_MS = 5 * 60_000
 const EMAIL_VERIFY_TTL_MS = 30 * 60_000
@@ -168,6 +214,7 @@ export class AuthentikIdentityProvider implements IdentityProvider {
   private introspectM2MFn?: (token: string) => Promise<TokenIntrospection>
 
   private socialStates = new Map<string, SocialState>()
+  private socialLinkStates = new Map<string, SocialLinkState>()
   private mfaChallenges = new Map<string, MfaChallenge>()
 
   constructor(deps: Partial<AuthentikProviderDeps> = {}) {
@@ -198,7 +245,7 @@ export class AuthentikIdentityProvider implements IdentityProvider {
   }
 
   // ── Session minting ───────────────────────────────────────────────────────
-  private async mintSession(user: BrokeredUser): Promise<BrokeredSession> {
+  private async mintSession(user: BrokeredUser, ctx?: SessionContext): Promise<BrokeredSession> {
     const sessionId = uuidv4()
     const expiresAt = new Date(this.now() + SESSION_TTL_MS)
     const token = jwt.sign({ userId: user.id, sessionId }, jwtSecret(), {
@@ -208,6 +255,13 @@ export class AuthentikIdentityProvider implements IdentityProvider {
       id: sessionId,
       user_id: user.id,
       expires_at: expiresAt,
+      // Device telemetry for manage-devices. Recorded once, at mint time: it
+      // describes where the session was ESTABLISHED from, which is what makes a
+      // session recognisable to its owner. Truncated because the user-agent is
+      // caller-controlled and otherwise unbounded.
+      ip: ctx?.ip ? String(ctx.ip).slice(0, 64) : null,
+      user_agent: ctx?.userAgent ? String(ctx.userAgent).slice(0, 512) : null,
+      last_seen_at: new Date(this.now()),
     })
     // Self-heal provisioning in the background — never blocks/fails the response.
     runInternalProvision(user.id).catch(err =>
@@ -224,7 +278,10 @@ export class AuthentikIdentityProvider implements IdentityProvider {
   }
 
   /** Gate a freshly-authenticated user through MFA step-up when factors exist. */
-  private async sessionOrChallenge(user: BrokeredUser): Promise<BrokeredSession> {
+  private async sessionOrChallenge(
+    user: BrokeredUser,
+    ctx?: SessionContext
+  ): Promise<BrokeredSession> {
     const factors = await this.loadActiveFactors(user.id)
     if (factors.length > 0) {
       const challengeId = crypto.randomBytes(24).toString('hex')
@@ -237,16 +294,36 @@ export class AuthentikIdentityProvider implements IdentityProvider {
         factors.map(f => ({ factorId: f.factorId, type: f.type }))
       )
     }
-    return this.mintSession(user)
+    return this.mintSession(user, ctx)
   }
 
   // ── Password login ────────────────────────────────────────────────────────
-  async passwordLogin(input: PasswordLoginInput): Promise<BrokeredSession> {
+  async passwordLogin(input: PasswordLoginInput, ctx?: SessionContext): Promise<BrokeredSession> {
     if (!input?.email || !input?.password) {
       throw new InvalidInputError('email and password are required')
     }
     const user = await this.passwordLoginFn(input.email, input.password)
-    return this.sessionOrChallenge(user)
+    // A successful password login PROVES a password sign-in method exists —
+    // the one truthful signal available for legacy rows whose has_password is
+    // still unknown (the identity store exposes no read path for it).
+    await this.markHasPassword(user.id, true)
+    return this.sessionOrChallenge(user, ctx)
+  }
+
+  /**
+   * Record known password state on the local projection.
+   *
+   * Only ever called where we have PROOF (a successful password login, an
+   * enrollment we drove, a set-password we performed) — never a guess. See
+   * migration 013 for why NULL/unknown exists and how it is resolved.
+   */
+  private async markHasPassword(userId: string, value: boolean): Promise<void> {
+    try {
+      await this.db('users').where({ id: userId }).update({ has_password: value })
+    } catch (err) {
+      // Never fail a sign-in over a projection write.
+      console.error('[security] has_password projection update failed: %s', (err as Error).message)
+    }
   }
 
   // ── Social login (server-brokered; browser never sees an internal host) ────
@@ -298,7 +375,20 @@ export class AuthentikIdentityProvider implements IdentityProvider {
     return { redirectUrl, state, codeVerifier }
   }
 
-  async brokerCallback(input: SocialCallbackInput): Promise<SocialCallbackResult> {
+  async brokerCallback(
+    input: SocialCallbackInput,
+    ctx?: SessionContext
+  ): Promise<SocialCallbackResult> {
+    // A LINK handshake (started by a signed-in user via startSocialLink) shares
+    // this callback but must NOT mint a session — it attaches a provider to the
+    // account that is already signed in. Checked first so a link state can never
+    // fall through into the sign-in path.
+    const link = this.socialLinkStates.get(input.state)
+    if (link) {
+      this.socialLinkStates.delete(input.state)
+      return this.completeSocialLink(input, link)
+    }
+
     const st = this.socialStates.get(input.state)
     if (!st || st.expiresAt < this.now()) {
       this.socialStates.delete(input.state)
@@ -314,7 +404,7 @@ export class AuthentikIdentityProvider implements IdentityProvider {
 
     // Mint the session now and hand back a single-use opaque code (never a token
     // in the URL). Social sign-in does not re-gate MFA at the browser hop.
-    const session = await this.mintSession(user)
+    const session = await this.mintSession(user, ctx)
     const code = crypto.randomBytes(32).toString('hex')
     // Shared store: a code minted here OR by the legacy /api/auth/oidc/callback
     // is redeemable by the SPA's /api/v1/security/session/exchange.
@@ -345,7 +435,7 @@ export class AuthentikIdentityProvider implements IdentityProvider {
   // outbox row + event). There is NO local bcrypt user — that split-brain (a
   // local user Authentik never knew about, thus unable to log in) is the bug this
   // replaces.
-  async signup(input: SignupInput): Promise<BrokeredSession> {
+  async signup(input: SignupInput, ctx?: SessionContext): Promise<BrokeredSession> {
     if (!input?.email || !input?.password) {
       throw new InvalidInputError('email and password are required')
     }
@@ -378,9 +468,13 @@ export class AuthentikIdentityProvider implements IdentityProvider {
       )
     }
 
+    // Enrollment always sets a password, so this account demonstrably HAS a
+    // password sign-in method — record it (this is proof, not a guess).
+    await this.markHasPassword(user.id, true)
+
     // Gate through MFA step-up if the (rare, freshly-enrolled) account already
     // has active factors — otherwise mint the session directly.
-    return this.sessionOrChallenge(user)
+    return this.sessionOrChallenge(user, ctx)
   }
 
   /**
@@ -644,7 +738,12 @@ export class AuthentikIdentityProvider implements IdentityProvider {
     return { challengeId, factorId, delivered: false }
   }
 
-  async verifyMfa(challengeId: string, factorId: string, code: string): Promise<BrokeredSession> {
+  async verifyMfa(
+    challengeId: string,
+    factorId: string,
+    code: string,
+    ctx?: SessionContext
+  ): Promise<BrokeredSession> {
     const ch = this.mfaChallenges.get(challengeId)
     if (!ch || ch.expiresAt < this.now()) {
       this.mfaChallenges.delete(challengeId)
@@ -658,7 +757,7 @@ export class AuthentikIdentityProvider implements IdentityProvider {
     if (!ok) throw new UnauthorizedError('invalid code')
     this.mfaChallenges.delete(challengeId)
     const user = await this.loadUser(ch.userId)
-    return this.mintSession(user)
+    return this.mintSession(user, ctx)
   }
 
   // ── Contact-ownership verification ────────────────────────────────────────
@@ -753,6 +852,251 @@ export class AuthentikIdentityProvider implements IdentityProvider {
       phoneVerified: !!row.phone_verified,
       phone: row.phone || undefined,
     }
+  }
+
+  // ── Manage devices (platform sessions) ────────────────────────────────────
+  //
+  // These read/write FuzeFront's OWN `sessions` table — the store that
+  // `authenticateToken` checks on every request. That is what makes revocation
+  // REAL rather than cosmetic: deleting the row invalidates the token on its
+  // next use, with no waiting for the JWT to expire.
+  //
+  // The identity vendor's own session objects are deliberately NOT surfaced:
+  // the platform session is the browser-facing truth, and exposing the vendor's
+  // would leak it across the provider boundary.
+
+  async listSessions(token: string): Promise<SessionDevice[]> {
+    // getUserInfo enforces that the CALLER's own session is still live, so a
+    // revoked token cannot enumerate the account's devices.
+    const { user } = await this.getUserInfo(token)
+    const decoded = this.verifySessionToken(token)
+
+    const rows = await this.db('sessions').where({ user_id: user.id }).select('*')
+    const nowMs = this.now()
+    return rows
+      // Expired-but-not-yet-reaped rows are not "active" — showing them would
+      // invite a user to revoke a session that already carries no access.
+      .filter(r => !r.expires_at || new Date(r.expires_at).getTime() > nowMs)
+      .map(r => {
+        const ua = parseUserAgent(r.user_agent)
+        return {
+          id: r.id,
+          device: ua.device,
+          browser: ua.browser,
+          os: ua.os,
+          ip: r.ip ?? null,
+          // Coarse geolocation needs a geo-IP source we do not deploy; the
+          // contract types it nullable, so report null rather than invent one.
+          geo: null,
+          lastSeenAt: r.last_seen_at
+            ? new Date(r.last_seen_at).getTime()
+            : r.created_at
+              ? new Date(r.created_at).getTime()
+              : undefined,
+          current: r.id === decoded.sessionId,
+        }
+      })
+      .sort((a, b) => (b.lastSeenAt ?? 0) - (a.lastSeenAt ?? 0))
+  }
+
+  async revokeSession(token: string, sessionId: string): Promise<void> {
+    const { user } = await this.getUserInfo(token)
+    // Scoped to the caller's own user_id: this is the object-level authorization
+    // check. Without it any signed-in user could revoke anyone's session by id.
+    // A non-matching id deletes nothing — idempotent, and it does not disclose
+    // whether that session exists on another account.
+    await this.db('sessions').where({ id: sessionId, user_id: user.id }).del()
+  }
+
+  async revokeOtherSessions(token: string): Promise<void> {
+    const { user } = await this.getUserInfo(token)
+    const decoded = this.verifySessionToken(token)
+    const q = this.db('sessions').where({ user_id: user.id })
+    if (decoded.sessionId) {
+      // Keep the caller's own session — "sign out everywhere else" must not sign
+      // the caller out.
+      q.whereNot({ id: decoded.sessionId })
+    }
+    await q.del()
+  }
+
+  // ── Account sign-in connections ───────────────────────────────────────────
+
+  /** Map identity-store source slugs to neutral provider slugs (unknown → dropped). */
+  private toNeutralConnections(
+    conns: Array<{ sourceSlug: string; createdAt?: number }>
+  ): SocialConnection[] {
+    return conns
+      .filter(c => SUPPORTED_SOCIAL_PROVIDERS.has(c.sourceSlug))
+      .map(c => ({ provider: c.sourceSlug, linkedAt: c.createdAt }))
+  }
+
+  /**
+   * Read the account's sign-in methods.
+   *
+   * Social links come from the identity store (authoritative). `hasPassword`
+   * comes from our local projection because the store exposes NO read path for
+   * password state — see migration 013. Unknown (NULL) reports FALSE: the safe
+   * reading, since it drives the UI to offer "set a password" and makes the
+   * unlink guard refuse rather than risk a lockout.
+   */
+  async getIdentityConnections(token: string): Promise<IdentityConnections> {
+    const { user } = await this.getUserInfo(token)
+    return this.connectionsForUser(user)
+  }
+
+  private async connectionsForUser(user: BrokeredUser): Promise<IdentityConnections> {
+    const pk = await findUserPk(user.email)
+    const conns = await listOAuthConnections(pk)
+    const row = await this.db('users').where({ id: user.id }).first()
+    return {
+      providers: this.toNeutralConnections(conns),
+      hasPassword: row?.has_password === true,
+    }
+  }
+
+  async startSocialLink(token: string, provider: string): Promise<SocialLinkStart> {
+    if (!SUPPORTED_SOCIAL_PROVIDERS.has(provider)) {
+      throw new InvalidInputError(`unsupported social provider: ${provider}`)
+    }
+    const { user } = await this.getUserInfo(token)
+
+    // Already linked ⇒ CONFLICT, per the contract.
+    const current = await this.connectionsForUser(user)
+    if (current.providers.some(p => p.provider === provider)) {
+      throw new ConflictError(`${provider} is already linked to this account`)
+    }
+
+    if (!this.oidc.isInitialized()) {
+      await this.oidc.initialize()
+    }
+    const state = crypto.randomBytes(24).toString('hex')
+    const { url, codeVerifier } = this.oidc.generateAuthUrl(state)
+    const authorize = new URL(url)
+    const authorizePath = `${idpProxyPrefix()}${authorize.pathname}${authorize.search}`
+
+    // Same same-host boundary rewrite as sign-in: the browser only ever transits
+    // the app host and the social provider's own consent host.
+    const redirectUrl =
+      `${idpProxyPrefix()}/source/oauth/login/${provider}/` +
+      `?next=${encodeURIComponent(authorizePath)}`
+
+    this.socialLinkStates.set(state, {
+      codeVerifier,
+      userId: user.id,
+      email: user.email,
+      provider,
+      redirectTo: '/account/security',
+      expiresAt: this.now() + 10 * 60_000,
+    })
+    return { redirectUrl, state, codeVerifier }
+  }
+
+  /**
+   * Finish a LINK handshake.
+   *
+   * The identity store performs the actual attachment when its source flow runs.
+   * Our job is the SAFETY check the store cannot make for us: that the identity
+   * that came back is the same account that started the handshake. Without this
+   * equality check, completing the flow while signed in as someone else would
+   * bind a stranger's social identity to this account (or this one to theirs) —
+   * an account-takeover primitive. Mismatch fails closed.
+   *
+   * Known limitation: because the browser transits the store's source flow, the
+   * store may have already matched/created its own account for that social
+   * identity before we can object. We reject the LINK (no session is minted, and
+   * nothing is attached to the caller's account), but we do not attempt to undo
+   * the store's own bookkeeping.
+   */
+  private async completeSocialLink(
+    input: SocialCallbackInput,
+    link: SocialLinkState
+  ): Promise<SocialCallbackResult> {
+    if (link.expiresAt < this.now()) {
+      throw new UnauthorizedError('invalid or expired state')
+    }
+    const identity = (await this.oidc.handleCallback(
+      input.code,
+      input.state,
+      link.codeVerifier
+    )) as BrokeredUser
+
+    if (
+      !identity?.email ||
+      identity.email.toLowerCase() !== link.email.toLowerCase()
+    ) {
+      throw new UnauthorizedError('social identity does not match the signed-in account')
+    }
+
+    // Confirm the store really did attach the connection — never report a link
+    // we cannot see.
+    const pk = await findUserPk(link.email)
+    const conns = await listOAuthConnections(pk)
+    if (!conns.some(c => c.sourceSlug === link.provider)) {
+      throw new UnauthorizedError('link did not complete')
+    }
+    return { code: '', redirectTo: link.redirectTo, linked: true, provider: link.provider }
+  }
+
+  async unlinkSocial(token: string, provider: string): Promise<IdentityConnections> {
+    if (!SUPPORTED_SOCIAL_PROVIDERS.has(provider)) {
+      throw new InvalidInputError(`unsupported social provider: ${provider}`)
+    }
+    const { user } = await this.getUserInfo(token)
+    const pk = await findUserPk(user.email)
+    const conns = await listOAuthConnections(pk)
+    const target = conns.find(c => c.sourceSlug === provider)
+    if (!target) throw new NotFoundError(`${provider} is not linked to this account`)
+
+    const row = await this.db('users').where({ id: user.id }).first()
+    const hasPassword = row?.has_password === true
+    const otherSocial = this.toNeutralConnections(conns).filter(c => c.provider !== provider)
+
+    // THE lockout guard. Fail-closed: an unknown (NULL) has_password counts as
+    // NO password, so an unproven account is told to set one first rather than
+    // being allowed to remove its last way back in.
+    if (!hasPassword && otherSocial.length === 0) {
+      throw new ConflictError(
+        'Unlinking would leave the account with no sign-in method. Set a password or link another provider first.'
+      )
+    }
+
+    await deleteOAuthConnection(target.pk)
+    return { providers: otherSocial, hasPassword }
+  }
+
+  // ── Set password (social-only accounts) ───────────────────────────────────
+  //
+  // The password is set IN THE IDENTITY STORE, which is the sole authority for
+  // credentials. FuzeFront deliberately stores no password hash of its own —
+  // a local hash would be a second, divergent credential the store never knows
+  // about (exactly the split-brain that server-brokered signup replaced).
+  async setPassword(token: string, newPassword: string): Promise<IdentityConnections> {
+    if (!newPassword || typeof newPassword !== 'string') {
+      throw new InvalidInputError('newPassword is required')
+    }
+    const { user } = await this.getUserInfo(token)
+    const row = await this.db('users').where({ id: user.id }).first()
+
+    // CONFLICT only on PROVEN existing password. An unknown (NULL) legacy row is
+    // allowed through: this endpoint adds a first password, and letting an
+    // already-authenticated owner set one converges the row to a known state.
+    // Changing a KNOWN password goes through the reset flow instead.
+    if (row?.has_password === true) {
+      throw new ConflictError('A password sign-in method already exists on this account')
+    }
+
+    const pk = await findUserPk(user.email)
+    try {
+      await setUserPassword(pk, newPassword)
+    } catch (err) {
+      if (err instanceof PasswordPolicyError) {
+        throw new InvalidInputError(`password rejected: ${err.message}`)
+      }
+      throw err
+    }
+    await this.markHasPassword(user.id, true)
+    return this.connectionsForUser(user)
   }
 }
 

--- a/backend/security/src/providers/authentik/accountApi.ts
+++ b/backend/security/src/providers/authentik/accountApi.ts
@@ -1,0 +1,145 @@
+/**
+ * Authentik admin-API calls for ACCOUNT sign-in methods (social source
+ * connections + password).
+ *
+ * Provider-internal: this is one of the few places the identity vendor is named.
+ * Everything above it speaks the neutral `IdentityProvider` contract, so the
+ * Authentik `pk`s, source slugs, and endpoint shapes below never cross the
+ * boundary. Swap this file to swap providers.
+ *
+ * Fail-closed: every call throws on any transport/HTTP error. A caller never
+ * receives a permissive default (e.g. "no connections", which would let the
+ * last-sign-in-method guard wave through an account lockout).
+ */
+
+/** A social source connection as Authentik models it. */
+export interface OAuthConnection {
+  /** Authentik connection pk — provider-internal, used only to unlink. */
+  pk: number
+  /** Authentik source slug; mapped to our neutral provider slug by the caller. */
+  sourceSlug: string
+  /** Epoch millis the connection was created, when Authentik reports it. */
+  createdAt?: number
+}
+
+function baseUrl(): string {
+  return (
+    process.env.AUTHENTIK_BASE_URL ||
+    process.env.AUTHENTIK_ISSUER_URL?.replace(/\/application\/o\/.*$/, '') ||
+    'http://localhost:9000'
+  ).replace(/\/$/, '')
+}
+
+function adminToken(): string {
+  const token = process.env.AUTHENTIK_ADMIN_TOKEN
+  if (!token) {
+    // Fail-closed: without admin credentials we cannot read connection state,
+    // and guessing it is exactly how an account gets locked out.
+    throw new Error('AUTHENTIK_ADMIN_TOKEN is not configured')
+  }
+  return token
+}
+
+function headers(): Record<string, string> {
+  return {
+    Authorization: `Bearer ${adminToken()}`,
+    Accept: 'application/json',
+  }
+}
+
+async function call(path: string, init: RequestInit = {}): Promise<Response> {
+  let res: Response
+  try {
+    res = await fetch(`${baseUrl()}${path}`, {
+      ...init,
+      headers: { ...headers(), ...(init.headers as Record<string, string>) },
+    })
+  } catch (err) {
+    throw new Error(`identity store unreachable: ${(err as Error).message}`)
+  }
+  return res
+}
+
+async function okJson(res: Response, what: string): Promise<any> {
+  if (!res.ok) {
+    const body = (await res.text().catch(() => '')).slice(0, 300)
+    throw new Error(`identity store ${what} failed: HTTP ${res.status} ${body}`)
+  }
+  return res.json()
+}
+
+/**
+ * Resolve the identity store's user pk from the email.
+ *
+ * Email is the natural key our local projection matches on (the local `id` is a
+ * generated uuid, deliberately NOT the OIDC `sub`), so it is the only join we
+ * have. `email=` is an exact filter in Authentik's user list API.
+ */
+export async function findUserPk(email: string): Promise<number> {
+  const res = await call(`/api/v3/core/users/?email=${encodeURIComponent(email)}`)
+  const data = await okJson(res, 'user lookup')
+  const results: any[] = data?.results ?? []
+  // Exact, case-insensitive match — never trust the filter to be exact-only.
+  const hit = results.find(
+    r => typeof r?.email === 'string' && r.email.toLowerCase() === email.toLowerCase()
+  )
+  if (!hit || typeof hit.pk !== 'number') {
+    throw new Error('identity store user not found')
+  }
+  return hit.pk
+}
+
+/** List the user's OAuth source connections. */
+export async function listOAuthConnections(userPk: number): Promise<OAuthConnection[]> {
+  const res = await call(`/api/v3/sources/user_connections/oauth/?user=${userPk}`)
+  const data = await okJson(res, 'connection list')
+  const results: any[] = data?.results ?? []
+  return results.map(r => ({
+    pk: r.pk,
+    // `source` may be an expanded object or a bare slug depending on version.
+    sourceSlug: typeof r.source === 'string' ? r.source : (r.source?.slug ?? ''),
+    createdAt: r.created ? new Date(r.created).getTime() : undefined,
+  }))
+}
+
+/** Delete one OAuth source connection by its connection pk. */
+export async function deleteOAuthConnection(connectionPk: number): Promise<void> {
+  const res = await call(`/api/v3/sources/user_connections/oauth/${connectionPk}/`, {
+    method: 'DELETE',
+  })
+  // 404 = already gone; unlink is idempotent, so that is a success.
+  if (!res.ok && res.status !== 404) {
+    const body = (await res.text().catch(() => '')).slice(0, 300)
+    throw new Error(`identity store unlink failed: HTTP ${res.status} ${body}`)
+  }
+}
+
+/**
+ * Set the user's password IN THE IDENTITY STORE (never a local hash).
+ *
+ * A policy rejection comes back as a 400 with the reasons; the caller maps that
+ * to a 400 rather than a generic failure.
+ */
+export async function setUserPassword(userPk: number, password: string): Promise<void> {
+  const res = await call(`/api/v3/core/users/${userPk}/set_password/`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ password }),
+  })
+  if (res.status === 400) {
+    const body = (await res.text().catch(() => '')).slice(0, 300)
+    throw new PasswordPolicyError(body || 'password rejected by policy')
+  }
+  if (!res.ok) {
+    const body = (await res.text().catch(() => '')).slice(0, 300)
+    throw new Error(`identity store set-password failed: HTTP ${res.status} ${body}`)
+  }
+}
+
+/** Thrown when the identity store rejects a password on policy grounds (→ 400). */
+export class PasswordPolicyError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'PasswordPolicyError'
+  }
+}

--- a/backend/security/src/providers/authentik/userAgent.ts
+++ b/backend/security/src/providers/authentik/userAgent.ts
@@ -1,0 +1,76 @@
+/**
+ * Minimal, dependency-free user-agent parsing for the manage-devices list.
+ *
+ * Scope is deliberately narrow: the `SessionDevice` contract types device /
+ * browser / os as nullable, best-effort display hints — they are shown to a
+ * human deciding "is this me?", never used for any security decision. So an
+ * unrecognised agent correctly yields nulls rather than a guess.
+ *
+ * No UA-parsing library is pulled in: those ship large, frequently-updated
+ * regex corpora to answer questions we do not ask (bot detection, engine
+ * versions, device models). Order matters below — several families spoof each
+ * other's tokens (every Chromium browser says "Chrome"; Edge/Opera say both),
+ * so the most specific brand must be tested first.
+ */
+
+export interface ParsedUserAgent {
+  device: string | null
+  browser: string | null
+  os: string | null
+}
+
+const EMPTY: ParsedUserAgent = { device: null, browser: null, os: null }
+
+/** Browser brands, MOST SPECIFIC FIRST (Chromium forks all claim "Chrome"). */
+const BROWSERS: Array<[RegExp, string]> = [
+  [/\bEdgA?\/|\bEdge\//i, 'Edge'],
+  [/\bOPR\/|\bOpera\//i, 'Opera'],
+  [/\bSamsungBrowser\//i, 'Samsung Internet'],
+  [/\bFirefox\/|\bFxiOS\//i, 'Firefox'],
+  [/\bChrome\/|\bCriOS\//i, 'Chrome'],
+  // Safari must come last: every WebKit browser carries a "Safari/" token.
+  [/\bSafari\//i, 'Safari'],
+]
+
+/** OS families, most specific first (Android must precede Linux). */
+const OSES: Array<[RegExp, string]> = [
+  [/\bWindows NT\b|\bWindows\b/i, 'Windows'],
+  [/\bAndroid\b/i, 'Android'],
+  [/\biPhone\b|\biPad\b|\biPod\b|\biOS\b/i, 'iOS'],
+  [/\bMac OS X\b|\bMacintosh\b/i, 'macOS'],
+  [/\bCrOS\b/i, 'ChromeOS'],
+  [/\bLinux\b|\bX11\b/i, 'Linux'],
+]
+
+/**
+ * Derive a coarse device class. Only the distinction a user actually needs to
+ * recognise a session ("my phone" vs "my laptop") — never a device model.
+ */
+function device(ua: string): string | null {
+  if (/\biPad\b/i.test(ua)) return 'Tablet'
+  if (/\biPhone\b|\biPod\b/i.test(ua)) return 'iPhone'
+  // Android encodes form factor by the presence of "Mobile": Android + Mobile
+  // is a phone, Android without it is a tablet.
+  if (/\bAndroid\b/i.test(ua)) return /\bMobile\b/i.test(ua) ? 'Phone' : 'Tablet'
+  if (/\bMobile\b/i.test(ua)) return 'Phone'
+  if (/\bWindows\b|\bMacintosh\b|\bMac OS X\b|\bCrOS\b|\bLinux\b|\bX11\b/i.test(ua)) return 'Desktop'
+  return null
+}
+
+function firstMatch(ua: string, table: Array<[RegExp, string]>): string | null {
+  for (const [re, name] of table) if (re.test(ua)) return name
+  return null
+}
+
+/**
+ * Parse a stored user-agent string. Returns all-nulls for absent/blank/unknown
+ * agents — the contract permits nulls, so we never fabricate a value.
+ */
+export function parseUserAgent(ua: string | null | undefined): ParsedUserAgent {
+  if (!ua || typeof ua !== 'string' || !ua.trim()) return { ...EMPTY }
+  return {
+    device: device(ua),
+    browser: firstMatch(ua, BROWSERS),
+    os: firstMatch(ua, OSES),
+  }
+}

--- a/backend/security/src/routes/security.ts
+++ b/backend/security/src/routes/security.ts
@@ -16,9 +16,14 @@ import {
   ConflictError,
   InvalidInputError,
   UnauthorizedError,
+  NotFoundError,
 } from '../providers/authentik/AuthentikIdentityProvider'
 import { appBaseUrl } from '../providers/authentik/config'
-import type { BrokeredSession, BrokeredUser } from '../providers/IdentityProvider'
+import type {
+  BrokeredSession,
+  BrokeredUser,
+  SessionContext,
+} from '../providers/IdentityProvider'
 
 const router = express.Router()
 
@@ -28,6 +33,22 @@ function bearer(req: Request): string | null {
   if (!h || Array.isArray(h)) return null
   const [scheme, token] = h.split(' ')
   return scheme?.toLowerCase() === 'bearer' && token ? token : null
+}
+
+/**
+ * Capture the device/IP a session is being minted from, for manage-devices.
+ *
+ * Display-only — never an authorization input, so a spoofed user-agent or
+ * X-Forwarded-For can mislabel a row in the user's own device list but cannot
+ * grant access. `req.ip` honours Express's `trust proxy` setting, which is the
+ * right place to decide how far down the proxy chain to believe.
+ */
+function sessionContext(req: Request): SessionContext {
+  const ua = req.headers['user-agent']
+  return {
+    ip: req.ip ?? null,
+    userAgent: typeof ua === 'string' ? ua : null,
+  }
 }
 
 function toApiUser(u: BrokeredUser) {
@@ -58,6 +79,10 @@ function sendError(res: Response, err: unknown): void {
   }
   if (err instanceof ConflictError) {
     res.status(409).json({ error: err.message, code: 'CONFLICT' })
+    return
+  }
+  if (err instanceof NotFoundError) {
+    res.status(404).json({ error: err.message, code: 'NOT_FOUND' })
     return
   }
   if (err instanceof UnauthorizedError) {
@@ -91,10 +116,13 @@ function requireBearer(req: Request, res: Response): string | null {
 // POST /v1/security/session — password login
 router.post('/session', async (req: Request, res: Response) => {
   try {
-    const session = await getIdentityProvider().passwordLogin({
-      email: req.body?.email,
-      password: req.body?.password,
-    })
+    const session = await getIdentityProvider().passwordLogin(
+      {
+        email: req.body?.email,
+        password: req.body?.password,
+      },
+      sessionContext(req)
+    )
     res.status(200).json(authenticatedSession(session))
   } catch (err) {
     if (err instanceof MfaRequiredError) {
@@ -176,11 +204,15 @@ router.get('/social/callback', async (req: Request, res: Response) => {
     const code = typeof req.query.code === 'string' ? req.query.code : ''
     const state = typeof req.query.state === 'string' ? req.query.state : ''
     if (!code || !state) throw new InvalidInputError('code and state are required')
-    const result = await getIdentityProvider().brokerCallback({ code, state })
+    const result = await getIdentityProvider().brokerCallback({ code, state }, sessionContext(req))
     // Clear the state cookie; append the FuzeFront opaque code (never a token).
     res.setHeader('Set-Cookie', ['sec_social_state=; HttpOnly; Secure; SameSite=Lax; Max-Age=0; Path=/'])
     const sep = result.redirectTo.includes('?') ? '&' : '?'
-    const dest = `${appBaseUrl()}${result.redirectTo}${sep}code=${encodeURIComponent(result.code)}`
+    // A LINK handshake mints no session, so there is no code to redeem — send
+    // the browser back with a neutral confirmation instead.
+    const dest = result.linked
+      ? `${appBaseUrl()}${result.redirectTo}${sep}linked=${encodeURIComponent(result.provider ?? '')}`
+      : `${appBaseUrl()}${result.redirectTo}${sep}code=${encodeURIComponent(result.code)}`
     res.redirect(302, dest)
   } catch (err) {
     // Fail-closed: send the browser back to the app with a neutral error.
@@ -192,13 +224,16 @@ router.get('/social/callback', async (req: Request, res: Response) => {
 // ── Signup ──────────────────────────────────────────────────────────────────
 router.post('/signup', async (req: Request, res: Response) => {
   try {
-    const session = await getIdentityProvider().signup({
-      email: req.body?.email,
-      password: req.body?.password,
-      firstName: req.body?.firstName,
-      lastName: req.body?.lastName,
-      tenantName: req.body?.tenantName,
-    })
+    const session = await getIdentityProvider().signup(
+      {
+        email: req.body?.email,
+        password: req.body?.password,
+        firstName: req.body?.firstName,
+        lastName: req.body?.lastName,
+        tenantName: req.body?.tenantName,
+      },
+      sessionContext(req)
+    )
     res.status(201).json({ token: session.token, sessionId: session.sessionId, user: toApiUser(session.user) })
   } catch (err) {
     sendError(res, err)
@@ -324,7 +359,12 @@ router.post('/mfa/verify', async (req: Request, res: Response) => {
     if (!req.body?.challengeId || !req.body?.factorId || !req.body?.code) {
       throw new InvalidInputError('challengeId, factorId and code are required')
     }
-    const session = await getIdentityProvider().verifyMfa(req.body.challengeId, req.body.factorId, req.body.code)
+    const session = await getIdentityProvider().verifyMfa(
+      req.body.challengeId,
+      req.body.factorId,
+      req.body.code,
+      sessionContext(req)
+    )
     res.status(200).json({ token: session.token, sessionId: session.sessionId, user: toApiUser(session.user) })
   } catch (err) {
     sendError(res, err)
@@ -382,6 +422,110 @@ router.get('/verify/status', async (req: Request, res: Response) => {
   try {
     const status = await getIdentityProvider().getVerificationStatus(token)
     res.status(200).json(status)
+  } catch (err) {
+    sendError(res, err)
+  }
+})
+
+// ── Manage devices (platform sessions) ────────────────────────────────────
+//
+// Note these are `/sessions` (plural) — the device-management collection —
+// distinct from the `/session` (singular) sign-in lifecycle above.
+
+// GET /v1/security/sessions — the caller's active sessions, current flagged
+router.get('/sessions', async (req: Request, res: Response) => {
+  const token = requireBearer(req, res)
+  if (!token) return
+  try {
+    const items = await getIdentityProvider().listSessions(token)
+    res.status(200).json({ items })
+  } catch (err) {
+    sendError(res, err)
+  }
+})
+
+// DELETE /v1/security/sessions — revoke all OTHER sessions, keep the caller's
+router.delete('/sessions', async (req: Request, res: Response) => {
+  const token = requireBearer(req, res)
+  if (!token) return
+  try {
+    await getIdentityProvider().revokeOtherSessions(token)
+    res.status(204).end()
+  } catch (err) {
+    sendError(res, err)
+  }
+})
+
+// DELETE /v1/security/sessions/{id} — revoke one session (idempotent)
+router.delete('/sessions/:id', async (req: Request, res: Response) => {
+  const token = requireBearer(req, res)
+  if (!token) return
+  try {
+    await getIdentityProvider().revokeSession(token, req.params.id)
+    res.status(204).end()
+  } catch (err) {
+    sendError(res, err)
+  }
+})
+
+// ── Account sign-in connections ───────────────────────────────────────────
+// GET /v1/security/identity/connections — linked providers + password state
+router.get('/identity/connections', async (req: Request, res: Response) => {
+  const token = requireBearer(req, res)
+  if (!token) return
+  try {
+    const conns = await getIdentityProvider().getIdentityConnections(token)
+    res.status(200).json(conns)
+  } catch (err) {
+    sendError(res, err)
+  }
+})
+
+// POST /v1/security/social/{provider}/link — begin linking for a signed-in user
+router.post('/social/:provider/link', async (req: Request, res: Response) => {
+  const token = requireBearer(req, res)
+  if (!token) return
+  try {
+    const { redirectUrl, state, codeVerifier } = await getIdentityProvider().startSocialLink(
+      token,
+      req.params.provider
+    )
+    // Same cookie contract as sign-in: the registered OIDC redirect_uri handler
+    // is replica-agnostic and reads state/PKCE from these HttpOnly cookies.
+    res.setHeader('Set-Cookie', [
+      `oidc_state=${state}; HttpOnly; Secure; SameSite=Lax; Max-Age=600; Path=/`,
+      `oidc_cv=${codeVerifier}; HttpOnly; Secure; SameSite=Lax; Max-Age=600; Path=/`,
+      `sec_social_state=${state}; HttpOnly; Secure; SameSite=Lax; Max-Age=600; Path=/`,
+    ])
+    // 200 + { redirectUrl } (not a 302): the caller is the SPA via fetch with a
+    // bearer token, and a redirect chased by fetch would never reach the browser.
+    res.status(200).json({ redirectUrl })
+  } catch (err) {
+    sendError(res, err)
+  }
+})
+
+// DELETE /v1/security/social/{provider}/link — unlink (409 if last method)
+router.delete('/social/:provider/link', async (req: Request, res: Response) => {
+  const token = requireBearer(req, res)
+  if (!token) return
+  try {
+    const conns = await getIdentityProvider().unlinkSocial(token, req.params.provider)
+    res.status(200).json(conns)
+  } catch (err) {
+    sendError(res, err)
+  }
+})
+
+// ── Set password (social-only accounts) ───────────────────────────────────
+// POST /v1/security/password — add a password; 409 if one already exists
+router.post('/password', async (req: Request, res: Response) => {
+  const token = requireBearer(req, res)
+  if (!token) return
+  try {
+    if (!req.body?.newPassword) throw new InvalidInputError('newPassword is required')
+    const conns = await getIdentityProvider().setPassword(token, req.body.newPassword)
+    res.status(200).json(conns)
   } catch (err) {
     sendError(res, err)
   }


### PR DESCRIPTION
Implements `GET|DELETE /sessions`, `DELETE /sessions/{id}`, `POST|DELETE /social/{provider}/link`, `GET /identity/connections`, `POST /password` — all in the frozen contract (#273) but **404 in production**.

**⚠️ UNVERIFIED — and incomplete.** `tsc`/`jest` never ran; **tests were never written.** Plan mode froze the agent mid-task and this was salvaged from an uncommitted worktree (it was ~40 minutes from being lost). Do not read it as done — it is *un-losable*, not finished.

## Real contract gap found while building this (needs a decision)
**Authentik exposes no read path for password state.** Verified against `core/api/users.py`: `UserSerializer` has **no** `has_password`, and `password` is writable only under `SERIALIZER_CONTEXT_BLUEPRINT`. But `GET /identity/connections` promises `hasPassword: boolean`, and unlink-last-method depends on it. **The contract asks for something the identity store cannot answer.**

Resolution (no bcrypt — Authentik stays the credential store): a **tri-state `users.has_password` projection**, `NULL` = unknown/legacy, written only from proof points (enrollment, successful password login, set-password). Deliberately **never defaulted**, because a guess is unsafe in *both* directions:
- guess `true` → a social-only legacy user unlinks their last sign-in method and is **locked out**
- guess `false` → silently **overwrite a real password**

It resolves fail-closed per operation instead: unlink treats `NULL` as "no password" → 409 ("set one first"); set-password allows `NULL` through and converges the row to a known value.

**This is a contract question, not an implementation detail.** If the projection is wrong, it belongs back in the contract PR rather than diverging in code.

## Still needed before merge
Tests: current-session marked, revoke-one kills only that token (#282 makes `sessions` authoritative, so this is now genuinely provable), revoke-others keeps current, unlink-last-method → 409, set-password-when-exists → 409, other users' sessions unaffected.

`hold` — deploy-on-push; ruleset requires 1 approving review.

Co-Authored-By: Claude