### PR TITLE
fix(pwa): stop the service worker swallowing Authentik OAuth redirects (Google sign-in flicker)

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -141,10 +141,25 @@ export default defineConfig({
       // NetworkFirst so the shell always fetches fresh federation assets.
       globPatterns: ['**/*.{html,css,ico,png,svg,woff,woff2}'],
       workbox: {
-        // Exclude /api/* from the SPA navigation fallback so full-page navigations
-        // to backend redirect endpoints (e.g. /api/auth/oidc/signup → 302) are not
-        // intercepted by the SW and silently served as index.html instead.
-        navigateFallbackDenylist: [/^\/api\//],
+        // Exclude server-owned paths from the SPA navigation fallback so full-page
+        // navigations to them are NOT intercepted by the SW and silently served as
+        // index.html. Two families must be excluded:
+        //   1. /api/* — backend redirect endpoints (e.g. /api/auth/oidc/* → 302).
+        //   2. Authentik's NATIVE paths, which the app Ingress reverse-proxies to
+        //      the IdP (see values-prod authentik.oidc comment): /source/*,
+        //      /application/*, /if/*, /outpost.goauthentik.io/*, /-/*. Social
+        //      sign-in navigates the browser to /source/oauth/login/<provider>/;
+        //      without these entries the SW served the cached SPA shell instead of
+        //      letting the redirect reach Authentik → the "login just flickers"
+        //      bug. This denylist MUST track the Ingress's Authentik path list.
+        navigateFallbackDenylist: [
+          /^\/api\//,
+          /^\/source\//,
+          /^\/application\//,
+          /^\/if\//,
+          /^\/outpost\.goauthentik\.io\//,
+          /^\/-\//,
+        ],
         runtimeCaching: [
           {
             // API + WebSocket upgrade paths — never cache


### PR DESCRIPTION
Diagnosed live with the product owner: **Sign in with Google flickered back to the login page.**

## Root cause
The PWA service worker's `navigateFallbackDenylist` only excluded `/api/*`. A full-page navigation to `/source/oauth/login/google/` (the app-Ingress-proxied Authentik source-launch) was intercepted by the SW and served the cached SPA shell instead of reaching Authentik. The app re-booted at that URL, found no token, and showed the login page again — the "flicker." `curl` worked (no SW); the browser did not.

The app Ingress reverse-proxies Authentik's native paths (`/source`, `/application`, `/if`, `/outpost.goauthentik.io`, `/-`) to the IdP. When those became app-hosted, this denylist was never updated to match — two lists that must agree, nothing checking them.

## Fix
Add the Authentik path families to `navigateFallbackDenylist`. Verified the regexes deny `/source/oauth/login/google/` and `/api/*`, and do **not** deny app routes like `/dashboard`.

## Scope / honesty
This fixes **Google** sign-in. **Password** login has a *separate* server-side cause — Authentik is responding very slowly in prod (measured 6.5s for OIDC discovery, 20s+ for the password flow), so the security service's server-side flow executor times out and reports "invalid credentials." That is not fixed here and is tracked separately (needs Authentik pod/DB health — cluster access).

Deploys the frontend on merge to master.

Refs #294

🤖 Generated with [Claude Code](https://claude.com/claude-code)