### PR TITLE
chore(fuzequality): seal Chroma credentials

### DIFF
--- a/FuzeQuality/deploy/helm/fuzequality/templates/chroma-sealed-secret.yaml
+++ b/FuzeQuality/deploy/helm/fuzequality/templates/chroma-sealed-secret.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  creationTimestamp: null
+  name: fuzequality-chroma-credentials
+  namespace: fuzequality
+spec:
+  encryptedData:
+    token: AgB19xACVbULIxe4u2zkp9+Lax7Z5Vmh4e0vApi1hdszR8+VHwilgjSPuWBtY4s7pljwlBdnHhDHvt0L6vDfT1dTH6zDuooqvLhqx7Twya1VLC9oyRbxAt48o5Ha7OC6rnlhwIZO8lIYkFGVAHpleVmgiA4Hzwmcoh68papRGJh/HoKPqntRCAJuEaWpE3l0YKhVxph3GI8hMs+Kav+5WAQeXNIocfz2EF7jIO+Mp8I/qnhwdLNiw+osXb46j+xhDtkUyOi38yFSp8rSuCoHnYzpAC8rTJk2UR/5gVblQHiH5RNVxPPx9i46XkgypE+2Bn47SGpXDCZ3azZ0YxFA2X11snQXA9fsfQBkBemtWLLthI447u3rndwb6x0V6GIXmoLgrpzRecKVTo7StBidNurS1kmJm7ZxaJ3Vo1dNTNhYnECcDUn3TqNNrYC9W9SuZmieFgqyEG85gRpJLUs7fTglAGmxOHmkVRNi4wez50GENG/kJ5OSAoX/zwnEmDNDpaJmnYYcf96LoECgP8wp1Qu8upzIs3LpDc5e6oQ/sw+hnl5+ARo0EQL7KUo+UwR0Il5hWRX6lRXAT2t5YgnSheo3/4DAf2Hkdfqp/FSyxxVwmZRhh5A+LbrHx3gIELe+zNPsZNkkCHOahDNQ+8sf+L7cm8qxIKIZUJJ2IMXQ/DQcolobSUa/5uc5jf2BMyrch/S8/m3Z+KdLfbkU2//WCiqERzKgszpJIaCZozeiQUO2v6xsYqlMI5GCx2q3+dyFCAIEZeTiBBf090h1BoH6VQgp
+  template:
+    metadata:
+      creationTimestamp: null
+      name: fuzequality-chroma-credentials
+      namespace: fuzequality
+    type: Opaque


### PR DESCRIPTION
Coordinated ciphertext-only rotation from FuzeInfra run 29779619844. The token is strictly sealed for namespace `fuzequality` and Secret `fuzequality-chroma-credentials`. Merge together with the companion FuzeInfra rotation PR.