### PR TITLE
design(frames): mfa-management — two-factor management approval frames

### DIFF
--- a/design/frames/mfa-management/01-mfa-overview.html
+++ b/design/frames/mfa-management/01-mfa-overview.html
@@ -1,0 +1,176 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Two-factor overview — MFA frames</title>
+<link rel="stylesheet" href="tokens.css" />
+<style>
+  .content { max-width: 760px; }
+  .panel { background: var(--bg-tertiary); border: 1px solid var(--border-color);
+    border-radius: var(--radius-lg); overflow: hidden; margin-bottom: var(--space-6); }
+  .panel__seam { height: 2px; background: var(--seam); }
+  .panel__head { display: flex; align-items: baseline; justify-content: space-between; gap: var(--space-3);
+    padding: var(--space-5) var(--space-5) var(--space-3); }
+  .panel__title { margin: 0; font-family: var(--font-display); font-size: var(--text-lg);
+    font-weight: var(--weight-semibold); }
+  .panel__hint { color: var(--text-tertiary); font-size: var(--text-sm); }
+  .state-label { font-family: var(--font-mono); font-size: var(--text-2xs); letter-spacing: var(--tracking-wide);
+    text-transform: uppercase; color: var(--text-tertiary); margin: var(--space-8) 0 var(--space-2); }
+  .factor { display: grid; grid-template-columns: auto 1fr auto; gap: var(--space-4); align-items: center;
+    padding: var(--space-4) var(--space-5); border-top: 1px solid var(--border-color); }
+  .factor__ico { width: 38px; height: 38px; border-radius: var(--radius-md); display: grid; place-items: center;
+    background: var(--accent-soft); color: var(--accent-color); font-size: var(--text-lg); }
+  .factor__main { display: flex; flex-direction: column; gap: var(--space-1); min-width: 0; }
+  .factor__name { font-weight: var(--weight-medium); color: var(--text-primary); }
+  .factor__sub { color: var(--text-secondary); font-size: var(--text-sm); }
+  .factor__actions { display: flex; gap: var(--space-2); }
+  .link-danger { background: transparent; border: 1px solid var(--border-color); color: var(--error-color);
+    font-family: var(--font-sans); font-size: var(--text-sm); border-radius: var(--radius-md);
+    padding: var(--space-1) var(--space-3); cursor: pointer; }
+  .link-danger:hover { border-color: var(--error-color); }
+  .add-menu { padding: var(--space-4) var(--space-5); border-top: 1px solid var(--border-color);
+    display: flex; flex-direction: column; gap: var(--space-3); }
+  .add-row { display: grid; grid-template-columns: auto 1fr auto; gap: var(--space-4); align-items: center;
+    padding: var(--space-3) var(--space-4); border: 1px solid var(--border-color); border-radius: var(--radius-md);
+    background: var(--bg-secondary); }
+  .add-row.is-disabled { opacity: 0.7; }
+  .add-row__ico { width: 32px; height: 32px; border-radius: var(--radius-sm); display: grid; place-items: center;
+    background: var(--bg-quaternary); color: var(--text-secondary); }
+  .add-row__txt small { display: block; color: var(--text-tertiary); font-size: var(--text-sm); }
+  .unavail { color: var(--warning-color); font-size: var(--text-2xs); font-family: var(--font-mono);
+    border: 1px solid rgba(245,185,80,0.4); border-radius: var(--radius-pill); padding: 2px var(--space-2);
+    text-transform: uppercase; letter-spacing: var(--tracking-wide); }
+  .skel-row { display: grid; grid-template-columns: 38px 1fr 80px; gap: var(--space-4); align-items: center;
+    padding: var(--space-4) var(--space-5); border-top: 1px solid var(--border-color); }
+  .ffb-skel { height: 14px; border-radius: var(--radius-pill);
+    background: linear-gradient(90deg, var(--bg-quaternary), var(--border-color), var(--bg-quaternary));
+    background-size: 200% 100%; animation: ffbsh 1.3s ease-in-out infinite; }
+  .ffb-skel.sq { height: 38px; width: 38px; border-radius: var(--radius-md); }
+  @keyframes ffbsh { 0%{background-position:200% 0} 100%{background-position:-200% 0} }
+  @media (prefers-reduced-motion: reduce){ .ffb-skel{ animation: none; } }
+  .msg { padding: var(--space-8) var(--space-5); text-align: center; color: var(--text-secondary); }
+  .msg h4 { margin: 0 0 var(--space-2); color: var(--text-primary); font-family: var(--font-display); }
+  .msg p { margin: 0 auto var(--space-4); max-width: 46ch; font-size: var(--text-sm); }
+  .banner { display: flex; gap: var(--space-3); align-items: flex-start; padding: var(--space-4) var(--space-5);
+    background: var(--warning-soft); border-top: 1px solid rgba(245,185,80,0.3); color: var(--text-secondary);
+    font-size: var(--text-sm); }
+</style>
+</head>
+<body>
+<div class="shell" data-frame="01-mfa-overview" data-route="/account/security/mfa">
+  <header class="topbar">
+    <span class="wordmark">Fuze<span class="fuse">Front</span></span>
+    <span class="spacer"></span>
+    <div class="launch-btn" aria-hidden="true">⋮⋮</div>
+    <div class="avatar">AR</div>
+  </header>
+  <div class="body">
+    <nav class="side">
+      <div class="section-label">Account</div>
+      <a class="nav-item" href="#">Profile</a>
+      <a class="nav-item active" href="#"><span class="ico">🛡️</span> Security</a>
+      <a class="nav-item" href="#">Sessions &amp; devices</a>
+      <a class="nav-item" href="#">Billing</a>
+    </nav>
+    <main class="content">
+      <h1 class="page-title">Two-factor authentication</h1>
+      <p class="page-sub">Add a second step to sign-in so a stolen password isn't enough. We'll ask for it
+        when you sign in on a new device.</p>
+
+      <!-- ═══ Populated ═══ -->
+      <div class="panel" data-panel="mfa-overview" data-state="loaded">
+        <div class="panel__seam"></div>
+        <div class="panel__head">
+          <h2 class="panel__title">Your methods</h2>
+          <span class="panel__hint">2 active</span>
+        </div>
+        <div class="factor" data-factor="totp" data-status="active">
+          <div class="factor__ico" aria-hidden="true">🔑</div>
+          <div class="factor__main">
+            <span class="factor__name">Authenticator app</span>
+            <span class="factor__sub">Added 12 Jun 2026 · 6-digit codes</span>
+          </div>
+          <div class="factor__actions">
+            <button class="link-danger" data-action="remove-factor" data-factor-id="fct_totp_1">Remove</button>
+          </div>
+        </div>
+        <div class="factor" data-factor="sms" data-status="active">
+          <div class="factor__ico" aria-hidden="true">💬</div>
+          <div class="factor__main">
+            <span class="factor__name">Text message</span>
+            <span class="factor__sub">Sent to •••• •• 4471</span>
+          </div>
+          <div class="factor__actions">
+            <button class="link-danger" data-action="remove-factor" data-factor-id="fct_sms_1">Remove</button>
+          </div>
+        </div>
+
+        <div class="add-menu" data-component="add-factor-menu">
+          <div class="panel__hint" style="color:var(--text-tertiary)">Add another method</div>
+          <a class="add-row" href="02-totp-enroll.html" data-add="totp" data-available="true">
+            <span class="add-row__ico" aria-hidden="true">🔑</span>
+            <span class="add-row__txt">Authenticator app
+              <small>Codes from an app on your phone — works offline. Recommended.</small></span>
+            <span class="btn btn-ghost" aria-hidden="true">Set up</span>
+          </a>
+          <!-- Honest degrade: SMS offered ONLY when methods.mfa.types includes 'sms' -->
+          <a class="add-row" href="03-sms-enroll.html" data-add="sms" data-available="true">
+            <span class="add-row__ico" aria-hidden="true">💬</span>
+            <span class="add-row__txt">Text message
+              <small>A code sent to your phone by text.</small></span>
+            <span class="btn btn-ghost" aria-hidden="true">Set up</span>
+          </a>
+        </div>
+      </div>
+
+      <div class="panel" data-panel="recovery-status">
+        <div class="panel__head">
+          <h2 class="panel__title">Recovery codes</h2>
+          <span class="panel__hint">8 of 10 unused</span>
+        </div>
+        <div class="banner">
+          <span aria-hidden="true">🗝️</span>
+          <span>One-time codes to get in if you lose your phone. Keep them somewhere safe —
+            <a href="04-recovery-codes.html" data-action="view-recovery">view or regenerate</a>.</span>
+        </div>
+      </div>
+
+      <!-- ═══ Empty (no MFA yet) ═══ -->
+      <div class="state-label">State · no methods yet (empty)</div>
+      <div class="panel" data-panel="mfa-overview" data-state="empty">
+        <div class="panel__seam"></div>
+        <div class="msg">
+          <h4>Two-factor isn't on yet</h4>
+          <p>Turn it on to protect your account. An authenticator app is the quickest and works without signal.</p>
+          <a class="btn btn-primary" href="02-totp-enroll.html" data-action="enroll-first" style="text-decoration:none">Set up authenticator</a>
+        </div>
+      </div>
+
+      <!-- ═══ Loading ═══ -->
+      <div class="state-label">State · loading</div>
+      <div class="panel" data-panel="mfa-overview" data-state="loading" aria-busy="true">
+        <div class="panel__seam"></div>
+        <div class="skel-row"><span class="ffb-skel sq"></span><span class="ffb-skel" style="width:60%"></span><span class="ffb-skel" style="width:64px"></span></div>
+        <div class="skel-row"><span class="ffb-skel sq"></span><span class="ffb-skel" style="width:45%"></span><span class="ffb-skel" style="width:64px"></span></div>
+      </div>
+
+      <!-- ═══ Error ═══ -->
+      <div class="state-label">State · couldn't load</div>
+      <div class="panel" data-panel="mfa-overview" data-state="error">
+        <div class="panel__seam"></div>
+        <div class="msg">
+          <h4>We couldn't load your methods</h4>
+          <p>Something went wrong on our end. Your methods are unchanged.</p>
+          <button class="btn btn-ghost" data-action="retry">Try again</button>
+        </div>
+      </div>
+    </main>
+  </div>
+  <div class="frame-nav">
+    <span class="caption">Frame <b>01 / 06</b> · Two-factor overview · <b>/account/security/mfa</b></span>
+    <span><a class="btn btn-ghost" href="index.html">All frames</a> <a class="btn btn-primary" href="02-totp-enroll.html" style="text-decoration:none">Next: add authenticator →</a></span>
+  </div>
+</div>
+</body>
+</html>

--- a/design/frames/mfa-management/02-totp-enroll.html
+++ b/design/frames/mfa-management/02-totp-enroll.html
@@ -1,0 +1,141 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Add authenticator — MFA frames</title>
+<link rel="stylesheet" href="tokens.css" />
+<style>
+  .content { max-width: 720px; }
+  .card { background: var(--bg-tertiary); border: 1px solid var(--border-color); border-radius: var(--radius-lg);
+    overflow: hidden; margin-bottom: var(--space-6); }
+  .card__seam { height: 2px; background: var(--seam); }
+  .card__body { padding: var(--space-6); }
+  .steps { display: flex; gap: var(--space-2); margin-bottom: var(--space-5); font-size: var(--text-sm); }
+  .steps span { color: var(--text-tertiary); }
+  .steps b { color: var(--accent-color); }
+  .enroll { display: grid; grid-template-columns: auto 1fr; gap: var(--space-6); align-items: start; }
+  @media (max-width: 560px){ .enroll { grid-template-columns: 1fr; } }
+  .qr { width: 168px; height: 168px; border-radius: var(--radius-md); background: var(--text-primary);
+    display: grid; place-items: center; color: var(--bg-primary); font-family: var(--font-mono);
+    font-size: var(--text-2xs); text-align: center; padding: var(--space-3); }
+  .qr__grid { width: 132px; height: 132px; background:
+    repeating-conic-gradient(var(--bg-primary) 0deg 90deg, var(--text-primary) 90deg 180deg) 0 0 / 22px 22px; border-radius: var(--radius-sm); }
+  .instr { color: var(--text-secondary); font-size: var(--text-md); line-height: 1.6; margin: 0 0 var(--space-4); }
+  .setup-key { display: flex; align-items: center; gap: var(--space-3); background: var(--bg-secondary);
+    border: 1px solid var(--border-color); border-radius: var(--radius-md); padding: var(--space-3) var(--space-4); }
+  .setup-key code { font-family: var(--font-mono); letter-spacing: 0.12em; color: var(--text-primary);
+    font-size: var(--text-md); }
+  .setup-key button { margin-left: auto; }
+  .verify { margin-top: var(--space-6); border-top: 1px solid var(--border-color); padding-top: var(--space-6); }
+  .verify label { display: block; font-weight: var(--weight-medium); margin-bottom: var(--space-2); }
+  /* OtpInput — proposed DS primitive (segmented one-time-code field) */
+  .otp { display: flex; gap: var(--space-2); }
+  .otp input { width: 44px; height: 52px; text-align: center; font-family: var(--font-mono);
+    font-size: var(--text-xl); color: var(--text-primary); background: var(--bg-secondary);
+    border: 1px solid var(--border-strong); border-radius: var(--radius-md); }
+  .otp input:focus { outline: none; border-color: var(--accent-color); box-shadow: 0 0 0 3px var(--accent-soft); }
+  .otp.is-error input { border-color: var(--error-color); }
+  .field-error { color: var(--error-color); font-size: var(--text-sm); margin-top: var(--space-3);
+    display: flex; align-items: center; gap: var(--space-2); }
+  .actions { margin-top: var(--space-6); display: flex; gap: var(--space-3); }
+  .state-label { font-family: var(--font-mono); font-size: var(--text-2xs); letter-spacing: var(--tracking-wide);
+    text-transform: uppercase; color: var(--text-tertiary); margin: var(--space-8) 0 var(--space-2); }
+</style>
+</head>
+<body>
+<div class="shell" data-frame="02-totp-enroll" data-route="/account/security/mfa/add/authenticator">
+  <header class="topbar">
+    <span class="wordmark">Fuze<span class="fuse">Front</span></span>
+    <span class="spacer"></span>
+    <div class="launch-btn" aria-hidden="true">⋮⋮</div>
+    <div class="avatar">AR</div>
+  </header>
+  <div class="body">
+    <nav class="side">
+      <div class="section-label">Account</div>
+      <a class="nav-item" href="#">Profile</a>
+      <a class="nav-item active" href="01-mfa-overview.html"><span class="ico">🛡️</span> Security</a>
+      <a class="nav-item" href="#">Sessions &amp; devices</a>
+      <a class="nav-item" href="#">Billing</a>
+    </nav>
+    <main class="content">
+      <h1 class="page-title">Add an authenticator app</h1>
+      <p class="page-sub">Use an app like the ones on your phone to generate 6-digit codes. Works without
+        signal or a SIM.</p>
+
+      <div class="card" data-component="totp-enroll" data-state="scan">
+        <div class="card__seam"></div>
+        <div class="card__body">
+          <div class="steps"><b>1 · Scan</b><span>›</span><span>2 · Confirm</span></div>
+          <div class="enroll">
+            <div class="qr" data-provisioning-uri="otpauth://totp/…" aria-label="Setup QR code">
+              <div class="qr__grid"></div>
+            </div>
+            <div>
+              <p class="instr">Scan this with your authenticator app. Can't scan? Enter the setup key by hand.</p>
+              <div class="setup-key" data-component="setup-key">
+                <code data-secret>JBSW Y3DP EHPK 3PXP</code>
+                <button class="btn btn-ghost" data-action="copy-secret">Copy</button>
+              </div>
+
+              <div class="verify" data-step="verify">
+                <label for="otp">Enter the 6-digit code from the app</label>
+                <div class="otp" data-component="otp-input" role="group" aria-label="One-time code">
+                  <input inputmode="numeric" maxlength="1" value="4" aria-label="digit 1" />
+                  <input inputmode="numeric" maxlength="1" value="9" aria-label="digit 2" />
+                  <input inputmode="numeric" maxlength="1" value="2" aria-label="digit 3" />
+                  <input inputmode="numeric" maxlength="1" value="0" aria-label="digit 4" />
+                  <input inputmode="numeric" maxlength="1" value="1" aria-label="digit 5" />
+                  <input inputmode="numeric" maxlength="1" value="7" aria-label="digit 6" />
+                </div>
+                <div class="actions">
+                  <button class="btn btn-primary" data-action="activate-factor">Turn on</button>
+                  <a class="btn btn-ghost" href="01-mfa-overview.html" style="text-decoration:none">Cancel</a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- ═══ Invalid code (400 on activate) ═══ -->
+      <div class="state-label">State · wrong code (fail-closed)</div>
+      <div class="card" data-component="totp-enroll" data-state="error-invalid">
+        <div class="card__seam"></div>
+        <div class="card__body">
+          <label>Enter the 6-digit code from the app</label>
+          <div class="otp is-error" data-component="otp-input" role="group" aria-label="One-time code">
+            <input inputmode="numeric" maxlength="1" value="1" aria-label="digit 1" />
+            <input inputmode="numeric" maxlength="1" value="1" aria-label="digit 2" />
+            <input inputmode="numeric" maxlength="1" value="1" aria-label="digit 3" />
+            <input inputmode="numeric" maxlength="1" value="1" aria-label="digit 4" />
+            <input inputmode="numeric" maxlength="1" value="1" aria-label="digit 5" />
+            <input inputmode="numeric" maxlength="1" value="1" aria-label="digit 6" />
+          </div>
+          <div class="field-error" data-error="invalid-code"><span aria-hidden="true">⚠</span>
+            That code didn't match. Codes change every 30 seconds — enter the current one.</div>
+        </div>
+      </div>
+
+      <!-- ═══ Expired code ═══ -->
+      <div class="state-label">State · code expired</div>
+      <div class="card" data-component="totp-enroll" data-state="error-expired">
+        <div class="card__seam"></div>
+        <div class="card__body">
+          <div class="field-error" data-error="expired-code"><span aria-hidden="true">⚠</span>
+            This code expired. Wait for the next one to appear in your app, then enter it.</div>
+          <div class="actions">
+            <button class="btn btn-primary" data-action="activate-factor">Try again</button>
+          </div>
+        </div>
+      </div>
+    </main>
+  </div>
+  <div class="frame-nav">
+    <span class="caption">Frame <b>02 / 06</b> · Add authenticator · <b>…/mfa/add/authenticator</b></span>
+    <span><a class="btn btn-ghost" href="01-mfa-overview.html">← Overview</a> <a class="btn btn-primary" href="03-sms-enroll.html" style="text-decoration:none">Next: add phone →</a></span>
+  </div>
+</div>
+</body>
+</html>

--- a/design/frames/mfa-management/03-sms-enroll.html
+++ b/design/frames/mfa-management/03-sms-enroll.html
@@ -1,0 +1,156 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Add phone (text message) — MFA frames</title>
+<link rel="stylesheet" href="tokens.css" />
+<style>
+  .content { max-width: 720px; }
+  .card { background: var(--bg-tertiary); border: 1px solid var(--border-color); border-radius: var(--radius-lg);
+    overflow: hidden; margin-bottom: var(--space-6); }
+  .card__seam { height: 2px; background: var(--seam); }
+  .card__body { padding: var(--space-6); }
+  .steps { display: flex; gap: var(--space-2); margin-bottom: var(--space-5); font-size: var(--text-sm); }
+  .steps span { color: var(--text-tertiary); } .steps b { color: var(--accent-color); }
+  .field { margin-bottom: var(--space-4); }
+  .field label { display: block; font-weight: var(--weight-medium); margin-bottom: var(--space-2); }
+  .field input[type=tel] { width: 100%; height: 44px; padding: 0 var(--space-4); color: var(--text-primary);
+    background: var(--bg-secondary); border: 1px solid var(--border-strong); border-radius: var(--radius-md);
+    font-size: var(--text-md); font-family: var(--font-sans); }
+  .field input:focus { outline: none; border-color: var(--accent-color); box-shadow: 0 0 0 3px var(--accent-soft); }
+  .hint { color: var(--text-tertiary); font-size: var(--text-sm); margin-top: var(--space-2); }
+  .otp { display: flex; gap: var(--space-2); }
+  .otp input { width: 44px; height: 52px; text-align: center; font-family: var(--font-mono);
+    font-size: var(--text-xl); color: var(--text-primary); background: var(--bg-secondary);
+    border: 1px solid var(--border-strong); border-radius: var(--radius-md); }
+  .otp input:focus { outline: none; border-color: var(--accent-color); box-shadow: 0 0 0 3px var(--accent-soft); }
+  .otp.is-error input { border-color: var(--error-color); }
+  .field-error { color: var(--error-color); font-size: var(--text-sm); margin-top: var(--space-3);
+    display: flex; align-items: center; gap: var(--space-2); }
+  .actions { margin-top: var(--space-6); display: flex; gap: var(--space-3); }
+  .state-label { font-family: var(--font-mono); font-size: var(--text-2xs); letter-spacing: var(--tracking-wide);
+    text-transform: uppercase; color: var(--text-tertiary); margin: var(--space-8) 0 var(--space-2); }
+  /* ChannelUnavailableNotice — honest degrade when methods.mfa.types excludes 'sms' */
+  .unavail-card { border-color: rgba(245,185,80,0.35); }
+  .unavail-body { display: flex; gap: var(--space-4); padding: var(--space-6); align-items: flex-start; }
+  .unavail-body .ico { width: 40px; height: 40px; border-radius: var(--radius-md); flex: none; display: grid;
+    place-items: center; background: var(--warning-soft); color: var(--warning-color); font-size: var(--text-lg); }
+  .unavail-body h3 { margin: 0 0 var(--space-2); font-family: var(--font-display); font-size: var(--text-lg); }
+  .unavail-body p { margin: 0 0 var(--space-4); color: var(--text-secondary); font-size: var(--text-md); line-height: 1.6; }
+  .disabled-field { opacity: 0.55; pointer-events: none; }
+</style>
+</head>
+<body>
+<div class="shell" data-frame="03-sms-enroll" data-route="/account/security/mfa/add/phone">
+  <header class="topbar">
+    <span class="wordmark">Fuze<span class="fuse">Front</span></span>
+    <span class="spacer"></span>
+    <div class="launch-btn" aria-hidden="true">⋮⋮</div>
+    <div class="avatar">AR</div>
+  </header>
+  <div class="body">
+    <nav class="side">
+      <div class="section-label">Account</div>
+      <a class="nav-item" href="#">Profile</a>
+      <a class="nav-item active" href="01-mfa-overview.html"><span class="ico">🛡️</span> Security</a>
+      <a class="nav-item" href="#">Sessions &amp; devices</a>
+      <a class="nav-item" href="#">Billing</a>
+    </nav>
+    <main class="content">
+      <h1 class="page-title">Add a phone for text-message codes</h1>
+      <p class="page-sub">We'll text a code to this number when you sign in. An authenticator app is more
+        reliable if you can use one.</p>
+
+      <!-- ═══ Channel UNAVAILABLE — the prod reality (text delivery not configured) ═══ -->
+      <div class="state-label">State · text-message codes unavailable (prod default)</div>
+      <div class="card unavail-card" data-component="channel-unavailable" data-state="channel-unavailable"
+           data-channel="sms" data-available="false">
+        <div class="card__seam"></div>
+        <div class="unavail-body">
+          <span class="ico" aria-hidden="true">💬</span>
+          <div>
+            <h3>Text-message codes aren't available right now</h3>
+            <p>This account can't receive sign-in codes by text yet. Use an authenticator app instead —
+              it's more secure and works without signal.</p>
+            <div class="actions" style="margin-top:0">
+              <a class="btn btn-primary" href="02-totp-enroll.html" style="text-decoration:none">Set up authenticator</a>
+              <a class="btn btn-ghost" href="01-mfa-overview.html" style="text-decoration:none">Back</a>
+            </div>
+          </div>
+        </div>
+        <div class="card__body disabled-field" aria-disabled="true">
+          <div class="field">
+            <label>Phone number</label>
+            <input type="tel" placeholder="+44 …" disabled />
+            <div class="hint">Disabled until text delivery is available.</div>
+          </div>
+        </div>
+      </div>
+
+      <!-- ═══ Available: enter number ═══ -->
+      <div class="state-label">State · available · enter number</div>
+      <div class="card" data-component="sms-enroll" data-state="enter-phone" data-available="true">
+        <div class="card__seam"></div>
+        <div class="card__body">
+          <div class="steps"><b>1 · Your number</b><span>›</span><span>2 · Confirm</span></div>
+          <div class="field">
+            <label for="phone">Phone number</label>
+            <input id="phone" type="tel" value="+44 7700 900471" data-field="phone" />
+            <div class="hint">Standard message rates may apply. We only use it for sign-in codes.</div>
+          </div>
+          <div class="actions" style="margin-top:0">
+            <button class="btn btn-primary" data-action="send-code">Send code</button>
+            <a class="btn btn-ghost" href="01-mfa-overview.html" style="text-decoration:none">Cancel</a>
+          </div>
+        </div>
+      </div>
+
+      <!-- ═══ Available: confirm code ═══ -->
+      <div class="state-label">State · available · confirm code</div>
+      <div class="card" data-component="sms-enroll" data-state="confirm-code" data-available="true">
+        <div class="card__seam"></div>
+        <div class="card__body">
+          <div class="steps"><span>1 · Your number</span><span>›</span><b>2 · Confirm</b></div>
+          <label>Enter the code we texted to •••• •• 4471</label>
+          <div class="otp" data-component="otp-input" role="group" aria-label="One-time code">
+            <input inputmode="numeric" maxlength="1" value="3" aria-label="digit 1" />
+            <input inputmode="numeric" maxlength="1" value="1" aria-label="digit 2" />
+            <input inputmode="numeric" maxlength="1" value="9" aria-label="digit 3" />
+            <input inputmode="numeric" maxlength="1" value="0" aria-label="digit 4" />
+            <input inputmode="numeric" maxlength="1" value="2" aria-label="digit 5" />
+            <input inputmode="numeric" maxlength="1" value="8" aria-label="digit 6" />
+          </div>
+          <div class="hint">Didn't get it? <a href="#" data-action="resend-code">Resend</a> — check the number is right.</div>
+          <div class="actions">
+            <button class="btn btn-primary" data-action="activate-factor">Turn on</button>
+          </div>
+        </div>
+      </div>
+
+      <!-- ═══ Invalid code ═══ -->
+      <div class="state-label">State · wrong / expired code (fail-closed)</div>
+      <div class="card" data-component="sms-enroll" data-state="error-invalid" data-available="true">
+        <div class="card__seam"></div>
+        <div class="card__body">
+          <div class="otp is-error" data-component="otp-input" role="group" aria-label="One-time code">
+            <input inputmode="numeric" maxlength="1" value="0" aria-label="digit 1" />
+            <input inputmode="numeric" maxlength="1" value="0" aria-label="digit 2" />
+            <input inputmode="numeric" maxlength="1" value="0" aria-label="digit 3" />
+            <input inputmode="numeric" maxlength="1" value="0" aria-label="digit 4" />
+            <input inputmode="numeric" maxlength="1" value="0" aria-label="digit 5" />
+            <input inputmode="numeric" maxlength="1" value="0" aria-label="digit 6" />
+          </div>
+          <div class="field-error" data-error="invalid-code"><span aria-hidden="true">⚠</span>
+            That code is wrong or has expired. Request a new one and enter it within a few minutes.</div>
+        </div>
+      </div>
+    </main>
+  </div>
+  <div class="frame-nav">
+    <span class="caption">Frame <b>03 / 06</b> · Add phone · <b>…/mfa/add/phone</b></span>
+    <span><a class="btn btn-ghost" href="02-totp-enroll.html">← Authenticator</a> <a class="btn btn-primary" href="04-recovery-codes.html" style="text-decoration:none">Next: recovery codes →</a></span>
+  </div>
+</div>
+</body>
+</html>

--- a/design/frames/mfa-management/04-recovery-codes.html
+++ b/design/frames/mfa-management/04-recovery-codes.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Recovery codes — MFA frames</title>
+<link rel="stylesheet" href="tokens.css" />
+<style>
+  .content { max-width: 720px; }
+  .card { background: var(--bg-tertiary); border: 1px solid var(--border-color); border-radius: var(--radius-lg);
+    overflow: hidden; margin-bottom: var(--space-6); }
+  .card__seam { height: 2px; background: var(--seam); }
+  .card__body { padding: var(--space-6); }
+  .warn-banner { display: flex; gap: var(--space-3); align-items: flex-start; padding: var(--space-4) var(--space-6);
+    background: var(--warning-soft); color: var(--text-secondary); font-size: var(--text-sm); }
+  .warn-banner b { color: var(--text-primary); }
+  .codes { display: grid; grid-template-columns: 1fr 1fr; gap: var(--space-3); margin: var(--space-2) 0 var(--space-5); }
+  @media (max-width: 480px){ .codes { grid-template-columns: 1fr; } }
+  .codes code { font-family: var(--font-mono); font-size: var(--text-md); letter-spacing: 0.1em;
+    color: var(--text-primary); background: var(--bg-secondary); border: 1px solid var(--border-color);
+    border-radius: var(--radius-md); padding: var(--space-3) var(--space-4); text-align: center; }
+  .codes code.used { color: var(--text-tertiary); text-decoration: line-through; }
+  .actions { display: flex; gap: var(--space-3); flex-wrap: wrap; }
+  .state-label { font-family: var(--font-mono); font-size: var(--text-2xs); letter-spacing: var(--tracking-wide);
+    text-transform: uppercase; color: var(--text-tertiary); margin: var(--space-8) 0 var(--space-2); }
+  .dialog { max-width: 460px; }
+  .dialog h3 { margin: 0 0 var(--space-2); font-family: var(--font-display); font-size: var(--text-lg); }
+  .dialog p { margin: 0 0 var(--space-5); color: var(--text-secondary); font-size: var(--text-md); line-height: 1.6; }
+  .ack { display: flex; gap: var(--space-2); align-items: center; margin-bottom: var(--space-5); font-size: var(--text-sm); color: var(--text-secondary); }
+</style>
+</head>
+<body>
+<div class="shell" data-frame="04-recovery-codes" data-route="/account/security/mfa/recovery-codes">
+  <header class="topbar">
+    <span class="wordmark">Fuze<span class="fuse">Front</span></span>
+    <span class="spacer"></span>
+    <div class="launch-btn" aria-hidden="true">⋮⋮</div>
+    <div class="avatar">AR</div>
+  </header>
+  <div class="body">
+    <nav class="side">
+      <div class="section-label">Account</div>
+      <a class="nav-item" href="#">Profile</a>
+      <a class="nav-item active" href="01-mfa-overview.html"><span class="ico">🛡️</span> Security</a>
+      <a class="nav-item" href="#">Sessions &amp; devices</a>
+      <a class="nav-item" href="#">Billing</a>
+    </nav>
+    <main class="content">
+      <h1 class="page-title">Recovery codes</h1>
+      <p class="page-sub">If you lose your phone, a recovery code gets you back in. Each one works once.</p>
+
+      <!-- ═══ Shown once (just generated) ═══ -->
+      <div class="card" data-component="recovery-codes" data-state="shown-once">
+        <div class="card__seam"></div>
+        <div class="warn-banner">
+          <span aria-hidden="true">⚠</span>
+          <span><b>Save these now — this is the only time you'll see them.</b> Store them in a password
+            manager or print them. We can't show them again.</span>
+        </div>
+        <div class="card__body">
+          <div class="codes" data-codes>
+            <code>4f2a-9c11</code><code>8b7d-1e04</code>
+            <code>2a6f-77bc</code><code>c390-4de1</code>
+            <code>9e15-6a02</code><code>0b84-3f7a</code>
+            <code>7d21-e9c8</code><code>5c60-12ab</code>
+            <code>a1f9-84d3</code><code>3e77-b520</code>
+          </div>
+          <div class="actions">
+            <button class="btn btn-primary" data-action="download-codes">Download</button>
+            <button class="btn btn-ghost" data-action="copy-codes">Copy</button>
+            <button class="btn btn-ghost" data-action="print-codes">Print</button>
+          </div>
+        </div>
+      </div>
+
+      <!-- ═══ Status (returning; codes hidden, only counts) ═══ -->
+      <div class="state-label">State · returning · codes hidden</div>
+      <div class="card" data-component="recovery-codes" data-state="status">
+        <div class="card__seam"></div>
+        <div class="card__body">
+          <p style="margin:0 0 var(--space-4); color:var(--text-secondary)">You have <b style="color:var(--text-primary)">8 of 10</b>
+            recovery codes left. For your safety we don't show used or existing codes — regenerate to get a fresh set.</p>
+          <div class="codes" aria-hidden="true">
+            <code class="used">•••• ••••</code><code class="used">•••• ••••</code>
+            <code>•••• ••••</code><code>•••• ••••</code>
+          </div>
+          <div class="actions">
+            <button class="btn btn-ghost" data-action="regenerate-open">Regenerate codes</button>
+          </div>
+        </div>
+      </div>
+
+      <!-- ═══ Regenerate confirm ═══ -->
+      <div class="state-label">State · regenerate confirm</div>
+      <div class="card dialog" data-component="recovery-codes" data-state="regenerate-confirm" role="alertdialog" aria-labelledby="rgt">
+        <div class="card__seam"></div>
+        <div class="card__body">
+          <h3 id="rgt">Regenerate recovery codes?</h3>
+          <p>This creates 10 new codes and <b>immediately invalidates your current set</b>. Any old codes
+            you saved will stop working.</p>
+          <label class="ack"><input type="checkbox" data-field="ack-invalidate" /> I understand my old codes will stop working.</label>
+          <div class="actions">
+            <button class="btn btn-primary" data-action="regenerate-confirm">Regenerate</button>
+            <button class="btn btn-ghost" data-action="cancel">Cancel</button>
+          </div>
+        </div>
+      </div>
+    </main>
+  </div>
+  <div class="frame-nav">
+    <span class="caption">Frame <b>04 / 06</b> · Recovery codes · <b>…/mfa/recovery-codes</b></span>
+    <span><a class="btn btn-ghost" href="03-sms-enroll.html">← Add phone</a> <a class="btn btn-primary" href="05-step-up-challenge.html" style="text-decoration:none">Next: step-up →</a></span>
+  </div>
+</div>
+</body>
+</html>

--- a/design/frames/mfa-management/05-step-up-challenge.html
+++ b/design/frames/mfa-management/05-step-up-challenge.html
@@ -1,0 +1,139 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Step-up challenge — MFA frames</title>
+<link rel="stylesheet" href="tokens.css" />
+<style>
+  .auth-wrap { min-height: 100vh; display: grid; place-items: center; padding: var(--space-8) var(--space-6) 80px; }
+  .stack { display: grid; gap: var(--space-6); width: 100%; max-width: 420px; }
+  .brand { text-align: center; margin-bottom: var(--space-2); }
+  .brand .wordmark { font-size: var(--text-xl); }
+  .card { background: var(--bg-tertiary); border: 1px solid var(--border-color); border-radius: var(--radius-lg);
+    overflow: hidden; }
+  .card__seam { height: 2px; background: var(--seam); }
+  .card__body { padding: var(--space-6); }
+  .card h2 { margin: 0 0 var(--space-2); font-family: var(--font-display); font-size: var(--text-lg); }
+  .card p.sub { margin: 0 0 var(--space-5); color: var(--text-secondary); font-size: var(--text-md); line-height: 1.5; }
+  .state-label { font-family: var(--font-mono); font-size: var(--text-2xs); letter-spacing: var(--tracking-wide);
+    text-transform: uppercase; color: var(--text-tertiary); text-align: center; }
+  .otp { display: flex; gap: var(--space-2); justify-content: center; }
+  .otp input { width: 44px; height: 52px; text-align: center; font-family: var(--font-mono);
+    font-size: var(--text-xl); color: var(--text-primary); background: var(--bg-secondary);
+    border: 1px solid var(--border-strong); border-radius: var(--radius-md); }
+  .otp input:focus { outline: none; border-color: var(--accent-color); box-shadow: 0 0 0 3px var(--accent-soft); }
+  .otp.is-error input { border-color: var(--error-color); }
+  .field-error { color: var(--error-color); font-size: var(--text-sm); margin-top: var(--space-3);
+    display: flex; align-items: center; gap: var(--space-2); justify-content: center; }
+  .actions { margin-top: var(--space-5); display: grid; gap: var(--space-3); }
+  .switch { text-align: center; margin-top: var(--space-4); font-size: var(--text-sm); }
+  .switch a { color: var(--accent-color); }
+  /* FactorPicker */
+  .picker { display: grid; gap: var(--space-3); }
+  .picker button { display: grid; grid-template-columns: auto 1fr auto; gap: var(--space-4); align-items: center;
+    text-align: left; padding: var(--space-4); background: var(--bg-secondary); border: 1px solid var(--border-color);
+    border-radius: var(--radius-md); color: var(--text-primary); cursor: pointer; font-family: var(--font-sans); }
+  .picker button:hover { border-color: var(--border-strong); }
+  .picker .ico { width: 32px; height: 32px; border-radius: var(--radius-sm); display: grid; place-items: center;
+    background: var(--accent-soft); color: var(--accent-color); }
+  .picker small { display: block; color: var(--text-tertiary); font-size: var(--text-sm); }
+</style>
+</head>
+<body>
+<div class="auth-wrap" data-frame="05-step-up-challenge" data-route="/login/mfa">
+  <div class="stack">
+    <div class="brand"><span class="wordmark">Fuze<span class="fuse">Front</span></span></div>
+
+    <!-- ═══ TOTP prompt (default factor) ═══ -->
+    <div class="card" data-component="mfa-challenge" data-state="totp-prompt" data-factor="totp">
+      <div class="card__seam"></div>
+      <div class="card__body">
+        <h2>Enter your code</h2>
+        <p class="sub">Open your authenticator app and enter the 6-digit code for <b>amara@rowan.co</b>.</p>
+        <div class="otp" data-component="otp-input" role="group" aria-label="One-time code">
+          <input inputmode="numeric" maxlength="1" aria-label="digit 1" />
+          <input inputmode="numeric" maxlength="1" aria-label="digit 2" />
+          <input inputmode="numeric" maxlength="1" aria-label="digit 3" />
+          <input inputmode="numeric" maxlength="1" aria-label="digit 4" />
+          <input inputmode="numeric" maxlength="1" aria-label="digit 5" />
+          <input inputmode="numeric" maxlength="1" aria-label="digit 6" />
+        </div>
+        <div class="actions">
+          <button class="btn btn-primary" data-action="verify-mfa">Verify &amp; sign in</button>
+        </div>
+        <div class="switch"><a href="#" data-action="choose-factor">Use a different method</a></div>
+      </div>
+    </div>
+
+    <!-- ═══ Choose a factor ═══ -->
+    <div class="state-label">State · choose a factor</div>
+    <div class="card" data-component="mfa-challenge" data-state="choose-factor">
+      <div class="card__seam"></div>
+      <div class="card__body">
+        <h2>Verify it's you</h2>
+        <p class="sub">Choose how to get your code.</p>
+        <div class="picker" data-component="factor-picker">
+          <button data-factor="totp" data-factor-id="fct_totp_1" data-action="challenge">
+            <span class="ico" aria-hidden="true">🔑</span>
+            <span>Authenticator app<small>Enter a code from your app</small></span>
+            <span aria-hidden="true">›</span>
+          </button>
+          <button data-factor="sms" data-factor-id="fct_sms_1" data-action="challenge">
+            <span class="ico" aria-hidden="true">💬</span>
+            <span>Text message<small>Send a code to •••• •• 4471</small></span>
+            <span aria-hidden="true">›</span>
+          </button>
+          <button data-factor="recovery" data-action="use-recovery">
+            <span class="ico" aria-hidden="true">🗝️</span>
+            <span>Recovery code<small>Use one of your saved backup codes</small></span>
+            <span aria-hidden="true">›</span>
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <!-- ═══ Invalid / expired code ═══ -->
+    <div class="state-label">State · wrong or expired code (fail-closed)</div>
+    <div class="card" data-component="mfa-challenge" data-state="error-invalid">
+      <div class="card__seam"></div>
+      <div class="card__body">
+        <h2>Enter your code</h2>
+        <p class="sub">That didn't work. Enter the current 6-digit code.</p>
+        <div class="otp is-error" data-component="otp-input" role="group" aria-label="One-time code">
+          <input inputmode="numeric" maxlength="1" value="1" aria-label="digit 1" />
+          <input inputmode="numeric" maxlength="1" value="2" aria-label="digit 2" />
+          <input inputmode="numeric" maxlength="1" value="3" aria-label="digit 3" />
+          <input inputmode="numeric" maxlength="1" value="4" aria-label="digit 4" />
+          <input inputmode="numeric" maxlength="1" value="5" aria-label="digit 5" />
+          <input inputmode="numeric" maxlength="1" value="6" aria-label="digit 6" />
+        </div>
+        <div class="field-error" data-error="invalid-code"><span aria-hidden="true">⚠</span>
+          Wrong or expired code. Codes change every 30 seconds.</div>
+        <div class="actions">
+          <button class="btn btn-primary" data-action="verify-mfa">Try again</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- ═══ Delivery failed (SMS challenge couldn't send) ═══ -->
+    <div class="state-label">State · couldn't send the text</div>
+    <div class="card" data-component="mfa-challenge" data-state="error-delivery" data-factor="sms">
+      <div class="card__seam"></div>
+      <div class="card__body">
+        <h2>We couldn't send your code</h2>
+        <p class="sub">The text didn't go through. Try again, or use your authenticator app or a recovery code instead.</p>
+        <div class="actions">
+          <button class="btn btn-primary" data-action="challenge">Resend text</button>
+          <button class="btn btn-ghost" data-action="choose-factor">Use another method</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="frame-nav">
+    <span class="caption">Frame <b>05 / 06</b> · Step-up challenge · <b>/login/mfa</b></span>
+    <span><a class="btn btn-ghost" href="04-recovery-codes.html">← Recovery codes</a> <a class="btn btn-primary" href="06-remove-factor.html" style="text-decoration:none">Next: remove method →</a></span>
+  </div>
+</div>
+</body>
+</html>

--- a/design/frames/mfa-management/06-remove-factor.html
+++ b/design/frames/mfa-management/06-remove-factor.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Remove a method — MFA frames</title>
+<link rel="stylesheet" href="tokens.css" />
+<style>
+  .content { max-width: 720px; }
+  .card { background: var(--bg-tertiary); border: 1px solid var(--border-color); border-radius: var(--radius-lg);
+    overflow: hidden; margin-bottom: var(--space-6); max-width: 480px; }
+  .card__seam { height: 2px; background: var(--seam); }
+  .card__seam.danger { background: var(--error-color); }
+  .card__seam.warn { background: var(--warning-color); }
+  .card__body { padding: var(--space-6); }
+  .card h3 { margin: 0 0 var(--space-2); font-family: var(--font-display); font-size: var(--text-lg); }
+  .card p { margin: 0 0 var(--space-5); color: var(--text-secondary); font-size: var(--text-md); line-height: 1.6; }
+  .target { display: flex; align-items: center; gap: var(--space-3); padding: var(--space-3) var(--space-4);
+    background: var(--bg-secondary); border: 1px solid var(--border-color); border-radius: var(--radius-md);
+    margin-bottom: var(--space-5); }
+  .target .ico { width: 32px; height: 32px; border-radius: var(--radius-sm); display: grid; place-items: center;
+    background: var(--accent-soft); color: var(--accent-color); }
+  .target b { color: var(--text-primary); } .target small { display:block; color: var(--text-tertiary); font-size: var(--text-sm); }
+  .actions { display: flex; gap: var(--space-3); }
+  .btn-danger { background: var(--error-color); color: var(--bg-primary); border: 1px solid transparent; }
+  .btn-danger:hover { filter: brightness(1.05); }
+  .notice { display: flex; gap: var(--space-3); align-items: flex-start; padding: var(--space-4);
+    border-radius: var(--radius-md); font-size: var(--text-sm); line-height: 1.55; margin-bottom: var(--space-5); }
+  .notice.block { background: var(--error-soft); color: var(--text-secondary); }
+  .notice.block b { color: var(--text-primary); }
+  .state-label { font-family: var(--font-mono); font-size: var(--text-2xs); letter-spacing: var(--tracking-wide);
+    text-transform: uppercase; color: var(--text-tertiary); margin: var(--space-8) 0 var(--space-2); }
+</style>
+</head>
+<body>
+<div class="shell" data-frame="06-remove-factor" data-route="/account/security/mfa">
+  <header class="topbar">
+    <span class="wordmark">Fuze<span class="fuse">Front</span></span>
+    <span class="spacer"></span>
+    <div class="launch-btn" aria-hidden="true">⋮⋮</div>
+    <div class="avatar">AR</div>
+  </header>
+  <div class="body">
+    <nav class="side">
+      <div class="section-label">Account</div>
+      <a class="nav-item" href="#">Profile</a>
+      <a class="nav-item active" href="01-mfa-overview.html"><span class="ico">🛡️</span> Security</a>
+      <a class="nav-item" href="#">Sessions &amp; devices</a>
+      <a class="nav-item" href="#">Billing</a>
+    </nav>
+    <main class="content">
+      <h1 class="page-title">Remove a method</h1>
+      <p class="page-sub">Removing a method means we won't ask for it at sign-in anymore.</p>
+
+      <!-- ═══ Confirm remove (one of several factors) ═══ -->
+      <div class="state-label">State · confirm (another factor remains)</div>
+      <div class="card" data-component="remove-factor-dialog" data-state="confirm" role="alertdialog" aria-labelledby="rm1">
+        <div class="card__seam danger"></div>
+        <div class="card__body">
+          <h3 id="rm1">Remove text-message codes?</h3>
+          <div class="target" data-factor-id="fct_sms_1" data-factor="sms">
+            <span class="ico" aria-hidden="true">💬</span>
+            <span><b>Text message</b><small>Sent to •••• •• 4471</small></span>
+          </div>
+          <p>You'll still have your authenticator app, so two-factor stays on.</p>
+          <div class="actions">
+            <button class="btn btn-danger" data-action="remove-confirm">Remove</button>
+            <button class="btn btn-ghost" data-action="cancel">Cancel</button>
+          </div>
+        </div>
+      </div>
+
+      <!-- ═══ Remove-last BLOCKED (409) — fail-closed ═══ -->
+      <div class="state-label">State · removing your only method (409 — blocked)</div>
+      <div class="card" data-component="remove-factor-dialog" data-state="remove-last-blocked"
+           data-http-status="409" role="alertdialog" aria-labelledby="rm2">
+        <div class="card__seam warn"></div>
+        <div class="card__body">
+          <h3 id="rm2">You can't remove your only method</h3>
+          <div class="target" data-factor-id="fct_totp_1" data-factor="totp">
+            <span class="ico" aria-hidden="true">🔑</span>
+            <span><b>Authenticator app</b><small>Your last remaining method</small></span>
+          </div>
+          <div class="notice block" data-error="remove-last">
+            <span aria-hidden="true">🔒</span>
+            <span><b>Two-factor is required for this account.</b> Removing your only method would lock you
+              out. Add another method first, then you can remove this one.</span>
+          </div>
+          <div class="actions">
+            <a class="btn btn-primary" href="02-totp-enroll.html" style="text-decoration:none">Add another method</a>
+            <button class="btn btn-ghost" data-action="cancel">Keep it</button>
+          </div>
+        </div>
+      </div>
+
+      <!-- ═══ Removed (success toast) ═══ -->
+      <div class="state-label">State · removed</div>
+      <div class="card" data-component="remove-factor-dialog" data-state="removed">
+        <div class="card__seam"></div>
+        <div class="card__body">
+          <h3>Text-message codes removed</h3>
+          <p>We won't ask for a text code at sign-in anymore. You can add it back any time.</p>
+          <div class="actions">
+            <a class="btn btn-ghost" href="01-mfa-overview.html" style="text-decoration:none">Back to methods</a>
+          </div>
+        </div>
+      </div>
+    </main>
+  </div>
+  <div class="frame-nav">
+    <span class="caption">Frame <b>06 / 06</b> · Remove a method · <b>/account/security/mfa</b></span>
+    <span><a class="btn btn-ghost" href="05-step-up-challenge.html">← Step-up</a> <a class="btn btn-primary" href="index.html" style="text-decoration:none">Back to all frames</a></span>
+  </div>
+</div>
+</body>
+</html>

--- a/design/frames/mfa-management/index.html
+++ b/design/frames/mfa-management/index.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>MFA management — Approval Frames</title>
+<link rel="stylesheet" href="tokens.css" />
+<style>
+  .wrap { max-width: 940px; margin: 0 auto; padding: var(--space-12) var(--space-8) var(--space-16); }
+  .eyebrow { font-family: var(--font-mono); font-size: var(--text-2xs); letter-spacing: var(--tracking-wide);
+    text-transform: uppercase; color: var(--cyan-400); margin-bottom: var(--space-3); }
+  h1 { font-family: var(--font-display); font-size: var(--text-2xl); letter-spacing: var(--tracking-display); margin: 0 0 var(--space-2); }
+  h2 { font-family: var(--font-display); font-size: var(--text-xl); letter-spacing: var(--tracking-display);
+    margin: var(--space-12) 0 var(--space-4); }
+  .lead { color: var(--text-secondary); margin: 0; max-width: 68ch; }
+  .crumb { font-size: var(--text-sm); color: var(--text-tertiary); margin: var(--space-4) 0 0; }
+  .crumb b { color: var(--text-secondary); font-weight: var(--weight-semibold); }
+  .grid { display: grid; grid-template-columns: 1fr 1fr; gap: var(--space-5); margin-top: var(--space-6); }
+  @media (max-width: 640px){ .grid { grid-template-columns: 1fr; } }
+  .frame-link { display: block; text-decoration: none; color: inherit; background: var(--bg-tertiary);
+    border: 1px solid var(--border-color); border-radius: var(--radius-lg); padding: var(--space-6);
+    position: relative; overflow: hidden; transition: transform var(--duration-base) var(--ease-standard); }
+  .frame-link:hover { transform: translateY(-2px); box-shadow: var(--shadow-md); border-color: var(--border-strong); }
+  .frame-link .seam { position: absolute; top: 0; left: 0; right: 0; height: 2px; background: var(--seam); opacity: 0; transition: opacity var(--duration-base); }
+  .frame-link:hover .seam { opacity: 1; }
+  .frame-link .step { font-family: var(--font-mono); font-size: var(--text-2xs); color: var(--text-tertiary); letter-spacing: var(--tracking-wide); }
+  .frame-link h3 { margin: var(--space-2) 0; font-size: var(--text-lg); }
+  .frame-link p { margin: 0; color: var(--text-tertiary); font-size: var(--text-sm); }
+  .frame-link .states { margin-top: var(--space-3); display: flex; flex-wrap: wrap; gap: var(--space-1); }
+  .tag { font-family: var(--font-mono); font-size: var(--text-2xs); padding: 1px var(--space-2);
+    border-radius: var(--radius-pill); border: 1px solid var(--border-color); color: var(--text-secondary); }
+  .tag.warn { color: var(--warning-color); border-color: rgba(245,185,80,0.4); }
+  .tag.err { color: var(--error-color); border-color: rgba(243,105,127,0.4); }
+  .inv { margin-top: var(--space-6); background: var(--bg-secondary); border: 1px solid var(--border-color);
+    border-radius: var(--radius-lg); padding: var(--space-6); }
+  .inv h3 { margin: 0 0 var(--space-3); font-size: var(--text-md); font-family: var(--font-mono);
+    letter-spacing: var(--tracking-wide); text-transform: uppercase; color: var(--text-tertiary); }
+  .inv dl { display: grid; grid-template-columns: max-content 1fr; gap: var(--space-3) var(--space-5); margin: 0; }
+  @media (max-width: 640px){ .inv dl { grid-template-columns: 1fr; gap: var(--space-1) 0; } }
+  .inv dt { color: var(--text-tertiary); font-size: var(--text-sm); padding-top: var(--space-1); }
+  .inv dd { margin: 0; }
+  .chip { display: inline-block; font-family: var(--font-mono); font-size: var(--text-2xs);
+    padding: 2px var(--space-2); margin: 0 var(--space-1) var(--space-1) 0; border-radius: var(--radius-sm);
+    background: var(--bg-quaternary); border: 1px solid var(--border-color); color: var(--text-secondary); }
+  .chip.flow { color: var(--cyan-400); border-color: rgba(41,211,230,0.4); }
+  .chip.pkg { color: var(--accent-color); border-color: rgba(110,92,255,0.4); }
+  .meta { margin-top: var(--space-10); font-size: var(--text-sm); color: var(--text-tertiary); line-height: 1.6; }
+  .meta code { font-family: var(--font-mono); color: var(--text-secondary); }
+  .pending { display: inline-flex; align-items: center; gap: 6px; font-family: var(--font-mono);
+    font-size: var(--text-2xs); padding: 2px 8px; border-radius: var(--radius-pill);
+    color: var(--warning-color); border: 1px solid rgba(245,185,80,0.4); text-transform: uppercase;
+    letter-spacing: var(--tracking-wide); margin-top: var(--space-4); }
+</style>
+</head>
+<body>
+<div class="wrap" data-frame="index" data-feature="mfa-management">
+  <div class="eyebrow">Contract-freeze · UX approval</div>
+  <h1>Account security — Two-factor authentication · Approval Frames</h1>
+  <p class="lead">These frames demonstrate the <b>MFA management</b> experience before any feature UI is
+    implemented: enrolling an authenticator app (TOTP), adding a phone for text-message codes, one-time
+    recovery codes, removing a method, and the step-up challenge shown mid sign-in. Approving them freezes
+    the visual + interaction contract the implementation and <code>frontend-test-engineer</code>'s
+    Playwright checks are verified against. Built in the fuse-seam design system (tokens only). No provider
+    name appears anywhere in the UI.</p>
+  <p class="crumb">Reached from the <b>Account security</b> hub (sibling feature) → <b>Two-factor authentication</b>.
+    Route base <code>/account/security/mfa</code>. The sign-in step-up lives on the login path <code>/login/mfa</code>.</p>
+
+  <h2>Walk the flow</h2>
+  <div class="grid">
+    <a href="01-mfa-overview.html" class="frame-link" data-nav="01-mfa-overview">
+      <div class="seam"></div>
+      <div class="step">Frame 01 · /account/security/mfa</div>
+      <h3>Two-factor overview</h3>
+      <p>Enrolled methods list, add-a-method menu, recovery-codes status. Authenticator is available; text-message codes are offered only when the channel can deliver.</p>
+      <div class="states"><span class="tag">populated</span><span class="tag">empty (no MFA)</span><span class="tag warn">loading</span><span class="tag err">load error</span></div>
+    </a>
+    <a href="02-totp-enroll.html" class="frame-link" data-nav="02-totp-enroll">
+      <div class="seam"></div>
+      <div class="step">Frame 02 · …/mfa/add/authenticator</div>
+      <h3>Add an authenticator app</h3>
+      <p>Scan the QR (or copy the setup key), then confirm with a 6-digit code. Fail-closed on a wrong or expired code.</p>
+      <div class="states"><span class="tag">scan + verify</span><span class="tag err">invalid code</span><span class="tag err">expired</span></div>
+    </a>
+    <a href="03-sms-enroll.html" class="frame-link" data-nav="03-sms-enroll">
+      <div class="seam"></div>
+      <div class="step">Frame 03 · …/mfa/add/phone</div>
+      <h3>Add a phone (text message)</h3>
+      <p>Enter a phone, receive a code, confirm. <b>Honest degrade:</b> when text messages can't be delivered the option is disabled with a reason — never offered as if it works.</p>
+      <div class="states"><span class="tag">enter + confirm</span><span class="tag warn">channel unavailable</span><span class="tag err">invalid code</span></div>
+    </a>
+    <a href="04-recovery-codes.html" class="frame-link" data-nav="04-recovery-codes">
+      <div class="seam"></div>
+      <div class="step">Frame 04 · …/mfa/recovery-codes</div>
+      <h3>Recovery codes</h3>
+      <p>Shown once, never retrievable again. Copy/download, then regenerate (which invalidates the old set).</p>
+      <div class="states"><span class="tag">shown once</span><span class="tag">regenerate confirm</span></div>
+    </a>
+    <a href="05-step-up-challenge.html" class="frame-link" data-nav="05-step-up-challenge">
+      <div class="seam"></div>
+      <div class="step">Frame 05 · /login/mfa</div>
+      <h3>Step-up challenge (mid sign-in)</h3>
+      <p>Login returned <code>mfa_required</code>. Pick a factor, enter the code, complete sign-in. Fail-closed on bad/expired code; delivery failure is surfaced.</p>
+      <div class="states"><span class="tag">TOTP prompt</span><span class="tag">choose factor</span><span class="tag err">invalid / expired</span></div>
+    </a>
+    <a href="06-remove-factor.html" class="frame-link" data-nav="06-remove-factor">
+      <div class="seam"></div>
+      <div class="step">Frame 06 · /account/security/mfa</div>
+      <h3>Remove a method</h3>
+      <p>Confirm removal. <b>Fail-closed:</b> removing your only remaining factor while two-factor is required is blocked (409) — you can't lock yourself out.</p>
+      <div class="states"><span class="tag">confirm</span><span class="tag err">remove-last blocked (409)</span></div>
+    </a>
+  </div>
+
+  <div class="inv" data-build-inventory>
+    <h3>Build inventory — what approving these frames approves</h3>
+    <dl>
+      <dt>Flows</dt>
+      <dd>
+        <span class="chip flow">MfaOverviewFlow · /account/security/mfa</span>
+        <span class="chip flow">TotpEnrollFlow · /account/security/mfa/add/authenticator</span>
+        <span class="chip flow">SmsEnrollFlow · /account/security/mfa/add/phone</span>
+        <span class="chip flow">RecoveryCodesFlow · /account/security/mfa/recovery-codes</span>
+        <span class="chip flow">MfaStepUpFlow · /login/mfa</span>
+      </dd>
+      <dt>Components</dt>
+      <dd>
+        <span class="chip">MfaOverviewPanel</span><span class="chip">MfaFactorList</span><span class="chip">MfaFactorRow</span>
+        <span class="chip">AddFactorMenu</span><span class="chip">TotpEnrollPanel</span><span class="chip">QrProvisioning</span>
+        <span class="chip">OtpInput</span><span class="chip">SmsEnrollPanel</span><span class="chip">ChannelUnavailableNotice</span>
+        <span class="chip">RecoveryCodesPanel</span><span class="chip">RemoveFactorDialog</span><span class="chip">MfaChallengeCard</span>
+        <span class="chip">FactorPicker</span>
+      </dd>
+      <dt>Packages</dt>
+      <dd>
+        <span class="chip pkg">@fuzefront/account-security-ui</span>
+        <span class="chip pkg">@fuzefront/security-client (existing)</span>
+      </dd>
+      <dt>Missing DS primitive</dt>
+      <dd><span class="chip">OtpInput</span> — a segmented one-time-code field is not yet in
+        <code>@fuzefront/design-system</code>. Named here for <code>frontend-engineer</code> to add as a
+        foundation primitive; not styled one-off.</dd>
+    </dl>
+  </div>
+
+  <span class="pending" data-approval-status="pending">● Awaiting approval</span>
+
+  <p class="meta">
+    Design system: <code>@fuzefront/design-system</code> (fuse-seam) ·
+    Contract: <code>packages/security/openapi.yaml</code> → <code>@fuzefront/security-client</code> ·
+    Package: <code>@fuzefront/account-security-ui</code> ·
+    Flag: <code>fuzefront.security.mfa-management</code> (default OFF).<br />
+    Honest-degrade signal: <code>GET /v1/security/methods</code> → <code>mfa.types</code> /
+    <code>verification.sms</code> gate whether text-message codes are offered. Per-flow approval lives in
+    <code>manifest.json</code>; approve by setting a flow's <code>approved: true</code> (+ approver + date)
+    or reply <code>@claude approve</code> / <code>@claude reject: &lt;reason&gt;</code>.
+  </p>
+</div>
+</body>
+</html>

--- a/design/frames/mfa-management/manifest.json
+++ b/design/frames/mfa-management/manifest.json
@@ -1,0 +1,216 @@
+{
+  "name": "MFA management — approval frames",
+  "description": "Contract-freeze UX artifacts for two-factor authentication management: enrol an authenticator (TOTP) or phone (text message), one-time recovery codes, remove a method, and the step-up challenge shown mid sign-in. Approving a flow approves its component/package plan before UI implementation. frontend-test-engineer drives Playwright against these via the data-frame / data-* hooks. No provider name appears in any consumer surface.",
+  "designSystem": "fuse-seam (@fuzefront/design-system)",
+  "entry": "index.html",
+  "contract": {
+    "openapi": "packages/security/openapi.yaml",
+    "client": "@fuzefront/security-client",
+    "component": "@fuzefront/account-security-ui",
+    "featureFlag": "fuzefront.security.mfa-management",
+    "schemas": [
+      "components.schemas.MfaFactor",
+      "components.schemas.MfaEnrollRequest",
+      "components.schemas.MfaEnrollResult",
+      "components.schemas.MfaCodeRequest",
+      "components.schemas.RecoveryCodes",
+      "components.schemas.MfaChallengeRequest",
+      "components.schemas.MfaChallengeAck",
+      "components.schemas.MfaVerifyRequest",
+      "components.schemas.AuthMethods"
+    ],
+    "endpoints": [
+      "GET /v1/security/methods",
+      "GET /v1/security/mfa/factors",
+      "POST /v1/security/mfa/factors",
+      "POST /v1/security/mfa/factors/{factorId}/activate",
+      "DELETE /v1/security/mfa/factors/{factorId}",
+      "POST /v1/security/mfa/recovery-codes",
+      "POST /v1/security/mfa/challenge",
+      "POST /v1/security/mfa/verify"
+    ]
+  },
+  "honestDegrade": {
+    "signal": "GET /v1/security/methods -> mfa.types / verification.sms",
+    "rule": "Offer the text-message (SMS) factor ONLY when mfa.types includes 'sms'. In prod the delivery channel is deployed but disabled, so SMS renders as ChannelUnavailableNotice (disabled, with a reason) and TOTP is the primary path. Never present an enrol/challenge button that cannot deliver.",
+    "frames": [
+      "03-sms-enroll",
+      "05-step-up-challenge"
+    ]
+  },
+  "build": {
+    "flows": [
+      {
+        "id": "mfa-overview",
+        "orchestrator": "MfaOverviewFlow",
+        "route": "/account/security/mfa",
+        "approved": false,
+        "approvedBy": null,
+        "approvedAt": null
+      },
+      {
+        "id": "totp-enroll",
+        "orchestrator": "TotpEnrollFlow",
+        "route": "/account/security/mfa/add/authenticator",
+        "approved": false,
+        "approvedBy": null,
+        "approvedAt": null
+      },
+      {
+        "id": "sms-enroll",
+        "orchestrator": "SmsEnrollFlow",
+        "route": "/account/security/mfa/add/phone",
+        "approved": false,
+        "approvedBy": null,
+        "approvedAt": null
+      },
+      {
+        "id": "recovery-codes",
+        "orchestrator": "RecoveryCodesFlow",
+        "route": "/account/security/mfa/recovery-codes",
+        "approved": false,
+        "approvedBy": null,
+        "approvedAt": null
+      },
+      {
+        "id": "mfa-step-up",
+        "orchestrator": "MfaStepUpFlow",
+        "route": "/login/mfa",
+        "approved": false,
+        "approvedBy": null,
+        "approvedAt": null
+      }
+    ],
+    "components": [
+      "MfaOverviewPanel",
+      "MfaFactorList",
+      "MfaFactorRow",
+      "AddFactorMenu",
+      "TotpEnrollPanel",
+      "QrProvisioning",
+      "OtpInput",
+      "SmsEnrollPanel",
+      "ChannelUnavailableNotice",
+      "RecoveryCodesPanel",
+      "RemoveFactorDialog",
+      "MfaChallengeCard",
+      "FactorPicker"
+    ],
+    "packages": [
+      "@fuzefront/account-security-ui"
+    ],
+    "missingDesignSystemPrimitives": [
+      {
+        "name": "OtpInput",
+        "reason": "A segmented one-time-code input (6 cells, paste-aware, error state) is not yet in @fuzefront/design-system. frontend-engineer to add it as a foundation primitive; not styled one-off in feature code."
+      }
+    ]
+  },
+  "frames": [
+    {
+      "id": "01-mfa-overview",
+      "file": "01-mfa-overview.html",
+      "label": "(01) Two-factor overview",
+      "route": "/account/security/mfa",
+      "flow": "mfa-overview",
+      "summary": "Enrolled methods list, add-a-method menu, recovery-codes status. Includes empty (no MFA), loading, and load-error states.",
+      "acceptanceNotes": "Renders factors from GET /mfa/factors with neutral labels (masked phone/email, never a provider name). Add-menu offers SMS only when methods.mfa.types includes 'sms'. Empty state invites first enrolment; error state offers retry.",
+      "testHooks": [
+        "[data-frame='01-mfa-overview']",
+        "[data-panel='mfa-overview'][data-state='loaded']",
+        "[data-panel='mfa-overview'][data-state='empty']",
+        "[data-panel='mfa-overview'][data-state='loading']",
+        "[data-panel='mfa-overview'][data-state='error']",
+        "[data-factor='totp']",
+        "[data-add='sms']",
+        "[data-action='remove-factor']",
+        "[data-action='retry']"
+      ]
+    },
+    {
+      "id": "02-totp-enroll",
+      "file": "02-totp-enroll.html",
+      "label": "(02) Add an authenticator app",
+      "route": "/account/security/mfa/add/authenticator",
+      "flow": "totp-enroll",
+      "summary": "QR + copyable setup key from MfaEnrollResult, then a 6-digit OtpInput to activate. Includes invalid-code and expired-code fail-closed states.",
+      "acceptanceNotes": "provisioningUri/secret come from POST /mfa/factors (type=totp). Activation via POST /mfa/factors/{factorId}/activate; a wrong/expired code shows an inline error and does not activate.",
+      "testHooks": [
+        "[data-frame='02-totp-enroll']",
+        "[data-component='totp-enroll'][data-state='scan']",
+        "[data-component='otp-input']",
+        "[data-action='activate-factor']",
+        "[data-state='error-invalid']",
+        "[data-state='error-expired']"
+      ]
+    },
+    {
+      "id": "03-sms-enroll",
+      "file": "03-sms-enroll.html",
+      "label": "(03) Add a phone (text message)",
+      "route": "/account/security/mfa/add/phone",
+      "flow": "sms-enroll",
+      "summary": "Enter phone -> confirm code. LEADS with the channel-unavailable state (prod reality: text delivery not configured); shows available enter/confirm and invalid-code states too.",
+      "acceptanceNotes": "Gate the entire flow on methods.mfa.types including 'sms'. When absent, render ChannelUnavailableNotice with a disabled field and route the user to TOTP. Never send a code that cannot be delivered.",
+      "testHooks": [
+        "[data-frame='03-sms-enroll']",
+        "[data-component='channel-unavailable'][data-available='false']",
+        "[data-component='sms-enroll'][data-state='enter-phone']",
+        "[data-component='sms-enroll'][data-state='confirm-code']",
+        "[data-action='send-code']",
+        "[data-state='error-invalid']"
+      ]
+    },
+    {
+      "id": "04-recovery-codes",
+      "file": "04-recovery-codes.html",
+      "label": "(04) Recovery codes",
+      "route": "/account/security/mfa/recovery-codes",
+      "flow": "recovery-codes",
+      "summary": "Shown-once reveal (copy/download/print), returning status with codes hidden, and a regenerate confirm that invalidates the prior set.",
+      "acceptanceNotes": "Codes from POST /mfa/recovery-codes are rendered once and never re-fetched. Regenerate requires an explicit acknowledgement that old codes stop working.",
+      "testHooks": [
+        "[data-frame='04-recovery-codes']",
+        "[data-component='recovery-codes'][data-state='shown-once']",
+        "[data-codes]",
+        "[data-action='download-codes']",
+        "[data-state='regenerate-confirm']",
+        "[data-action='regenerate-confirm']"
+      ]
+    },
+    {
+      "id": "05-step-up-challenge",
+      "file": "05-step-up-challenge.html",
+      "label": "(05) Step-up challenge (mid sign-in)",
+      "route": "/login/mfa",
+      "flow": "mfa-step-up",
+      "summary": "TOTP prompt, factor picker (from MfaRequiredChallenge.factors), invalid/expired fail-closed, and an SMS delivery-failure fallback.",
+      "acceptanceNotes": "Driven by an mfa_required SessionResult (challengeId + factors). Verify via POST /mfa/verify; bad/expired codes fail closed. SMS delivery failure surfaces and offers other factors.",
+      "testHooks": [
+        "[data-frame='05-step-up-challenge']",
+        "[data-component='mfa-challenge'][data-state='totp-prompt']",
+        "[data-component='factor-picker']",
+        "[data-action='verify-mfa']",
+        "[data-state='error-invalid']",
+        "[data-state='error-delivery']"
+      ]
+    },
+    {
+      "id": "06-remove-factor",
+      "file": "06-remove-factor.html",
+      "label": "(06) Remove a method",
+      "route": "/account/security/mfa",
+      "flow": "mfa-overview",
+      "summary": "Confirm removal when another factor remains; remove-last BLOCKED (409) when two-factor is required; and the removed success state.",
+      "acceptanceNotes": "DELETE /mfa/factors/{factorId}. When it would remove the caller's only active factor under an enforced-MFA policy, the server returns 409 and the UI blocks removal, routing the user to add another method first.",
+      "testHooks": [
+        "[data-frame='06-remove-factor']",
+        "[data-component='remove-factor-dialog'][data-state='confirm']",
+        "[data-component='remove-factor-dialog'][data-state='remove-last-blocked'][data-http-status='409']",
+        "[data-action='remove-confirm']",
+        "[data-error='remove-last']"
+      ]
+    }
+  ],
+  "stamp": "sha256:958ca1ab9d9c44d6f08926502c8bbd7261ef41e37b1736384cf66bd32bab0446"
+}

--- a/design/frames/mfa-management/tokens.css
+++ b/design/frames/mfa-management/tokens.css
@@ -1,0 +1,235 @@
+/* fuse-seam design-system tokens (subset), inlined so these approval frames are
+   self-contained / portable. Mirrors design-system/tokens/*.css. These frames are
+   contract-freeze UX artifacts — approve the frames = approve the model. */
+:root {
+  /* brand / accent */
+  --indigo-500: #6e5cff;
+  --cyan-400: #29d3e6;
+  --accent-color: var(--indigo-500);
+  --accent-hover: #5a48e6;
+  --accent-soft: rgba(110, 92, 255, 0.14);
+  --accent-2: var(--cyan-400);
+  --seam: linear-gradient(90deg, var(--accent-color) 0%, var(--accent-2) 100%);
+
+  /* graphite surfaces (dark default) */
+  --bg-primary: #0f131c;
+  --bg-secondary: #11161f;
+  --bg-tertiary: #141a26;
+  --bg-quaternary: #1b2230;
+  --border-color: #232b3a;
+  --border-strong: #313b4d;
+
+  --text-primary: #e7ebf2;
+  --text-secondary: #aab3c2;
+  --text-tertiary: #6b7585;
+
+  --success-color: #34d399;
+  --warning-color: #f5b950;
+  --error-color: #f3697f;
+
+  /* type */
+  --font-display: "Space Grotesk", "Inter", system-ui, sans-serif;
+  --font-sans: "Inter", system-ui, -apple-system, sans-serif;
+  --font-mono: "JetBrains Mono", ui-monospace, "SF Mono", monospace;
+  --text-2xs: 11px;
+  --text-xs: 12px;
+  --text-sm: 13px;
+  --text-md: 14px;
+  --text-lg: 16px;
+  --text-xl: 20px;
+  --text-2xl: 26px;
+  --weight-regular: 400;
+  --weight-medium: 500;
+  --weight-semibold: 600;
+  --tracking-wide: 0.04em;
+  --tracking-display: -0.01em;
+
+  /* spacing / radii / shadow */
+  --space-1: 4px; --space-2: 8px; --space-3: 12px; --space-4: 16px;
+  --space-5: 20px; --space-6: 24px; --space-7: 28px; --space-8: 32px;
+  --space-10: 40px; --space-12: 48px; --space-16: 64px;
+  --radius-sm: 6px; --radius-md: 10px; --radius-lg: 14px; --radius-xl: 20px;
+  --radius-pill: 999px;
+  --shadow-xs: 0 1px 2px rgba(0,0,0,0.3);
+  --shadow-md: 0 6px 20px rgba(0,0,0,0.4);
+  --shadow-lg: 0 16px 48px rgba(0,0,0,0.5);
+  --shadow-accent: 0 8px 24px rgba(110,92,255,0.35);
+
+  --top-bar-height: 60px;
+  --side-panel-width: 240px;
+  --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+  --duration-fast: 120ms;
+  --duration-base: 200ms;
+}
+
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  font-family: var(--font-sans);
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  -webkit-font-smoothing: antialiased;
+}
+.mono { font-family: var(--font-mono); }
+
+/* ---- shared portal-shell chrome used across frames ---- */
+.shell { display: flex; flex-direction: column; height: 100vh; }
+.topbar {
+  height: var(--top-bar-height);
+  flex: none;
+  display: flex; align-items: center; gap: var(--space-4);
+  padding: 0 var(--space-6);
+  background: var(--bg-secondary);
+  border-bottom: 1px solid var(--border-color);
+  position: relative;
+}
+.topbar::after {
+  content: ""; position: absolute; left: 0; right: 0; bottom: -1px;
+  height: 2px; background: var(--seam); opacity: 0.7;
+}
+.wordmark {
+  font-family: var(--font-display); font-weight: var(--weight-semibold);
+  font-size: var(--text-lg); letter-spacing: var(--tracking-display);
+}
+.wordmark .fuse {
+  background: var(--seam); -webkit-background-clip: text;
+  background-clip: text; color: transparent;
+}
+.topbar .spacer { flex: 1; }
+.launch-btn {
+  width: 34px; height: 34px; border-radius: var(--radius-md);
+  display: grid; place-items: center; cursor: pointer;
+  background: var(--bg-quaternary); border: 1px solid var(--border-color);
+}
+.avatar {
+  width: 32px; height: 32px; border-radius: var(--radius-pill);
+  background: var(--seam); display: grid; place-items: center;
+  font-weight: var(--weight-semibold); font-size: var(--text-sm); color: #0b0e15;
+}
+.body { flex: 1; display: flex; min-height: 0; }
+
+.side {
+  width: var(--side-panel-width); flex: none;
+  background: var(--bg-secondary);
+  border-right: 1px solid var(--border-color);
+  padding: var(--space-4) var(--space-3);
+  display: flex; flex-direction: column; gap: var(--space-1);
+  overflow-y: auto;
+}
+.side .section-label {
+  font-family: var(--font-mono); font-size: var(--text-2xs);
+  letter-spacing: var(--tracking-wide); text-transform: uppercase;
+  color: var(--text-tertiary); margin: var(--space-4) var(--space-2) var(--space-2);
+}
+.nav-item {
+  display: flex; align-items: center; gap: var(--space-3);
+  padding: var(--space-2) var(--space-3); border-radius: var(--radius-md);
+  color: var(--text-secondary); font-size: var(--text-md); cursor: pointer;
+  text-decoration: none;
+}
+.nav-item:hover { background: var(--bg-quaternary); color: var(--text-primary); }
+.nav-item.active {
+  background: var(--accent-soft); color: var(--text-primary);
+  box-shadow: inset 2px 0 0 var(--accent-color);
+}
+.nav-item .ico { width: 18px; text-align: center; }
+
+.content { flex: 1; overflow: auto; padding: var(--space-8); min-width: 0; }
+.page-title {
+  font-family: var(--font-display); font-size: var(--text-2xl);
+  letter-spacing: var(--tracking-display); margin: 0 0 var(--space-2);
+}
+.page-sub { color: var(--text-secondary); margin: 0 0 var(--space-6); }
+
+.btn {
+  font-family: var(--font-sans); font-size: var(--text-md);
+  font-weight: var(--weight-medium); border-radius: var(--radius-md);
+  padding: var(--space-2) var(--space-4); cursor: pointer; border: 1px solid transparent;
+}
+.btn-primary { background: var(--accent-color); color: #0b0e15; box-shadow: var(--shadow-accent); }
+.btn-primary:hover { background: var(--accent-hover); }
+.btn-ghost { background: transparent; color: var(--text-secondary); border-color: var(--border-color); }
+.btn-ghost:hover { color: var(--text-primary); border-color: var(--border-strong); }
+
+.badge {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-family: var(--font-mono); font-size: var(--text-2xs);
+  padding: 2px 8px; border-radius: var(--radius-pill);
+  border: 1px solid var(--border-color); color: var(--text-secondary);
+  text-transform: uppercase; letter-spacing: var(--tracking-wide);
+}
+.badge.activated { color: var(--success-color); border-color: rgba(52,211,153,0.4); }
+.badge.registered { color: var(--warning-color); border-color: rgba(245,185,80,0.4); }
+.badge.mf { color: var(--cyan-400); border-color: rgba(41,211,230,0.4); }
+.badge.builtin { color: var(--accent-color); border-color: rgba(110,92,255,0.4); }
+.badge.standalone { color: var(--text-primary); border-color: var(--border-strong); }
+
+.dot { width: 9px; height: 9px; border-radius: var(--radius-pill); display: inline-block; }
+.dot.healthy { background: var(--success-color); }
+.dot.down { background: var(--error-color); }
+
+/* approval-frame footer nav */
+.frame-nav {
+  position: fixed; bottom: 0; left: 0; right: 0;
+  display: flex; align-items: center; justify-content: space-between;
+  gap: var(--space-4); padding: var(--space-3) var(--space-6);
+  background: rgba(17,22,31,0.92); backdrop-filter: blur(8px);
+  border-top: 1px solid var(--border-color); z-index: 50;
+}
+.frame-nav .caption { font-size: var(--text-sm); color: var(--text-tertiary); }
+.frame-nav .caption b { color: var(--text-secondary); font-weight: var(--weight-semibold); }
+.frame-nav a { text-decoration: none; }
+.content { padding-bottom: 72px; }
+
+/* ---- invoice status pill soft tokens (mirror @fuzefront/design-system semantic *-soft) ---- */
+:root {
+  --success-soft: rgba(52, 211, 153, 0.14);
+  --warning-soft: rgba(245, 185, 80, 0.14);
+  --error-soft:   rgba(243, 105, 127, 0.14);
+  --neutral-soft: rgba(170, 179, 194, 0.12);
+}
+
+/* ---- InvoiceHistoryPanel (design-system-first; tokens only) ---- */
+.ffb-invoices { background: var(--bg-tertiary); border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg); position: relative; overflow: hidden; max-width: 720px; }
+.ffb-invoices__seam { height: 2px; background: var(--seam); }
+.ffb-invoices__head { display: flex; align-items: baseline; justify-content: space-between;
+  gap: var(--space-3); padding: var(--space-5) var(--space-5) var(--space-3); }
+.ffb-invoices__title { margin: 0; font-family: var(--font-display); font-size: var(--text-lg);
+  font-weight: var(--weight-semibold); color: var(--text-primary); }
+.ffb-invoices__count { color: var(--text-tertiary); font-size: var(--text-sm);
+  font-variant-numeric: tabular-nums; }
+.ffb-invoices__list { display: flex; flex-direction: column; }
+.ffb-invoice-row { display: grid; grid-template-columns: 1fr auto; gap: var(--space-1) var(--space-4);
+  padding: var(--space-4) var(--space-5); border-top: 1px solid var(--border-color); align-items: center; }
+.ffb-invoice-row__main { display: flex; flex-direction: column; gap: var(--space-1); min-width: 0; }
+.ffb-invoice-row__top { display: flex; align-items: center; gap: var(--space-3); flex-wrap: wrap; }
+.ffb-invoice-row__num { font-weight: var(--weight-medium); color: var(--text-primary);
+  font-variant-numeric: tabular-nums; }
+.ffb-invoice-row__date { color: var(--text-secondary); font-size: var(--text-sm); }
+.ffb-invoice-row__side { display: flex; align-items: center; gap: var(--space-4); justify-content: flex-end; }
+.ffb-invoice-row__amount { color: var(--text-primary); font-weight: var(--weight-semibold);
+  font-variant-numeric: tabular-nums; text-align: end; }
+.ffb-pill { display: inline-flex; align-items: center; gap: var(--space-1);
+  padding: 2px var(--space-2); border-radius: var(--radius-pill); font-size: var(--text-2xs);
+  font-weight: var(--weight-semibold); text-transform: capitalize; white-space: nowrap; }
+.ffb-pill__dot { width: 6px; height: 6px; border-radius: var(--radius-pill); background: currentColor; }
+.ffb-pill--paid { background: var(--success-soft); color: var(--success-color); }
+.ffb-pill--open { background: var(--warning-soft); color: var(--warning-color); }
+.ffb-pill--void { background: var(--neutral-soft); color: var(--text-secondary); }
+.ffb-pill--uncollectible { background: var(--error-soft); color: var(--error-color); }
+.ffb-dl { display: inline-flex; align-items: center; gap: var(--space-1); color: var(--accent-color);
+  text-decoration: none; font-size: var(--text-sm); font-weight: var(--weight-medium);
+  padding: var(--space-1) var(--space-2); border-radius: var(--radius-sm); min-height: 32px; }
+.ffb-dl:hover { background: var(--accent-soft); }
+.ffb-dl svg { width: 14px; height: 14px; }
+.ffb-invoices__foot { padding: var(--space-4) var(--space-5); border-top: 1px solid var(--border-color);
+  display: flex; justify-content: center; }
+.ffb-skel { height: 14px; border-radius: var(--radius-pill); background:
+  linear-gradient(90deg, var(--bg-quaternary), var(--border-color), var(--bg-quaternary));
+  background-size: 200% 100%; animation: ffbsh 1.3s ease-in-out infinite; }
+@keyframes ffbsh { 0%{background-position:200% 0} 100%{background-position:-200% 0} }
+@media (prefers-reduced-motion: reduce){ .ffb-skel{ animation: none; } }
+.ffb-empty { padding: var(--space-8) var(--space-5); text-align: center; color: var(--text-secondary); }
+.ffb-empty__icon { width: 40px; height: 40px; margin: 0 auto var(--space-3); color: var(--text-tertiary); }
+.ffb-note { font-size: var(--text-sm); color: var(--text-secondary); }


### PR DESCRIPTION
## MFA management — UX approval frames (frames-only)

Navigable HTML frames for **two-factor authentication management**, authored by `product-designer` before any UI is built. Merging (after approval) is the gate that dispatches RED Playwright specs + the frontend fan-out. **No UI exists yet.**

Contract: `packages/security/openapi.yaml` → `@fuzefront/security-client` (frozen, not modified). Reached from the sibling **Account security** hub.

### Flows (per-flow `approved: false` — awaiting review)
| Flow | Route |
|---|---|
| MfaOverviewFlow | `/account/security/mfa` |
| TotpEnrollFlow | `/account/security/mfa/add/authenticator` |
| SmsEnrollFlow | `/account/security/mfa/add/phone` |
| RecoveryCodesFlow | `/account/security/mfa/recovery-codes` |
| MfaStepUpFlow | `/login/mfa` |

### States are contract, not decoration
- Overview: loaded / **empty (no MFA)** / loading / load-error+retry
- TOTP: scan+verify / **invalid code** / **expired code** (fail-closed)
- SMS: **channel-unavailable** (prod reality — text delivery disabled; degrades honestly on `methods.mfa.types`) / enter / confirm / invalid
- Recovery: shown-once / status / regenerate-confirm (invalidates prior set)
- Step-up: TOTP prompt / choose factor / invalid-expired / **delivery-failed** fallback
- Remove: confirm / **remove-last blocked (409)** / removed

### Build inventory (approving the frames approves this plan)
- **Components:** MfaOverviewPanel, MfaFactorList, AddFactorMenu, TotpEnrollPanel, QrProvisioning, **OtpInput**, SmsEnrollPanel, ChannelUnavailableNotice, RecoveryCodesPanel, RemoveFactorDialog, MfaChallengeCard, FactorPicker
- **Package:** `@fuzefront/account-security-ui`
- **Missing DS primitive named (not built here):** `OtpInput` segmented code field — `frontend-engineer` to add to `@fuzefront/design-system` as a foundation.

Design-system-first (fuse-seam tokens only); no provider names on any surface. Manifest stamped (`scripts/stamp-frames.mjs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)