### PR TITLE
fix(fuzequality): manage deployment namespace

### DIFF
--- a/FuzeQuality/deploy/helm/fuzequality/templates/namespace.yaml
+++ b/FuzeQuality/deploy/helm/fuzequality/templates/namespace.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: fuzequality
+    app.kubernetes.io/part-of: fuzequality
+  annotations:
+    # Sync hooks are evaluated before Argo's implicit CreateNamespace action.
+    # Explicit ownership at wave -2 guarantees the migration hook at wave -1
+    # always has a namespace on the first deployment.
+    argocd.argoproj.io/sync-wave: "-2"


### PR DESCRIPTION
## Summary
- manage the dedicated FuzeQuality namespace as a chart resource
- create it at Argo sync wave -2 before the migration Sync hook at wave -1
- retain CreateNamespace as a fallback in the Application

## Validation
- Helm lint with production values
- Helm template confirms Namespace wave -2
- git diff --check