### PR TITLE
chore(governance): refresh governance-sync shim to the v1.2.0 template

### DIFF
--- a/.github/workflows/governance-sync.yml
+++ b/.github/workflows/governance-sync.yml
@@ -101,8 +101,17 @@ jobs:
             git push origin "HEAD:${HEAD_REF}"
             echo "::notice::Reconciled and pushed $committable managed file(s) to ${HEAD_REF}."
           fi
-          if [ "$workflows" != "0" ] || [ "$missing" != "0" ]; then
-            echo "::error::Governance drift the token cannot auto-fix — $workflows workflow file(s), $missing missing file(s). Run scripts/sdlc-bootstrap.sh and open a PR."
-            git --no-pager diff; exit 1
+          # Workflow drift is ADVISORY, not blocking. The default GITHUB_TOKEN cannot push
+          # .github/workflows/**, and repos legitimately customise them (cron stagger, extra
+          # jobs) — so failing here would be permanently red AND unactionable by this workflow.
+          # The nightly governance sweep opens a fix PR for genuine staleness.
+          if [ "$workflows" != "0" ]; then
+            echo "::warning::$workflows workflow file(s) differ from the FuzeSDLC canonical (advisory — this job cannot push workflow changes). Run scripts/sdlc-bootstrap.sh if they are genuinely stale."
           fi
-          echo "Governance in sync with FuzeSDLC ${{ steps.ref.outputs.ref }}."
+          # A manifest-DECLARED agent missing from the repo IS blocking: real breakage, and
+          # scripts/sdlc-bootstrap.sh fixes it deterministically.
+          if [ "$missing" != "0" ]; then
+            echo "::error::$missing manifest-declared file(s) are MISSING from this repo. Run scripts/sdlc-bootstrap.sh and open a PR."
+            exit 1
+          fi
+          echo "Governance in sync with FuzeSDLC ${{ steps.ref.outputs.ref }} (workflow drift, if any, is advisory)."


### PR DESCRIPTION
Refreshes the `governance-sync` shim to the **v1.2.0** canonical ([FuzeSDLC#49](https://github.com/izzywdev/FuzeSDLC/pull/49)).

Two bugs were caught by canarying the newly-distributed `FUZESDLC_DEPLOY_KEY` on **one** repo before the fleet ([FuzeInfra#309](https://github.com/izzywdev/FuzeInfra/pull/309)):

1. The reconciler **wrote** workflow files → `git add -A` staged unpushable `.github/workflows/**` → the commit-back push was **rejected** (`failed to push some refs`), killing reconciliation even for the agent/framework files it *could* have pushed.
2. Workflow drift **failed** the check — 10 drifted workflows in FuzeInfra alone would have made every PR permanently red on something this job structurally cannot fix. Alarm fatigue, then a bypassed gate.

**New semantics:** workflows are **detect-only** (a `::warning::`, never written — so this repo's own workflow customisations are never clobbered); only a **missing manifest-declared agent** fails, because that's real breakage the bootstrapper fixes deterministically.

The **script** half arrives automatically (fetched from the hub at `baselineRef`). This shim is a **workflow file**, and workflows are now deliberately detect-only — so `governance-sync` **cannot self-update**. Hence this PR. That's the intended trade: never clobbering your workflow customisations costs self-healing on this one file.

Verified green end-to-end on [FuzeInfra#310](https://github.com/izzywdev/FuzeInfra/pull/310) before fanning out.