### PR TITLE
feat: frame stamp tooling + design-approval auto-flip pipeline

### DIFF
--- a/.github/workflows/design-approval.yml
+++ b/.github/workflows/design-approval.yml
@@ -1,0 +1,199 @@
+name: design-approval
+
+# Turns an in-frame "Approve" click into a verified, signed manifest flip.
+#
+# The in-frame approval control opens a prefilled GitHub issue (label
+# `design-approval`) carrying a YAML block: feature / flow / route / decision / stamp.
+# This workflow enforces, IN ORDER and FAIL-CLOSED:
+#   1. Authorization — issue author must be the repo owner or a CODEOWNER
+#      (derived from .github/CODEOWNERS, never hand-listed here).
+#   2. Staleness    — recompute the feature's current stamp (scripts/stamp-frames.mjs)
+#      and compare to the issue's stamp. Mismatch (or empty) → do NOT flip.
+#   3. Idempotency  — if the flow is already approved at this stamp → "already recorded".
+#   4. Write        — on approve, flip build.flows[<flow>].approved via the Contents
+#      API (server-side commits are signed → satisfies required_signatures) on master.
+#      On reject, comment and leave the issue open for the designer to iterate.
+#
+# on: issues:[opened] ONLY — edits can't re-fire (avoids double-trigger). Every
+# expectation is DERIVED from a source of truth (stamp from files, flip target from
+# the parsed issue, authorization from CODEOWNERS); nothing is hand-mirrored.
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  contents: write   # flip the manifest on master via Contents API
+  issues: write     # comment + close
+
+concurrency:
+  group: design-approval-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  approve:
+    if: contains(github.event.issue.labels.*.name, 'design-approval')
+    runs-on: ubuntu-latest
+    steps:
+      # Actions pinned to immutable commit SHAs (repo hardening standard).
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
+        with:
+          ref: master   # frames + the manifest we flip live on master
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
+        with:
+          node-version: '20'
+
+      - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+            const { execFileSync } = require('child_process');
+            const { owner, repo } = context.repo;
+            const issue = context.payload.issue;
+            const issueNumber = issue.number;
+            const author = issue.user.login;
+
+            const comment = (body) =>
+              github.rest.issues.createComment({ owner, repo, issue_number: issueNumber, body });
+
+            // ---- Parse the YAML block (fail-closed). ----
+            function parseBlock(body) {
+              if (!body) throw new Error('issue body is empty');
+              // Prefer a fenced ```yaml block; else scan the whole body for key: value.
+              const fence = body.match(/```(?:ya?ml)?\s*([\s\S]*?)```/i);
+              const text = fence ? fence[1] : body;
+              const out = {};
+              for (const rawLine of text.split(/\r?\n/)) {
+                const m = rawLine.match(/^\s*([A-Za-z_][\w-]*)\s*:\s*(.*?)\s*$/);
+                if (!m) continue;
+                let v = m[2].replace(/^["']|["']$/g, '').trim();
+                out[m[1].toLowerCase()] = v;
+              }
+              return out;
+            }
+
+            let data;
+            try {
+              data = parseBlock(issue.body);
+            } catch (e) {
+              await comment(`Design approval could not parse this issue. No action taken (fail-closed).\n\n> ${e.message}`);
+              core.setFailed(`parse error: ${e.message}`);
+              return;
+            }
+
+            const feature = data.feature;
+            const flowId = data.flow;
+            const decision = (data.decision || '').toLowerCase();
+            const issueStamp = data.stamp || '';
+            if (!feature || !flowId || !decision) {
+              await comment(`Design approval block is missing required fields (need feature, flow, decision). No action taken (fail-closed).\n\nParsed: \`${JSON.stringify(data)}\``);
+              core.setFailed('missing required fields');
+              return;
+            }
+
+            // ---- 1. Authorization — owner or a CODEOWNER (derived, not restated). ----
+            function codeownerLogins() {
+              const logins = new Set([owner.toLowerCase()]);
+              for (const p of ['.github/CODEOWNERS', 'CODEOWNERS', 'docs/CODEOWNERS']) {
+                if (fs.existsSync(p)) {
+                  for (const mm of fs.readFileSync(p, 'utf8').matchAll(/@([A-Za-z0-9-]+)/g)) {
+                    logins.add(mm[1].toLowerCase());
+                  }
+                }
+              }
+              return logins;
+            }
+            const authorized = codeownerLogins().has(author.toLowerCase());
+            if (!authorized) {
+              await comment(`@${author} is not authorized to approve designs (must be the repo owner or a CODEOWNER). No action taken.`);
+              core.setFailed(`unauthorized actor: ${author}`);
+              return;
+            }
+
+            // ---- Locate the manifest + flow (flip target derived from the issue). ----
+            const manifestPath = path.join('design', 'frames', feature, 'manifest.json');
+            if (!fs.existsSync(manifestPath)) {
+              await comment(`No manifest found for feature \`${feature}\` at \`${manifestPath}\`. No action taken (fail-closed).`);
+              core.setFailed(`manifest not found: ${manifestPath}`);
+              return;
+            }
+            const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+            const flows = manifest?.build?.flows;
+            if (!Array.isArray(flows)) {
+              await comment(`Manifest for \`${feature}\` has no \`build.flows\` array. No action taken (fail-closed).`);
+              core.setFailed('no build.flows');
+              return;
+            }
+            const flow = flows.find((f) => f.id === flowId);
+            if (!flow) {
+              const ids = flows.map((f) => f.id).join(', ');
+              await comment(`Flow \`${flowId}\` not found in \`${feature}\` (available: ${ids}). No action taken (fail-closed).`);
+              core.setFailed(`flow not found: ${flowId}`);
+              return;
+            }
+
+            // ---- 2. Staleness — recompute current stamp from the files. ----
+            let computedStamp;
+            try {
+              const out = execFileSync('node', ['scripts/stamp-frames.mjs', '--feature', feature, '--json'], { encoding: 'utf8' });
+              computedStamp = JSON.parse(out.slice(out.indexOf('{')))[feature];
+            } catch (e) {
+              await comment(`Could not compute the current stamp for \`${feature}\`. No action taken (fail-closed).\n\n> ${e.message}`);
+              core.setFailed(`stamp compute failed: ${e.message}`);
+              return;
+            }
+            if (!computedStamp) {
+              await comment(`No stamp could be computed for \`${feature}\`. No action taken (fail-closed).`);
+              core.setFailed('no computed stamp');
+              return;
+            }
+            if (!issueStamp) {
+              await comment(`This approval carries no \`stamp\`, so staleness cannot be verified against the frames you saw. A maintainer must confirm and re-stamp before this can be recorded. No flip performed (fail-closed).\n\nCurrent computed stamp: \`${computedStamp}\``);
+              core.setFailed('empty issue stamp — cannot verify');
+              return;
+            }
+            if (issueStamp !== computedStamp) {
+              await comment(`The frames changed since you viewed them (stamp \`${issueStamp}\` ≠ \`${computedStamp}\`). This approval will NOT be recorded — please re-review the current frames and approve again. No flip performed (fail-closed).`);
+              core.setFailed(`stale stamp: issue=${issueStamp} computed=${computedStamp}`);
+              return;
+            }
+
+            // ---- 3. Idempotency — already approved at this stamp? ----
+            if (flow.approved === true && manifest.stamp === computedStamp) {
+              await comment(`Flow \`${flowId}\` of \`${feature}\` is already recorded as approved at this stamp (\`${computedStamp}\`). A double-submit is not a second approval — no action taken.`);
+              if (issue.state === 'open') {
+                await github.rest.issues.update({ owner, repo, issue_number: issueNumber, state: 'closed' });
+              }
+              return;
+            }
+
+            // ---- Reject → comment onto the record, leave open, do NOT flip. ----
+            if (decision !== 'approve') {
+              const notes = data.notes ? `\n\n> ${data.notes}` : '';
+              await comment(`Decision recorded: **${decision}** for flow \`${flowId}\` of \`${feature}\` by @${author}. The frames are NOT flipped; the issue stays open for the designer to iterate.${notes}`);
+              return;
+            }
+
+            // ---- 4. Write — flip approved via the Contents API (signed), on master. ----
+            flow.approved = true;
+            flow.approvedBy = author;
+            flow.approvedAt = new Date().toISOString();
+            const newContent = JSON.stringify(manifest, null, 2) + '\n';
+
+            // Get the current sha of the file on master to update in place.
+            const cur = await github.rest.repos.getContent({ owner, repo, path: manifestPath, ref: 'master' });
+            const sha = cur.data.sha;
+            const commitMsg =
+              `design(approve): ${feature}/${flowId} approved by @${author} (stamp ${computedStamp.slice(0, 12)})\n\n` +
+              `Recorded from design-approval issue #${issueNumber}.`;
+
+            await github.rest.repos.createOrUpdateFileContents({
+              owner, repo, path: manifestPath, message: commitMsg,
+              content: Buffer.from(newContent, 'utf8').toString('base64'),
+              sha, branch: 'master',
+            });
+
+            await comment(`Approved: flow \`${flowId}\` of \`${feature}\` is now recorded \`approved: true\` (by @${author}, stamp \`${computedStamp}\`). Committed to \`master\` via the Contents API (signed). Closing this approval request.`);
+            await github.rest.issues.update({ owner, repo, issue_number: issueNumber, state: 'closed' });

--- a/.github/workflows/gate-frames-stamped.yml
+++ b/.github/workflows/gate-frames-stamped.yml
@@ -1,0 +1,36 @@
+name: gate-frames-stamped
+
+# A PR that touches design/frames/** must carry an up-to-date `stamp` in each
+# feature manifest. The stamp is DERIVED from the files (scripts/stamp-frames.mjs);
+# this gate recomputes it and fails if any manifest's recorded stamp is stale.
+# That is what stops an approval binding to frames that changed after stamping —
+# without it the stamp is a hand-maintained mirror that silently drifts.
+
+on:
+  pull_request:
+    paths:
+      - 'design/frames/**'
+      - 'scripts/stamp-frames.mjs'
+      - '.github/workflows/gate-frames-stamped.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: gate-frames-stamped-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  stamped:
+    runs-on: ubuntu-latest
+    steps:
+      # Actions pinned to immutable commit SHAs (repo hardening standard — a mutable
+      # tag can be silently repointed by the action owner).
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
+        with:
+          node-version: '20'
+
+      - name: Verify every feature manifest stamp is current
+        run: node scripts/stamp-frames.mjs --check

--- a/design/frames/account-security/manifest.json
+++ b/design/frames/account-security/manifest.json
@@ -1,5 +1,5 @@
 {
-  "name": "Account Security hub \u2014 approval frames",
+  "name": "Account Security hub — approval frames",
   "description": "Contract-freeze UX artifacts for the account-security hub: the navigational spine linking password, two-factor, devices & sessions, API tokens, and connected accounts. Approving these frames approves the AccountSecurityHub visual + interaction model and its component/package plan before UI implementation. frontend-test-engineer drives Playwright against these via the data-frame / data-* hooks.",
   "designSystem": "fuse-seam (@fuzefront/design-system)",
   "entry": "index.html",
@@ -15,7 +15,7 @@
       "GET /v1/security/identity/connections",
       "GET /v1/security/methods"
     ],
-    "component": "@fuzefront/account-security-ui \u2192 AccountSecurityHub",
+    "component": "@fuzefront/account-security-ui → AccountSecurityHub",
     "featureFlag": "fuzefront.account-security.hub"
   },
   "build": {
@@ -43,7 +43,7 @@
       "@fuzefront/account-security-ui"
     ],
     "designSystemAdditions": [
-      "StatusCallout \u2014 soft-tinted inline banner (icon + title + text + actions) for warn/error states; not yet in @fuzefront/design-system base. Named here for frontend-engineer to add as a foundation PR; drawn from tokens only in these frames, never one-offed into feature code."
+      "StatusCallout — soft-tinted inline banner (icon + title + text + actions) for warn/error states; not yet in @fuzefront/design-system base. Named here for frontend-engineer to add as a foundation PR; drawn from tokens only in these frames, never one-offed into feature code."
     ]
   },
   "frames": [
@@ -70,7 +70,7 @@
       "file": "02-states.html",
       "label": "(b) States & fail-closed",
       "route": "/account/security",
-      "summary": "Loading skeleton, load error + retry, social-only account (hasPassword:false \u2192 set a password first), and the last-sign-in-method 409 unlink guard.",
+      "summary": "Loading skeleton, load error + retry, social-only account (hasPassword:false → set a password first), and the last-sign-in-method 409 unlink guard.",
       "acceptanceNotes": "loading shows skeleton summary + card grid; error shows the StatusCallout with data-action='retry'; no-password shows the set-password-first guard (data-guard='set-password-first', data-action='set-password'); last-method shows the 409 guard (data-guard='last-sign-in-method'). No identity-vendor name in the DOM.",
       "testHooks": [
         "[data-frame='02-states']",
@@ -84,5 +84,5 @@
       ]
     }
   ],
-  "stamp": "a11e48335755a02bd7478c308f6830382a9cdbd7316a115cc812b80c01ded787"
+  "stamp": "5b06d15d452c0155d7da20e8f9e7819a3c31b66e32d05e139e5be2472041a476"
 }

--- a/design/frames/account-security/manifest.json
+++ b/design/frames/account-security/manifest.json
@@ -6,8 +6,15 @@
   "contract": {
     "openapi": "packages/security/openapi.yaml",
     "client": "@fuzefront/security-client",
-    "schemas": ["components.schemas.IdentityConnections", "components.schemas.SocialConnection", "components.schemas.AuthMethods"],
-    "endpoints": ["GET /v1/security/identity/connections", "GET /v1/security/methods"],
+    "schemas": [
+      "components.schemas.IdentityConnections",
+      "components.schemas.SocialConnection",
+      "components.schemas.AuthMethods"
+    ],
+    "endpoints": [
+      "GET /v1/security/identity/connections",
+      "GET /v1/security/methods"
+    ],
     "component": "@fuzefront/account-security-ui → AccountSecurityHub",
     "featureFlag": "fuzefront.account-security.hub"
   },
@@ -32,7 +39,9 @@
       "SecurityCardGridSkeleton",
       "LoadErrorRetry"
     ],
-    "packages": ["@fuzefront/account-security-ui"],
+    "packages": [
+      "@fuzefront/account-security-ui"
+    ],
     "designSystemAdditions": [
       "StatusCallout — soft-tinted inline banner (icon + title + text + actions) for warn/error states; not yet in @fuzefront/design-system base. Named here for frontend-engineer to add as a foundation PR; drawn from tokens only in these frames, never one-offed into feature code."
     ]
@@ -74,5 +83,6 @@
         "[data-guard='last-sign-in-method']"
       ]
     }
-  ]
+  ],
+  "stamp": "a11e48335755a02bd7478c308f6830382a9cdbd7316a115cc812b80c01ded787"
 }

--- a/design/frames/api-tokens/manifest.json
+++ b/design/frames/api-tokens/manifest.json
@@ -7,7 +7,11 @@
     "openapi": "packages/security/openapi.yaml",
     "backingRouter": "backend/security/src/routes/api-tokens.ts",
     "client": "@fuzefront/security-client",
-    "schemas": ["ApiToken", "ApiTokenCreate", "ApiTokenCreateResponse"],
+    "schemas": [
+      "ApiToken",
+      "ApiTokenCreate",
+      "ApiTokenCreateResponse"
+    ],
     "endpoints": [
       "GET /api/organizations/{orgId}/tokens",
       "POST /api/organizations/{orgId}/tokens",
@@ -23,13 +27,29 @@
   },
   "build": {
     "flows": [
-      { "id": "service-tokens", "orchestrator": "ServiceTokensFlow", "route": "/settings/tokens", "approved": false, "approvedBy": null, "approvedAt": null }
+      {
+        "id": "service-tokens",
+        "orchestrator": "ServiceTokensFlow",
+        "route": "/settings/tokens",
+        "approved": false,
+        "approvedBy": null,
+        "approvedAt": null
+      }
     ],
     "components": [
-      "TokenList", "TokenRow", "ScopeChips", "CreateTokenDialog", "ScopePicker",
-      "RevealOncePanel", "CopySecretButton", "RevokeTokenDialog", "AccessDeniedNotice"
+      "TokenList",
+      "TokenRow",
+      "ScopeChips",
+      "CreateTokenDialog",
+      "ScopePicker",
+      "RevealOncePanel",
+      "CopySecretButton",
+      "RevokeTokenDialog",
+      "AccessDeniedNotice"
     ],
-    "packages": ["@fuzefront/service-tokens-ui"]
+    "packages": [
+      "@fuzefront/service-tokens-ui"
+    ]
   },
   "frames": [
     {
@@ -124,5 +144,6 @@
         "[data-http='403']"
       ]
     }
-  ]
+  ],
+  "stamp": "e62cc20f911134d329ade006aae9d8183979208fad812ae493de892781dfa6d4"
 }

--- a/design/frames/authz-admin/manifest.json
+++ b/design/frames/authz-admin/manifest.json
@@ -6,7 +6,13 @@
   "contract": {
     "openapi": "packages/security/openapi.yaml",
     "client": "@fuzefront/security-client",
-    "schemas": ["Member", "MemberCreate", "MemberPage", "Role", "RoleAssignment"],
+    "schemas": [
+      "Member",
+      "MemberCreate",
+      "MemberPage",
+      "Role",
+      "RoleAssignment"
+    ],
     "endpoints": [
       "GET /v1/security/tenants/{tenantId}/members",
       "POST /v1/security/tenants/{tenantId}/members",
@@ -23,13 +29,28 @@
   },
   "build": {
     "flows": [
-      { "id": "access-admin", "orchestrator": "AccessAdminFlow", "route": "/settings/access", "approved": false, "approvedBy": null, "approvedAt": null }
+      {
+        "id": "access-admin",
+        "orchestrator": "AccessAdminFlow",
+        "route": "/settings/access",
+        "approved": false,
+        "approvedBy": null,
+        "approvedAt": null
+      }
     ],
     "components": [
-      "MemberList", "MemberRow", "RolePill", "AddMemberDialog",
-      "ChangeRoleDialog", "RemoveMemberDialog", "RolePicker", "AccessDeniedNotice"
+      "MemberList",
+      "MemberRow",
+      "RolePill",
+      "AddMemberDialog",
+      "ChangeRoleDialog",
+      "RemoveMemberDialog",
+      "RolePicker",
+      "AccessDeniedNotice"
     ],
-    "packages": ["@fuzefront/access-admin-ui"]
+    "packages": [
+      "@fuzefront/access-admin-ui"
+    ]
   },
   "frames": [
     {
@@ -120,5 +141,6 @@
         "[data-http='403']"
       ]
     }
-  ]
+  ],
+  "stamp": "0e34fa03737f27b7a3a140a956fd7a1c101e14be775992c97326a08132705cc4"
 }

--- a/design/frames/billing-invoices/manifest.json
+++ b/design/frames/billing-invoices/manifest.json
@@ -8,8 +8,14 @@
   "contract": {
     "openapi": "services/billing-service/openapi.yaml",
     "client": "@fuzefront/billing-client",
-    "schemas": ["components.schemas.BillingInvoice", "components.schemas.InvoiceListResponse"],
-    "endpoints": ["GET /api/v1/billing/invoices", "POST /api/v1/billing/invoices/sync"],
+    "schemas": [
+      "components.schemas.BillingInvoice",
+      "components.schemas.InvoiceListResponse"
+    ],
+    "endpoints": [
+      "GET /api/v1/billing/invoices",
+      "POST /api/v1/billing/invoices/sync"
+    ],
     "component": "@fuzefront/billing-ui → InvoiceHistoryPanel",
     "featureFlag": "fuzefront.billing.invoice-history"
   },
@@ -47,5 +53,6 @@
         "[data-status='uncollectible']"
       ]
     }
-  ]
+  ],
+  "stamp": "b8077a647c64b27298ec9bc2c564dd5b2bc0ea1cf574bcc15c6f5331eb7c150d"
 }

--- a/design/frames/devices-sessions/manifest.json
+++ b/design/frames/devices-sessions/manifest.json
@@ -118,5 +118,5 @@
       ]
     }
   ],
-  "stamp": "sha256:63330704eae4b892c358a95c13490b5c916a6d050c2a2cc37baac3cb3ade68a8"
+  "stamp": "63330704eae4b892c358a95c13490b5c916a6d050c2a2cc37baac3cb3ade68a8"
 }

--- a/design/frames/federated-apps/manifest.json
+++ b/design/frames/federated-apps/manifest.json
@@ -14,33 +14,58 @@
       "id": "01-app-menu",
       "file": "01-app-menu.html",
       "label": "(a) Application menu",
-      "capabilities": [1, 4],
+      "capabilities": [
+        1,
+        4
+      ],
       "summary": "App menu + launcher with built-in Clock and newly-registered Market.",
-      "testHooks": ["[data-frame='01-app-menu']", "[data-app='clock']", "[data-app='market']"]
+      "testHooks": [
+        "[data-frame='01-app-menu']",
+        "[data-app='clock']",
+        "[data-app='market']"
+      ]
     },
     {
       "id": "02-register-activate",
       "file": "02-register-activate.html",
       "label": "(b) Register -> Activate",
-      "capabilities": [1],
+      "capabilities": [
+        1
+      ],
       "summary": "Add-application form (manifest fields) -> registered -> activate -> visible.",
-      "testHooks": ["[data-frame='02-register-activate']", "[data-action='activate']"]
+      "testHooks": [
+        "[data-frame='02-register-activate']",
+        "[data-action='activate']"
+      ]
     },
     {
       "id": "03-menu-substitution",
       "file": "03-menu-substitution.html",
       "label": "(c) Menu substitution",
-      "capabilities": [2],
+      "capabilities": [
+        2
+      ],
       "summary": "Studio app substitutes the portal side menu; host keeps return-to-portal.",
-      "testHooks": ["[data-frame='03-menu-substitution']", "[data-substituted='true']", "[data-app='__host_return']"]
+      "testHooks": [
+        "[data-frame='03-menu-substitution']",
+        "[data-substituted='true']",
+        "[data-app='__host_return']"
+      ]
     },
     {
       "id": "04-standalone",
       "file": "04-standalone.html",
       "label": "(d) Standalone app",
-      "capabilities": [3],
+      "capabilities": [
+        3
+      ],
       "summary": "Standalone non-portal landing page: FuzeFront infra, no portal chrome.",
-      "testHooks": ["[data-frame='04-standalone']", "[data-mode='standalone']", "[data-chrome='none']"]
+      "testHooks": [
+        "[data-frame='04-standalone']",
+        "[data-mode='standalone']",
+        "[data-chrome='none']"
+      ]
     }
-  ]
+  ],
+  "stamp": "644fa5fa6e8760dc794a8887cd37ffeeabd2b5d34343b08d92f924521bb55a76"
 }

--- a/design/frames/locked-app-mode/manifest.json
+++ b/design/frames/locked-app-mode/manifest.json
@@ -7,7 +7,11 @@
     "openapi": "services/app-registry-service/openapi.yaml",
     "client": "@fuzefront/app-registry-client",
     "manifestSchema": "components.schemas.AppManifest",
-    "newFields": ["AppMode.locked", "AppManifest.branding", "AppManifest.native"]
+    "newFields": [
+      "AppMode.locked",
+      "AppManifest.branding",
+      "AppManifest.native"
+    ]
   },
   "entry": "index.html",
   "frames": [
@@ -16,28 +20,47 @@
       "file": "01-white-label-login.html",
       "label": "(a) White-label login",
       "summary": "Locked-domain sign-in — product brand only, FuzeFront hidden; auth served same-origin by the platform.",
-      "testHooks": ["[data-frame='01-white-label-login']", "[data-mode='locked'][data-whitelabel='true']", "[data-app='fuzesocial']", "[data-action='login']"]
+      "testHooks": [
+        "[data-frame='01-white-label-login']",
+        "[data-mode='locked'][data-whitelabel='true']",
+        "[data-app='fuzesocial']",
+        "[data-action='login']"
+      ]
     },
     {
       "id": "02-locked-shell",
       "file": "02-locked-shell.html",
       "label": "(b) Locked product shell",
       "summary": "Product runs full-screen with its OWN chrome — no 9-dots launcher, no org-switcher, no return-to-portal, no FuzeFront wordmark. Platform infra active but hidden.",
-      "testHooks": ["[data-frame='02-locked-shell']", "[data-mode='locked'][data-chrome='none']", "[data-launcher='absent']", "[data-return-portal='absent']"]
+      "testHooks": [
+        "[data-frame='02-locked-shell']",
+        "[data-mode='locked'][data-chrome='none']",
+        "[data-launcher='absent']",
+        "[data-return-portal='absent']"
+      ]
     },
     {
       "id": "03-locked-mobile",
       "file": "03-locked-mobile.html",
       "label": "(c) Locked mobile shell",
       "summary": "375px white-label product surface with touch tab-bar + safe-area padding — the TWA viewport.",
-      "testHooks": ["[data-frame='03-locked-mobile']", "[data-mode='locked'][data-viewport='375']", ".m-tabbar"]
+      "testHooks": [
+        "[data-frame='03-locked-mobile']",
+        "[data-mode='locked'][data-viewport='375']",
+        ".m-tabbar"
+      ]
     },
     {
       "id": "04-native-app-home",
       "file": "04-native-app-home.html",
       "label": "(d) Separate native apps",
       "summary": "Phone home screen: each product is its OWN installed app (distinct package id / signing key / assetlinks) — no single FuzeFront container app.",
-      "testHooks": ["[data-frame='04-native-app-home']", "[data-container='absent']", "[data-app='fuzesocial'][data-packageid='com.fuzefront.fuzesocial']"]
+      "testHooks": [
+        "[data-frame='04-native-app-home']",
+        "[data-container='absent']",
+        "[data-app='fuzesocial'][data-packageid='com.fuzefront.fuzesocial']"
+      ]
     }
-  ]
+  ],
+  "stamp": "57046a2faef2dda04026c43aaac0ce677b571fab58bb3ff8181183f35d092098"
 }

--- a/design/frames/mfa-management/manifest.json
+++ b/design/frames/mfa-management/manifest.json
@@ -212,5 +212,5 @@
       ]
     }
   ],
-  "stamp": "sha256:958ca1ab9d9c44d6f08926502c8bbd7261ef41e37b1736384cf66bd32bab0446"
+  "stamp": "958ca1ab9d9c44d6f08926502c8bbd7261ef41e37b1736384cf66bd32bab0446"
 }

--- a/design/frames/password-reset/manifest.json
+++ b/design/frames/password-reset/manifest.json
@@ -60,7 +60,9 @@
       "SetPasswordForm",
       "PasswordPolicyHints"
     ],
-    "packages": ["@fuzefront/account-security-ui"],
+    "packages": [
+      "@fuzefront/account-security-ui"
+    ],
     "designSystemAdditions": [
       "PasswordStrengthMeter — segmented strength bar + policy hints; not yet in @fuzefront/design-system base. Named for frontend-engineer to add as a foundation PR; drawn from tokens only here.",
       "StatusCallout — shared soft-tinted inline banner (also named by the account-security frames); used by token-invalid / policy / 409 states. Foundation PR before implementation; never one-offed."
@@ -75,7 +77,12 @@
       "flow": "reset",
       "summary": "Unauthenticated email entry. Submitting always continues; a footnote states the same confirmation shows either way.",
       "acceptanceNotes": "POST /session/password/reset-request with { email }. Button data-action='send-reset'. No response detail is surfaced that could reveal account existence.",
-      "testHooks": ["[data-frame='01-request']", "[data-panel='reset-request']", "[data-input='email']", "[data-action='send-reset']"]
+      "testHooks": [
+        "[data-frame='01-request']",
+        "[data-panel='reset-request']",
+        "[data-input='email']",
+        "[data-action='send-reset']"
+      ]
     },
     {
       "id": "02-sent",
@@ -85,7 +92,13 @@
       "flow": "reset",
       "summary": "Unconditional 202 confirmation. The screen explicitly states it renders identically whether or not an account exists (no user enumeration).",
       "acceptanceNotes": "data-http='202'. Copy must never assert an account exists. data-security-note='no-enumeration' present. Resend + back-to-sign-in affordances.",
-      "testHooks": ["[data-frame='02-sent']", "[data-panel='reset-sent']", "[data-http='202']", "[data-security-note='no-enumeration']", "[data-action='resend']"]
+      "testHooks": [
+        "[data-frame='02-sent']",
+        "[data-panel='reset-sent']",
+        "[data-http='202']",
+        "[data-security-note='no-enumeration']",
+        "[data-action='resend']"
+      ]
     },
     {
       "id": "03-set-new",
@@ -95,7 +108,14 @@
       "flow": "reset",
       "summary": "From the emailed token link (valid). New password + confirm, live PasswordStrengthMeter and policy hints.",
       "acceptanceNotes": "POST /session/password/reset-confirm with { token, newPassword }. data-token-state='valid'. Strength meter (data-meter) + policy hints (data-policy-hints) render from the entered value.",
-      "testHooks": ["[data-frame='03-set-new']", "[data-panel='reset-confirm']", "[data-token-state='valid']", "[data-input='new-password']", "[data-meter]", "[data-action='set-new-password']"]
+      "testHooks": [
+        "[data-frame='03-set-new']",
+        "[data-panel='reset-confirm']",
+        "[data-token-state='valid']",
+        "[data-input='new-password']",
+        "[data-meter]",
+        "[data-action='set-new-password']"
+      ]
     },
     {
       "id": "04-done",
@@ -105,7 +125,12 @@
       "flow": "reset",
       "summary": "Success. States other sessions were revoked; CTA to sign in.",
       "acceptanceNotes": "Shown after 200 from reset-confirm. data-security-note='sessions-revoked'. data-action='go-sign-in'.",
-      "testHooks": ["[data-frame='04-done']", "[data-panel='reset-done']", "[data-security-note='sessions-revoked']", "[data-action='go-sign-in']"]
+      "testHooks": [
+        "[data-frame='04-done']",
+        "[data-panel='reset-done']",
+        "[data-security-note='sessions-revoked']",
+        "[data-action='go-sign-in']"
+      ]
     },
     {
       "id": "05-signed-in",
@@ -115,7 +140,16 @@
       "flow": "change-password",
       "summary": "Two variants: change an existing password (current + new + confirm), and set a first password on a Google-only account (no current field, hasPassword:false).",
       "acceptanceNotes": "Variant 'change' (data-has-password='true') posts reset-confirm-style change with current password; variant 'set' (data-has-password='false') posts POST /password. Forgot-current links to the reset flow.",
-      "testHooks": ["[data-frame='05-signed-in']", "[data-variant='change']", "[data-has-password='true']", "[data-input='current-password']", "[data-action='change-password']", "[data-variant='set']", "[data-has-password='false']", "[data-action='set-password']"]
+      "testHooks": [
+        "[data-frame='05-signed-in']",
+        "[data-variant='change']",
+        "[data-has-password='true']",
+        "[data-input='current-password']",
+        "[data-action='change-password']",
+        "[data-variant='set']",
+        "[data-has-password='false']",
+        "[data-action='set-password']"
+      ]
     },
     {
       "id": "06-states",
@@ -125,7 +159,20 @@
       "flow": "change-password",
       "summary": "Submitting, expired/invalid token, password-policy rejection, generic failure + retry, set-password-when-one-exists (409), wrong current password.",
       "acceptanceNotes": "Each state carries data-state; policy/token/409 use the StatusCallout or field-error. Expired token routes back to request; 409 routes to change/reset; wrong-current shows an inline field error.",
-      "testHooks": ["[data-frame='06-states']", "[data-state='submitting']", "[data-state='token-invalid']", "[data-token-state='invalid']", "[data-state='policy-rejected']", "[data-error='password-policy']", "[data-state='error']", "[data-action='retry']", "[data-state='already-has-password']", "[data-error='password-exists']", "[data-state='wrong-current']"]
+      "testHooks": [
+        "[data-frame='06-states']",
+        "[data-state='submitting']",
+        "[data-state='token-invalid']",
+        "[data-token-state='invalid']",
+        "[data-state='policy-rejected']",
+        "[data-error='password-policy']",
+        "[data-state='error']",
+        "[data-action='retry']",
+        "[data-state='already-has-password']",
+        "[data-error='password-exists']",
+        "[data-state='wrong-current']"
+      ]
     }
-  ]
+  ],
+  "stamp": "c62d2eb9679ac64459ea6d171c9a146ff896b7f16d8ffc4e4ed626aa9e40e6fa"
 }

--- a/scripts/stamp-frames.mjs
+++ b/scripts/stamp-frames.mjs
@@ -1,0 +1,176 @@
+#!/usr/bin/env node
+/**
+ * stamp-frames.mjs — compute a stable content "stamp" for each design/frames/<feature>/**
+ * and record it in that feature's manifest.json `stamp` field.
+ *
+ * WHY: an approval must bind to the exact frames a reviewer saw. The stamp is a
+ * sha256 over the feature's files. If the frames change afterward, the stamp
+ * changes and a stale approval is detectable (gate-frames-stamped in CI,
+ * design-approval.yml at approval time). The stamp is DERIVED from the files —
+ * never a hand-maintained mirror. It is the single source of truth's fingerprint.
+ *
+ * The manifest's own `stamp` field is EXCLUDED from the hash (read manifest,
+ * delete `stamp`, canonically re-serialize, hash that) so the stamp never
+ * depends on itself — writing it does not change the value it must equal.
+ *
+ * CLI:
+ *   node scripts/stamp-frames.mjs --check   recompute all; exit non-zero + list drifted; change nothing
+ *   node scripts/stamp-frames.mjs --write   recompute all; write `stamp` into each manifest
+ *   node scripts/stamp-frames.mjs --json     print {feature: stamp} and exit 0 (no writes)
+ *   [--frames <dir>]                         override design/frames location
+ *   [--feature <slug>]                       restrict to one feature (used by design-approval.yml)
+ *
+ * Node 20, stdlib only.
+ */
+import { readdir, readFile, writeFile, stat } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// fileURLToPath, not new URL().pathname — the latter yields "/D:/..." on Windows.
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+function arg(name, fallback) {
+  const i = process.argv.indexOf(name);
+  return i !== -1 && process.argv[i + 1] ? process.argv[i + 1] : fallback;
+}
+const hasFlag = (name) => process.argv.includes(name);
+
+const framesDir = path.resolve(arg('--frames', path.join(repoRoot, 'design', 'frames')));
+const onlyFeature = arg('--feature', null);
+
+/** Deterministic JSON: object keys sorted recursively, arrays order-preserved.
+ *  Two logically-equal manifests serialize identically regardless of key order. */
+function canonicalize(value) {
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (value && typeof value === 'object') {
+    const out = {};
+    for (const key of Object.keys(value).sort()) out[key] = canonicalize(value[key]);
+    return out;
+  }
+  return value;
+}
+
+const sha256 = (buf) => createHash('sha256').update(buf).digest('hex');
+
+/** Recursively list files under dir, returned as POSIX-style relative paths. */
+async function listFiles(dir, base = dir) {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files = [];
+  for (const e of entries) {
+    const abs = path.join(dir, e.name);
+    if (e.isDirectory()) {
+      files.push(...(await listFiles(abs, base)));
+    } else if (e.isFile()) {
+      files.push(path.relative(base, abs).split(path.sep).join('/'));
+    }
+  }
+  return files;
+}
+
+/**
+ * Compute the stamp of a single feature directory.
+ * Hash = sha256 over each file (sorted by relative path) as:
+ *   "<relpath>\0<per-file-hash>\n"
+ * where per-file-hash is:
+ *   - manifest.json: sha256 of the canonical JSON with `stamp` removed (self-excluding),
+ *   - any other file: sha256 of the raw bytes.
+ * A manifest that fails to parse is a hard error — an unparseable manifest must
+ * not silently hash as "some bytes" and mask corruption.
+ */
+async function computeStamp(featureDir) {
+  const rels = (await listFiles(featureDir)).sort();
+  const h = createHash('sha256');
+  for (const rel of rels) {
+    const abs = path.join(featureDir, rel);
+    let fileHash;
+    if (rel === 'manifest.json') {
+      const raw = await readFile(abs, 'utf8');
+      let manifest;
+      try {
+        manifest = JSON.parse(raw);
+      } catch (err) {
+        throw new Error(`manifest.json in ${featureDir} is not valid JSON: ${err.message}`);
+      }
+      const { stamp, ...rest } = manifest; // exclude own stamp
+      void stamp;
+      fileHash = sha256(JSON.stringify(canonicalize(rest)));
+    } else {
+      fileHash = sha256(await readFile(abs));
+    }
+    h.update(`${rel}\0${fileHash}\n`);
+  }
+  return h.digest('hex');
+}
+
+/** Feature directories present on disk. `_`/`.`-prefixed dirs are scaffolding. */
+async function discoverFeatures() {
+  if (!existsSync(framesDir)) throw new Error(`frames dir not found: ${framesDir}`);
+  const entries = await readdir(framesDir, { withFileTypes: true });
+  const features = [];
+  for (const e of entries) {
+    if (!e.isDirectory() || e.name.startsWith('_') || e.name.startsWith('.')) continue;
+    if (onlyFeature && e.name !== onlyFeature) continue;
+    const manifestPath = path.join(framesDir, e.name, 'manifest.json');
+    if (!existsSync(manifestPath)) continue; // only features with a manifest are stampable
+    features.push({ slug: e.name, dir: path.join(framesDir, e.name), manifestPath });
+  }
+  return features.sort((a, b) => a.slug.localeCompare(b.slug));
+}
+
+async function main() {
+  const write = hasFlag('--write');
+  const check = hasFlag('--check');
+  const json = hasFlag('--json');
+  if (!write && !check && !json) {
+    console.error('usage: stamp-frames.mjs (--check | --write | --json) [--frames <dir>] [--feature <slug>]');
+    process.exit(2);
+  }
+
+  const features = await discoverFeatures();
+  const result = {};
+  const drifted = [];
+
+  for (const f of features) {
+    const computed = await computeStamp(f.dir);
+    result[f.slug] = computed;
+    const manifest = JSON.parse(await readFile(f.manifestPath, 'utf8'));
+    const current = manifest.stamp ?? null;
+
+    if (json) continue;
+
+    if (current !== computed) {
+      drifted.push({ slug: f.slug, current, computed });
+      if (write) {
+        manifest.stamp = computed;
+        // Preserve human-friendly 2-space formatting + trailing newline.
+        await writeFile(f.manifestPath, JSON.stringify(manifest, null, 2) + '\n', 'utf8');
+        console.log(`stamped ${f.slug}: ${computed}`);
+      }
+    } else {
+      console.log(`ok      ${f.slug}: ${computed}`);
+    }
+  }
+
+  if (json) {
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+
+  if (check) {
+    if (drifted.length) {
+      console.error(`\n${drifted.length} manifest stamp(s) are stale (run: node scripts/stamp-frames.mjs --write):`);
+      for (const d of drifted) console.error(`  - ${d.slug}: manifest=${d.current ?? '<none>'} computed=${d.computed}`);
+      process.exit(1);
+    }
+    console.log(`\nAll ${features.length} feature stamp(s) up to date.`);
+  }
+
+  if (write && !drifted.length) console.log(`\nAll ${features.length} feature stamp(s) already up to date.`);
+}
+
+main().catch((err) => {
+  console.error(err.message ?? err);
+  process.exit(1);
+});


### PR DESCRIPTION
Builds the two deferred pieces of the design-approval pipeline (plan: docs/planning/design-first-ui-pipeline.md).

## D1 scripts/stamp-frames.mjs
Stable sha256 stamp of design/frames/<feature>/** into each manifest stamp field, EXCLUDING the manifest own stamp so it never depends on itself. CLI --check/--write/--json/--feature, Node20 stdlib-only. Backfills all 9 manifests. Verified: --write then --check exit 0; a mutated frame makes --check exit 1 naming the drift.

## D2 gate-frames-stamped.yml
PRs touching design/frames/** run stamp-frames --check; stale stamp fails.

## D3 design-approval.yml
on issues:[opened], concurrency per issue, label-gated. Fail-closed IN ORDER: (1) auth owner/CODEOWNER derived from CODEOWNERS; (2) staleness recompute vs issue stamp; (3) idempotency; (4) flip build.flows[flow].approved via Contents API (signed) on master; reject leaves issue open. Flip target derived from parsed issue. Actions pinned to SHAs.

Actions cannot open PRs here by design, so the agent opens this PR.

Generated with Claude Code