### PR TITLE
ci(fuzequality): publish and pin backend/frontend images

### DIFF
--- a/.github/workflows/fuzequality-release.yml
+++ b/.github/workflows/fuzequality-release.yml
@@ -1,0 +1,119 @@
+name: Release FuzeQuality images
+
+on:
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: Why this FuzeQuality release is being built
+        required: false
+        default: manual release
+  push:
+    branches: [master]
+    paths:
+      - 'FuzeQuality/**'
+      - '.github/workflows/fuzequality-release.yml'
+
+concurrency:
+  group: fuzequality-release
+  cancel-in-progress: false
+
+jobs:
+  build-and-bump:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute immutable image tag
+        id: tag
+        run: echo "sha=${GITHUB_SHA::12}" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push FuzeQuality backend
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: FuzeQuality/docker/Dockerfile
+          target: service
+          push: true
+          tags: |
+            ghcr.io/izzywdev/fuzequality-backend:${{ steps.tag.outputs.sha }}
+            ghcr.io/izzywdev/fuzequality-backend:latest
+          cache-from: type=gha,scope=fuzequality-backend
+          cache-to: type=gha,mode=max,scope=fuzequality-backend
+
+      - name: Build and push FuzeQuality frontend
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: FuzeQuality/docker/Dockerfile
+          target: web
+          push: true
+          tags: |
+            ghcr.io/izzywdev/fuzequality-frontend:${{ steps.tag.outputs.sha }}
+            ghcr.io/izzywdev/fuzequality-frontend:latest
+          cache-from: type=gha,scope=fuzequality-frontend
+          cache-to: type=gha,mode=max,scope=fuzequality-frontend
+
+      - name: Bump FuzeQuality production image tags
+        env:
+          SSH_KEY: ${{ secrets.RELEASE_BUMP_SSH_KEY }}
+          FILE: FuzeQuality/deploy/helm/fuzequality/values-prod.yaml
+          IMAGE_TAG: ${{ steps.tag.outputs.sha }}
+        run: |
+          set -euo pipefail
+          mkdir -p ~/.ssh
+          printf '%s\n' "$SSH_KEY" > ~/.ssh/release_bump
+          chmod 600 ~/.ssh/release_bump
+          ssh-keyscan github.com >> ~/.ssh/known_hosts 2>/dev/null
+          export GIT_SSH_COMMAND="ssh -i ~/.ssh/release_bump -o IdentitiesOnly=yes"
+          git config user.name "fuzefront-release"
+          git config user.email "release-bump@users.noreply.github.com"
+          git remote set-url --push origin "git@github.com:${GITHUB_REPOSITORY}.git"
+
+          for attempt in 1 2 3; do
+            git fetch origin master
+            git checkout --detach --force FETCH_HEAD
+            awk -v sha="$IMAGE_TAG" '
+              hot {
+                hot=0
+                if ($0 ~ /^[[:space:]]*tag:/) {
+                  match($0, /^[[:space:]]*/)
+                  print substr($0, 1, RLENGTH) "tag: " sha ($0 ~ /\r$/ ? "\r" : "")
+                  n++
+                  next
+                }
+              }
+              /repository: ghcr\.io\/izzywdev\/fuzequality-backend\r?$/ { hot=1 }
+              /repository: ghcr\.io\/izzywdev\/fuzequality-frontend\r?$/ { hot=1 }
+              { print }
+              END { print n+0 > "/tmp/fuzequality-bump-count" }
+            ' "$FILE" > /tmp/fuzequality-values-prod.yaml
+            COUNT=$(cat /tmp/fuzequality-bump-count)
+            if [ "$COUNT" -ne 2 ]; then
+              echo "::error::expected 2 FuzeQuality image tag rewrites, got ${COUNT}"
+              exit 1
+            fi
+            if cmp -s "$FILE" /tmp/fuzequality-values-prod.yaml; then
+              echo "FuzeQuality values already reference ${IMAGE_TAG}"
+              exit 0
+            fi
+            cp /tmp/fuzequality-values-prod.yaml "$FILE"
+            git commit -m "release: fuzequality images ${IMAGE_TAG} [skip ci]" -- "$FILE"
+            if git push origin HEAD:master; then
+              exit 0
+            fi
+            echo "push rejected on attempt ${attempt}; retrying from current master"
+          done
+          echo "::error::could not push the FuzeQuality image tag bump after 3 attempts"
+          exit 1


### PR DESCRIPTION
## Summary
- build the FuzeQuality backend and frontend Docker targets
- publish immutable SHA and latest tags to GHCR
- update only the two FuzeQuality production image tags through the established release deploy-key GitOps path
- serialize releases to avoid tag-bump races

## Validation
- backend Docker target builds locally
- frontend Docker target builds locally and runs type-check, 6 tests, and Vite production build
- git diff --check