### PR TITLE
feat(deploy): wire server-brokered Google sign-in env into security chart

### DIFF
--- a/deploy/helm/fuzefront/templates/security.yaml
+++ b/deploy/helm/fuzefront/templates/security.yaml
@@ -159,6 +159,35 @@ spec:
               value: /etc/fuzefront-ca/ca.crt
             {{- end }}
             {{- end }}
+            # ---- Server-brokered Google sign-in (PR #329) ----
+            # googleOidc.ts talks to Google directly using these creds; the
+            # brokered flow 302s back to ${FRONTEND_URL}/dashboard on success
+            # (FRONTEND_URL is set above). GOOGLE_CLIENT_ID/SECRET reuse the SAME
+            # keys the Authentik pods consume from the fuzefront-secrets
+            # SealedSecret; optional:true so the pod still starts when Google is
+            # unconfigured in an env (then SECURITY_GOOGLE_BROKERED should be off).
+            - name: GOOGLE_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "fuzefront.secretName" . }}
+                  key: GOOGLE_CLIENT_ID
+                  optional: true
+            - name: GOOGLE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "fuzefront.secretName" . }}
+                  key: GOOGLE_CLIENT_SECRET
+                  optional: true
+            # External browser-facing callback URL registered in the Google
+            # console. Prod = app host; dev overrides via securityService.googleRedirectUri.
+            - name: GOOGLE_REDIRECT_URI
+              value: {{ .Values.securityService.googleRedirectUri | default "https://app.fuzefront.com/api/v1/security/social/google/callback" | quote }}
+            # KILL-SWITCH: "true" = server-brokered Google (googleOidc.ts) is the
+            # source of truth; "false" = revert to the legacy Authentik Google
+            # source flow with NO rebuild — the instant rollback is flipping
+            # securityService.googleBrokered to "false" in values and re-syncing.
+            - name: SECURITY_GOOGLE_BROKERED
+              value: {{ .Values.securityService.googleBrokered | default "false" | quote }}
           readinessProbe:
             httpGet:
               path: /health

--- a/deploy/helm/fuzefront/values-prod.yaml
+++ b/deploy/helm/fuzefront/values-prod.yaml
@@ -79,6 +79,12 @@ securityService:
   # is a stopgap. PROPER FIX: externalize that state to Redis (FuzeInfra provisions
   # it — delegate the DB/credentials request via @claude), then restore replicas: 2.
   replicas: 1
+  # Server-brokered Google sign-in (PR #329). "true" = enabled — owner has
+  # registered this callback in the Google console. Instant rollback: set to
+  # "false" to revert to the legacy Authentik Google source flow (no rebuild).
+  googleBrokered: "true"
+  # Prod browser-facing Google callback URL (app host, not auth-dev).
+  googleRedirectUri: "https://app.fuzefront.com/api/v1/security/social/google/callback"
 
 applicationsService:
   enabled: true   # serves /api/apps (MF app registry) — needed for MF apps to load

--- a/deploy/helm/fuzefront/values.yaml
+++ b/deploy/helm/fuzefront/values.yaml
@@ -184,6 +184,10 @@ securityService:
   tolerations: []
   # security-service owns auth; keep it co-located with the DB-heavy node-1 by
   # default (no-op here, set in values-prod if desired).
+  # Server-brokered Google sign-in (PR #329). OFF by default; prod enables it.
+  googleBrokered: "false"
+  # Browser-facing Google callback URL. Dev default here; prod overrides in values-prod.
+  googleRedirectUri: "https://auth-dev.fuzefront.com/api/v1/security/social/google/callback"
 
 applicationsService:
   enabled: false


### PR DESCRIPTION
## What
Chart wiring only (no app code) for the server-brokered Google sign-in merged in PR #329. Adds the env the security-service reads to the `fuzefront-security` container.

## Changes
- `templates/security.yaml`: adds `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` (secretKeyRef from `fuzefront-secrets`, same keys Authentik consumes, `optional: true`), `GOOGLE_REDIRECT_URI` (literal from `securityService.googleRedirectUri`), and `SECURITY_GOOGLE_BROKERED` kill-switch (from `securityService.googleBrokered`).
- `values.yaml`: defaults `googleBrokered: "false"`, dev `googleRedirectUri`.
- `values-prod.yaml`: `googleBrokered: "true"` (owner registered prod callback), prod `googleRedirectUri`.

`FRONTEND_URL` was already present on the container — left unchanged.

**Instant rollback:** flip `securityService.googleBrokered` to `"false"` — reverts to the legacy Authentik Google source flow, no rebuild.

## Verified
- `helm lint -f values-prod.yaml` → 0 failed
- `helm template -f values-prod.yaml` → exit 0; all four env vars render on the `fuzefront-security` Deployment (GOOGLE_CLIENT_ID/SECRET as secretKeyRef, GOOGLE_REDIRECT_URI + SECURITY_GOOGLE_BROKERED as literals).

Out of scope (owner): image build + `securityService.image.tag` bump + live-cluster verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)