### PR TITLE
frames(api-tokens): service-token (M2M) UX contract

### DIFF
--- a/design/frames/api-tokens/01-tokens.html
+++ b/design/frames/api-tokens/01-tokens.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Service tokens — api-tokens frame (a)</title>
+<link rel="stylesheet" href="tokens.css" />
+<link rel="stylesheet" href="frame.css" />
+</head>
+<body>
+<div class="wrap" data-frame="01-tokens">
+  <a class="back" href="index.html">← All frames</a>
+  <div class="eyebrow">Frame (a) · route /settings/tokens</div>
+  <h1>Service tokens</h1>
+  <p class="lead">Machine-to-machine credentials that let your services and scripts call the API on
+    this organization's behalf. Each token carries only the scopes you choose. The secret is shown
+    once, when you create it — after that only its prefix is ever displayed.</p>
+
+  <div class="panel" data-panel="token-list">
+    <div class="panel-head">
+      <div>
+        <h2>Tokens</h2>
+        <p class="sub"><span data-count="tokens">3</span> active in Northwind</p>
+      </div>
+      <button class="btn btn-accent" data-action="create-token">Create token</button>
+    </div>
+
+    <table class="tbl">
+      <thead>
+        <tr><th>Name</th><th>Scopes</th><th>Created</th><th>Last used</th><th class="right">Actions</th></tr>
+      </thead>
+      <tbody>
+        <tr data-token="tok_1001" data-prefix="ff_tok_EXAMPLE1">
+          <td>
+            <div class="who">CI deploy bot</div>
+            <div class="muted mono" data-token-prefix>ff_tok_EXAMPLE1…</div>
+          </td>
+          <td><div class="chips">
+            <span class="chip" data-scope="apps:read">apps:read</span>
+            <span class="chip" data-scope="apps:deploy">apps:deploy</span>
+          </div></td>
+          <td class="muted stamp">14 Mar 2026</td>
+          <td class="muted stamp"><span class="dot-live"></span> 2 min ago</td>
+          <td class="right">
+            <button class="btn btn-ghost btn-danger" data-action="revoke-token" data-target="tok_1001">Revoke</button>
+          </td>
+        </tr>
+        <tr data-token="tok_1002" data-prefix="ff_tok_EXAMPLE2">
+          <td>
+            <div class="who">Metrics exporter</div>
+            <div class="muted mono" data-token-prefix>ff_tok_EXAMPLE2…</div>
+          </td>
+          <td><div class="chips">
+            <span class="chip" data-scope="metrics:read">metrics:read</span>
+          </div></td>
+          <td class="muted stamp">2 Feb 2026</td>
+          <td class="muted stamp">6 days ago</td>
+          <td class="right">
+            <button class="btn btn-ghost btn-danger" data-action="revoke-token" data-target="tok_1002">Revoke</button>
+          </td>
+        </tr>
+        <tr data-token="tok_1003" data-prefix="ff_tok_EXAMPLE3">
+          <td>
+            <div class="who">Backup script</div>
+            <div class="muted mono" data-token-prefix>ff_tok_EXAMPLE3…</div>
+          </td>
+          <td><div class="chips">
+            <span class="chip" data-scope="storage:read">storage:read</span>
+            <span class="chip more" data-scope-more>+2 more</span>
+          </div></td>
+          <td class="muted stamp">9 Jan 2026</td>
+          <td class="muted stamp">Never used</td>
+          <td class="right">
+            <button class="btn btn-ghost btn-danger" data-action="revoke-token" data-target="tok_1003">Revoke</button>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  <p class="note">
+    <b>Contract.</b> Rows come from <code>GET /api/organizations/{orgId}/tokens</code>
+    (<code>backend/security/src/routes/api-tokens.ts</code>). Each item exposes
+    <code>name</code>, <code>token_prefix</code>, <code>scopes</code>, <code>created_at</code>,
+    <code>expires_at</code> — the raw secret is never returned by list, only the prefix. Revoke is
+    <code>DELETE /api/organizations/{orgId}/tokens/{tokenId}</code>.
+    <br /><br />
+    <b>⚠ "Last used" is not backed yet — this frame proposes it.</b> The token record has no
+    <code>last_used_at</code> field today. Approving this frame commissions that field (updated on
+    introspection/use) so operators can spot dormant or leaked credentials. Until it exists the
+    column reads <i>"—"</i> for every token; it must not fabricate activity.
+    <br /><br />
+    <b>Neutral by contract.</b> No identity/authorization vendor is named anywhere — these are
+    FuzeFront service tokens, full stop.
+  </p>
+
+  <nav class="pager"><a href="index.html">Index</a><a href="02-create-token.html">Next: Create token →</a></nav>
+</div>
+</body>
+</html>

--- a/design/frames/api-tokens/02-create-token.html
+++ b/design/frames/api-tokens/02-create-token.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Create token — api-tokens frame (b)</title>
+<link rel="stylesheet" href="tokens.css" />
+<link rel="stylesheet" href="frame.css" />
+</head>
+<body>
+<div class="wrap" data-frame="02-create-token">
+  <a class="back" href="index.html">← All frames</a>
+  <div class="eyebrow">Frame (b) · route /settings/tokens</div>
+  <h1>Create token</h1>
+  <p class="lead">Give the token a name you'll recognise later and grant only the scopes it needs.
+    Fewer scopes means less damage if it leaks. The secret appears on the next screen — once.</p>
+
+  <div class="modal" data-panel="create-token">
+    <div class="modal-head"><h2>Create a service token</h2></div>
+    <div class="modal-body">
+      <div class="field">
+        <label class="label" for="name">Name</label>
+        <input class="input" id="name" data-input="name" type="text" value="CI deploy bot"
+          placeholder="e.g. CI deploy bot" />
+        <p class="hint">For your reference only. Name it after where it runs, so you can find it later.</p>
+      </div>
+
+      <div class="field">
+        <span class="label">Scopes</span>
+        <label class="check-row" data-scope-option="apps:read" data-selected="true">
+          <input type="checkbox" checked />
+          <span><span class="cl">apps:read</span><span class="cd">Read applications and their config.</span></span>
+        </label>
+        <label class="check-row" data-scope-option="apps:deploy" data-selected="true">
+          <input type="checkbox" checked />
+          <span><span class="cl">apps:deploy</span><span class="cd">Trigger deployments. Cannot delete apps.</span></span>
+        </label>
+        <label class="check-row" data-scope-option="metrics:read">
+          <input type="checkbox" />
+          <span><span class="cl">metrics:read</span><span class="cd">Read metrics and usage data.</span></span>
+        </label>
+        <label class="check-row" data-scope-option="storage:read">
+          <input type="checkbox" />
+          <span><span class="cl">storage:read</span><span class="cd">Read stored objects. Cannot write or delete.</span></span>
+        </label>
+        <p class="hint">At least one scope is required. A token with no scopes can't do anything.</p>
+      </div>
+
+      <div class="field">
+        <label class="label" for="expiry">Expiry <span class="muted">(optional)</span></label>
+        <select class="select" id="expiry" data-input="expiry">
+          <option value="30">30 days</option>
+          <option value="90" selected>90 days</option>
+          <option value="365">1 year</option>
+          <option value="">No expiry</option>
+        </select>
+        <p class="hint">Short-lived tokens are safer. You can always create a new one.</p>
+      </div>
+    </div>
+    <div class="modal-foot">
+      <button class="btn btn-ghost" data-action="cancel">Cancel</button>
+      <button class="btn btn-accent" data-action="submit-create-token">Create token</button>
+    </div>
+  </div>
+
+  <p class="note">
+    <b>Contract.</b> <code>POST /api/organizations/{orgId}/tokens</code> with
+    <code>{ name, scopes[], expires_at? }</code> → <code>201</code> returning the token metadata
+    <b>plus the raw secret exactly once</b> (frame c). Scope options should be rendered from the
+    org's available scope catalogue rather than hard-coded; the four shown are illustrative
+    <code>Resource:action</code> strings.
+    <br /><br />
+    <b>Fail-closed.</b> Submit is disabled until a name is present and at least one scope is
+    checked — a zero-scope token is never created. Scopes are additive grants, never a bypass of
+    the org's own access rules.
+  </p>
+
+  <nav class="pager"><a href="01-tokens.html">← Tokens</a><a href="03-reveal-once.html">Next: Secret shown once →</a></nav>
+</div>
+</body>
+</html>

--- a/design/frames/api-tokens/03-reveal-once.html
+++ b/design/frames/api-tokens/03-reveal-once.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Secret shown once — api-tokens frame (c)</title>
+<link rel="stylesheet" href="tokens.css" />
+<link rel="stylesheet" href="frame.css" />
+</head>
+<body>
+<div class="wrap" data-frame="03-reveal-once">
+  <a class="back" href="index.html">← All frames</a>
+  <div class="eyebrow">Frame (c) · route /settings/tokens</div>
+  <h1>Copy your token now</h1>
+  <p class="lead">This is the one moment the full secret exists on screen. We store only a hash of
+    it — we can't show it again and we can't recover it. If you lose it, revoke this token and
+    create a new one. This is the most important screen in the flow.</p>
+
+  <div class="modal" data-panel="reveal-once" style="max-width: 560px">
+    <div class="modal-head"><h2>“CI deploy bot” is ready</h2></div>
+    <div class="modal-body">
+      <div class="field">
+        <span class="label">Token secret</span>
+        <div class="secret" data-panel="secret">
+          <code data-token-secret>ff_tok_EXAMPLE_NOT_A_REAL_TOKEN</code>
+          <button class="copy-btn" data-action="copy-secret" aria-label="Copy token to clipboard">
+            <span aria-hidden="true">⧉</span> Copy
+          </button>
+        </div>
+        <p class="hint" data-copy-status hidden>Copied to your clipboard.</p>
+      </div>
+
+      <div class="banner banner-error" data-warning="unrecoverable">
+        <span>
+          <b>You won't see this again</b>
+          <p>We keep only a one-way hash of this secret. Once you leave this screen it is gone for
+            good — there is no “show token” button anywhere. Store it in your secrets manager now.</p>
+        </span>
+      </div>
+
+      <label class="ack-row" data-input="ack">
+        <input type="checkbox" data-ack-checkbox />
+        <span class="at">I've stored this token somewhere safe. I understand it can't be shown again.</span>
+      </label>
+    </div>
+    <div class="modal-foot">
+      <button class="btn btn-accent" data-action="done" disabled data-requires-ack>Done</button>
+    </div>
+  </div>
+
+  <p class="note">
+    <b>Contract.</b> The raw secret is the <code>token</code> field returned <b>only</b> on the
+    <code>201</code> from <code>POST /api/organizations/{orgId}/tokens</code>
+    (<code>backend/security/src/routes/api-tokens.ts</code> reveals it once and stores a hash). No
+    list or get endpoint ever returns it again.
+    <br /><br />
+    <b>Interaction rules this frame freezes.</b> (1) <b>Copy affordance</b> —
+    <code>data-action="copy-secret"</code> writes the full secret to the clipboard and confirms via
+    <code>data-copy-status</code>. (2) <b>Explicit acknowledgement</b> — <code>Done</code> stays
+    disabled (<code>data-requires-ack</code>) until the user ticks <code>data-ack-checkbox</code>,
+    so no one dismisses the only copy by reflex. (3) <b>Honest, unrecoverable warning</b> — the
+    copy shown is an obviously-fake placeholder; a real implementation never logs or re-renders the
+    secret. Navigating away discards it from the DOM.
+  </p>
+
+  <nav class="pager"><a href="02-create-token.html">← Create token</a><a href="04-revoke.html">Next: Revoke →</a></nav>
+</div>
+</body>
+</html>

--- a/design/frames/api-tokens/04-revoke.html
+++ b/design/frames/api-tokens/04-revoke.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Revoke token — api-tokens frame (d)</title>
+<link rel="stylesheet" href="tokens.css" />
+<link rel="stylesheet" href="frame.css" />
+</head>
+<body>
+<div class="wrap" data-frame="04-revoke">
+  <a class="back" href="index.html">← All frames</a>
+  <div class="eyebrow">Frame (d) · route /settings/tokens</div>
+  <h1>Revoke token</h1>
+  <p class="lead">Revoking is immediate and permanent. Any service still using the token starts
+    failing right away — so the confirm is honest about what breaks, especially when the token is
+    in active use.</p>
+
+  <div class="state-block">
+    <div class="state-label">(d1) Revoke — confirm</div>
+    <div class="modal" data-panel="revoke-token" data-variant="ordinary">
+      <div class="modal-head"><h2>Revoke “Backup script”?</h2></div>
+      <div class="modal-body">
+        <div class="banner banner-warn">
+          <span>
+            <b>This can't be undone</b>
+            <p>The token <code class="mono">ff_tok_EXAMPLE3…</code> stops working immediately.
+              Anything using it will get 401s until you issue a new token and update it.</p>
+          </span>
+        </div>
+      </div>
+      <div class="modal-foot">
+        <button class="btn btn-ghost" data-action="cancel">Cancel</button>
+        <button class="btn btn-accent btn-danger" data-action="confirm-revoke" data-target="tok_1003">Revoke token</button>
+      </div>
+    </div>
+  </div>
+
+  <div class="state-block">
+    <div class="state-label">(d2) Token in active use — type to confirm</div>
+    <div class="modal" data-panel="revoke-token" data-variant="in-use" data-state="active">
+      <div class="modal-head"><h2>Revoke “CI deploy bot”?</h2></div>
+      <div class="modal-body">
+        <div class="banner banner-error" data-warning="in-use">
+          <span>
+            <b>This token was used 2 minutes ago</b>
+            <p>It's actively in use. Revoking it will break whatever depends on it right now —
+              deploys, jobs, or integrations may fail immediately. Make sure you've rotated it first.</p>
+          </span>
+        </div>
+        <div class="field">
+          <label class="label" for="confirm">Type the token name to confirm</label>
+          <input class="input" id="confirm" data-input="confirm-name" type="text" placeholder="CI deploy bot" />
+          <p class="hint">This extra step exists because the token is live. It prevents an accidental revoke.</p>
+        </div>
+      </div>
+      <div class="modal-foot">
+        <button class="btn btn-ghost" data-action="cancel">Cancel</button>
+        <button class="btn btn-accent btn-danger" data-action="confirm-revoke" data-target="tok_1001" disabled data-requires-name-match>Revoke token</button>
+      </div>
+    </div>
+  </div>
+
+  <p class="note">
+    <b>Contract.</b> <code>DELETE /api/organizations/{orgId}/tokens/{tokenId}</code> → <code>204</code>
+    (idempotent). Revocation is server-side and immediate; the row disappears from the list on success.
+    <br /><br />
+    <b>Interaction rules.</b> (d1) an ordinary token gets a single confirm. (d2) a token that shows
+    recent activity ("in active use") escalates to type-to-confirm — <code>Revoke</code> stays
+    disabled (<code>data-requires-name-match</code>) until the typed name matches, because revoking
+    a live credential is a foot-gun that deserves friction. "Active use" is derived from the same
+    last-used signal frame (a) commissions; until that field exists, treat every token as ordinary
+    (d1) rather than guessing.
+  </p>
+
+  <nav class="pager"><a href="03-reveal-once.html">← Secret shown once</a><a href="05-states.html">Next: States →</a></nav>
+</div>
+</body>
+</html>

--- a/design/frames/api-tokens/05-states.html
+++ b/design/frames/api-tokens/05-states.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>States — api-tokens frame (e)</title>
+<link rel="stylesheet" href="tokens.css" />
+<link rel="stylesheet" href="frame.css" />
+</head>
+<body>
+<div class="wrap" data-frame="05-states">
+  <a class="back" href="index.html">← All frames</a>
+  <div class="eyebrow">Frame (e) · route /settings/tokens</div>
+  <h1>States</h1>
+  <p class="lead">Every state a consumer must render is contract, not decoration. Loading, the
+    no-tokens invitation, a load failure, and the authorization denial that must never become a
+    sign-in prompt.</p>
+
+  <!-- e1 loading -->
+  <div class="state-block">
+    <div class="state-label">(e1) Loading</div>
+    <div class="panel" data-panel="token-list" data-state="loading" aria-busy="true">
+      <div class="panel-head"><div><h2>Tokens</h2><p class="sub">Loading…</p></div></div>
+      <table class="tbl"><tbody>
+        <tr><td><div class="skel" style="width: 55%"></div></td><td><div class="skel" style="width: 70%"></div></td><td><div class="skel" style="width: var(--space-16)"></div></td><td><div class="skel" style="width: var(--space-16)"></div></td><td class="right"><div class="skel" style="width: 40%; margin-left: auto"></div></td></tr>
+        <tr><td><div class="skel" style="width: 45%"></div></td><td><div class="skel" style="width: 50%"></div></td><td><div class="skel" style="width: var(--space-16)"></div></td><td><div class="skel" style="width: var(--space-16)"></div></td><td class="right"><div class="skel" style="width: 40%; margin-left: auto"></div></td></tr>
+      </tbody></table>
+    </div>
+  </div>
+
+  <!-- e2 empty -->
+  <div class="state-block">
+    <div class="state-label">(e2) No tokens yet</div>
+    <div class="panel" data-panel="token-list" data-state="empty">
+      <div class="panel-head">
+        <div><h2>Tokens</h2><p class="sub"><span data-count="tokens">0</span> in Northwind</p></div>
+        <button class="btn btn-accent" data-action="create-token">Create token</button>
+      </div>
+      <div class="empty">
+        <h3>No service tokens yet</h3>
+        <p>Create a token to let a service, CI job, or script call the API for Northwind. You choose
+          exactly what it can do, and you'll see the secret once.</p>
+        <button class="btn btn-accent" data-action="create-token">Create your first token</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- e3 error -->
+  <div class="state-block">
+    <div class="state-label">(e3) Couldn't load</div>
+    <div class="panel" data-panel="token-list" data-state="error">
+      <div class="panel-head"><div><h2>Tokens</h2></div></div>
+      <div class="empty">
+        <div class="banner banner-error" data-error-code="LOAD_FAILED" style="text-align: left">
+          <span>
+            <b>We couldn't load your tokens</b>
+            <p>Something went wrong on our end. Your existing tokens still work — try again.</p>
+          </span>
+        </div>
+        <button class="btn" data-action="retry">Try again</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- e4 403 forbidden -->
+  <div class="state-block">
+    <div class="state-label">(e4) Not allowed — 403, never a sign-in redirect</div>
+    <div class="panel" data-panel="token-list" data-state="forbidden">
+      <div class="panel-head"><div><h2>Tokens</h2></div></div>
+      <div class="empty">
+        <div class="banner banner-info" data-error-code="FORBIDDEN" data-http="403" style="text-align: left">
+          <span>
+            <b>You don't have access to manage tokens</b>
+            <p>You're signed in, but your role in Northwind can't view or manage service tokens.
+              Ask an admin of Northwind if you need this.</p>
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <p class="note">
+    <b>Contract.</b> Loading covers the in-flight <code>GET /api/organizations/{orgId}/tokens</code>.
+    Empty is the first-run state — a new org has no tokens, and the invitation is to create one.
+    Error covers a non-2xx list response with <code>data-action="retry"</code>.
+    <br /><br />
+    <b>⚠ (e4) is the rule this frame exists to enforce. A <code>403</code> is an authorization
+    denial, NOT an authentication failure.</b> The caller is signed in and their session is valid;
+    they simply lack the role to manage tokens. Render the denial in place — never redirect to
+    sign-in. Only a <code>401</code> (no/expired session) triggers re-authentication. Bouncing a
+    permission-denied user to a login page they'll pass straight through is the exact failure this
+    state is contract for.
+  </p>
+
+  <nav class="pager"><a href="04-revoke.html">← Revoke</a><a href="index.html">Back to index →</a></nav>
+</div>
+</body>
+</html>

--- a/design/frames/api-tokens/frame.css
+++ b/design/frames/api-tokens/frame.css
@@ -1,0 +1,174 @@
+/* authz-admin frame chrome. Design-system-first: every value below resolves to a
+   fuse-seam token declared in tokens.css. No raw hex / raw px / one-off type here. */
+
+.wrap { max-width: 940px; margin: 0 auto; padding: var(--space-10) var(--space-8) var(--space-16); }
+
+.back { display: inline-block; margin-bottom: var(--space-6); color: var(--text-tertiary);
+  font-size: var(--text-sm); text-decoration: none; }
+.back:hover { color: var(--text-secondary); }
+
+.eyebrow { font-family: var(--font-mono); font-size: var(--text-2xs); letter-spacing: var(--tracking-wide);
+  text-transform: uppercase; color: var(--cyan-400); margin-bottom: var(--space-3); }
+
+h1 { font-family: var(--font-display); font-size: var(--text-2xl);
+  letter-spacing: var(--tracking-display); margin: 0 0 var(--space-2); }
+h2 { font-family: var(--font-display); font-size: var(--text-lg); margin: 0; }
+h3 { font-size: var(--text-md); margin: 0 0 var(--space-2); }
+
+.lead { color: var(--text-secondary); margin: 0 0 var(--space-8); max-width: 68ch; }
+.sub { color: var(--text-tertiary); font-size: var(--text-sm); margin: var(--space-1) 0 0; }
+
+/* ---- panel ---- */
+.panel { background: var(--bg-secondary); border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg); overflow: hidden; }
+.panel + .panel { margin-top: var(--space-6); }
+.panel-head { display: flex; align-items: center; justify-content: space-between;
+  gap: var(--space-4); padding: var(--space-5) var(--space-6);
+  border-bottom: 1px solid var(--border-color); }
+.panel-foot { padding: var(--space-4) var(--space-6); border-top: 1px solid var(--border-color); }
+.panel-body { padding: var(--space-6); }
+
+/* ---- table ---- */
+.tbl { width: 100%; border-collapse: collapse; }
+.tbl th { text-align: left; font-size: var(--text-2xs); text-transform: uppercase;
+  letter-spacing: var(--tracking-wide); color: var(--text-tertiary);
+  font-weight: var(--weight-medium); padding: var(--space-3) var(--space-6);
+  border-bottom: 1px solid var(--border-color); }
+.tbl td { padding: var(--space-4) var(--space-6); border-bottom: 1px solid var(--border-color);
+  font-size: var(--text-md); vertical-align: middle; }
+.tbl tr:last-child td { border-bottom: none; }
+.right { text-align: right; }
+.who { display: flex; align-items: center; gap: var(--space-2); }
+
+/* ---- pills ---- */
+.pill { display: inline-block; padding: var(--space-1) var(--space-3);
+  border-radius: var(--radius-pill); font-size: var(--text-xs);
+  font-weight: var(--weight-medium); background: var(--bg-quaternary);
+  color: var(--text-secondary); border: 1px solid var(--border-color); }
+.pill-accent { background: var(--accent-soft); color: var(--accent-2);
+  border-color: var(--accent-color); }
+.tag { font-size: var(--text-2xs); color: var(--text-tertiary);
+  border: 1px solid var(--border-color); border-radius: var(--radius-sm);
+  padding: 0 var(--space-1); }
+
+/* ---- buttons ---- */
+.btn { font-family: var(--font-sans); font-size: var(--text-sm);
+  font-weight: var(--weight-medium); padding: var(--space-2) var(--space-4);
+  border-radius: var(--radius-md); border: 1px solid var(--border-strong);
+  background: var(--bg-quaternary); color: var(--text-primary); cursor: pointer;
+  transition: background var(--duration-fast) var(--ease-standard); }
+.btn:hover { background: var(--bg-tertiary); }
+.btn:focus-visible { outline: 2px solid var(--accent-color); outline-offset: 2px; }
+.btn-accent { background: var(--accent-color); border-color: var(--accent-color); }
+.btn-accent:hover { background: var(--accent-hover); }
+.btn-ghost { background: transparent; border-color: transparent; color: var(--text-secondary); }
+.btn-ghost:hover { background: var(--bg-quaternary); color: var(--text-primary); }
+.btn-danger { color: var(--error-color); }
+.btn[disabled] { opacity: 0.45; cursor: not-allowed; }
+
+/* ---- form ---- */
+.field { margin-bottom: var(--space-5); }
+.label { display: block; font-size: var(--text-sm); font-weight: var(--weight-medium);
+  margin-bottom: var(--space-2); }
+.hint { font-size: var(--text-xs); color: var(--text-tertiary); margin: var(--space-2) 0 0; }
+.input, .select { width: 100%; padding: var(--space-3) var(--space-4);
+  background: var(--bg-primary); border: 1px solid var(--border-strong);
+  border-radius: var(--radius-md); color: var(--text-primary);
+  font-family: var(--font-sans); font-size: var(--text-md); }
+.input:focus, .select:focus { outline: none; border-color: var(--accent-color);
+  box-shadow: 0 0 0 3px var(--accent-soft); }
+
+.radio-row { display: flex; align-items: flex-start; gap: var(--space-3);
+  padding: var(--space-4); border: 1px solid var(--border-color);
+  border-radius: var(--radius-md); margin-bottom: var(--space-3); cursor: pointer; }
+.radio-row[data-selected="true"] { border-color: var(--accent-color); background: var(--accent-soft); }
+.radio-row .rl { font-weight: var(--weight-medium); font-size: var(--text-md); }
+.radio-row .rd { font-size: var(--text-xs); color: var(--text-tertiary); margin-top: var(--space-1); }
+
+/* ---- banners ---- */
+.banner { display: flex; gap: var(--space-3); padding: var(--space-4) var(--space-5);
+  border-radius: var(--radius-md); font-size: var(--text-sm); margin-bottom: var(--space-5);
+  border: 1px solid var(--border-color); background: var(--bg-tertiary); }
+.banner b { display: block; margin-bottom: var(--space-1); }
+.banner-error { border-color: var(--error-color); color: var(--text-primary); }
+.banner-warn { border-color: var(--warning-color); }
+.banner-info { border-color: var(--accent-color); }
+.banner p { margin: 0; color: var(--text-secondary); }
+
+/* ---- states ---- */
+.skel { height: var(--space-4); border-radius: var(--radius-sm);
+  background: var(--bg-quaternary); animation: pulse var(--duration-base) infinite alternate; }
+@keyframes pulse { from { opacity: 0.5; } to { opacity: 1; } }
+@media (prefers-reduced-motion: reduce) { .skel { animation: none; } }
+.empty { text-align: center; padding: var(--space-12) var(--space-6); }
+.empty h3 { margin-bottom: var(--space-2); }
+.empty p { color: var(--text-tertiary); font-size: var(--text-sm);
+  margin: 0 auto var(--space-5); max-width: 44ch; }
+
+/* ---- modal (rendered inline/static in these frames) ---- */
+.modal { max-width: 460px; margin: 0 auto; background: var(--bg-secondary);
+  border: 1px solid var(--border-strong); border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-lg); overflow: hidden; }
+.modal-head { padding: var(--space-5) var(--space-6); border-bottom: 1px solid var(--border-color); }
+.modal-body { padding: var(--space-6); }
+.modal-foot { display: flex; justify-content: flex-end; gap: var(--space-3);
+  padding: var(--space-4) var(--space-6); border-top: 1px solid var(--border-color);
+  background: var(--bg-tertiary); }
+
+.note { font-size: var(--text-sm); color: var(--text-tertiary); margin-top: var(--space-8);
+  line-height: 1.6; }
+.note code { font-family: var(--font-mono); color: var(--text-secondary); font-size: var(--text-xs); }
+.note b { color: var(--text-secondary); }
+
+.pager { display: flex; justify-content: space-between; margin-top: var(--space-10);
+  padding-top: var(--space-5); border-top: 1px solid var(--border-color); }
+.pager a { color: var(--accent-2); text-decoration: none; font-size: var(--text-sm); }
+.pager a:hover { text-decoration: underline; }
+
+.state-block { margin-bottom: var(--space-8); }
+.state-label { font-family: var(--font-mono); font-size: var(--text-2xs);
+  text-transform: uppercase; letter-spacing: var(--tracking-wide);
+  color: var(--text-tertiary); margin-bottom: var(--space-3); }
+
+/* ─────────── api-tokens additions (design-system-first; tokens only) ─────────── */
+
+/* scope chips */
+.chips { display: flex; flex-wrap: wrap; gap: var(--space-2); }
+.chip { display: inline-flex; align-items: center; gap: var(--space-1);
+  font-family: var(--font-mono); font-size: var(--text-2xs);
+  padding: var(--space-1) var(--space-3); border-radius: var(--radius-pill);
+  background: var(--bg-quaternary); color: var(--text-secondary);
+  border: 1px solid var(--border-color); }
+.chip.more { color: var(--text-tertiary); }
+
+/* checkbox scope picker rows */
+.check-row { display: flex; align-items: flex-start; gap: var(--space-3);
+  padding: var(--space-3) var(--space-4); border: 1px solid var(--border-color);
+  border-radius: var(--radius-md); margin-bottom: var(--space-3); cursor: pointer; }
+.check-row[data-selected="true"] { border-color: var(--accent-color); background: var(--accent-soft); }
+.check-row .cl { font-family: var(--font-mono); font-weight: var(--weight-medium); font-size: var(--text-sm); }
+.check-row .cd { font-size: var(--text-xs); color: var(--text-tertiary); margin-top: var(--space-1); }
+
+/* last-used / meta cells */
+.muted { color: var(--text-tertiary); font-size: var(--text-sm); }
+.stamp { font-variant-numeric: tabular-nums; }
+.dot-live { width: 8px; height: 8px; border-radius: var(--radius-pill);
+  background: var(--success-color); display: inline-block; }
+
+/* the reveal-once secret block */
+.secret { display: flex; align-items: center; gap: var(--space-3);
+  background: var(--bg-primary); border: 1px solid var(--accent-color);
+  border-radius: var(--radius-md); padding: var(--space-4) var(--space-5); }
+.secret code { font-family: var(--font-mono); font-size: var(--text-md);
+  color: var(--text-primary); word-break: break-all; flex: 1; }
+.copy-btn { display: inline-flex; align-items: center; gap: var(--space-2);
+  flex: none; font-family: var(--font-sans); font-size: var(--text-sm);
+  font-weight: var(--weight-medium); padding: var(--space-2) var(--space-4);
+  border-radius: var(--radius-md); border: 1px solid var(--accent-color);
+  background: var(--accent-color); color: #0b0e15; cursor: pointer; }
+.copy-btn:hover { background: var(--accent-hover); }
+
+.ack-row { display: flex; align-items: flex-start; gap: var(--space-3);
+  margin-top: var(--space-5); padding: var(--space-4);
+  border: 1px solid var(--border-color); border-radius: var(--radius-md); cursor: pointer; }
+.ack-row .at { font-size: var(--text-sm); }

--- a/design/frames/api-tokens/index.html
+++ b/design/frames/api-tokens/index.html
@@ -1,0 +1,132 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Service tokens — Approval Frames</title>
+<link rel="stylesheet" href="tokens.css" />
+<link rel="stylesheet" href="frame.css" />
+<style>
+  .grid { display: grid; grid-template-columns: 1fr 1fr; gap: var(--space-5); margin-top: var(--space-6); }
+  @media (max-width: 640px){ .grid { grid-template-columns: 1fr; } }
+  .frame-link { display: block; text-decoration: none; color: inherit; background: var(--bg-tertiary);
+    border: 1px solid var(--border-color); border-radius: var(--radius-lg); padding: var(--space-6);
+    position: relative; overflow: hidden; transition: transform var(--duration-base) var(--ease-standard); }
+  .frame-link:hover { transform: translateY(-2px); box-shadow: var(--shadow-md); border-color: var(--border-strong); }
+  .frame-link.key { border-color: var(--accent-color); }
+  .frame-link .seam { position: absolute; top: 0; left: 0; right: 0; height: 2px; background: var(--seam); opacity: 0; transition: opacity var(--duration-base); }
+  .frame-link:hover .seam, .frame-link.key .seam { opacity: 1; }
+  .frame-link .step { font-family: var(--font-mono); font-size: var(--text-2xs); color: var(--text-tertiary); letter-spacing: var(--tracking-wide); }
+  .frame-link h3 { margin: var(--space-2) 0; font-size: var(--text-lg); }
+  .frame-link p { margin: 0; color: var(--text-tertiary); font-size: var(--text-sm); }
+  .inv { margin-top: var(--space-10); background: var(--bg-secondary); border: 1px solid var(--border-color);
+    border-radius: var(--radius-lg); padding: var(--space-6); }
+  .inv h2 { font-family: var(--font-display); font-size: var(--text-lg); margin: 0 0 var(--space-2); }
+  .inv .lead2 { color: var(--text-tertiary); font-size: var(--text-sm); margin: 0 0 var(--space-5); }
+  .inv-grid { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: var(--space-5); }
+  @media (max-width: 720px){ .inv-grid { grid-template-columns: 1fr; } }
+  .inv-col h4 { font-family: var(--font-mono); font-size: var(--text-2xs); text-transform: uppercase;
+    letter-spacing: var(--tracking-wide); color: var(--cyan-400); margin: 0 0 var(--space-3); }
+  .inv-col ul { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: var(--space-2); }
+  .inv-col li { font-size: var(--text-sm); color: var(--text-secondary); }
+  .inv-col code { font-family: var(--font-mono); font-size: var(--text-xs); color: var(--text-primary); }
+  .flowrow { display: flex; align-items: baseline; gap: var(--space-2); }
+  .flowrow .rt { font-family: var(--font-mono); font-size: var(--text-2xs); color: var(--text-tertiary); }
+  .pending { display: inline-flex; align-items: center; gap: 6px; font-family: var(--font-mono);
+    font-size: var(--text-2xs); padding: 2px 8px; border-radius: var(--radius-pill);
+    color: var(--warning-color); border: 1px solid var(--border-color); text-transform: uppercase;
+    letter-spacing: var(--tracking-wide); margin-top: var(--space-4); }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <div class="eyebrow">Contract-freeze · UX approval</div>
+  <h1>Service tokens · Approval Frames</h1>
+  <p class="lead">The consumer surface for machine-to-machine credentials: create a scoped service
+    token, copy its secret the one time it's shown, list active tokens by prefix, and revoke.
+    Backed by FuzeFront's own Security API — no identity or authorization vendor is named anywhere.
+    Reached from the account-security area, alongside access administration. Walk each frame below;
+    the reveal-once screen (c) is the one that matters most.</p>
+
+  <div class="grid" data-nav="frames">
+    <a href="01-tokens.html" class="frame-link" data-frame-link="01-tokens">
+      <div class="seam"></div><div class="step">Frame (a) · /settings/tokens</div>
+      <h3>Service tokens</h3>
+      <p>The list: name, prefix, scope chips, created, last-used, revoke.</p>
+    </a>
+    <a href="02-create-token.html" class="frame-link" data-frame-link="02-create-token">
+      <div class="seam"></div><div class="step">Frame (b) · /settings/tokens</div>
+      <h3>Create token</h3>
+      <p>Name + scope checkboxes + optional expiry. At least one scope required.</p>
+    </a>
+    <a href="03-reveal-once.html" class="frame-link key" data-frame-link="03-reveal-once">
+      <div class="seam"></div><div class="step">Frame (c) · /settings/tokens · MOST IMPORTANT</div>
+      <h3>Secret shown once</h3>
+      <p>Copy affordance, explicit "I've saved it" ack, honest unrecoverable warning.</p>
+    </a>
+    <a href="04-revoke.html" class="frame-link" data-frame-link="04-revoke">
+      <div class="seam"></div><div class="step">Frame (d) · /settings/tokens</div>
+      <h3>Revoke token</h3>
+      <p>Ordinary confirm, plus type-to-confirm when the token is in active use.</p>
+    </a>
+    <a href="05-states.html" class="frame-link" data-frame-link="05-states">
+      <div class="seam"></div><div class="step">Frame (e) · /settings/tokens</div>
+      <h3>States</h3>
+      <p>Loading, no-tokens invitation, load error+retry, and 403 (never a sign-in redirect).</p>
+    </a>
+  </div>
+
+  <div class="inv" data-panel="build-inventory">
+    <h2>Build inventory</h2>
+    <p class="lead2">Approving these frames approves this component/package plan. Implementation
+      cannot quietly invent a different architecture. Mirrored in <code>manifest.json</code> →
+      <code>build</code>.</p>
+    <div class="inv-grid">
+      <div class="inv-col" data-inv="flows">
+        <h4>Flows</h4>
+        <ul>
+          <li data-flow="service-tokens">
+            <div class="flowrow"><code>ServiceTokensFlow</code></div>
+            <div class="rt">route /settings/tokens · approved: false</div>
+          </li>
+        </ul>
+      </div>
+      <div class="inv-col" data-inv="components">
+        <h4>Components</h4>
+        <ul>
+          <li><code>TokenList</code></li>
+          <li><code>TokenRow</code></li>
+          <li><code>ScopeChips</code></li>
+          <li><code>CreateTokenDialog</code></li>
+          <li><code>ScopePicker</code></li>
+          <li><code>RevealOncePanel</code></li>
+          <li><code>CopySecretButton</code></li>
+          <li><code>RevokeTokenDialog</code></li>
+          <li><code>AccessDeniedNotice</code></li>
+        </ul>
+      </div>
+      <div class="inv-col" data-inv="packages">
+        <h4>Packages</h4>
+        <ul>
+          <li><code>@fuzefront/service-tokens-ui</code></li>
+        </ul>
+      </div>
+    </div>
+  </div>
+
+  <span class="pending" data-approval-status="pending">● Awaiting approval — per flow</span>
+
+  <p class="note">
+    Design system: <code>@fuzefront/design-system</code> (fuse-seam, tokens only) ·
+    Contract: <code>backend/security/src/routes/api-tokens.ts</code> → <code>@fuzefront/security-client</code> ·
+    Component: <code>@fuzefront/service-tokens-ui → ServiceTokensFlow</code>.<br />
+    <b>Commissioned by approval:</b> (1) a <code>last_used_at</code> field on the token record
+    (frames a, d) — not backed today; (2) bringing the token CRUD endpoints into the frozen
+    <code>packages/security/openapi.yaml</code> (only issue + introspect live there now). The raw
+    secret shown is a deliberately-fake placeholder. Approve per-flow by setting
+    <code>approved: true</code> in <code>manifest.json</code>, or reply <code>@claude approve</code>
+    / <code>@claude reject: &lt;reason&gt;</code>.
+  </p>
+</div>
+</body>
+</html>

--- a/design/frames/api-tokens/manifest.json
+++ b/design/frames/api-tokens/manifest.json
@@ -1,0 +1,128 @@
+{
+  "name": "Service tokens (M2M) — approval frames",
+  "description": "Contract-freeze UX artifacts for the vendor-neutral machine-to-machine service-token surface (create-scoped → reveal-once secret → list → revoke) backed by FuzeFront's Security API. Approving a flow approves its visual + interaction model AND the component/package build inventory before UI implementation. frontend-test-engineer drives Playwright against these via the data-frame / data-* hooks. The reveal-once screen (03) is the most important in the flow.",
+  "designSystem": "fuse-seam (@fuzefront/design-system)",
+  "entry": "index.html",
+  "contract": {
+    "openapi": "packages/security/openapi.yaml",
+    "backingRouter": "backend/security/src/routes/api-tokens.ts",
+    "client": "@fuzefront/security-client",
+    "schemas": ["ApiToken", "ApiTokenCreate", "ApiTokenCreateResponse"],
+    "endpoints": [
+      "GET /api/organizations/{orgId}/tokens",
+      "POST /api/organizations/{orgId}/tokens",
+      "GET /api/organizations/{orgId}/tokens/{tokenId}",
+      "DELETE /api/organizations/{orgId}/tokens/{tokenId}"
+    ],
+    "commissionedByApproval": [
+      "last_used_at on the token record (frames a, d) — not backed today; column reads '—' until it exists",
+      "bring the token CRUD endpoints into the frozen packages/security/openapi.yaml (only POST /v1/security/tokens issue + introspect live there now)"
+    ],
+    "component": "@fuzefront/service-tokens-ui → ServiceTokensFlow",
+    "featureFlag": "fuzefront.security.service-tokens"
+  },
+  "build": {
+    "flows": [
+      { "id": "service-tokens", "orchestrator": "ServiceTokensFlow", "route": "/settings/tokens", "approved": false, "approvedBy": null, "approvedAt": null }
+    ],
+    "components": [
+      "TokenList", "TokenRow", "ScopeChips", "CreateTokenDialog", "ScopePicker",
+      "RevealOncePanel", "CopySecretButton", "RevokeTokenDialog", "AccessDeniedNotice"
+    ],
+    "packages": ["@fuzefront/service-tokens-ui"]
+  },
+  "frames": [
+    {
+      "id": "01-tokens",
+      "file": "01-tokens.html",
+      "label": "(a) Service tokens",
+      "route": "/settings/tokens",
+      "flow": "service-tokens",
+      "summary": "Token list: name + prefix, scope chips, created, last-used, per-row revoke.",
+      "acceptanceNotes": "Rows from GET /api/organizations/{orgId}/tokens exposing name, token_prefix, scopes, created_at, expires_at — never the raw secret. 'Last used' is not backed yet (no last_used_at field); it renders '—' until commissioned, never fabricated activity. No vendor name in the DOM.",
+      "testHooks": [
+        "[data-frame='01-tokens']",
+        "[data-panel='token-list']",
+        "[data-token='tok_1001']",
+        "[data-token-prefix]",
+        "[data-scope='apps:read']",
+        "[data-action='create-token']",
+        "[data-action='revoke-token']"
+      ]
+    },
+    {
+      "id": "02-create-token",
+      "file": "02-create-token.html",
+      "label": "(b) Create token",
+      "route": "/settings/tokens",
+      "flow": "service-tokens",
+      "summary": "Name + scope checkboxes + optional expiry. Submit disabled until a name and at least one scope are present.",
+      "acceptanceNotes": "POST /api/organizations/{orgId}/tokens with { name, scopes[], expires_at? } → 201 with the raw secret returned once (frame c). Scope options should render from the org scope catalogue; the four shown are illustrative Resource:action strings. Fail-closed: no zero-scope token can be created.",
+      "testHooks": [
+        "[data-frame='02-create-token']",
+        "[data-panel='create-token']",
+        "[data-input='name']",
+        "[data-scope-option='apps:read']",
+        "[data-input='expiry']",
+        "[data-action='submit-create-token']"
+      ]
+    },
+    {
+      "id": "03-reveal-once",
+      "file": "03-reveal-once.html",
+      "label": "(c) Secret shown once — MOST IMPORTANT",
+      "route": "/settings/tokens",
+      "flow": "service-tokens",
+      "summary": "The one-time reveal: full secret with copy affordance, an unrecoverable warning, and an explicit ack gating Done.",
+      "acceptanceNotes": "The raw secret is the 'token' field returned ONLY on the 201 create; the backend stores a hash and never returns it again. Copy writes to clipboard (data-action='copy-secret' → data-copy-status). Done stays disabled (data-requires-ack) until data-ack-checkbox is ticked. The displayed secret MUST be an obviously-fake placeholder (ff_tok_EXAMPLE_NOT_A_REAL_TOKEN); a real impl never logs or re-renders it and discards it on navigation.",
+      "testHooks": [
+        "[data-frame='03-reveal-once']",
+        "[data-panel='reveal-once']",
+        "[data-panel='secret']",
+        "[data-token-secret]",
+        "[data-action='copy-secret']",
+        "[data-copy-status]",
+        "[data-ack-checkbox]",
+        "[data-requires-ack]",
+        "[data-action='done']"
+      ]
+    },
+    {
+      "id": "04-revoke",
+      "file": "04-revoke.html",
+      "label": "(d) Revoke token",
+      "route": "/settings/tokens",
+      "flow": "service-tokens",
+      "summary": "Ordinary confirm (d1), plus type-to-confirm escalation when the token is in active use (d2).",
+      "acceptanceNotes": "DELETE /api/organizations/{orgId}/tokens/{tokenId} → 204 (idempotent), immediate. d2 gates Revoke behind a name match (data-requires-name-match) for a token showing recent use. 'Active use' derives from the same last-used signal frame (a) commissions; until it exists, treat every token as ordinary (d1).",
+      "testHooks": [
+        "[data-frame='04-revoke']",
+        "[data-panel='revoke-token']",
+        "[data-variant='in-use']",
+        "[data-warning='in-use']",
+        "[data-input='confirm-name']",
+        "[data-requires-name-match]",
+        "[data-action='confirm-revoke']"
+      ]
+    },
+    {
+      "id": "05-states",
+      "file": "05-states.html",
+      "label": "(e) States",
+      "route": "/settings/tokens",
+      "flow": "service-tokens",
+      "summary": "Loading skeleton, no-tokens invitation, load error+retry, and 403 forbidden shown in place.",
+      "acceptanceNotes": "Loading = aria-busy skeleton for in-flight GET tokens. Empty is the first-run invitation to create. Error shows data-action='retry'. A 403 is an AUTHORIZATION denial rendered in place — NEVER a redirect to sign-in (only a 401 re-authenticates).",
+      "testHooks": [
+        "[data-frame='05-states']",
+        "[data-state='loading']",
+        "[data-state='empty']",
+        "[data-state='error']",
+        "[data-action='retry']",
+        "[data-state='forbidden']",
+        "[data-error-code='FORBIDDEN']",
+        "[data-http='403']"
+      ]
+    }
+  ]
+}

--- a/design/frames/api-tokens/tokens.css
+++ b/design/frames/api-tokens/tokens.css
@@ -1,0 +1,235 @@
+/* fuse-seam design-system tokens (subset), inlined so these approval frames are
+   self-contained / portable. Mirrors design-system/tokens/*.css. These frames are
+   contract-freeze UX artifacts — approve the frames = approve the model. */
+:root {
+  /* brand / accent */
+  --indigo-500: #6e5cff;
+  --cyan-400: #29d3e6;
+  --accent-color: var(--indigo-500);
+  --accent-hover: #5a48e6;
+  --accent-soft: rgba(110, 92, 255, 0.14);
+  --accent-2: var(--cyan-400);
+  --seam: linear-gradient(90deg, var(--accent-color) 0%, var(--accent-2) 100%);
+
+  /* graphite surfaces (dark default) */
+  --bg-primary: #0f131c;
+  --bg-secondary: #11161f;
+  --bg-tertiary: #141a26;
+  --bg-quaternary: #1b2230;
+  --border-color: #232b3a;
+  --border-strong: #313b4d;
+
+  --text-primary: #e7ebf2;
+  --text-secondary: #aab3c2;
+  --text-tertiary: #6b7585;
+
+  --success-color: #34d399;
+  --warning-color: #f5b950;
+  --error-color: #f3697f;
+
+  /* type */
+  --font-display: "Space Grotesk", "Inter", system-ui, sans-serif;
+  --font-sans: "Inter", system-ui, -apple-system, sans-serif;
+  --font-mono: "JetBrains Mono", ui-monospace, "SF Mono", monospace;
+  --text-2xs: 11px;
+  --text-xs: 12px;
+  --text-sm: 13px;
+  --text-md: 14px;
+  --text-lg: 16px;
+  --text-xl: 20px;
+  --text-2xl: 26px;
+  --weight-regular: 400;
+  --weight-medium: 500;
+  --weight-semibold: 600;
+  --tracking-wide: 0.04em;
+  --tracking-display: -0.01em;
+
+  /* spacing / radii / shadow */
+  --space-1: 4px; --space-2: 8px; --space-3: 12px; --space-4: 16px;
+  --space-5: 20px; --space-6: 24px; --space-7: 28px; --space-8: 32px;
+  --space-10: 40px; --space-12: 48px; --space-16: 64px;
+  --radius-sm: 6px; --radius-md: 10px; --radius-lg: 14px; --radius-xl: 20px;
+  --radius-pill: 999px;
+  --shadow-xs: 0 1px 2px rgba(0,0,0,0.3);
+  --shadow-md: 0 6px 20px rgba(0,0,0,0.4);
+  --shadow-lg: 0 16px 48px rgba(0,0,0,0.5);
+  --shadow-accent: 0 8px 24px rgba(110,92,255,0.35);
+
+  --top-bar-height: 60px;
+  --side-panel-width: 240px;
+  --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+  --duration-fast: 120ms;
+  --duration-base: 200ms;
+}
+
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  font-family: var(--font-sans);
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  -webkit-font-smoothing: antialiased;
+}
+.mono { font-family: var(--font-mono); }
+
+/* ---- shared portal-shell chrome used across frames ---- */
+.shell { display: flex; flex-direction: column; height: 100vh; }
+.topbar {
+  height: var(--top-bar-height);
+  flex: none;
+  display: flex; align-items: center; gap: var(--space-4);
+  padding: 0 var(--space-6);
+  background: var(--bg-secondary);
+  border-bottom: 1px solid var(--border-color);
+  position: relative;
+}
+.topbar::after {
+  content: ""; position: absolute; left: 0; right: 0; bottom: -1px;
+  height: 2px; background: var(--seam); opacity: 0.7;
+}
+.wordmark {
+  font-family: var(--font-display); font-weight: var(--weight-semibold);
+  font-size: var(--text-lg); letter-spacing: var(--tracking-display);
+}
+.wordmark .fuse {
+  background: var(--seam); -webkit-background-clip: text;
+  background-clip: text; color: transparent;
+}
+.topbar .spacer { flex: 1; }
+.launch-btn {
+  width: 34px; height: 34px; border-radius: var(--radius-md);
+  display: grid; place-items: center; cursor: pointer;
+  background: var(--bg-quaternary); border: 1px solid var(--border-color);
+}
+.avatar {
+  width: 32px; height: 32px; border-radius: var(--radius-pill);
+  background: var(--seam); display: grid; place-items: center;
+  font-weight: var(--weight-semibold); font-size: var(--text-sm); color: #0b0e15;
+}
+.body { flex: 1; display: flex; min-height: 0; }
+
+.side {
+  width: var(--side-panel-width); flex: none;
+  background: var(--bg-secondary);
+  border-right: 1px solid var(--border-color);
+  padding: var(--space-4) var(--space-3);
+  display: flex; flex-direction: column; gap: var(--space-1);
+  overflow-y: auto;
+}
+.side .section-label {
+  font-family: var(--font-mono); font-size: var(--text-2xs);
+  letter-spacing: var(--tracking-wide); text-transform: uppercase;
+  color: var(--text-tertiary); margin: var(--space-4) var(--space-2) var(--space-2);
+}
+.nav-item {
+  display: flex; align-items: center; gap: var(--space-3);
+  padding: var(--space-2) var(--space-3); border-radius: var(--radius-md);
+  color: var(--text-secondary); font-size: var(--text-md); cursor: pointer;
+  text-decoration: none;
+}
+.nav-item:hover { background: var(--bg-quaternary); color: var(--text-primary); }
+.nav-item.active {
+  background: var(--accent-soft); color: var(--text-primary);
+  box-shadow: inset 2px 0 0 var(--accent-color);
+}
+.nav-item .ico { width: 18px; text-align: center; }
+
+.content { flex: 1; overflow: auto; padding: var(--space-8); min-width: 0; }
+.page-title {
+  font-family: var(--font-display); font-size: var(--text-2xl);
+  letter-spacing: var(--tracking-display); margin: 0 0 var(--space-2);
+}
+.page-sub { color: var(--text-secondary); margin: 0 0 var(--space-6); }
+
+.btn {
+  font-family: var(--font-sans); font-size: var(--text-md);
+  font-weight: var(--weight-medium); border-radius: var(--radius-md);
+  padding: var(--space-2) var(--space-4); cursor: pointer; border: 1px solid transparent;
+}
+.btn-primary { background: var(--accent-color); color: #0b0e15; box-shadow: var(--shadow-accent); }
+.btn-primary:hover { background: var(--accent-hover); }
+.btn-ghost { background: transparent; color: var(--text-secondary); border-color: var(--border-color); }
+.btn-ghost:hover { color: var(--text-primary); border-color: var(--border-strong); }
+
+.badge {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-family: var(--font-mono); font-size: var(--text-2xs);
+  padding: 2px 8px; border-radius: var(--radius-pill);
+  border: 1px solid var(--border-color); color: var(--text-secondary);
+  text-transform: uppercase; letter-spacing: var(--tracking-wide);
+}
+.badge.activated { color: var(--success-color); border-color: rgba(52,211,153,0.4); }
+.badge.registered { color: var(--warning-color); border-color: rgba(245,185,80,0.4); }
+.badge.mf { color: var(--cyan-400); border-color: rgba(41,211,230,0.4); }
+.badge.builtin { color: var(--accent-color); border-color: rgba(110,92,255,0.4); }
+.badge.standalone { color: var(--text-primary); border-color: var(--border-strong); }
+
+.dot { width: 9px; height: 9px; border-radius: var(--radius-pill); display: inline-block; }
+.dot.healthy { background: var(--success-color); }
+.dot.down { background: var(--error-color); }
+
+/* approval-frame footer nav */
+.frame-nav {
+  position: fixed; bottom: 0; left: 0; right: 0;
+  display: flex; align-items: center; justify-content: space-between;
+  gap: var(--space-4); padding: var(--space-3) var(--space-6);
+  background: rgba(17,22,31,0.92); backdrop-filter: blur(8px);
+  border-top: 1px solid var(--border-color); z-index: 50;
+}
+.frame-nav .caption { font-size: var(--text-sm); color: var(--text-tertiary); }
+.frame-nav .caption b { color: var(--text-secondary); font-weight: var(--weight-semibold); }
+.frame-nav a { text-decoration: none; }
+.content { padding-bottom: 72px; }
+
+/* ---- invoice status pill soft tokens (mirror @fuzefront/design-system semantic *-soft) ---- */
+:root {
+  --success-soft: rgba(52, 211, 153, 0.14);
+  --warning-soft: rgba(245, 185, 80, 0.14);
+  --error-soft:   rgba(243, 105, 127, 0.14);
+  --neutral-soft: rgba(170, 179, 194, 0.12);
+}
+
+/* ---- InvoiceHistoryPanel (design-system-first; tokens only) ---- */
+.ffb-invoices { background: var(--bg-tertiary); border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg); position: relative; overflow: hidden; max-width: 720px; }
+.ffb-invoices__seam { height: 2px; background: var(--seam); }
+.ffb-invoices__head { display: flex; align-items: baseline; justify-content: space-between;
+  gap: var(--space-3); padding: var(--space-5) var(--space-5) var(--space-3); }
+.ffb-invoices__title { margin: 0; font-family: var(--font-display); font-size: var(--text-lg);
+  font-weight: var(--weight-semibold); color: var(--text-primary); }
+.ffb-invoices__count { color: var(--text-tertiary); font-size: var(--text-sm);
+  font-variant-numeric: tabular-nums; }
+.ffb-invoices__list { display: flex; flex-direction: column; }
+.ffb-invoice-row { display: grid; grid-template-columns: 1fr auto; gap: var(--space-1) var(--space-4);
+  padding: var(--space-4) var(--space-5); border-top: 1px solid var(--border-color); align-items: center; }
+.ffb-invoice-row__main { display: flex; flex-direction: column; gap: var(--space-1); min-width: 0; }
+.ffb-invoice-row__top { display: flex; align-items: center; gap: var(--space-3); flex-wrap: wrap; }
+.ffb-invoice-row__num { font-weight: var(--weight-medium); color: var(--text-primary);
+  font-variant-numeric: tabular-nums; }
+.ffb-invoice-row__date { color: var(--text-secondary); font-size: var(--text-sm); }
+.ffb-invoice-row__side { display: flex; align-items: center; gap: var(--space-4); justify-content: flex-end; }
+.ffb-invoice-row__amount { color: var(--text-primary); font-weight: var(--weight-semibold);
+  font-variant-numeric: tabular-nums; text-align: end; }
+.ffb-pill { display: inline-flex; align-items: center; gap: var(--space-1);
+  padding: 2px var(--space-2); border-radius: var(--radius-pill); font-size: var(--text-2xs);
+  font-weight: var(--weight-semibold); text-transform: capitalize; white-space: nowrap; }
+.ffb-pill__dot { width: 6px; height: 6px; border-radius: var(--radius-pill); background: currentColor; }
+.ffb-pill--paid { background: var(--success-soft); color: var(--success-color); }
+.ffb-pill--open { background: var(--warning-soft); color: var(--warning-color); }
+.ffb-pill--void { background: var(--neutral-soft); color: var(--text-secondary); }
+.ffb-pill--uncollectible { background: var(--error-soft); color: var(--error-color); }
+.ffb-dl { display: inline-flex; align-items: center; gap: var(--space-1); color: var(--accent-color);
+  text-decoration: none; font-size: var(--text-sm); font-weight: var(--weight-medium);
+  padding: var(--space-1) var(--space-2); border-radius: var(--radius-sm); min-height: 32px; }
+.ffb-dl:hover { background: var(--accent-soft); }
+.ffb-dl svg { width: 14px; height: 14px; }
+.ffb-invoices__foot { padding: var(--space-4) var(--space-5); border-top: 1px solid var(--border-color);
+  display: flex; justify-content: center; }
+.ffb-skel { height: 14px; border-radius: var(--radius-pill); background:
+  linear-gradient(90deg, var(--bg-quaternary), var(--border-color), var(--bg-quaternary));
+  background-size: 200% 100%; animation: ffbsh 1.3s ease-in-out infinite; }
+@keyframes ffbsh { 0%{background-position:200% 0} 100%{background-position:-200% 0} }
+@media (prefers-reduced-motion: reduce){ .ffb-skel{ animation: none; } }
+.ffb-empty { padding: var(--space-8) var(--space-5); text-align: center; color: var(--text-secondary); }
+.ffb-empty__icon { width: 40px; height: 40px; margin: 0 auto var(--space-3); color: var(--text-tertiary); }
+.ffb-note { font-size: var(--text-sm); color: var(--text-secondary); }


### PR DESCRIPTION
## Frames-only PR — service tokens (machine-to-machine credentials)

Navigable HTML frames for the **api-tokens** UI feature, authored by `product-designer` **before** any UI implementation. Merging this (approved) is the gate that dispatches RED Playwright specs and the frontend fan-out. Reached from the account-security area, alongside access administration.

**Scope:** `design/frames/api-tokens/**` only. No feature code, tests, or config.

### Flows & screens
- `01-tokens` — list: name + prefix, scope chips, created, last-used, revoke
- `02-create-token` — name + scopes + optional expiry (fail-closed: name + ≥1 scope required)
- `03-reveal-once` — **the secret shown exactly once**: copy affordance, explicit "I've saved it" ack gating Done, honest unrecoverable warning. Obviously-fake placeholder (`ff_tok_EXAMPLE_NOT_A_REAL_TOKEN`)
- `04-revoke` — ordinary confirm **+ type-to-confirm when the token is in active use**
- `05-states` — loading, no-tokens invitation, load error, and **403-in-place (never a sign-in redirect)**

### States are contract
Loading, empty, error, the reveal-once unrecoverable case, revoking a token in active use, and a 403 authorization denial rendered in place — never a login bounce.

### Build inventory (in `index.html` + `manifest.json` → `build`)
- Flow `ServiceTokensFlow` → `/settings/tokens` (`approved: false`)
- Components: TokenList, TokenRow, ScopeChips, CreateTokenDialog, ScopePicker, RevealOncePanel, CopySecretButton, RevokeTokenDialog, AccessDeniedNotice
- Package: `@fuzefront/service-tokens-ui`

### Contract
Backing router `backend/security/src/routes/api-tokens.ts` (create/list/revoke, reveal-once secret + `token_prefix`) → `@fuzefront/security-client`. **Commissioned by approval:** (1) a `last_used_at` field (not backed today — column reads `—`); (2) bringing the token CRUD into the frozen `packages/security/openapi.yaml` (only issue + introspect live there now). Flagged honestly in-frame.

Design-system-first (fuse-seam tokens only). No identity vendor named anywhere; no clientId/clientSecret operator plumbing on the consumer surface. Per-flow `approved: false` awaiting review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)