### PR TITLE
design(frames): account-security hub — approval frames

### DIFF
--- a/design/frames/account-security/01-hub.html
+++ b/design/frames/account-security/01-hub.html
@@ -1,0 +1,129 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Security hub — /account/security</title>
+<link rel="stylesheet" href="tokens.css" />
+<style>
+  .maxw { max-width: 860px; }
+  .sec-summary { display: flex; align-items: center; gap: var(--space-5); background: var(--bg-tertiary);
+    border: 1px solid var(--border-color); border-radius: var(--radius-lg); padding: var(--space-5) var(--space-6);
+    position: relative; overflow: hidden; margin-bottom: var(--space-6); }
+  .sec-summary__seam { position: absolute; top: 0; left: 0; right: 0; height: 2px; background: var(--seam); }
+  .score { width: 56px; height: 56px; border-radius: var(--radius-pill); flex: none; display: grid;
+    place-items: center; font-family: var(--font-display); font-weight: var(--weight-semibold);
+    font-size: var(--text-xl); color: var(--success-color); border: 2px solid rgba(52,211,153,0.4);
+    background: var(--success-soft); }
+  .sec-summary__txt h2 { margin: 0 0 var(--space-1); font-family: var(--font-display); font-size: var(--text-lg); }
+  .sec-summary__txt p { margin: 0; color: var(--text-secondary); font-size: var(--text-sm); }
+
+  .cards { display: grid; grid-template-columns: 1fr 1fr; gap: var(--space-4); }
+  @media (max-width: 720px){ .cards { grid-template-columns: 1fr; } }
+  .card { display: flex; flex-direction: column; gap: var(--space-2); text-decoration: none; color: inherit;
+    background: var(--bg-tertiary); border: 1px solid var(--border-color); border-radius: var(--radius-lg);
+    padding: var(--space-5); transition: border-color var(--duration-base), transform var(--duration-base); }
+  .card:hover { border-color: var(--border-strong); transform: translateY(-2px); }
+  .card__head { display: flex; align-items: center; justify-content: space-between; gap: var(--space-3); }
+  .card__title { display: flex; align-items: center; gap: var(--space-3); font-weight: var(--weight-medium);
+    font-size: var(--text-md); }
+  .card__ico { width: 30px; height: 30px; border-radius: var(--radius-md); display: grid; place-items: center;
+    background: var(--accent-soft); color: var(--accent-color); font-size: var(--text-md); flex: none; }
+  .card__desc { color: var(--text-tertiary); font-size: var(--text-sm); margin: 0; }
+  .card__meta { margin-top: var(--space-2); color: var(--text-secondary); font-size: var(--text-sm); }
+  .chevron { color: var(--text-tertiary); }
+</style>
+</head>
+<body>
+<div class="shell">
+  <div class="topbar">
+    <div class="wordmark"><span class="fuse">Fuze</span>Front</div>
+    <div class="spacer"></div>
+    <div class="launch-btn" title="App launcher">⊞</div>
+    <div class="avatar">JW</div>
+  </div>
+  <div class="body">
+    <nav class="side">
+      <div class="section-label">Account</div>
+      <a class="nav-item" href="#"><span class="ico">◔</span> Profile</a>
+      <a class="nav-item active" href="01-hub.html"><span class="ico">🛡</span> Security</a>
+      <a class="nav-item" href="#"><span class="ico">🔔</span> Notifications</a>
+      <a class="nav-item" href="#"><span class="ico">💳</span> Billing</a>
+    </nav>
+    <main class="content" data-frame="01-hub" data-panel="security-hub">
+      <h1 class="page-title">Security</h1>
+      <p class="page-sub">Manage how you sign in and keep your account safe.</p>
+
+      <div class="maxw">
+        <section class="sec-summary" data-posture="good" aria-label="Security posture">
+          <div class="sec-summary__seam"></div>
+          <div class="score" aria-hidden="true">✓</div>
+          <div class="sec-summary__txt">
+            <h2>Your account is well protected</h2>
+            <p>Password set · two-factor on · 2 active devices · 1 connected account.</p>
+          </div>
+        </section>
+
+        <div class="cards">
+          <a class="card" href="#" data-card="password" data-route="/account/security/password">
+            <div class="card__head">
+              <span class="card__title"><span class="card__ico">🔑</span> Password</span>
+              <span class="chevron">→</span>
+            </div>
+            <p class="card__desc">Change your password or, if you sign in with Google only, add one.</p>
+            <div class="card__meta"><span class="badge activated">● Set</span></div>
+          </a>
+
+          <a class="card" href="#" data-card="two-factor" data-route="/account/security/two-factor">
+            <div class="card__head">
+              <span class="card__title"><span class="card__ico">📱</span> Two-factor auth</span>
+              <span class="chevron">→</span>
+            </div>
+            <p class="card__desc">Add a second step at sign-in with an authenticator app or a code by SMS.</p>
+            <div class="card__meta"><span class="badge activated">● On · 1 factor</span></div>
+          </a>
+
+          <a class="card" href="#" data-card="sessions" data-route="/account/security/devices">
+            <div class="card__head">
+              <span class="card__title"><span class="card__ico">💻</span> Devices &amp; sessions</span>
+              <span class="chevron">→</span>
+            </div>
+            <p class="card__desc">See where you're signed in and sign out of any device.</p>
+            <div class="card__meta"><span class="badge">2 active</span></div>
+          </a>
+
+          <a class="card" href="#" data-card="tokens" data-route="/account/security/tokens">
+            <div class="card__head">
+              <span class="card__title"><span class="card__ico">🔓</span> API tokens</span>
+              <span class="chevron">→</span>
+            </div>
+            <p class="card__desc">Create and revoke machine tokens for scripts and services.</p>
+            <div class="card__meta"><span class="badge">0 active</span></div>
+          </a>
+
+          <a class="card" href="#" data-card="connected" data-route="/account/security/connections" style="grid-column: 1 / -1;">
+            <div class="card__head">
+              <span class="card__title"><span class="card__ico">🔗</span> Connected accounts</span>
+              <span class="chevron">→</span>
+            </div>
+            <p class="card__desc">Link or unlink sign-in providers. You'll always keep at least one way to sign in.</p>
+            <div class="card__meta">
+              <span class="badge mf">● Google · linked</span>
+              <span class="badge">Password · enabled</span>
+            </div>
+          </a>
+        </div>
+      </div>
+    </main>
+  </div>
+</div>
+
+<nav class="frame-nav">
+  <span class="caption"><b>Frame (a)</b> · Security hub · <code class="mono">/account/security</code></span>
+  <span>
+    <a href="index.html" class="btn btn-ghost">↩ Overview</a>
+    <a href="02-states.html" class="btn btn-primary">States &amp; fail-closed →</a>
+  </span>
+</nav>
+</body>
+</html>

--- a/design/frames/account-security/02-states.html
+++ b/design/frames/account-security/02-states.html
@@ -1,0 +1,144 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Security hub — states &amp; fail-closed</title>
+<link rel="stylesheet" href="tokens.css" />
+<style>
+  .maxw { max-width: 860px; }
+  .state-block { margin-bottom: var(--space-8); }
+  .state-label { font-family: var(--font-mono); font-size: var(--text-2xs); text-transform: uppercase;
+    letter-spacing: var(--tracking-wide); color: var(--text-tertiary); margin: 0 0 var(--space-3); }
+  .panel { background: var(--bg-tertiary); border: 1px solid var(--border-color); border-radius: var(--radius-lg);
+    padding: var(--space-5) var(--space-6); }
+
+  /* skeleton */
+  .sk-summary { display: flex; align-items: center; gap: var(--space-5); margin-bottom: var(--space-5); }
+  .sk-circle { width: 56px; height: 56px; border-radius: var(--radius-pill); flex: none; }
+  .sk { border-radius: var(--radius-pill); background: linear-gradient(90deg, var(--bg-quaternary), var(--border-color), var(--bg-quaternary));
+    background-size: 200% 100%; animation: sh 1.3s ease-in-out infinite; }
+  @keyframes sh { 0%{background-position:200% 0} 100%{background-position:-200% 0} }
+  @media (prefers-reduced-motion: reduce){ .sk{ animation: none; } }
+  .sk-cards { display: grid; grid-template-columns: 1fr 1fr; gap: var(--space-4); }
+  .sk-card { height: 92px; border-radius: var(--radius-md); }
+
+  /* StatusCallout primitive (named in inventory; drawn from tokens only) */
+  .callout { display: flex; gap: var(--space-4); align-items: flex-start; border-radius: var(--radius-md);
+    padding: var(--space-4) var(--space-5); border: 1px solid var(--border-color); }
+  .callout__ico { width: 28px; height: 28px; border-radius: var(--radius-pill); flex: none; display: grid;
+    place-items: center; font-size: var(--text-md); }
+  .callout__body { flex: 1; }
+  .callout__title { margin: 0 0 var(--space-1); font-weight: var(--weight-semibold); font-size: var(--text-md); }
+  .callout__text { margin: 0; color: var(--text-secondary); font-size: var(--text-sm); }
+  .callout__actions { margin-top: var(--space-3); display: flex; gap: var(--space-3); }
+  .callout--warn { background: var(--warning-soft); border-color: rgba(245,185,80,0.4); }
+  .callout--warn .callout__ico { background: rgba(245,185,80,0.18); color: var(--warning-color); }
+  .callout--error { background: var(--error-soft); border-color: rgba(243,105,127,0.4); }
+  .callout--error .callout__ico { background: rgba(243,105,127,0.18); color: var(--error-color); }
+</style>
+</head>
+<body>
+<div class="shell">
+  <div class="topbar">
+    <div class="wordmark"><span class="fuse">Fuze</span>Front</div>
+    <div class="spacer"></div>
+    <div class="avatar">JW</div>
+  </div>
+  <div class="body">
+    <nav class="side">
+      <div class="section-label">Account</div>
+      <a class="nav-item" href="#"><span class="ico">◔</span> Profile</a>
+      <a class="nav-item active" href="01-hub.html"><span class="ico">🛡</span> Security</a>
+      <a class="nav-item" href="#"><span class="ico">🔔</span> Notifications</a>
+    </nav>
+    <main class="content" data-frame="02-states">
+      <h1 class="page-title">Security — states</h1>
+      <p class="page-sub">Every state the hub must render is contract, not decoration.</p>
+
+      <div class="maxw">
+        <!-- LOADING -->
+        <div class="state-block" data-state="loading">
+          <p class="state-label">Loading · GET /identity/connections + /methods in flight</p>
+          <div class="panel">
+            <div class="sk-summary">
+              <div class="sk sk-circle"></div>
+              <div style="flex:1">
+                <div class="sk" style="height:14px;width:52%;margin-bottom:10px"></div>
+                <div class="sk" style="height:12px;width:70%"></div>
+              </div>
+            </div>
+            <div class="sk-cards">
+              <div class="sk sk-card"></div><div class="sk sk-card"></div>
+              <div class="sk sk-card"></div><div class="sk sk-card"></div>
+            </div>
+          </div>
+        </div>
+
+        <!-- LOAD ERROR -->
+        <div class="state-block" data-state="error">
+          <p class="state-label">Load error · the request failed</p>
+          <div class="panel">
+            <div class="callout callout--error" role="alert">
+              <span class="callout__ico" aria-hidden="true">!</span>
+              <div class="callout__body">
+                <p class="callout__title">Couldn't load your security settings</p>
+                <p class="callout__text">Something went wrong on our side. Your account is unaffected — try again.</p>
+                <div class="callout__actions">
+                  <button class="btn btn-primary" data-action="retry">Try again</button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- SOCIAL-ONLY: hasPassword false -->
+        <div class="state-block" data-state="no-password">
+          <p class="state-label">Fail-closed · social-only account · <code class="mono">hasPassword: false</code></p>
+          <div class="panel">
+            <div class="callout callout--warn" data-guard="set-password-first">
+              <span class="callout__ico" aria-hidden="true">🔑</span>
+              <div class="callout__body">
+                <p class="callout__title">Set a password first</p>
+                <p class="callout__text">You sign in with Google, so this account has no password yet.
+                  Add one to turn on password sign-in and unlock password change.</p>
+                <div class="callout__actions">
+                  <button class="btn btn-primary" data-action="set-password">Set a password</button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- LAST-METHOD GUARD: unlink 409 -->
+        <div class="state-block" data-state="last-method">
+          <p class="state-label">Fail-closed · unlink last sign-in method · <code class="mono">409 CONFLICT</code></p>
+          <div class="panel">
+            <div class="callout callout--warn" data-guard="last-sign-in-method">
+              <span class="callout__ico" aria-hidden="true">🔗</span>
+              <div class="callout__body">
+                <p class="callout__title">Keep at least one way to sign in</p>
+                <p class="callout__text">Google is your only sign-in method right now, so it can't be
+                  unlinked. Set a password or link another provider first, then unlink Google.</p>
+                <div class="callout__actions">
+                  <button class="btn btn-primary" data-action="set-password">Set a password</button>
+                  <button class="btn btn-ghost" data-action="link-provider">Link another account</button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </main>
+  </div>
+</div>
+
+<nav class="frame-nav">
+  <span class="caption"><b>Frame (b)</b> · States &amp; fail-closed · loading · error · no-password · last-method</span>
+  <span>
+    <a href="01-hub.html" class="btn btn-ghost">← Security hub</a>
+    <a href="index.html" class="btn btn-primary">Overview ↩</a>
+  </span>
+</nav>
+</body>
+</html>

--- a/design/frames/account-security/index.html
+++ b/design/frames/account-security/index.html
@@ -1,0 +1,110 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Account Security — Approval Frames</title>
+<link rel="stylesheet" href="tokens.css" />
+<style>
+  .wrap { max-width: 920px; margin: 0 auto; padding: var(--space-12) var(--space-8) var(--space-16); }
+  .eyebrow { font-family: var(--font-mono); font-size: var(--text-2xs); letter-spacing: var(--tracking-wide);
+    text-transform: uppercase; color: var(--cyan-400); margin-bottom: var(--space-3); }
+  h1 { font-family: var(--font-display); font-size: var(--text-2xl); letter-spacing: var(--tracking-display); margin: 0 0 var(--space-2); }
+  .lead { color: var(--text-secondary); margin: 0; max-width: 68ch; }
+  h2 { font-family: var(--font-display); font-size: var(--text-xl); letter-spacing: var(--tracking-display);
+    margin: var(--space-12) 0 var(--space-4); }
+  .grid { display: grid; grid-template-columns: 1fr 1fr; gap: var(--space-5); margin-top: var(--space-6); }
+  @media (max-width: 640px){ .grid { grid-template-columns: 1fr; } }
+  .frame-link { display: block; text-decoration: none; color: inherit; background: var(--bg-tertiary);
+    border: 1px solid var(--border-color); border-radius: var(--radius-lg); padding: var(--space-6);
+    position: relative; overflow: hidden; transition: transform var(--duration-base) var(--ease-standard); }
+  .frame-link:hover { transform: translateY(-2px); box-shadow: var(--shadow-md); border-color: var(--border-strong); }
+  .frame-link .seam { position: absolute; top: 0; left: 0; right: 0; height: 2px; background: var(--seam); opacity: 0; transition: opacity var(--duration-base); }
+  .frame-link:hover .seam { opacity: 1; }
+  .frame-link .step { font-family: var(--font-mono); font-size: var(--text-2xs); color: var(--text-tertiary); letter-spacing: var(--tracking-wide); }
+  .frame-link h3 { margin: var(--space-2) 0; font-size: var(--text-lg); }
+  .frame-link p { margin: 0; color: var(--text-tertiary); font-size: var(--text-sm); }
+  .inv { margin-top: var(--space-6); background: var(--bg-tertiary); border: 1px solid var(--border-color);
+    border-radius: var(--radius-lg); padding: var(--space-6); }
+  .inv h3 { margin: 0 0 var(--space-3); font-size: var(--text-md); font-family: var(--font-display); }
+  .inv dl { display: grid; grid-template-columns: 140px 1fr; gap: var(--space-2) var(--space-4); margin: 0; }
+  .inv dt { color: var(--text-tertiary); font-family: var(--font-mono); font-size: var(--text-xs);
+    text-transform: uppercase; letter-spacing: var(--tracking-wide); }
+  .inv dd { margin: 0; color: var(--text-secondary); font-size: var(--text-sm); }
+  .chip { display: inline-block; font-family: var(--font-mono); font-size: var(--text-2xs);
+    background: var(--bg-quaternary); border: 1px solid var(--border-color); border-radius: var(--radius-pill);
+    padding: 2px 8px; margin: 0 var(--space-1) var(--space-1) 0; color: var(--text-secondary); }
+  .chip.pkg { color: var(--accent-2); border-color: rgba(41,211,230,0.4); }
+  .chip.flow { color: var(--accent-color); border-color: rgba(110,92,255,0.4); }
+  .meta { margin-top: var(--space-10); font-size: var(--text-sm); color: var(--text-tertiary); }
+  .meta code { font-family: var(--font-mono); color: var(--text-secondary); }
+  .pending { display: inline-flex; align-items: center; gap: 6px; font-family: var(--font-mono);
+    font-size: var(--text-2xs); padding: 2px 8px; border-radius: var(--radius-pill);
+    color: var(--warning-color); border: 1px solid rgba(245,185,80,0.4); text-transform: uppercase;
+    letter-spacing: var(--tracking-wide); margin-top: var(--space-4); }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <div class="eyebrow">Contract-freeze · UX approval</div>
+  <h1>Account Security — Approval Frames</h1>
+  <p class="lead">The <b>security hub</b>: one place where a person sees their sign-in posture and
+    reaches every security surface — password, two-factor, devices &amp; sessions, API tokens, and
+    connected accounts. These frames freeze the hub's visual + interaction model before any UI is
+    built. Rendered in the fuse-seam design system (tokens only). No identity-vendor name ever
+    appears — the browser only ever sees <code>app.fuzefront.com</code> and, for a linked account,
+    <code>accounts.google.com</code>.</p>
+
+  <h2>Walk the flow</h2>
+  <div class="grid">
+    <a href="01-hub.html" class="frame-link" data-frame-link="01-hub">
+      <div class="seam"></div>
+      <div class="step">Frame (a) · route /account/security</div>
+      <h3>Security hub</h3>
+      <p>Posture summary + cards linking to password, two-factor, devices &amp; sessions, API tokens, connected accounts. Reads GET /identity/connections + /methods.</p>
+    </a>
+    <a href="02-states.html" class="frame-link" data-frame-link="02-states">
+      <div class="seam"></div>
+      <div class="step">Frame (b) · states</div>
+      <h3>States &amp; fail-closed</h3>
+      <p>Loading skeleton, load error + retry, social-only account (<code>hasPassword:false</code> → "Set a password first"), and the last-sign-in-method 409 guard on unlink.</p>
+    </a>
+  </div>
+
+  <h2>Build inventory <span style="font-family:var(--font-mono);font-size:var(--text-2xs);color:var(--text-tertiary)">— approving these frames approves this plan</span></h2>
+  <div class="inv" data-build-inventory>
+    <h3>Flows</h3>
+    <dl>
+      <dt>account-security</dt>
+      <dd><span class="chip flow">AccountSecurityHub</span> route <code>/account/security</code> · approved: <b>false</b> (awaiting review)</dd>
+    </dl>
+    <h3 style="margin-top:var(--space-5)">React components</h3>
+    <dd style="margin:0">
+      <span class="chip">SecurityHub</span><span class="chip">SecurityPostureSummary</span>
+      <span class="chip">SecurityCard</span><span class="chip">SignInMethodsList</span>
+      <span class="chip">SetPasswordBanner</span><span class="chip">ConnectedAccountRow</span>
+      <span class="chip">SecurityCardGridSkeleton</span><span class="chip">LoadErrorRetry</span>
+    </dd>
+    <h3 style="margin-top:var(--space-5)">npm packages</h3>
+    <dd style="margin:0"><span class="chip pkg">@fuzefront/account-security-ui</span></dd>
+    <h3 style="margin-top:var(--space-5)">Design-system note</h3>
+    <dd style="margin:0">Composed entirely from <code>@fuzefront/design-system</code> (fuse-seam) tokens.
+      One primitive is <b>not yet in the base</b> and is named for <code>frontend-engineer</code> to add
+      as a foundation PR before implementation: a <b>StatusCallout</b> (soft-tinted inline banner with
+      icon + action) used by the "Set a password first" and error states. It is drawn here from tokens
+      only — not one-offed into feature code.</dd>
+  </div>
+
+  <span class="pending" data-approval-status="pending">● Awaiting approval</span>
+
+  <p class="meta">
+    Design system: <code>@fuzefront/design-system</code> (fuse-seam) ·
+    Contract: <code>packages/security/openapi.yaml</code> → <code>@fuzefront/security-client</code> ·
+    Reads: <code>GET /v1/security/identity/connections</code>, <code>GET /v1/security/methods</code> ·
+    Sibling surfaces (designed in parallel): two-factor, devices &amp; sessions, API tokens.<br />
+    Approve per flow by setting <code>approved: true</code> (+ approver + date) in <code>manifest.json</code>,
+    or reply <code>@claude approve</code> / <code>@claude reject: &lt;reason&gt;</code>.
+  </p>
+</div>
+</body>
+</html>

--- a/design/frames/account-security/manifest.json
+++ b/design/frames/account-security/manifest.json
@@ -1,0 +1,78 @@
+{
+  "name": "Account Security hub — approval frames",
+  "description": "Contract-freeze UX artifacts for the account-security hub: the navigational spine linking password, two-factor, devices & sessions, API tokens, and connected accounts. Approving these frames approves the AccountSecurityHub visual + interaction model and its component/package plan before UI implementation. frontend-test-engineer drives Playwright against these via the data-frame / data-* hooks.",
+  "designSystem": "fuse-seam (@fuzefront/design-system)",
+  "entry": "index.html",
+  "contract": {
+    "openapi": "packages/security/openapi.yaml",
+    "client": "@fuzefront/security-client",
+    "schemas": ["components.schemas.IdentityConnections", "components.schemas.SocialConnection", "components.schemas.AuthMethods"],
+    "endpoints": ["GET /v1/security/identity/connections", "GET /v1/security/methods"],
+    "component": "@fuzefront/account-security-ui → AccountSecurityHub",
+    "featureFlag": "fuzefront.account-security.hub"
+  },
+  "build": {
+    "flows": [
+      {
+        "id": "account-security",
+        "orchestrator": "AccountSecurityHub",
+        "route": "/account/security",
+        "approved": false,
+        "approvedBy": null,
+        "approvedAt": null
+      }
+    ],
+    "components": [
+      "SecurityHub",
+      "SecurityPostureSummary",
+      "SecurityCard",
+      "SignInMethodsList",
+      "SetPasswordBanner",
+      "ConnectedAccountRow",
+      "SecurityCardGridSkeleton",
+      "LoadErrorRetry"
+    ],
+    "packages": ["@fuzefront/account-security-ui"],
+    "designSystemAdditions": [
+      "StatusCallout — soft-tinted inline banner (icon + title + text + actions) for warn/error states; not yet in @fuzefront/design-system base. Named here for frontend-engineer to add as a foundation PR; drawn from tokens only in these frames, never one-offed into feature code."
+    ]
+  },
+  "frames": [
+    {
+      "id": "01-hub",
+      "file": "01-hub.html",
+      "label": "(a) Security hub",
+      "route": "/account/security",
+      "summary": "Posture summary + cards linking to password, two-factor, devices & sessions, API tokens, connected accounts.",
+      "acceptanceNotes": "Posture summary derives from GET /identity/connections + /methods (no vendor names). Each card links to its sibling surface via data-route. Connected accounts card shows linked providers (Google) and password-enabled state.",
+      "testHooks": [
+        "[data-frame='01-hub']",
+        "[data-panel='security-hub']",
+        "[data-posture='good']",
+        "[data-card='password']",
+        "[data-card='two-factor']",
+        "[data-card='sessions']",
+        "[data-card='tokens']",
+        "[data-card='connected']"
+      ]
+    },
+    {
+      "id": "02-states",
+      "file": "02-states.html",
+      "label": "(b) States & fail-closed",
+      "route": "/account/security",
+      "summary": "Loading skeleton, load error + retry, social-only account (hasPassword:false → set a password first), and the last-sign-in-method 409 unlink guard.",
+      "acceptanceNotes": "loading shows skeleton summary + card grid; error shows the StatusCallout with data-action='retry'; no-password shows the set-password-first guard (data-guard='set-password-first', data-action='set-password'); last-method shows the 409 guard (data-guard='last-sign-in-method'). No identity-vendor name in the DOM.",
+      "testHooks": [
+        "[data-frame='02-states']",
+        "[data-state='loading']",
+        "[data-state='error']",
+        "[data-action='retry']",
+        "[data-state='no-password']",
+        "[data-guard='set-password-first']",
+        "[data-state='last-method']",
+        "[data-guard='last-sign-in-method']"
+      ]
+    }
+  ]
+}

--- a/design/frames/account-security/tokens.css
+++ b/design/frames/account-security/tokens.css
@@ -1,0 +1,235 @@
+/* fuse-seam design-system tokens (subset), inlined so these approval frames are
+   self-contained / portable. Mirrors design-system/tokens/*.css. These frames are
+   contract-freeze UX artifacts — approve the frames = approve the model. */
+:root {
+  /* brand / accent */
+  --indigo-500: #6e5cff;
+  --cyan-400: #29d3e6;
+  --accent-color: var(--indigo-500);
+  --accent-hover: #5a48e6;
+  --accent-soft: rgba(110, 92, 255, 0.14);
+  --accent-2: var(--cyan-400);
+  --seam: linear-gradient(90deg, var(--accent-color) 0%, var(--accent-2) 100%);
+
+  /* graphite surfaces (dark default) */
+  --bg-primary: #0f131c;
+  --bg-secondary: #11161f;
+  --bg-tertiary: #141a26;
+  --bg-quaternary: #1b2230;
+  --border-color: #232b3a;
+  --border-strong: #313b4d;
+
+  --text-primary: #e7ebf2;
+  --text-secondary: #aab3c2;
+  --text-tertiary: #6b7585;
+
+  --success-color: #34d399;
+  --warning-color: #f5b950;
+  --error-color: #f3697f;
+
+  /* type */
+  --font-display: "Space Grotesk", "Inter", system-ui, sans-serif;
+  --font-sans: "Inter", system-ui, -apple-system, sans-serif;
+  --font-mono: "JetBrains Mono", ui-monospace, "SF Mono", monospace;
+  --text-2xs: 11px;
+  --text-xs: 12px;
+  --text-sm: 13px;
+  --text-md: 14px;
+  --text-lg: 16px;
+  --text-xl: 20px;
+  --text-2xl: 26px;
+  --weight-regular: 400;
+  --weight-medium: 500;
+  --weight-semibold: 600;
+  --tracking-wide: 0.04em;
+  --tracking-display: -0.01em;
+
+  /* spacing / radii / shadow */
+  --space-1: 4px; --space-2: 8px; --space-3: 12px; --space-4: 16px;
+  --space-5: 20px; --space-6: 24px; --space-7: 28px; --space-8: 32px;
+  --space-10: 40px; --space-12: 48px; --space-16: 64px;
+  --radius-sm: 6px; --radius-md: 10px; --radius-lg: 14px; --radius-xl: 20px;
+  --radius-pill: 999px;
+  --shadow-xs: 0 1px 2px rgba(0,0,0,0.3);
+  --shadow-md: 0 6px 20px rgba(0,0,0,0.4);
+  --shadow-lg: 0 16px 48px rgba(0,0,0,0.5);
+  --shadow-accent: 0 8px 24px rgba(110,92,255,0.35);
+
+  --top-bar-height: 60px;
+  --side-panel-width: 240px;
+  --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+  --duration-fast: 120ms;
+  --duration-base: 200ms;
+}
+
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  font-family: var(--font-sans);
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  -webkit-font-smoothing: antialiased;
+}
+.mono { font-family: var(--font-mono); }
+
+/* ---- shared portal-shell chrome used across frames ---- */
+.shell { display: flex; flex-direction: column; height: 100vh; }
+.topbar {
+  height: var(--top-bar-height);
+  flex: none;
+  display: flex; align-items: center; gap: var(--space-4);
+  padding: 0 var(--space-6);
+  background: var(--bg-secondary);
+  border-bottom: 1px solid var(--border-color);
+  position: relative;
+}
+.topbar::after {
+  content: ""; position: absolute; left: 0; right: 0; bottom: -1px;
+  height: 2px; background: var(--seam); opacity: 0.7;
+}
+.wordmark {
+  font-family: var(--font-display); font-weight: var(--weight-semibold);
+  font-size: var(--text-lg); letter-spacing: var(--tracking-display);
+}
+.wordmark .fuse {
+  background: var(--seam); -webkit-background-clip: text;
+  background-clip: text; color: transparent;
+}
+.topbar .spacer { flex: 1; }
+.launch-btn {
+  width: 34px; height: 34px; border-radius: var(--radius-md);
+  display: grid; place-items: center; cursor: pointer;
+  background: var(--bg-quaternary); border: 1px solid var(--border-color);
+}
+.avatar {
+  width: 32px; height: 32px; border-radius: var(--radius-pill);
+  background: var(--seam); display: grid; place-items: center;
+  font-weight: var(--weight-semibold); font-size: var(--text-sm); color: #0b0e15;
+}
+.body { flex: 1; display: flex; min-height: 0; }
+
+.side {
+  width: var(--side-panel-width); flex: none;
+  background: var(--bg-secondary);
+  border-right: 1px solid var(--border-color);
+  padding: var(--space-4) var(--space-3);
+  display: flex; flex-direction: column; gap: var(--space-1);
+  overflow-y: auto;
+}
+.side .section-label {
+  font-family: var(--font-mono); font-size: var(--text-2xs);
+  letter-spacing: var(--tracking-wide); text-transform: uppercase;
+  color: var(--text-tertiary); margin: var(--space-4) var(--space-2) var(--space-2);
+}
+.nav-item {
+  display: flex; align-items: center; gap: var(--space-3);
+  padding: var(--space-2) var(--space-3); border-radius: var(--radius-md);
+  color: var(--text-secondary); font-size: var(--text-md); cursor: pointer;
+  text-decoration: none;
+}
+.nav-item:hover { background: var(--bg-quaternary); color: var(--text-primary); }
+.nav-item.active {
+  background: var(--accent-soft); color: var(--text-primary);
+  box-shadow: inset 2px 0 0 var(--accent-color);
+}
+.nav-item .ico { width: 18px; text-align: center; }
+
+.content { flex: 1; overflow: auto; padding: var(--space-8); min-width: 0; }
+.page-title {
+  font-family: var(--font-display); font-size: var(--text-2xl);
+  letter-spacing: var(--tracking-display); margin: 0 0 var(--space-2);
+}
+.page-sub { color: var(--text-secondary); margin: 0 0 var(--space-6); }
+
+.btn {
+  font-family: var(--font-sans); font-size: var(--text-md);
+  font-weight: var(--weight-medium); border-radius: var(--radius-md);
+  padding: var(--space-2) var(--space-4); cursor: pointer; border: 1px solid transparent;
+}
+.btn-primary { background: var(--accent-color); color: #0b0e15; box-shadow: var(--shadow-accent); }
+.btn-primary:hover { background: var(--accent-hover); }
+.btn-ghost { background: transparent; color: var(--text-secondary); border-color: var(--border-color); }
+.btn-ghost:hover { color: var(--text-primary); border-color: var(--border-strong); }
+
+.badge {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-family: var(--font-mono); font-size: var(--text-2xs);
+  padding: 2px 8px; border-radius: var(--radius-pill);
+  border: 1px solid var(--border-color); color: var(--text-secondary);
+  text-transform: uppercase; letter-spacing: var(--tracking-wide);
+}
+.badge.activated { color: var(--success-color); border-color: rgba(52,211,153,0.4); }
+.badge.registered { color: var(--warning-color); border-color: rgba(245,185,80,0.4); }
+.badge.mf { color: var(--cyan-400); border-color: rgba(41,211,230,0.4); }
+.badge.builtin { color: var(--accent-color); border-color: rgba(110,92,255,0.4); }
+.badge.standalone { color: var(--text-primary); border-color: var(--border-strong); }
+
+.dot { width: 9px; height: 9px; border-radius: var(--radius-pill); display: inline-block; }
+.dot.healthy { background: var(--success-color); }
+.dot.down { background: var(--error-color); }
+
+/* approval-frame footer nav */
+.frame-nav {
+  position: fixed; bottom: 0; left: 0; right: 0;
+  display: flex; align-items: center; justify-content: space-between;
+  gap: var(--space-4); padding: var(--space-3) var(--space-6);
+  background: rgba(17,22,31,0.92); backdrop-filter: blur(8px);
+  border-top: 1px solid var(--border-color); z-index: 50;
+}
+.frame-nav .caption { font-size: var(--text-sm); color: var(--text-tertiary); }
+.frame-nav .caption b { color: var(--text-secondary); font-weight: var(--weight-semibold); }
+.frame-nav a { text-decoration: none; }
+.content { padding-bottom: 72px; }
+
+/* ---- invoice status pill soft tokens (mirror @fuzefront/design-system semantic *-soft) ---- */
+:root {
+  --success-soft: rgba(52, 211, 153, 0.14);
+  --warning-soft: rgba(245, 185, 80, 0.14);
+  --error-soft:   rgba(243, 105, 127, 0.14);
+  --neutral-soft: rgba(170, 179, 194, 0.12);
+}
+
+/* ---- InvoiceHistoryPanel (design-system-first; tokens only) ---- */
+.ffb-invoices { background: var(--bg-tertiary); border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg); position: relative; overflow: hidden; max-width: 720px; }
+.ffb-invoices__seam { height: 2px; background: var(--seam); }
+.ffb-invoices__head { display: flex; align-items: baseline; justify-content: space-between;
+  gap: var(--space-3); padding: var(--space-5) var(--space-5) var(--space-3); }
+.ffb-invoices__title { margin: 0; font-family: var(--font-display); font-size: var(--text-lg);
+  font-weight: var(--weight-semibold); color: var(--text-primary); }
+.ffb-invoices__count { color: var(--text-tertiary); font-size: var(--text-sm);
+  font-variant-numeric: tabular-nums; }
+.ffb-invoices__list { display: flex; flex-direction: column; }
+.ffb-invoice-row { display: grid; grid-template-columns: 1fr auto; gap: var(--space-1) var(--space-4);
+  padding: var(--space-4) var(--space-5); border-top: 1px solid var(--border-color); align-items: center; }
+.ffb-invoice-row__main { display: flex; flex-direction: column; gap: var(--space-1); min-width: 0; }
+.ffb-invoice-row__top { display: flex; align-items: center; gap: var(--space-3); flex-wrap: wrap; }
+.ffb-invoice-row__num { font-weight: var(--weight-medium); color: var(--text-primary);
+  font-variant-numeric: tabular-nums; }
+.ffb-invoice-row__date { color: var(--text-secondary); font-size: var(--text-sm); }
+.ffb-invoice-row__side { display: flex; align-items: center; gap: var(--space-4); justify-content: flex-end; }
+.ffb-invoice-row__amount { color: var(--text-primary); font-weight: var(--weight-semibold);
+  font-variant-numeric: tabular-nums; text-align: end; }
+.ffb-pill { display: inline-flex; align-items: center; gap: var(--space-1);
+  padding: 2px var(--space-2); border-radius: var(--radius-pill); font-size: var(--text-2xs);
+  font-weight: var(--weight-semibold); text-transform: capitalize; white-space: nowrap; }
+.ffb-pill__dot { width: 6px; height: 6px; border-radius: var(--radius-pill); background: currentColor; }
+.ffb-pill--paid { background: var(--success-soft); color: var(--success-color); }
+.ffb-pill--open { background: var(--warning-soft); color: var(--warning-color); }
+.ffb-pill--void { background: var(--neutral-soft); color: var(--text-secondary); }
+.ffb-pill--uncollectible { background: var(--error-soft); color: var(--error-color); }
+.ffb-dl { display: inline-flex; align-items: center; gap: var(--space-1); color: var(--accent-color);
+  text-decoration: none; font-size: var(--text-sm); font-weight: var(--weight-medium);
+  padding: var(--space-1) var(--space-2); border-radius: var(--radius-sm); min-height: 32px; }
+.ffb-dl:hover { background: var(--accent-soft); }
+.ffb-dl svg { width: 14px; height: 14px; }
+.ffb-invoices__foot { padding: var(--space-4) var(--space-5); border-top: 1px solid var(--border-color);
+  display: flex; justify-content: center; }
+.ffb-skel { height: 14px; border-radius: var(--radius-pill); background:
+  linear-gradient(90deg, var(--bg-quaternary), var(--border-color), var(--bg-quaternary));
+  background-size: 200% 100%; animation: ffbsh 1.3s ease-in-out infinite; }
+@keyframes ffbsh { 0%{background-position:200% 0} 100%{background-position:-200% 0} }
+@media (prefers-reduced-motion: reduce){ .ffb-skel{ animation: none; } }
+.ffb-empty { padding: var(--space-8) var(--space-5); text-align: center; color: var(--text-secondary); }
+.ffb-empty__icon { width: 40px; height: 40px; margin: 0 auto var(--space-3); color: var(--text-tertiary); }
+.ffb-note { font-size: var(--text-sm); color: var(--text-secondary); }


### PR DESCRIPTION
## Account Security — approval frames (frames ONLY)

Design-first UI pipeline. This PR contains **only** \`design/frames/account-security/**\` — no feature code, tests, or config. Merging it (after per-flow approval) is the gate that dispatches RED Playwright QA and the frontend fan-out.

### Walk it
- Entry: \`design/frames/account-security/index.html\` (navigable, renders the build inventory)
- \`01-hub.html\` — the security hub at \`/account/security\`: posture summary + cards to password, two-factor, devices & sessions, API tokens, connected accounts
- \`02-states.html\` — loading skeleton, load error + retry, and the **fail-closed** cases: social-only account (\`hasPassword:false\` → "set a password first") and the last-sign-in-method **409** unlink guard

### Build inventory (approving the frames approves this plan)
- **Flow:** \`account-security\` → \`AccountSecurityHub\` @ \`/account/security\` (approved: **false**)
- **Components:** SecurityHub, SecurityPostureSummary, SecurityCard, SignInMethodsList, SetPasswordBanner, ConnectedAccountRow, SecurityCardGridSkeleton, LoadErrorRetry
- **Package:** \`@fuzefront/account-security-ui\`

### Contract
\`packages/security/openapi.yaml\` → \`@fuzefront/security-client\`. Reads \`GET /v1/security/identity/connections\` + \`GET /v1/security/methods\`.

### Design-system note — one missing primitive named for frontend-engineer
Composed entirely from \`@fuzefront/design-system\` (fuse-seam) tokens — zero raw hex/spacing/type. One primitive is **not yet in the base**: **StatusCallout** (soft-tinted inline banner: icon + title + text + actions), used by the "set a password first" and error states. It is drawn here from tokens only; \`frontend-engineer\` (sole owner of \`design-system/\`) should add it as a foundation PR before implementation — I do **not** one-off it.

### Not done
No UI exists yet. Components, the flow orchestrator, the npm package, and the e2e specs are unbuilt and are fanned out only **after** these frames are approved and merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)