### PR TITLE
fix: stop doubling remoteEntry.js URL in legacy app-registry route

### DIFF
--- a/backend/src/routes/appRegistry.ts
+++ b/backend/src/routes/appRegistry.ts
@@ -14,10 +14,11 @@ function rowToRegistryApp(row: any) {
 
   const integration: Record<string, unknown> = { type: row.integration_type }
   if (row.integration_type === 'module-federation') {
-    // `remote_url` in the legacy table is the base dir (e.g. ".../assets").
-    // The registry schema expects the full remoteEntry URL.
-    const base = (row.remote_url as string).replace(/\/$/, '')
-    integration.remoteEntry = `${base}/remoteEntry.js`
+    // `remote_url` may hold a full remoteEntry URL (stored by the applications
+    // service as `manifest.integration.remoteEntry`) OR a legacy base directory.
+    // Append /remoteEntry.js only when it is not already a .js file URL.
+    const raw = (row.remote_url as string).replace(/\/$/, '')
+    integration.remoteEntry = raw.endsWith('.js') ? raw : `${raw}/remoteEntry.js`
     integration.scope = row.scope
     integration.module = row.module
   } else {


### PR DESCRIPTION
## Summary

- `rowToRegistryApp()` in `backend/src/routes/appRegistry.ts` assumed `remote_url` was a base directory and unconditionally appended `/remoteEntry.js` to it.
- The applications service stores `manifest.integration.remoteEntry` (the **full** entry URL, e.g. `https://fuzeservice.prod.fuzefront.com/assets/remoteEntry.js`) in the `remote_url` column.
- The concatenation produced a doubled path: `…/assets/remoteEntry.js/remoteEntry.js`, causing a 404 on every MFE remote-entry fetch and breaking all federated app loads.

**Fix:** skip the `/remoteEntry.js` append when `remote_url` already ends with `.js` (i.e. it is already a complete entry URL). Legacy rows that stored a bare base directory (no `.js` suffix) continue to get the suffix appended as before.

## Test plan

- [ ] Load any federated app (Clock, FuzeAgent, FuzeService, etc.) in the portal — confirm it loads instead of hitting a 404 on `…/remoteEntry.js/remoteEntry.js`
- [ ] Verify legacy apps that stored a bare base URL in `remote_url` (no `.js` suffix) still have `/remoteEntry.js` appended correctly

---
_Generated by [Claude Code](https://claude.ai/code/session_01FF5XkWUVEGTDayUkALsH7j)_