### PR TITLE
feat(fuzequality): derive scenario-specific API coverage

### DIFF
--- a/FuzeQuality/packages/core/src/coverage.ts
+++ b/FuzeQuality/packages/core/src/coverage.ts
@@ -16,6 +16,7 @@ function matchingEvidence(subject: ApiOperation | FrontendSurface, tests: TestCa
       ? [subject.operationId, subject.path, `${subject.method} ${subject.path}`]
       : [subject.name, subject.routePath, subject.sourcePath]
   return tests.filter(test =>
+    test.assertionCount > 0 &&
     tokens
       .filter((token): token is string => Boolean(token))
       .some(token =>
@@ -24,6 +25,33 @@ function matchingEvidence(subject: ApiOperation | FrontendSurface, tests: TestCa
           .includes(token.toLowerCase())
       )
   )
+}
+
+function scenarioEvidence(
+  tests: TestCase[],
+  keywords: string[],
+  options: { all?: boolean } = {}
+) {
+  const normalized = keywords.map(keyword => keyword.toLowerCase())
+  return tests
+    .filter(test => {
+      const text = `${test.title} ${test.targets.join(' ')}`.toLowerCase()
+      return options.all
+        ? normalized.every(keyword => text.includes(keyword))
+        : normalized.some(keyword => text.includes(keyword))
+    })
+    .map(test => test.id)
+}
+
+function qualifiedScenarioEvidence(tests: TestCase[], qualifier: string, keywords: string[]) {
+  const normalizedQualifier = qualifier.toLowerCase()
+  const normalizedKeywords = keywords.filter(Boolean).map(keyword => keyword.toLowerCase())
+  return tests
+    .filter(test => {
+      const text = `${test.title} ${test.targets.join(' ')}`.toLowerCase()
+      return text.includes(normalizedQualifier) && normalizedKeywords.some(keyword => text.includes(keyword))
+    })
+    .map(test => test.id)
 }
 
 function expectation(
@@ -49,7 +77,8 @@ function expectation(
 }
 
 export function buildApiExpectations(operation: ApiOperation, tests: TestCase[]) {
-  const evidence = matchingEvidence(operation, tests).map(test => test.id)
+  const matchedTests = matchingEvidence(operation, tests)
+  const evidence = matchedTests.map(test => test.id)
   const result = [
     expectation(
       'api-operation',
@@ -69,7 +98,7 @@ export function buildApiExpectations(operation: ApiOperation, tests: TestCase[])
         'authentication-missing',
         'Missing authentication is rejected',
         'api.security.authentication',
-        evidence
+        scenarioEvidence(matchedTests, ['unauthenticated', 'missing auth', 'without auth', '401'])
       ),
       expectation(
         'api-operation',
@@ -77,7 +106,7 @@ export function buildApiExpectations(operation: ApiOperation, tests: TestCase[])
         'authorization',
         'Insufficient privileges are rejected',
         'api.security.authorization',
-        evidence,
+        scenarioEvidence(matchedTests, ['unauthorized', 'forbidden', 'insufficient privilege', '403']),
         'recommended'
       )
     )
@@ -91,9 +120,35 @@ export function buildApiExpectations(operation: ApiOperation, tests: TestCase[])
         `missing-${parameter.location}-${parameter.name}`,
         `Required ${parameter.location} parameter “${parameter.name}” is validated`,
         'api.parameter.required',
-        evidence
+        scenarioEvidence(matchedTests, [parameter.name, 'missing'], { all: true })
       )
     )
+
+
+    const schema = parameter.schema ?? {}
+    const boundaryRules: Array<[string, string, string[]]> = [
+      ['minimum', 'minimum boundary', ['minimum', 'below minimum', 'too small']],
+      ['maximum', 'maximum boundary', ['maximum', 'above maximum', 'too large']],
+      ['minLength', 'minimum length boundary', ['minimum length', 'too short']],
+      ['maxLength', 'maximum length boundary', ['maximum length', 'too long']],
+      ['pattern', 'pattern constraint', ['pattern', 'invalid format']],
+      ['enum', 'allowed-value constraint', ['enum', 'unsupported value', 'invalid value']],
+      ['format', `${String(schema.format ?? 'declared')} format`, ['format', String(schema.format ?? '')]],
+    ]
+    for (const [keyword, label, evidenceKeywords] of boundaryRules) {
+      if (!(keyword in schema)) continue
+      result.push(
+        expectation(
+          'api-operation',
+          operation.id,
+          `parameter-${parameter.location}-${parameter.name}-${keyword.toLowerCase()}`,
+          `${parameter.name} enforces its ${label}`,
+          `api.parameter.${keyword}`,
+          qualifiedScenarioEvidence(matchedTests, parameter.name, evidenceKeywords),
+          'recommended'
+        )
+      )
+    }
   }
 
   const hasIdentifier = /\{[^}]*id[^}]*\}/i.test(operation.path)
@@ -105,7 +160,7 @@ export function buildApiExpectations(operation: ApiOperation, tests: TestCase[])
         'resource-not-found',
         'Unknown resource identifier returns a controlled response',
         'api.resource.not-found',
-        evidence,
+        scenarioEvidence(matchedTests, ['not found', 'unknown id', 'missing resource', '404']),
         'recommended'
       )
     )
@@ -119,8 +174,24 @@ export function buildApiExpectations(operation: ApiOperation, tests: TestCase[])
         'invalid-content-type',
         'Unsupported request content type is rejected',
         'api.content-type.invalid',
-        evidence,
+        scenarioEvidence(matchedTests, ['content type', '415', 'unsupported media']),
         'recommended'
+      )
+    )
+  }
+
+
+  for (const response of operation.responses) {
+    const successful = /^2\d\d$/.test(response)
+    result.push(
+      expectation(
+        'api-operation',
+        operation.id,
+        `response-${response}`,
+        `Declared ${response} response is asserted`,
+        successful ? 'api.response.success' : 'api.response.error',
+        scenarioEvidence(matchedTests, [response, `status ${response}`]),
+        successful ? 'required' : 'recommended'
       )
     )
   }

--- a/FuzeQuality/packages/scanner/src/scanner.test.ts
+++ b/FuzeQuality/packages/scanner/src/scanner.test.ts
@@ -35,7 +35,7 @@ paths:
       operationId: getUser
       security: [{ bearerAuth: [] }]
       parameters:
-        - { name: id, in: path, required: true, schema: { type: string } }
+        - { name: id, in: path, required: true, schema: { type: string, minLength: 4, pattern: '^[a-z0-9]+$' } }
       responses: { '200': { description: ok }, '404': { description: missing } }
 `
     )
@@ -55,6 +55,43 @@ paths:
     expect(result.surfaces.some(surface => surface.name === 'UserPage')).toBe(true)
     expect(result.tests.some(test => test.framework === 'supertest')).toBe(true)
     expect(result.expectations.some(item => item.kind === 'authentication-missing')).toBe(true)
+    expect(result.expectations.find(item => item.kind === 'happy-path')?.coverage).toBe('covered-explicit')
+    expect(result.expectations.find(item => item.kind === 'authentication-missing')?.coverage).toBe('gap')
+    expect(result.expectations.find(item => item.kind === 'missing-path-id')?.coverage).toBe('gap')
+    expect(result.expectations.some(item => item.kind === 'parameter-path-id-minlength')).toBe(true)
+    expect(result.expectations.some(item => item.kind === 'parameter-path-id-pattern')).toBe(true)
+    expect(result.expectations.find(item => item.kind === 'response-200')?.coverage).toBe('gap')
+  })
+
+  it('credits scenario coverage only to assertion-bearing tests that name the scenario', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'fuzequality-evidence-'))
+    await mkdir(join(root, 'tests'), { recursive: true })
+    await writeFile(
+      join(root, 'openapi.yaml'),
+      `openapi: 3.0.0
+info: { title: Sample, version: 1.0.0 }
+paths:
+  /users/{id}:
+    get:
+      operationId: getUser
+      security: [{ bearerAuth: [] }]
+      parameters:
+        - { name: id, in: path, required: true, schema: { type: string } }
+      responses: { '200': { description: ok }, '401': { description: unauthenticated }, '404': { description: missing } }
+`
+    )
+    await writeFile(
+      join(root, 'tests', 'users.test.ts'),
+      `test('getUser returns status 200', () => { expect(true).toBe(true) })
+       test('getUser rejects missing auth with 401', () => { expect(true).toBe(true) })
+       test('getUser handles 404 not found', () => { expect(true).toBe(true) })`
+    )
+
+    const result = await scanRepository(repository, root)
+    expect(result.expectations.find(item => item.kind === 'authentication-missing')?.coverage).toBe('covered-explicit')
+    expect(result.expectations.find(item => item.kind === 'response-200')?.coverage).toBe('covered-explicit')
+    expect(result.expectations.find(item => item.kind === 'response-404')?.coverage).toBe('covered-explicit')
+    expect(result.expectations.find(item => item.kind === 'missing-path-id')?.coverage).toBe('gap')
   })
 
   it('rejects credentials embedded in repository URLs', () => {


### PR DESCRIPTION
## Summary
- require assertion-bearing tests for executable coverage evidence
- keep authentication, authorization, missing-field, not-found, and content-type evidence scenario-specific
- derive boundary expectations from minimum/maximum/length/pattern/enum/format constraints
- create explicit expectations for declared success and error responses
- add fixtures proving broad endpoint tests do not overstate negative-path coverage

## Validation
- Docker production build
- TypeScript type-check
- Vitest: 7 passed, 1 live integration skipped
- Vite production build
- git diff --check