### PR TITLE
frames(authz-admin): access administration UX contract

### DIFF
--- a/design/frames/authz-admin/01-members.html
+++ b/design/frames/authz-admin/01-members.html
@@ -47,9 +47,9 @@
             <button class="btn btn-ghost btn-danger" data-action="remove-member" data-target="u_1002">Remove</button>
           </td>
         </tr>
-        <tr data-member="u_1003" data-role="member">
+        <tr data-member="u_1003" data-role="editor">
           <td><div class="who">linus@northwind.example</div></td>
-          <td><span class="pill" data-role-pill="member">Member</span></td>
+          <td><span class="pill" data-role-pill="editor">Editor</span></td>
           <td class="right">
             <button class="btn btn-ghost" data-action="change-role" data-target="u_1003">Change role</button>
             <button class="btn btn-ghost btn-danger" data-action="remove-member" data-target="u_1003">Remove</button>

--- a/design/frames/authz-admin/01-members.html
+++ b/design/frames/authz-admin/01-members.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Members &amp; roles — authz-admin frame (a)</title>
+<link rel="stylesheet" href="tokens.css" />
+<link rel="stylesheet" href="frame.css" />
+</head>
+<body>
+<div class="wrap" data-frame="01-members">
+  <a class="back" href="index.html">← All frames</a>
+  <div class="eyebrow">Frame (a) · route /settings/access</div>
+  <h1>Members &amp; roles</h1>
+  <p class="lead">The administration surface for one organization. Roles come from the tenant's
+    role catalogue — a bounded, policy-defined set, not free text.</p>
+
+  <div class="panel" data-panel="member-list">
+    <div class="panel-head">
+      <div>
+        <h2>Members</h2>
+        <p class="sub"><span data-count="members">4</span> people in Northwind</p>
+      </div>
+      <button class="btn btn-accent" data-action="add-member">Add member</button>
+    </div>
+
+    <table class="tbl">
+      <thead>
+        <tr><th>Person</th><th>Role</th><th class="right">Actions</th></tr>
+      </thead>
+      <tbody>
+        <tr data-member="u_1001" data-role="admin" data-self="true">
+          <td>
+            <div class="who">ada@northwind.example <span class="tag">You</span></div>
+          </td>
+          <td><span class="pill pill-accent" data-role-pill="admin">Admin</span></td>
+          <td class="right">
+            <button class="btn btn-ghost" data-action="change-role" data-target="u_1001">Change role</button>
+            <button class="btn btn-ghost btn-danger" data-action="remove-member" data-target="u_1001">Remove</button>
+          </td>
+        </tr>
+        <tr data-member="u_1002" data-role="admin">
+          <td><div class="who">grace@northwind.example</div></td>
+          <td><span class="pill pill-accent" data-role-pill="admin">Admin</span></td>
+          <td class="right">
+            <button class="btn btn-ghost" data-action="change-role" data-target="u_1002">Change role</button>
+            <button class="btn btn-ghost btn-danger" data-action="remove-member" data-target="u_1002">Remove</button>
+          </td>
+        </tr>
+        <tr data-member="u_1003" data-role="member">
+          <td><div class="who">linus@northwind.example</div></td>
+          <td><span class="pill" data-role-pill="member">Member</span></td>
+          <td class="right">
+            <button class="btn btn-ghost" data-action="change-role" data-target="u_1003">Change role</button>
+            <button class="btn btn-ghost btn-danger" data-action="remove-member" data-target="u_1003">Remove</button>
+          </td>
+        </tr>
+        <tr data-member="u_1004" data-role="viewer">
+          <td><div class="who">edsger@northwind.example</div></td>
+          <td><span class="pill" data-role-pill="viewer">Viewer</span></td>
+          <td class="right">
+            <button class="btn btn-ghost" data-action="change-role" data-target="u_1004">Change role</button>
+            <button class="btn btn-ghost btn-danger" data-action="remove-member" data-target="u_1004">Remove</button>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    <div class="panel-foot">
+      <button class="btn btn-ghost" data-action="load-more">Load more</button>
+    </div>
+  </div>
+
+  <p class="note">
+    <b>Contract.</b> Rows come from <code>GET /v1/security/tenants/{tenantId}/members</code>
+    (<code>MemberPage</code> — cursor-paginated; "Load more" advances <code>page.cursor</code>).
+    Role pills are keyed to <code>GET /v1/security/tenants/{tenantId}/roles</code>
+    (<code>Role.key</code> → <code>Role.name</code>). A member with no roles renders no pill, never a blank cell.
+  </p>
+
+  <nav class="pager"><a href="index.html">Index</a><a href="02-add-member.html">Next: Add member →</a></nav>
+</div>
+</body>
+</html>

--- a/design/frames/authz-admin/02-add-member.html
+++ b/design/frames/authz-admin/02-add-member.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Add member — authz-admin frame (b)</title>
+<link rel="stylesheet" href="tokens.css" />
+<link rel="stylesheet" href="frame.css" />
+</head>
+<body>
+<div class="wrap" data-frame="02-add-member">
+  <a class="back" href="index.html">← All frames</a>
+  <div class="eyebrow">Frame (b) · route /settings/access</div>
+  <h1>Add member</h1>
+  <p class="lead">Adding someone to the organization and choosing what they can do is one step,
+    not two. Role is required — there is no "add now, decide later" path that leaves a person
+    in the org with undefined access.</p>
+
+  <div class="modal" data-panel="add-member">
+    <div class="modal-head"><h2>Add member to Northwind</h2></div>
+    <div class="modal-body">
+      <div class="field">
+        <label class="label" for="email">Email address</label>
+        <input class="input" id="email" data-input="email" type="email" value="hedy@northwind.example" />
+        <p class="hint">They get access as soon as you add them.</p>
+      </div>
+
+      <div class="field">
+        <span class="label">Role</span>
+        <label class="radio-row" data-role-option="admin">
+          <input type="radio" name="role" value="admin" />
+          <span>
+            <span class="rl">Admin</span>
+            <span class="rd">Full access, including managing members and roles.</span>
+          </span>
+        </label>
+        <label class="radio-row" data-role-option="editor" data-selected="true">
+          <input type="radio" name="role" value="editor" checked />
+          <span>
+            <span class="rl">Editor</span>
+            <span class="rd">Create and change apps and content. Cannot manage members.</span>
+          </span>
+        </label>
+        <label class="radio-row" data-role-option="viewer">
+          <input type="radio" name="role" value="viewer" />
+          <span>
+            <span class="rl">Viewer</span>
+            <span class="rd">Read-only access.</span>
+          </span>
+        </label>
+      </div>
+    </div>
+    <div class="modal-foot">
+      <button class="btn btn-ghost" data-action="cancel">Cancel</button>
+      <button class="btn btn-accent" data-action="submit-add-member">Add member</button>
+    </div>
+  </div>
+
+  <p class="note">
+    <b>Contract.</b> <code>POST /v1/security/tenants/{tenantId}/members</code> (<code>MemberCreate</code>
+    → <code>201 Member</code>). Role options are rendered from
+    <code>GET /v1/security/tenants/{tenantId}/roles</code> — <b>never hard-coded</b>. The three shown
+    (<code>admin</code>/<code>editor</code>/<code>viewer</code>) are today's catalogue, not a fixed list.
+    <br /><br />
+    <b>Fail-closed — an empty role catalogue is not an empty form.</b> The roles endpoint returns
+    <code>{ items: [] }</code> both when a tenant genuinely has no roles <i>and</i> when the policy
+    engine is unreachable. This form must never render zero role options and stay submittable:
+    if <code>items</code> is empty, disable submit and show the error state in frame (e). Silently
+    adding a person with no role is the failure this rule exists to prevent.
+  </p>
+
+  <nav class="pager"><a href="01-members.html">← Members</a><a href="03-change-role.html">Next: Change role →</a></nav>
+</div>
+</body>
+</html>

--- a/design/frames/authz-admin/03-change-role.html
+++ b/design/frames/authz-admin/03-change-role.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Change role — authz-admin frame (c)</title>
+<link rel="stylesheet" href="tokens.css" />
+<link rel="stylesheet" href="frame.css" />
+</head>
+<body>
+<div class="wrap" data-frame="03-change-role">
+  <a class="back" href="index.html">← All frames</a>
+  <div class="eyebrow">Frame (c) · route /settings/access</div>
+  <h1>Change role</h1>
+  <p class="lead">Two variants. The first is the ordinary change. The second is the one that
+    matters: the organization's last admin cannot be demoted.</p>
+
+  <div class="state-block">
+    <div class="state-label">(c1) Ordinary change</div>
+    <div class="modal" data-panel="change-role" data-variant="ordinary">
+      <div class="modal-head"><h2>Change role — linus@northwind.example</h2></div>
+      <div class="modal-body">
+        <label class="radio-row" data-role-option="admin">
+          <input type="radio" name="r1" value="admin" />
+          <span><span class="rl">Admin</span><span class="rd">Full access, including managing members and roles.</span></span>
+        </label>
+        <label class="radio-row" data-role-option="editor" data-selected="true">
+          <input type="radio" name="r1" value="editor" checked />
+          <span><span class="rl">Editor</span><span class="rd">Create and change apps and content. Cannot manage members.</span></span>
+        </label>
+        <label class="radio-row" data-role-option="viewer">
+          <input type="radio" name="r1" value="viewer" />
+          <span><span class="rl">Viewer</span><span class="rd">Read-only access.</span></span>
+        </label>
+      </div>
+      <div class="modal-foot">
+        <button class="btn btn-ghost" data-action="cancel">Cancel</button>
+        <button class="btn btn-accent" data-action="submit-change-role">Save role</button>
+      </div>
+    </div>
+  </div>
+
+  <div class="state-block">
+    <div class="state-label">(c2) Last admin — refused</div>
+    <div class="modal" data-panel="change-role" data-variant="last-admin" data-state="blocked">
+      <div class="modal-head"><h2>Change role — ada@northwind.example</h2></div>
+      <div class="modal-body">
+        <div class="banner banner-warn" data-error-code="LAST_ADMIN">
+          <span>
+            <b>Northwind needs at least one admin</b>
+            <p>Ada is the only admin. Make someone else an admin first, then change Ada's role.</p>
+          </span>
+        </div>
+        <label class="radio-row" data-role-option="admin" data-selected="true">
+          <input type="radio" name="r2" value="admin" checked />
+          <span><span class="rl">Admin</span><span class="rd">Full access, including managing members and roles.</span></span>
+        </label>
+        <label class="radio-row" data-role-option="editor" data-disabled="true">
+          <input type="radio" name="r2" value="editor" disabled />
+          <span><span class="rl">Editor</span><span class="rd">Unavailable — would leave Northwind with no admin.</span></span>
+        </label>
+        <label class="radio-row" data-role-option="viewer" data-disabled="true">
+          <input type="radio" name="r2" value="viewer" disabled />
+          <span><span class="rl">Viewer</span><span class="rd">Unavailable — would leave Northwind with no admin.</span></span>
+        </label>
+      </div>
+      <div class="modal-foot">
+        <button class="btn btn-ghost" data-action="cancel">Cancel</button>
+        <button class="btn btn-accent" data-action="submit-change-role" disabled>Save role</button>
+      </div>
+    </div>
+  </div>
+
+  <p class="note">
+    <b>Contract.</b> <code>PUT /v1/security/tenants/{tenantId}/members/{userId}/roles</code>
+    (<code>RoleAssignment</code> → <code>200 Member</code>). Replaces the member's assignment.
+    <br /><br />
+    <b>⚠ The last-admin refusal does not exist yet — this frame proposes it.</b> There is no
+    last-admin guard in <code>backend/security/src/routes/authz.ts</code> or in the contract today;
+    the call would succeed and leave the org unadministrable. Approving this frame commissions:
+    (1) a <code>409 LAST_ADMIN</code> response on this operation, and (2) a client-side pre-check so
+    the UI disables the option rather than letting the user discover the refusal by failing.
+    <b>The disabled control is an affordance, not the enforcement</b> — the server must refuse
+    independently, because a client-side guard is not a guard.
+    <br /><br />
+    <b>⚠ Role replacement is destructive today.</b> The provider implements "replace" as
+    remove-then-re-add, so a partial failure can leave a member with <i>no</i> roles. Until that is
+    atomic, a failed save must re-fetch and show the member's true current role — never assume
+    the prior value held.
+  </p>
+
+  <nav class="pager"><a href="02-add-member.html">← Add member</a><a href="04-remove-member.html">Next: Remove member →</a></nav>
+</div>
+</body>
+</html>

--- a/design/frames/authz-admin/04-remove-member.html
+++ b/design/frames/authz-admin/04-remove-member.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Remove member — authz-admin frame (d)</title>
+<link rel="stylesheet" href="tokens.css" />
+<link rel="stylesheet" href="frame.css" />
+</head>
+<body>
+<div class="wrap" data-frame="04-remove-member">
+  <a class="back" href="index.html">← All frames</a>
+  <div class="eyebrow">Frame (d) · route /settings/access</div>
+  <h1>Remove member</h1>
+  <p class="lead">Removing someone revokes their access to the whole organization. Like demoting,
+    the one case that matters is the last admin: an organization can never be left with no one
+    able to administer it.</p>
+
+  <div class="state-block">
+    <div class="state-label">(d1) Ordinary removal — confirm</div>
+    <div class="modal" data-panel="remove-member" data-variant="ordinary">
+      <div class="modal-head"><h2>Remove linus@northwind.example?</h2></div>
+      <div class="modal-body">
+        <div class="banner banner-warn">
+          <span>
+            <b>They lose access to Northwind immediately</b>
+            <p>Any active sessions end and their role assignment is deleted. You can add them
+              again later, but their role won't be restored automatically.</p>
+          </span>
+        </div>
+      </div>
+      <div class="modal-foot">
+        <button class="btn btn-ghost" data-action="cancel">Cancel</button>
+        <button class="btn btn-accent btn-danger" data-action="confirm-remove-member" data-target="u_1003">Remove member</button>
+      </div>
+    </div>
+  </div>
+
+  <div class="state-block">
+    <div class="state-label">(d2) Last admin — refused</div>
+    <div class="modal" data-panel="remove-member" data-variant="last-admin" data-state="blocked">
+      <div class="modal-head"><h2>Remove ada@northwind.example?</h2></div>
+      <div class="modal-body">
+        <div class="banner banner-error" data-error-code="LAST_ADMIN">
+          <span>
+            <b>Northwind needs at least one admin</b>
+            <p>Ada is the only admin. Make someone else an admin first, then remove Ada.</p>
+          </span>
+        </div>
+      </div>
+      <div class="modal-foot">
+        <button class="btn btn-ghost" data-action="cancel">Cancel</button>
+        <button class="btn btn-accent btn-danger" data-action="confirm-remove-member" data-target="u_1001" disabled>Remove member</button>
+      </div>
+    </div>
+  </div>
+
+  <p class="note">
+    <b>Contract.</b> <code>DELETE /v1/security/tenants/{tenantId}/members/{userId}</code>
+    (idempotent → <code>204</code>). Removing an already-absent member still returns 204, so the
+    UI treats a 204 and a 404-then-refresh identically: the row is gone.
+    <br /><br />
+    <b>⚠ The last-admin refusal does not exist yet — this frame proposes it.</b> Today
+    <code>backend/security/src/routes/authz.ts</code> would delete the last admin and leave the org
+    unadministrable. Approving this frame commissions a <code>409 LAST_ADMIN</code> on this
+    operation AND the client-side pre-check that disables the button. <b>The disabled button is an
+    affordance, not the guard</b> — the server must refuse independently.
+    <br /><br />
+    <b>403 is not this.</b> A member without permission to remove others gets a
+    <code>403 FORBIDDEN</code> (frame (e)) — that is an authorization denial, shown in place, never
+    a sign-in redirect. The last-admin 409 is different: the caller <i>is</i> allowed, but the
+    <i>action</i> is refused to protect the org.
+  </p>
+
+  <nav class="pager"><a href="03-change-role.html">← Change role</a><a href="05-states.html">Next: States →</a></nav>
+</div>
+</body>
+</html>

--- a/design/frames/authz-admin/05-states.html
+++ b/design/frames/authz-admin/05-states.html
@@ -1,0 +1,125 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>States — authz-admin frame (e)</title>
+<link rel="stylesheet" href="tokens.css" />
+<link rel="stylesheet" href="frame.css" />
+</head>
+<body>
+<div class="wrap" data-frame="05-states">
+  <a class="back" href="index.html">← All frames</a>
+  <div class="eyebrow">Frame (e) · route /settings/access</div>
+  <h1>States</h1>
+  <p class="lead">Every state a consumer must render is contract, not decoration. Loading, the
+    single-member org, a load failure, an empty role catalogue, and — the one that is most often
+    got wrong — an authorization denial that must never become a sign-in prompt.</p>
+
+  <!-- e1 loading -->
+  <div class="state-block">
+    <div class="state-label">(e1) Loading</div>
+    <div class="panel" data-panel="member-list" data-state="loading" aria-busy="true">
+      <div class="panel-head">
+        <div><h2>Members</h2><p class="sub">Loading…</p></div>
+      </div>
+      <table class="tbl"><tbody>
+        <tr><td><div class="skel" style="width: 60%"></div></td><td><div class="skel" style="width: var(--space-16)"></div></td><td class="right"><div class="skel" style="width: 40%; margin-left: auto"></div></td></tr>
+        <tr><td><div class="skel" style="width: 50%"></div></td><td><div class="skel" style="width: var(--space-16)"></div></td><td class="right"><div class="skel" style="width: 40%; margin-left: auto"></div></td></tr>
+        <tr><td><div class="skel" style="width: 55%"></div></td><td><div class="skel" style="width: var(--space-16)"></div></td><td class="right"><div class="skel" style="width: 40%; margin-left: auto"></div></td></tr>
+      </tbody></table>
+    </div>
+  </div>
+
+  <!-- e2 empty / single-member -->
+  <div class="state-block">
+    <div class="state-label">(e2) Single-member org — it's just you</div>
+    <div class="panel" data-panel="member-list" data-state="empty">
+      <div class="panel-head">
+        <div><h2>Members</h2><p class="sub"><span data-count="members">1</span> person in Northwind</p></div>
+        <button class="btn btn-accent" data-action="add-member">Add member</button>
+      </div>
+      <div class="empty">
+        <h3>You're the only member</h3>
+        <p>You're the admin of Northwind. Invite teammates to collaborate — they'll get the role
+          you choose when you add them.</p>
+        <button class="btn btn-accent" data-action="add-member">Add your first teammate</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- e3 load error -->
+  <div class="state-block">
+    <div class="state-label">(e3) Couldn't load</div>
+    <div class="panel" data-panel="member-list" data-state="error">
+      <div class="panel-head"><div><h2>Members</h2></div></div>
+      <div class="empty">
+        <div class="banner banner-error" data-error-code="LOAD_FAILED" style="text-align: left">
+          <span>
+            <b>We couldn't load the members</b>
+            <p>Something went wrong on our end. Your access hasn't changed — try again.</p>
+          </span>
+        </div>
+        <button class="btn" data-action="retry">Try again</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- e4 empty role catalogue -->
+  <div class="state-block">
+    <div class="state-label">(e4) No roles to assign — add-member blocked</div>
+    <div class="modal" data-panel="add-member" data-state="no-roles">
+      <div class="modal-head"><h2>Add member to Northwind</h2></div>
+      <div class="modal-body">
+        <div class="banner banner-warn" data-error-code="NO_ROLES">
+          <span>
+            <b>No roles are available right now</b>
+            <p>We can't add someone without a role, so this is paused. This is usually temporary —
+              try again in a moment. If it persists, contact support.</p>
+          </span>
+        </div>
+      </div>
+      <div class="modal-foot">
+        <button class="btn btn-ghost" data-action="cancel">Cancel</button>
+        <button class="btn btn-accent" data-action="submit-add-member" disabled>Add member</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- e5 403 forbidden — NOT a login prompt -->
+  <div class="state-block">
+    <div class="state-label">(e5) Not allowed — 403, never a sign-in redirect</div>
+    <div class="panel" data-panel="member-list" data-state="forbidden">
+      <div class="panel-head"><div><h2>Members</h2></div></div>
+      <div class="empty">
+        <div class="banner banner-info" data-error-code="FORBIDDEN" data-http="403" style="text-align: left">
+          <span>
+            <b>You don't have access to manage members</b>
+            <p>You're signed in, but your role in Northwind can't add, remove, or change members.
+              Ask an admin of Northwind if you need this.</p>
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <p class="note">
+    <b>Contract.</b> Loading covers the in-flight
+    <code>GET /v1/security/tenants/{tenantId}/members</code>. Empty is a real, common state — a
+    brand-new org has exactly one member. Error covers a non-2xx list response with
+    <code>data-action="retry"</code>. (e4) covers
+    <code>GET /v1/security/tenants/{tenantId}/roles</code> returning <code>{ items: [] }</code> —
+    the add/change forms must fail closed, never render a submittable form with zero roles.
+    <br /><br />
+    <b>⚠ (e5) is the rule this frame exists to enforce. A <code>403</code> is an authorization
+    denial, NOT an authentication failure.</b> The member is signed in; their token is valid; they
+    simply lack permission. The UI shows this denial <i>in place</i> and never redirects to
+    sign-in. Only a <code>401</code> (no/expired session) triggers re-authentication. Conflating
+    the two — bouncing a permission-denied user to a login page they'll sail straight back through —
+    is the exact failure this state is contract for.
+  </p>
+
+  <nav class="pager"><a href="04-remove-member.html">← Remove member</a><a href="index.html">Back to index →</a></nav>
+</div>
+</body>
+</html>

--- a/design/frames/authz-admin/frame.css
+++ b/design/frames/authz-admin/frame.css
@@ -1,0 +1,131 @@
+/* authz-admin frame chrome. Design-system-first: every value below resolves to a
+   fuse-seam token declared in tokens.css. No raw hex / raw px / one-off type here. */
+
+.wrap { max-width: 940px; margin: 0 auto; padding: var(--space-10) var(--space-8) var(--space-16); }
+
+.back { display: inline-block; margin-bottom: var(--space-6); color: var(--text-tertiary);
+  font-size: var(--text-sm); text-decoration: none; }
+.back:hover { color: var(--text-secondary); }
+
+.eyebrow { font-family: var(--font-mono); font-size: var(--text-2xs); letter-spacing: var(--tracking-wide);
+  text-transform: uppercase; color: var(--cyan-400); margin-bottom: var(--space-3); }
+
+h1 { font-family: var(--font-display); font-size: var(--text-2xl);
+  letter-spacing: var(--tracking-display); margin: 0 0 var(--space-2); }
+h2 { font-family: var(--font-display); font-size: var(--text-lg); margin: 0; }
+h3 { font-size: var(--text-md); margin: 0 0 var(--space-2); }
+
+.lead { color: var(--text-secondary); margin: 0 0 var(--space-8); max-width: 68ch; }
+.sub { color: var(--text-tertiary); font-size: var(--text-sm); margin: var(--space-1) 0 0; }
+
+/* ---- panel ---- */
+.panel { background: var(--bg-secondary); border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg); overflow: hidden; }
+.panel + .panel { margin-top: var(--space-6); }
+.panel-head { display: flex; align-items: center; justify-content: space-between;
+  gap: var(--space-4); padding: var(--space-5) var(--space-6);
+  border-bottom: 1px solid var(--border-color); }
+.panel-foot { padding: var(--space-4) var(--space-6); border-top: 1px solid var(--border-color); }
+.panel-body { padding: var(--space-6); }
+
+/* ---- table ---- */
+.tbl { width: 100%; border-collapse: collapse; }
+.tbl th { text-align: left; font-size: var(--text-2xs); text-transform: uppercase;
+  letter-spacing: var(--tracking-wide); color: var(--text-tertiary);
+  font-weight: var(--weight-medium); padding: var(--space-3) var(--space-6);
+  border-bottom: 1px solid var(--border-color); }
+.tbl td { padding: var(--space-4) var(--space-6); border-bottom: 1px solid var(--border-color);
+  font-size: var(--text-md); vertical-align: middle; }
+.tbl tr:last-child td { border-bottom: none; }
+.right { text-align: right; }
+.who { display: flex; align-items: center; gap: var(--space-2); }
+
+/* ---- pills ---- */
+.pill { display: inline-block; padding: var(--space-1) var(--space-3);
+  border-radius: var(--radius-pill); font-size: var(--text-xs);
+  font-weight: var(--weight-medium); background: var(--bg-quaternary);
+  color: var(--text-secondary); border: 1px solid var(--border-color); }
+.pill-accent { background: var(--accent-soft); color: var(--accent-2);
+  border-color: var(--accent-color); }
+.tag { font-size: var(--text-2xs); color: var(--text-tertiary);
+  border: 1px solid var(--border-color); border-radius: var(--radius-sm);
+  padding: 0 var(--space-1); }
+
+/* ---- buttons ---- */
+.btn { font-family: var(--font-sans); font-size: var(--text-sm);
+  font-weight: var(--weight-medium); padding: var(--space-2) var(--space-4);
+  border-radius: var(--radius-md); border: 1px solid var(--border-strong);
+  background: var(--bg-quaternary); color: var(--text-primary); cursor: pointer;
+  transition: background var(--duration-fast) var(--ease-standard); }
+.btn:hover { background: var(--bg-tertiary); }
+.btn:focus-visible { outline: 2px solid var(--accent-color); outline-offset: 2px; }
+.btn-accent { background: var(--accent-color); border-color: var(--accent-color); }
+.btn-accent:hover { background: var(--accent-hover); }
+.btn-ghost { background: transparent; border-color: transparent; color: var(--text-secondary); }
+.btn-ghost:hover { background: var(--bg-quaternary); color: var(--text-primary); }
+.btn-danger { color: var(--error-color); }
+.btn[disabled] { opacity: 0.45; cursor: not-allowed; }
+
+/* ---- form ---- */
+.field { margin-bottom: var(--space-5); }
+.label { display: block; font-size: var(--text-sm); font-weight: var(--weight-medium);
+  margin-bottom: var(--space-2); }
+.hint { font-size: var(--text-xs); color: var(--text-tertiary); margin: var(--space-2) 0 0; }
+.input, .select { width: 100%; padding: var(--space-3) var(--space-4);
+  background: var(--bg-primary); border: 1px solid var(--border-strong);
+  border-radius: var(--radius-md); color: var(--text-primary);
+  font-family: var(--font-sans); font-size: var(--text-md); }
+.input:focus, .select:focus { outline: none; border-color: var(--accent-color);
+  box-shadow: 0 0 0 3px var(--accent-soft); }
+
+.radio-row { display: flex; align-items: flex-start; gap: var(--space-3);
+  padding: var(--space-4); border: 1px solid var(--border-color);
+  border-radius: var(--radius-md); margin-bottom: var(--space-3); cursor: pointer; }
+.radio-row[data-selected="true"] { border-color: var(--accent-color); background: var(--accent-soft); }
+.radio-row .rl { font-weight: var(--weight-medium); font-size: var(--text-md); }
+.radio-row .rd { font-size: var(--text-xs); color: var(--text-tertiary); margin-top: var(--space-1); }
+
+/* ---- banners ---- */
+.banner { display: flex; gap: var(--space-3); padding: var(--space-4) var(--space-5);
+  border-radius: var(--radius-md); font-size: var(--text-sm); margin-bottom: var(--space-5);
+  border: 1px solid var(--border-color); background: var(--bg-tertiary); }
+.banner b { display: block; margin-bottom: var(--space-1); }
+.banner-error { border-color: var(--error-color); color: var(--text-primary); }
+.banner-warn { border-color: var(--warning-color); }
+.banner-info { border-color: var(--accent-color); }
+.banner p { margin: 0; color: var(--text-secondary); }
+
+/* ---- states ---- */
+.skel { height: var(--space-4); border-radius: var(--radius-sm);
+  background: var(--bg-quaternary); animation: pulse var(--duration-base) infinite alternate; }
+@keyframes pulse { from { opacity: 0.5; } to { opacity: 1; } }
+@media (prefers-reduced-motion: reduce) { .skel { animation: none; } }
+.empty { text-align: center; padding: var(--space-12) var(--space-6); }
+.empty h3 { margin-bottom: var(--space-2); }
+.empty p { color: var(--text-tertiary); font-size: var(--text-sm);
+  margin: 0 auto var(--space-5); max-width: 44ch; }
+
+/* ---- modal (rendered inline/static in these frames) ---- */
+.modal { max-width: 460px; margin: 0 auto; background: var(--bg-secondary);
+  border: 1px solid var(--border-strong); border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-lg); overflow: hidden; }
+.modal-head { padding: var(--space-5) var(--space-6); border-bottom: 1px solid var(--border-color); }
+.modal-body { padding: var(--space-6); }
+.modal-foot { display: flex; justify-content: flex-end; gap: var(--space-3);
+  padding: var(--space-4) var(--space-6); border-top: 1px solid var(--border-color);
+  background: var(--bg-tertiary); }
+
+.note { font-size: var(--text-sm); color: var(--text-tertiary); margin-top: var(--space-8);
+  line-height: 1.6; }
+.note code { font-family: var(--font-mono); color: var(--text-secondary); font-size: var(--text-xs); }
+.note b { color: var(--text-secondary); }
+
+.pager { display: flex; justify-content: space-between; margin-top: var(--space-10);
+  padding-top: var(--space-5); border-top: 1px solid var(--border-color); }
+.pager a { color: var(--accent-2); text-decoration: none; font-size: var(--text-sm); }
+.pager a:hover { text-decoration: underline; }
+
+.state-block { margin-bottom: var(--space-8); }
+.state-label { font-family: var(--font-mono); font-size: var(--text-2xs);
+  text-transform: uppercase; letter-spacing: var(--tracking-wide);
+  color: var(--text-tertiary); margin-bottom: var(--space-3); }

--- a/design/frames/authz-admin/index.html
+++ b/design/frames/authz-admin/index.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Access administration — Approval Frames</title>
+<link rel="stylesheet" href="tokens.css" />
+<link rel="stylesheet" href="frame.css" />
+<style>
+  .grid { display: grid; grid-template-columns: 1fr 1fr; gap: var(--space-5); margin-top: var(--space-6); }
+  @media (max-width: 640px){ .grid { grid-template-columns: 1fr; } }
+  .frame-link { display: block; text-decoration: none; color: inherit; background: var(--bg-tertiary);
+    border: 1px solid var(--border-color); border-radius: var(--radius-lg); padding: var(--space-6);
+    position: relative; overflow: hidden; transition: transform var(--duration-base) var(--ease-standard); }
+  .frame-link:hover { transform: translateY(-2px); box-shadow: var(--shadow-md); border-color: var(--border-strong); }
+  .frame-link .seam { position: absolute; top: 0; left: 0; right: 0; height: 2px; background: var(--seam); opacity: 0; transition: opacity var(--duration-base); }
+  .frame-link:hover .seam { opacity: 1; }
+  .frame-link .step { font-family: var(--font-mono); font-size: var(--text-2xs); color: var(--text-tertiary); letter-spacing: var(--tracking-wide); }
+  .frame-link h3 { margin: var(--space-2) 0; font-size: var(--text-lg); }
+  .frame-link p { margin: 0; color: var(--text-tertiary); font-size: var(--text-sm); }
+  .inv { margin-top: var(--space-10); background: var(--bg-secondary); border: 1px solid var(--border-color);
+    border-radius: var(--radius-lg); padding: var(--space-6); }
+  .inv h2 { font-family: var(--font-display); font-size: var(--text-lg); margin: 0 0 var(--space-2); }
+  .inv .lead2 { color: var(--text-tertiary); font-size: var(--text-sm); margin: 0 0 var(--space-5); }
+  .inv-grid { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: var(--space-5); }
+  @media (max-width: 720px){ .inv-grid { grid-template-columns: 1fr; } }
+  .inv-col h4 { font-family: var(--font-mono); font-size: var(--text-2xs); text-transform: uppercase;
+    letter-spacing: var(--tracking-wide); color: var(--cyan-400); margin: 0 0 var(--space-3); }
+  .inv-col ul { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: var(--space-2); }
+  .inv-col li { font-size: var(--text-sm); color: var(--text-secondary); }
+  .inv-col code { font-family: var(--font-mono); font-size: var(--text-xs); color: var(--text-primary); }
+  .flowrow { display: flex; align-items: baseline; gap: var(--space-2); }
+  .flowrow .rt { font-family: var(--font-mono); font-size: var(--text-2xs); color: var(--text-tertiary); }
+  .pending { display: inline-flex; align-items: center; gap: 6px; font-family: var(--font-mono);
+    font-size: var(--text-2xs); padding: 2px 8px; border-radius: var(--radius-pill);
+    color: var(--warning-color); border: 1px solid var(--border-color); text-transform: uppercase;
+    letter-spacing: var(--tracking-wide); margin-top: var(--space-4); }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <div class="eyebrow">Contract-freeze · UX approval</div>
+  <h1>Access administration · Approval Frames</h1>
+  <p class="lead">The consumer surface for administering who is in an organization and what they can
+    do — members, roles, invitations, removals. Backed by FuzeFront's own Security API; no identity
+    or policy vendor name appears anywhere in the UI. These frames freeze the flow, its states, and
+    the build inventory before any UI is written. Walk each frame below.</p>
+
+  <div class="grid" data-nav="frames">
+    <a href="01-members.html" class="frame-link" data-frame-link="01-members">
+      <div class="seam"></div><div class="step">Frame (a) · /settings/access</div>
+      <h3>Members &amp; roles</h3>
+      <p>The list: people in the org, their role pill, per-row change-role / remove. Cursor "Load more".</p>
+    </a>
+    <a href="02-add-member.html" class="frame-link" data-frame-link="02-add-member">
+      <div class="seam"></div><div class="step">Frame (b) · /settings/access</div>
+      <h3>Add member</h3>
+      <p>Email + required role in one step. Roles come from the tenant catalogue, never hard-coded.</p>
+    </a>
+    <a href="03-change-role.html" class="frame-link" data-frame-link="03-change-role">
+      <div class="seam"></div><div class="step">Frame (c) · /settings/access</div>
+      <h3>Change role</h3>
+      <p>Ordinary change, plus the refusal: the org's last admin cannot be demoted.</p>
+    </a>
+    <a href="04-remove-member.html" class="frame-link" data-frame-link="04-remove-member">
+      <div class="seam"></div><div class="step">Frame (d) · /settings/access</div>
+      <h3>Remove member</h3>
+      <p>Confirm removal, plus the refusal: the org's last admin cannot be removed.</p>
+    </a>
+    <a href="05-states.html" class="frame-link" data-frame-link="05-states">
+      <div class="seam"></div><div class="step">Frame (e) · /settings/access</div>
+      <h3>States</h3>
+      <p>Loading, single-member org, load error, empty role catalogue, and 403 (never a sign-in redirect).</p>
+    </a>
+  </div>
+
+  <div class="inv" data-panel="build-inventory">
+    <h2>Build inventory</h2>
+    <p class="lead2">Approving these frames approves this component/package plan. Implementation
+      cannot quietly invent a different architecture. Mirrored in <code>manifest.json</code> →
+      <code>build</code>.</p>
+    <div class="inv-grid">
+      <div class="inv-col" data-inv="flows">
+        <h4>Flows</h4>
+        <ul>
+          <li data-flow="access-admin">
+            <div class="flowrow"><code>AccessAdminFlow</code></div>
+            <div class="rt">route /settings/access · approved: false</div>
+          </li>
+        </ul>
+      </div>
+      <div class="inv-col" data-inv="components">
+        <h4>Components</h4>
+        <ul>
+          <li><code>MemberList</code></li>
+          <li><code>MemberRow</code></li>
+          <li><code>RolePill</code></li>
+          <li><code>AddMemberDialog</code></li>
+          <li><code>ChangeRoleDialog</code></li>
+          <li><code>RemoveMemberDialog</code></li>
+          <li><code>RolePicker</code></li>
+          <li><code>AccessDeniedNotice</code></li>
+        </ul>
+      </div>
+      <div class="inv-col" data-inv="packages">
+        <h4>Packages</h4>
+        <ul>
+          <li><code>@fuzefront/access-admin-ui</code></li>
+        </ul>
+      </div>
+    </div>
+  </div>
+
+  <span class="pending" data-approval-status="pending">● Awaiting approval — per flow</span>
+
+  <p class="note">
+    Design system: <code>@fuzefront/design-system</code> (fuse-seam, tokens only) ·
+    Contract: <code>packages/security/openapi.yaml</code> → <code>@fuzefront/security-client</code> ·
+    Component: <code>@fuzefront/access-admin-ui → AccessAdminFlow</code>.<br />
+    <b>Commissioned by approval:</b> a <code>409 LAST_ADMIN</code> guard on demote/remove (frames c2,
+    d2) — it does not exist in the contract today. Reached from the <code>account-security</code> hub.
+    Approve per-flow by setting <code>approved: true</code> in <code>manifest.json</code>, or reply
+    <code>@claude approve</code> / <code>@claude reject: &lt;reason&gt;</code>.
+  </p>
+</div>
+</body>
+</html>

--- a/design/frames/authz-admin/manifest.json
+++ b/design/frames/authz-admin/manifest.json
@@ -1,0 +1,124 @@
+{
+  "name": "Access administration — approval frames",
+  "description": "Contract-freeze UX artifacts for the vendor-neutral tenant/org access-administration surface (members, roles, invite/add, change-role, remove) backed by FuzeFront's Security API. Approving a flow approves its visual + interaction model AND the component/package build inventory before UI implementation. frontend-test-engineer drives Playwright against these via the data-frame / data-* hooks.",
+  "designSystem": "fuse-seam (@fuzefront/design-system)",
+  "entry": "index.html",
+  "contract": {
+    "openapi": "packages/security/openapi.yaml",
+    "client": "@fuzefront/security-client",
+    "schemas": ["Member", "MemberCreate", "MemberPage", "Role", "RoleAssignment"],
+    "endpoints": [
+      "GET /v1/security/tenants/{tenantId}/members",
+      "POST /v1/security/tenants/{tenantId}/members",
+      "GET /v1/security/tenants/{tenantId}/roles",
+      "PUT /v1/security/tenants/{tenantId}/members/{userId}/roles",
+      "DELETE /v1/security/tenants/{tenantId}/members/{userId}"
+    ],
+    "commissionedByApproval": [
+      "409 LAST_ADMIN on demote (PUT .../members/{userId}/roles) — does not exist in the contract today",
+      "409 LAST_ADMIN on remove (DELETE .../members/{userId}) — does not exist in the contract today"
+    ],
+    "component": "@fuzefront/access-admin-ui → AccessAdminFlow",
+    "featureFlag": "fuzefront.security.access-admin"
+  },
+  "build": {
+    "flows": [
+      { "id": "access-admin", "orchestrator": "AccessAdminFlow", "route": "/settings/access", "approved": false, "approvedBy": null, "approvedAt": null }
+    ],
+    "components": [
+      "MemberList", "MemberRow", "RolePill", "AddMemberDialog",
+      "ChangeRoleDialog", "RemoveMemberDialog", "RolePicker", "AccessDeniedNotice"
+    ],
+    "packages": ["@fuzefront/access-admin-ui"]
+  },
+  "frames": [
+    {
+      "id": "01-members",
+      "file": "01-members.html",
+      "label": "(a) Members & roles",
+      "route": "/settings/access",
+      "flow": "access-admin",
+      "summary": "Member list for one org: person, role pill (from the tenant role catalogue), per-row change-role / remove, cursor 'Load more'.",
+      "acceptanceNotes": "Rows render from GET /members (MemberPage, cursor). Role pills key to GET /roles (Role.key → Role.name). A member with no roles renders no pill, never a blank cell. Self-row is tagged 'You'. No vendor name in the DOM.",
+      "testHooks": [
+        "[data-frame='01-members']",
+        "[data-panel='member-list']",
+        "[data-member='u_1001']",
+        "[data-role-pill='admin']",
+        "[data-action='add-member']",
+        "[data-action='change-role']",
+        "[data-action='remove-member']",
+        "[data-action='load-more']"
+      ]
+    },
+    {
+      "id": "02-add-member",
+      "file": "02-add-member.html",
+      "label": "(b) Add member",
+      "route": "/settings/access",
+      "flow": "access-admin",
+      "summary": "Email + required role in a single step. Role options rendered from the tenant role catalogue.",
+      "acceptanceNotes": "POST /members (MemberCreate → 201 Member). Role radios come from GET /roles, never hard-coded. Fail-closed: an empty role catalogue disables submit (see frame e4) rather than adding a person with no role.",
+      "testHooks": [
+        "[data-frame='02-add-member']",
+        "[data-panel='add-member']",
+        "[data-input='email']",
+        "[data-role-option='admin']",
+        "[data-action='submit-add-member']"
+      ]
+    },
+    {
+      "id": "03-change-role",
+      "file": "03-change-role.html",
+      "label": "(c) Change role",
+      "route": "/settings/access",
+      "flow": "access-admin",
+      "summary": "Ordinary role change (c1) plus the last-admin refusal (c2): the org's only admin cannot be demoted.",
+      "acceptanceNotes": "PUT /members/{userId}/roles (RoleAssignment → 200 Member). c2 proposes a 409 LAST_ADMIN + client pre-check that disables the demote options; the disabled control is an affordance, the server must refuse independently. A failed save re-fetches true current role (replace is non-atomic today).",
+      "testHooks": [
+        "[data-frame='03-change-role']",
+        "[data-panel='change-role']",
+        "[data-variant='last-admin']",
+        "[data-error-code='LAST_ADMIN']",
+        "[data-action='submit-change-role']"
+      ]
+    },
+    {
+      "id": "04-remove-member",
+      "file": "04-remove-member.html",
+      "label": "(d) Remove member",
+      "route": "/settings/access",
+      "flow": "access-admin",
+      "summary": "Confirm removal (d1) plus the last-admin refusal (d2): the org's only admin cannot be removed.",
+      "acceptanceNotes": "DELETE /members/{userId} (idempotent → 204). d2 proposes a 409 LAST_ADMIN + client pre-check disabling the button. 403 (no permission) is distinct — shown in place per frame e5, never a sign-in redirect.",
+      "testHooks": [
+        "[data-frame='04-remove-member']",
+        "[data-panel='remove-member']",
+        "[data-variant='last-admin']",
+        "[data-error-code='LAST_ADMIN']",
+        "[data-action='confirm-remove-member']"
+      ]
+    },
+    {
+      "id": "05-states",
+      "file": "05-states.html",
+      "label": "(e) States",
+      "route": "/settings/access",
+      "flow": "access-admin",
+      "summary": "Loading skeleton, single-member org empty state, load error+retry, empty role catalogue (add blocked), and 403 forbidden shown in place.",
+      "acceptanceNotes": "Loading = aria-busy skeleton for in-flight GET /members. Empty is a real state (a fresh org has one member). Error shows data-action='retry'. e4: GET /roles returning {items:[]} disables the add form. e5: a 403 is an AUTHORIZATION denial rendered in place — NEVER a redirect to sign-in (only a 401 re-authenticates).",
+      "testHooks": [
+        "[data-frame='05-states']",
+        "[data-state='loading']",
+        "[data-state='empty']",
+        "[data-state='error']",
+        "[data-action='retry']",
+        "[data-state='no-roles']",
+        "[data-error-code='NO_ROLES']",
+        "[data-state='forbidden']",
+        "[data-error-code='FORBIDDEN']",
+        "[data-http='403']"
+      ]
+    }
+  ]
+}

--- a/design/frames/authz-admin/tokens.css
+++ b/design/frames/authz-admin/tokens.css
@@ -1,0 +1,235 @@
+/* fuse-seam design-system tokens (subset), inlined so these approval frames are
+   self-contained / portable. Mirrors design-system/tokens/*.css. These frames are
+   contract-freeze UX artifacts — approve the frames = approve the model. */
+:root {
+  /* brand / accent */
+  --indigo-500: #6e5cff;
+  --cyan-400: #29d3e6;
+  --accent-color: var(--indigo-500);
+  --accent-hover: #5a48e6;
+  --accent-soft: rgba(110, 92, 255, 0.14);
+  --accent-2: var(--cyan-400);
+  --seam: linear-gradient(90deg, var(--accent-color) 0%, var(--accent-2) 100%);
+
+  /* graphite surfaces (dark default) */
+  --bg-primary: #0f131c;
+  --bg-secondary: #11161f;
+  --bg-tertiary: #141a26;
+  --bg-quaternary: #1b2230;
+  --border-color: #232b3a;
+  --border-strong: #313b4d;
+
+  --text-primary: #e7ebf2;
+  --text-secondary: #aab3c2;
+  --text-tertiary: #6b7585;
+
+  --success-color: #34d399;
+  --warning-color: #f5b950;
+  --error-color: #f3697f;
+
+  /* type */
+  --font-display: "Space Grotesk", "Inter", system-ui, sans-serif;
+  --font-sans: "Inter", system-ui, -apple-system, sans-serif;
+  --font-mono: "JetBrains Mono", ui-monospace, "SF Mono", monospace;
+  --text-2xs: 11px;
+  --text-xs: 12px;
+  --text-sm: 13px;
+  --text-md: 14px;
+  --text-lg: 16px;
+  --text-xl: 20px;
+  --text-2xl: 26px;
+  --weight-regular: 400;
+  --weight-medium: 500;
+  --weight-semibold: 600;
+  --tracking-wide: 0.04em;
+  --tracking-display: -0.01em;
+
+  /* spacing / radii / shadow */
+  --space-1: 4px; --space-2: 8px; --space-3: 12px; --space-4: 16px;
+  --space-5: 20px; --space-6: 24px; --space-7: 28px; --space-8: 32px;
+  --space-10: 40px; --space-12: 48px; --space-16: 64px;
+  --radius-sm: 6px; --radius-md: 10px; --radius-lg: 14px; --radius-xl: 20px;
+  --radius-pill: 999px;
+  --shadow-xs: 0 1px 2px rgba(0,0,0,0.3);
+  --shadow-md: 0 6px 20px rgba(0,0,0,0.4);
+  --shadow-lg: 0 16px 48px rgba(0,0,0,0.5);
+  --shadow-accent: 0 8px 24px rgba(110,92,255,0.35);
+
+  --top-bar-height: 60px;
+  --side-panel-width: 240px;
+  --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+  --duration-fast: 120ms;
+  --duration-base: 200ms;
+}
+
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  font-family: var(--font-sans);
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  -webkit-font-smoothing: antialiased;
+}
+.mono { font-family: var(--font-mono); }
+
+/* ---- shared portal-shell chrome used across frames ---- */
+.shell { display: flex; flex-direction: column; height: 100vh; }
+.topbar {
+  height: var(--top-bar-height);
+  flex: none;
+  display: flex; align-items: center; gap: var(--space-4);
+  padding: 0 var(--space-6);
+  background: var(--bg-secondary);
+  border-bottom: 1px solid var(--border-color);
+  position: relative;
+}
+.topbar::after {
+  content: ""; position: absolute; left: 0; right: 0; bottom: -1px;
+  height: 2px; background: var(--seam); opacity: 0.7;
+}
+.wordmark {
+  font-family: var(--font-display); font-weight: var(--weight-semibold);
+  font-size: var(--text-lg); letter-spacing: var(--tracking-display);
+}
+.wordmark .fuse {
+  background: var(--seam); -webkit-background-clip: text;
+  background-clip: text; color: transparent;
+}
+.topbar .spacer { flex: 1; }
+.launch-btn {
+  width: 34px; height: 34px; border-radius: var(--radius-md);
+  display: grid; place-items: center; cursor: pointer;
+  background: var(--bg-quaternary); border: 1px solid var(--border-color);
+}
+.avatar {
+  width: 32px; height: 32px; border-radius: var(--radius-pill);
+  background: var(--seam); display: grid; place-items: center;
+  font-weight: var(--weight-semibold); font-size: var(--text-sm); color: #0b0e15;
+}
+.body { flex: 1; display: flex; min-height: 0; }
+
+.side {
+  width: var(--side-panel-width); flex: none;
+  background: var(--bg-secondary);
+  border-right: 1px solid var(--border-color);
+  padding: var(--space-4) var(--space-3);
+  display: flex; flex-direction: column; gap: var(--space-1);
+  overflow-y: auto;
+}
+.side .section-label {
+  font-family: var(--font-mono); font-size: var(--text-2xs);
+  letter-spacing: var(--tracking-wide); text-transform: uppercase;
+  color: var(--text-tertiary); margin: var(--space-4) var(--space-2) var(--space-2);
+}
+.nav-item {
+  display: flex; align-items: center; gap: var(--space-3);
+  padding: var(--space-2) var(--space-3); border-radius: var(--radius-md);
+  color: var(--text-secondary); font-size: var(--text-md); cursor: pointer;
+  text-decoration: none;
+}
+.nav-item:hover { background: var(--bg-quaternary); color: var(--text-primary); }
+.nav-item.active {
+  background: var(--accent-soft); color: var(--text-primary);
+  box-shadow: inset 2px 0 0 var(--accent-color);
+}
+.nav-item .ico { width: 18px; text-align: center; }
+
+.content { flex: 1; overflow: auto; padding: var(--space-8); min-width: 0; }
+.page-title {
+  font-family: var(--font-display); font-size: var(--text-2xl);
+  letter-spacing: var(--tracking-display); margin: 0 0 var(--space-2);
+}
+.page-sub { color: var(--text-secondary); margin: 0 0 var(--space-6); }
+
+.btn {
+  font-family: var(--font-sans); font-size: var(--text-md);
+  font-weight: var(--weight-medium); border-radius: var(--radius-md);
+  padding: var(--space-2) var(--space-4); cursor: pointer; border: 1px solid transparent;
+}
+.btn-primary { background: var(--accent-color); color: #0b0e15; box-shadow: var(--shadow-accent); }
+.btn-primary:hover { background: var(--accent-hover); }
+.btn-ghost { background: transparent; color: var(--text-secondary); border-color: var(--border-color); }
+.btn-ghost:hover { color: var(--text-primary); border-color: var(--border-strong); }
+
+.badge {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-family: var(--font-mono); font-size: var(--text-2xs);
+  padding: 2px 8px; border-radius: var(--radius-pill);
+  border: 1px solid var(--border-color); color: var(--text-secondary);
+  text-transform: uppercase; letter-spacing: var(--tracking-wide);
+}
+.badge.activated { color: var(--success-color); border-color: rgba(52,211,153,0.4); }
+.badge.registered { color: var(--warning-color); border-color: rgba(245,185,80,0.4); }
+.badge.mf { color: var(--cyan-400); border-color: rgba(41,211,230,0.4); }
+.badge.builtin { color: var(--accent-color); border-color: rgba(110,92,255,0.4); }
+.badge.standalone { color: var(--text-primary); border-color: var(--border-strong); }
+
+.dot { width: 9px; height: 9px; border-radius: var(--radius-pill); display: inline-block; }
+.dot.healthy { background: var(--success-color); }
+.dot.down { background: var(--error-color); }
+
+/* approval-frame footer nav */
+.frame-nav {
+  position: fixed; bottom: 0; left: 0; right: 0;
+  display: flex; align-items: center; justify-content: space-between;
+  gap: var(--space-4); padding: var(--space-3) var(--space-6);
+  background: rgba(17,22,31,0.92); backdrop-filter: blur(8px);
+  border-top: 1px solid var(--border-color); z-index: 50;
+}
+.frame-nav .caption { font-size: var(--text-sm); color: var(--text-tertiary); }
+.frame-nav .caption b { color: var(--text-secondary); font-weight: var(--weight-semibold); }
+.frame-nav a { text-decoration: none; }
+.content { padding-bottom: 72px; }
+
+/* ---- invoice status pill soft tokens (mirror @fuzefront/design-system semantic *-soft) ---- */
+:root {
+  --success-soft: rgba(52, 211, 153, 0.14);
+  --warning-soft: rgba(245, 185, 80, 0.14);
+  --error-soft:   rgba(243, 105, 127, 0.14);
+  --neutral-soft: rgba(170, 179, 194, 0.12);
+}
+
+/* ---- InvoiceHistoryPanel (design-system-first; tokens only) ---- */
+.ffb-invoices { background: var(--bg-tertiary); border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg); position: relative; overflow: hidden; max-width: 720px; }
+.ffb-invoices__seam { height: 2px; background: var(--seam); }
+.ffb-invoices__head { display: flex; align-items: baseline; justify-content: space-between;
+  gap: var(--space-3); padding: var(--space-5) var(--space-5) var(--space-3); }
+.ffb-invoices__title { margin: 0; font-family: var(--font-display); font-size: var(--text-lg);
+  font-weight: var(--weight-semibold); color: var(--text-primary); }
+.ffb-invoices__count { color: var(--text-tertiary); font-size: var(--text-sm);
+  font-variant-numeric: tabular-nums; }
+.ffb-invoices__list { display: flex; flex-direction: column; }
+.ffb-invoice-row { display: grid; grid-template-columns: 1fr auto; gap: var(--space-1) var(--space-4);
+  padding: var(--space-4) var(--space-5); border-top: 1px solid var(--border-color); align-items: center; }
+.ffb-invoice-row__main { display: flex; flex-direction: column; gap: var(--space-1); min-width: 0; }
+.ffb-invoice-row__top { display: flex; align-items: center; gap: var(--space-3); flex-wrap: wrap; }
+.ffb-invoice-row__num { font-weight: var(--weight-medium); color: var(--text-primary);
+  font-variant-numeric: tabular-nums; }
+.ffb-invoice-row__date { color: var(--text-secondary); font-size: var(--text-sm); }
+.ffb-invoice-row__side { display: flex; align-items: center; gap: var(--space-4); justify-content: flex-end; }
+.ffb-invoice-row__amount { color: var(--text-primary); font-weight: var(--weight-semibold);
+  font-variant-numeric: tabular-nums; text-align: end; }
+.ffb-pill { display: inline-flex; align-items: center; gap: var(--space-1);
+  padding: 2px var(--space-2); border-radius: var(--radius-pill); font-size: var(--text-2xs);
+  font-weight: var(--weight-semibold); text-transform: capitalize; white-space: nowrap; }
+.ffb-pill__dot { width: 6px; height: 6px; border-radius: var(--radius-pill); background: currentColor; }
+.ffb-pill--paid { background: var(--success-soft); color: var(--success-color); }
+.ffb-pill--open { background: var(--warning-soft); color: var(--warning-color); }
+.ffb-pill--void { background: var(--neutral-soft); color: var(--text-secondary); }
+.ffb-pill--uncollectible { background: var(--error-soft); color: var(--error-color); }
+.ffb-dl { display: inline-flex; align-items: center; gap: var(--space-1); color: var(--accent-color);
+  text-decoration: none; font-size: var(--text-sm); font-weight: var(--weight-medium);
+  padding: var(--space-1) var(--space-2); border-radius: var(--radius-sm); min-height: 32px; }
+.ffb-dl:hover { background: var(--accent-soft); }
+.ffb-dl svg { width: 14px; height: 14px; }
+.ffb-invoices__foot { padding: var(--space-4) var(--space-5); border-top: 1px solid var(--border-color);
+  display: flex; justify-content: center; }
+.ffb-skel { height: 14px; border-radius: var(--radius-pill); background:
+  linear-gradient(90deg, var(--bg-quaternary), var(--border-color), var(--bg-quaternary));
+  background-size: 200% 100%; animation: ffbsh 1.3s ease-in-out infinite; }
+@keyframes ffbsh { 0%{background-position:200% 0} 100%{background-position:-200% 0} }
+@media (prefers-reduced-motion: reduce){ .ffb-skel{ animation: none; } }
+.ffb-empty { padding: var(--space-8) var(--space-5); text-align: center; color: var(--text-secondary); }
+.ffb-empty__icon { width: 40px; height: 40px; margin: 0 auto var(--space-3); color: var(--text-tertiary); }
+.ffb-note { font-size: var(--text-sm); color: var(--text-secondary); }


### PR DESCRIPTION
## Frames-only PR — access administration (members / roles)

Navigable HTML frames for the **authz-admin** UI feature, authored by `product-designer` **before** any UI implementation. Merging this (approved) is the gate that dispatches RED Playwright specs and the frontend fan-out.

**Scope:** `design/frames/authz-admin/**` only. No feature code, tests, or config.

### Flows & screens
- `01-members` — member list, role pills (from the tenant catalogue), per-row change/remove, cursor load-more
- `02-add-member` — email + required role in one step
- `03-change-role` — ordinary change **+ last-admin refusal (c2)**
- `04-remove-member` — confirm removal **+ last-admin refusal (d2)**
- `05-states` — loading, single-member org, load error, empty role catalogue, and **403-in-place (never a sign-in redirect)**

### States are contract
Loading, empty, error, empty-role-catalogue (add fail-closed), last-admin refusal (409 commissioned), and a 403 authorization denial rendered in place — never a login bounce.

### Build inventory (in `index.html` + `manifest.json` → `build`)
- Flow `AccessAdminFlow` → `/settings/access` (`approved: false`)
- Components: MemberList, MemberRow, RolePill, AddMemberDialog, ChangeRoleDialog, RemoveMemberDialog, RolePicker, AccessDeniedNotice
- Package: `@fuzefront/access-admin-ui`

### Contract
`packages/security/openapi.yaml` → `@fuzefront/security-client` (members/roles endpoints). **Commissioned by approval:** a `409 LAST_ADMIN` guard on demote/remove — it does not exist server-side today (flagged in-frame).

Design-system-first (fuse-seam tokens only). No identity/authorization vendor named anywhere. Per-flow `approved: false` awaiting review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)