### PR TITLE
chore(authentik): upgrade IdP 2024.12.3 -> 2026.5.5 (latest stable)

### DIFF
--- a/deploy/helm/fuzefront/values.yaml
+++ b/deploy/helm/fuzefront/values.yaml
@@ -541,7 +541,7 @@ authentik:
   enabled: true
   image:
     repository: ghcr.io/goauthentik/server
-    tag: "2024.12.3"
+    tag: "2026.5.5"
   host: auth.fuzefront.dev.local
   dbName: authentik # must pre-exist in the FuzeInfra Postgres
   cookieDomain: fuzefront.dev.local


### PR DESCRIPTION
Upgrades prod Authentik from **2024.12.3 → 2026.5.5** (latest stable, confirmed pullable from `ghcr.io/goauthentik/server`).

**Why:** the IdP is ~18 months old (security patches), and 2026.5 has `SourceStage` — enabling a fully UI-free social-login flow that 2024.12 structurally cannot (the browser currently transits `/if/flow` + `/if/user`).

## RISK — read before merging
This is a **7-major-version jump**; Authentik recommends one major at a time. Migrations run cumulatively on the worker at startup. The main failure mode: the custom blueprints (`flow-enrollment`, `source-google`, `provider-oidc`, `brand-fuseseam`, `stages-mfa`, `stages-sms`) reference models/fields that changed across releases — if a blueprint entry fails to apply, the just-fixed sign-in flows could revert.

## Safety measures taken
- **Pre-upgrade `pg_dump` of the `authentik` DB** taken and copied **off-cluster** (custom format, 2.2M, `PGDMP`-verified) before this change. Migrations are one-way → rollback = **restore that dump AND revert this tag**, not a tag-revert alone.
- Deploy will be **watched live**: worker migration logs → blueprint-apply logs → a real sign-in verification. Roll back on any failure.
- `AUTHENTIK_WEB__WORKERS` / `AUTHENTIK_OUTPOSTS__DISABLE_EMBEDDED_OUTPOST` may have changed across versions — verifying post-upgrade.

`helm template` + `helm lint` clean. It is only an upstream image tag (no FuzeFront build needed); Argo pulls it on sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)