### PR TITLE
fix(authentik): disable the unused embedded outpost + pin 4 web workers

### DIFF
--- a/deploy/helm/fuzefront/templates/authentik.yaml
+++ b/deploy/helm/fuzefront/templates/authentik.yaml
@@ -34,6 +34,24 @@
   value: "true"
 - name: AUTHENTIK_ERROR_REPORTING__ENABLED
   value: "false"
+# Disable the embedded (proxy) outpost. FuzeFront uses OAuth2/OIDC providers
+# only — verified in prod: 3 oauth2 providers, 0 proxy providers, and the
+# "authentik Embedded Outpost" had 0 providers attached, i.e. it served nothing.
+# Despite that it ran an ak-api-controller poll loop hitting /api/v3/outposts/
+# every 3s, and every call failed ("invalid header field value for
+# Authorization"). Measured on a live pod: 40 failed outpost polls per 2 min vs
+# 14 real requests — roughly 3x the genuine traffic, all of it waste, against
+# only 2 gunicorn workers. That starved real auth requests (avg 1522ms, tail
+# 20-37s) and is why sign-in intermittently timed out. Turning it off removes
+# the load entirely; re-enable ONLY if a proxy/forward-auth provider is added.
+- name: AUTHENTIK_OUTPOSTS__DISABLE_EMBEDDED_OUTPOST
+  value: "true"
+# Size the web worker pool explicitly. Authentik derives it from visible CPU,
+# which under the container's 1-CPU limit yielded just 2 workers — too few to
+# absorb a burst of concurrent auth flows, so requests queued and clients timed
+# out. Pin it so the pool never silently shrinks with a limit change.
+- name: AUTHENTIK_WEB__WORKERS
+  value: {{ .Values.authentik.webWorkers | default 4 | quote }}
 - name: AUTHENTIK_COOKIE_DOMAIN
   value: {{ .Values.authentik.cookieDomain | quote }}
 # Bootstrap the akadmin user with a known password/token so the initial-setup
@@ -206,9 +224,13 @@ spec:
           volumeMounts:
             - { name: media,       mountPath: /media }
             - { name: blueprints,  mountPath: /blueprints/fuzefront, readOnly: true }
+          # 2 CPU so the 4 pinned web workers have somewhere to run; the 1-CPU
+          # limit is what capped Authentik at 2 workers. Average CPU looked idle
+          # (21m/1000m) during the outage because workers were blocked on queued
+          # requests, not computing — low utilisation was not spare headroom.
           resources:
-            requests: { cpu: 100m, memory: 384Mi }
-            limits:   { cpu: "1",  memory: 768Mi }
+            requests: { cpu: 200m, memory: 512Mi }
+            limits:   { cpu: "2",  memory: 1Gi }
       volumes:
         - name: media
           emptyDir: {}


### PR DESCRIPTION
The **actual** cause of the prod sign-in failures. My earlier probe-timeout fix (#318) stopped k8s evicting the pod, but sign-in still took **24-37s** afterwards — so the 1s probe timeout was a symptom amplifier, not the root cause.

## Measured on the live pod
- gunicorn boots with **only TWO workers** (`Booting worker with pid: 66/67`) — `AUTHENTIK_WEB__WORKERS` is unset, so Authentik derives it from the container's 1-CPU limit.
- the embedded outpost polls `/api/v3/outposts/instances/` **every 3s and every call fails**: `invalid header field value for "Authorization"`. **40 failed polls per 2 min vs 14 real requests** — ~3x the genuine traffic, all waste.
- real requests averaged **1522ms** with a 20-37s tail; the router logged `context canceled: failed to proxy to backend` as clients gave up.

Two workers, permanently occupied by a failing poll loop, cannot serve auth. A self-inflicted DoS.

## The outpost is provably unused
Prod has **3 oauth2 providers, 0 proxy providers**, and the "authentik Embedded Outpost" has **0 providers attached**. It serves nothing. Disabled via `AUTHENTIK_OUTPOSTS__DISABLE_EMBEDDED_OUTPOST` — re-enable only if a proxy/forward-auth provider is ever added.

## Also
- Pin `AUTHENTIK_WEB__WORKERS=4` (values-overridable) so the pool never silently shrinks with a limit change.
- Server to 2 CPU / 1Gi so those workers have somewhere to run.

## Note for the next person
The pod's **average** CPU read 21m of 1000m during the outage — which looks like ample headroom and nearly led me to rule resourcing out entirely. The workers were **blocked on queued requests, not computing**. Average utilisation is the wrong signal for a saturated worker pool.

`helm template` + `helm lint` clean; verified the env vars and resources land on the `authentik-server` container specifically.

Refs #294

🤖 Generated with [Claude Code](https://claude.com/claude-code)