### PR TITLE
fix(oidc): raise the 3500ms HTTP timeout that was killing Google sign-in

### DIFF
--- a/backend/security/src/services/oidc.ts
+++ b/backend/security/src/services/oidc.ts
@@ -1,7 +1,15 @@
-import { Issuer, Client, generators } from 'openid-client';
+import { Issuer, Client, generators, custom } from 'openid-client';
 import { db } from '../config/database';
 import { User } from '../types/shared';
 import { defaultEventPublisher } from './eventPublisher';
+
+/**
+ * HTTP timeout for every server-side OIDC call (discovery, token grant, userinfo,
+ * jwks). openid-client defaults to 3500ms, which is BELOW Authentik's real p99 and
+ * broke Google sign-in outright — see the note in initialize(). Overridable via
+ * OIDC_HTTP_TIMEOUT_MS so it can be tuned per environment without a rebuild.
+ */
+const OIDC_HTTP_TIMEOUT_MS = Number(process.env.OIDC_HTTP_TIMEOUT_MS) || 15000;
 
 interface OIDCConfig {
   issuerUrl: string;
@@ -26,7 +34,19 @@ class OIDCService {
   async initialize(): Promise<void> {
     try {
       console.log('🔧 Initializing OIDC client...');
-      
+
+      // Raise openid-client's HTTP timeout. Its default is 3500ms, which is too
+      // short for Authentik's token endpoint and silently broke Google sign-in:
+      // the browser completed Google auth, the callback arrived with a valid code
+      // and state, and the code->token grant then died with
+      //   RPError: outgoing request timed out after 3500ms
+      // surfacing to the user as ?error=authentication_failed. Authentik averages
+      // ~1.3s per request with multi-second spikes, and the grant is several
+      // round-trips, so 3.5s is under the real p99. Applied via
+      // setHttpOptionsDefaults so it covers discovery, the token grant, userinfo
+      // and jwks — not just the one call that happened to fail first.
+      custom.setHttpOptionsDefaults({ timeout: OIDC_HTTP_TIMEOUT_MS });
+
       // Discover the issuer
       const issuer = await Issuer.discover(this.config.issuerUrl);
       console.log('✅ Discovered issuer:', issuer.metadata.issuer);


### PR DESCRIPTION
The **final link** in the prod sign-in outage.

With the security service pinned to 1 replica (`f6faf4de`), the PKCE state is now found correctly — the callback logs `hasCode: true, hasState: true`. The only remaining failure is the code→token grant:

```
RPError: outgoing request timed out after 3500ms
  at Client.grant (openid-client/lib/client.js:1370)
  at OIDCService.handleCallback (oidc.js:109)
```

**3500ms is openid-client's default, and it is below Authentik's real p99.** The IdP averages ~1.3s per request with multi-second spikes, and the grant is several round-trips. So Google auth completed, the callback arrived with a valid code and state, and the exchange timed out — surfacing to the user as the opaque `?error=authentication_failed`.

## Fix
`custom.setHttpOptionsDefaults({ timeout })` so it covers **discovery, the token grant, userinfo and jwks** — not just the one call that happened to fail first. Default 15000ms, overridable via `OIDC_HTTP_TIMEOUT_MS` so it can be tuned per environment without a rebuild.

## Deploy caveat (important)
This is a **code** change, so it needs an image build. The release pipeline's `deploy-application` job is currently **skipped** (gated behind a failing AWS Terraform job that reads a non-existent ELB/ASG), so merging alone will **not** ship it — the `securityService.image.tag` in `values-prod.yaml` will need a manual bump, exactly as the frontend did in `6ec957ce`.

Refs #294

🤖 Generated with [Claude Code](https://claude.com/claude-code)