### PR TITLE
fix(fuzequality): create namespace before migrations

### DIFF
--- a/FuzeQuality/deploy/helm/fuzequality/templates/jobs.yaml
+++ b/FuzeQuality/deploy/helm/fuzequality/templates/jobs.yaml
@@ -5,7 +5,11 @@ metadata:
   labels:
     {{- include "fuzequality.labels" . | nindent 4 }}
   annotations:
-    argocd.argoproj.io/hook: PreSync
+    # CreateNamespace is processed before the Sync phase. A PreSync hook can
+    # otherwise race the first deployment because its target namespace does
+    # not exist yet.
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/sync-wave: "-1"
     argocd.argoproj.io/hook-delete-policy: BeforeHookCreation,HookSucceeded
 spec:
   backoffLimit: 3


### PR DESCRIPTION
## Summary
- run the migration as a negative-wave Argo Sync hook
- allow CreateNamespace to establish the FuzeQuality namespace before the migration Job
- preserve migration ordering ahead of wave-0 workloads

## Validation
- Helm lint with production values
- Helm template confirms Sync hook and wave -1
- git diff --check