### PR TITLE
feat(fuzequality): persist content-addressed scan diagnostics

### DIFF
--- a/FuzeQuality/db/migrations/002_scan_diagnostics.sql
+++ b/FuzeQuality/db/migrations/002_scan_diagnostics.sql
@@ -1,0 +1,15 @@
+CREATE TABLE IF NOT EXISTS fuzequality.scan_diagnostics (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  repository_id uuid NOT NULL REFERENCES fuzequality.repositories(id),
+  revision text NOT NULL,
+  source_path text NOT NULL,
+  category text NOT NULL,
+  severity text NOT NULL,
+  code text NOT NULL,
+  message text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (repository_id, revision, source_path, code)
+);
+
+CREATE INDEX IF NOT EXISTS idx_scan_diagnostics_repository
+  ON fuzequality.scan_diagnostics(repository_id, severity);

--- a/FuzeQuality/packages/contracts/src/index.ts
+++ b/FuzeQuality/packages/contracts/src/index.ts
@@ -150,6 +150,19 @@ export type Suggestion = {
   createdAt: string
 }
 
+export type ScanDiagnostic = {
+  sourcePath: string
+  category: 'openapi' | 'test' | 'frontend' | 'storybook'
+  severity: 'error' | 'warning'
+  code: string
+  message: string
+}
+
+export type CatalogScanDiagnostic = ScanDiagnostic & {
+  repositoryId: string
+  revision: string
+}
+
 export type ScanResult = {
   repository: Repository
   revision: string
@@ -158,6 +171,7 @@ export type ScanResult = {
   tests: TestCase[]
   expectations: TestExpectation[]
   findings: CatalogFinding[]
+  diagnostics: ScanDiagnostic[]
   scannedAt: string
 }
 
@@ -168,6 +182,7 @@ export type Portfolio = {
   tests: TestCase[]
   expectations: TestExpectation[]
   findings: CatalogFinding[]
+  diagnostics: CatalogScanDiagnostic[]
   requirements: Requirement[]
   flows: Flow[]
   suggestions: Suggestion[]

--- a/FuzeQuality/packages/core/src/store.ts
+++ b/FuzeQuality/packages/core/src/store.ts
@@ -28,6 +28,7 @@ const emptyPortfolio = (): Portfolio => ({
   tests: [],
   expectations: [],
   findings: [],
+  diagnostics: [],
   requirements: [],
   flows: [],
   suggestions: [],
@@ -94,6 +95,10 @@ export class MemoryCatalogStore implements CatalogStore {
       ...this.data.findings.filter(item => item.repositoryId !== result.repository.id),
       ...result.findings,
     ]
+    this.data.diagnostics = [
+      ...this.data.diagnostics.filter(item => item.repositoryId !== result.repository.id),
+      ...result.diagnostics.map(item => ({ ...item, repositoryId: result.repository.id, revision: result.revision })),
+    ]
   }
 
   async decideSuggestion(id: string, decision: 'confirm' | 'reject') {
@@ -128,13 +133,14 @@ export class PostgresCatalogStore implements CatalogStore {
   }
 
   async portfolio(): Promise<Portfolio> {
-    const [repositories, operations, surfaces, tests, expectations, findings, requirements, flows, steps, suggestions] = await Promise.all([
+    const [repositories, operations, surfaces, tests, expectations, findings, diagnostics, requirements, flows, steps, suggestions] = await Promise.all([
       this.pool.query('SELECT * FROM fuzequality.repositories WHERE enabled = true ORDER BY name'),
       this.pool.query('SELECT * FROM fuzequality.api_operations WHERE active = true ORDER BY path, method'),
       this.pool.query('SELECT * FROM fuzequality.frontend_surfaces WHERE active = true ORDER BY package_name, name'),
       this.pool.query('SELECT * FROM fuzequality.test_cases WHERE active = true ORDER BY source_path, title'),
       this.pool.query('SELECT * FROM fuzequality.test_expectations WHERE active = true ORDER BY subject_id, kind'),
       this.pool.query('SELECT * FROM fuzequality.findings ORDER BY severity, title'),
+      this.pool.query('SELECT * FROM fuzequality.scan_diagnostics ORDER BY source_path, code'),
       this.pool.query('SELECT * FROM fuzequality.requirements WHERE active = true ORDER BY jira_key'),
       this.pool.query('SELECT * FROM fuzequality.flows WHERE status <> \'rejected\' ORDER BY updated_at DESC'),
       this.pool.query('SELECT * FROM fuzequality.flow_steps ORDER BY flow_id, position'),
@@ -162,6 +168,7 @@ export class PostgresCatalogStore implements CatalogStore {
       tests: tests.rows.map(row => ({ id: row.id, repositoryId: row.repository_id, framework: row.framework, level: row.test_level, title: row.title, sourcePath: row.source_path, assertionCount: row.assertion_count, targets: row.targets })),
       expectations: expectations.rows.map(row => ({ id: row.id, subjectType: row.subject_type, subjectId: row.subject_id, kind: row.kind, label: row.label, priority: row.priority, rule: row.rule, coverage: row.coverage, evidenceIds: row.evidence_ids })),
       findings: findings.rows.map(row => ({ id: row.id, repositoryId: row.repository_id ?? undefined, subjectId: row.subject_id ?? undefined, type: row.type, severity: row.severity, title: row.title, detail: row.detail, status: row.status })),
+      diagnostics: diagnostics.rows.map(row => ({ repositoryId: row.repository_id, revision: row.revision, sourcePath: row.source_path, category: row.category, severity: row.severity, code: row.code, message: row.message })),
       requirements: requirements.rows.map(row => ({ id: row.id, jiraKey: row.jira_key, issueType: row.issue_type, parentKey: row.parent_key ?? undefined, summary: row.summary, description: row.normalized_description, status: row.status, project: row.project, updatedAt: row.source_updated_at.toISOString() })),
       flows: flows.rows.map(row => ({ id: row.id, requirementId: row.requirement_id, title: row.title, owner: row.owner ?? undefined, origin: row.origin, status: row.status, steps: steps.rows.filter(step => step.flow_id === row.id).map(step => ({ id: step.id, position: step.position, actor: step.actor, action: step.action, expectedOutcome: step.expected_outcome, variant: step.variant, targetIds: step.target_ids })) })),
       suggestions: suggestions.rows.map(row => ({ id: row.id, requirementId: row.requirement_id, type: row.type, title: row.title, confidence: Number(row.confidence), evidence: row.evidence, payload: row.payload, state: row.state, createdAt: row.created_at.toISOString() })),
@@ -201,6 +208,8 @@ export class PostgresCatalogStore implements CatalogStore {
       for (const item of result.expectations) await client.query(`INSERT INTO fuzequality.test_expectations (id,subject_type,subject_id,kind,label,priority,rule,coverage,evidence_ids) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9) ON CONFLICT (id) DO UPDATE SET label=EXCLUDED.label,priority=EXCLUDED.priority,rule=EXCLUDED.rule,coverage=EXCLUDED.coverage,evidence_ids=EXCLUDED.evidence_ids,active=true,updated_at=now()`, [item.id,item.subjectType,item.subjectId,item.kind,item.label,item.priority,item.rule,item.coverage,JSON.stringify(item.evidenceIds)])
       await client.query('DELETE FROM fuzequality.findings WHERE repository_id=$1', [result.repository.id])
       for (const item of result.findings) await client.query(`INSERT INTO fuzequality.findings (id,repository_id,subject_id,type,severity,title,detail,status) VALUES ($1,$2,$3,$4,$5,$6,$7,$8)`, [item.id,item.repositoryId,item.subjectId,item.type,item.severity,item.title,item.detail,item.status])
+      await client.query('DELETE FROM fuzequality.scan_diagnostics WHERE repository_id=$1', [result.repository.id])
+      for (const item of result.diagnostics) await client.query(`INSERT INTO fuzequality.scan_diagnostics (repository_id,revision,source_path,category,severity,code,message) VALUES ($1,$2,$3,$4,$5,$6,$7)`, [result.repository.id,result.revision,item.sourcePath,item.category,item.severity,item.code,item.message])
       await client.query('UPDATE fuzequality.repositories SET last_scan_status=\'complete\',last_scan_at=$2,updated_at=now() WHERE id=$1', [result.repository.id,result.scannedAt])
       await client.query('COMMIT')
     } catch (error) { await client.query('ROLLBACK'); throw error } finally { client.release() }
@@ -330,6 +339,7 @@ export function demoPortfolio(): Partial<Portfolio> {
     tests,
     expectations,
     findings: buildFindings(repositoryId, operations, surfaces, expectations),
+    diagnostics: [],
     requirements: [
       {
         id: 'req-fuze-142',

--- a/FuzeQuality/packages/scanner/src/index.ts
+++ b/FuzeQuality/packages/scanner/src/index.ts
@@ -7,6 +7,7 @@ import type {
   ApiOperation,
   FrontendSurface,
   Repository,
+  ScanDiagnostic,
   ScanResult,
   TestCase,
 } from '@fuzequality/contracts'
@@ -18,6 +19,8 @@ import {
 
 const digest = (...parts: string[]) =>
   createHash('sha256').update(parts.join('\u0000')).digest('hex').slice(0, 24)
+
+const fingerprint = (content: string) => createHash('sha256').update(content).digest('hex')
 
 const normalize = (path: string) => path.split(sep).join('/')
 
@@ -203,11 +206,22 @@ async function scanFrontend(
 ) {
   const packageFiles = await fg('**/package.json', { cwd: root, ignore })
   const surfaces: FrontendSurface[] = []
+  const fingerprints: string[] = []
+  const diagnostics: ScanDiagnostic[] = []
   for (const packageFile of packageFiles) {
     let packageJson: Record<string, unknown>
     try {
-      packageJson = JSON.parse(await readText(root, packageFile))
-    } catch {
+      const packageContent = await readText(root, packageFile)
+      fingerprints.push(`${normalize(packageFile)}:${fingerprint(packageContent)}`)
+      packageJson = JSON.parse(packageContent)
+    } catch (error) {
+      diagnostics.push({
+        sourcePath: normalize(packageFile),
+        category: 'frontend',
+        severity: 'error',
+        code: 'invalid-package-manifest',
+        message: error instanceof Error ? error.message : String(error),
+      })
       continue
     }
     const packageRoot = normalize(packageFile.replace(/\/?package\.json$/, ''))
@@ -217,7 +231,20 @@ async function scanFrontend(
       ignore,
     })
     for (const file of sourceFiles) {
-      const source = await readText(root, file)
+      let source: string
+      try {
+        source = await readText(root, file)
+        fingerprints.push(`${normalize(file)}:${fingerprint(source)}`)
+      } catch (error) {
+        diagnostics.push({
+          sourcePath: normalize(file),
+          category: 'frontend',
+          severity: 'error',
+          code: 'unreadable-source',
+          message: error instanceof Error ? error.message : String(error),
+        })
+        continue
+      }
       const routeMatches = [
         ...source.matchAll(/(?:path|to)\s*[=:]\s*['"]([^'"]+)['"]/g),
       ]
@@ -259,7 +286,11 @@ async function scanFrontend(
       }
     }
   }
-  return [...new Map(surfaces.map(surface => [surface.id, surface])).values()]
+  return {
+    surfaces: [...new Map(surfaces.map(surface => [surface.id, surface])).values()],
+    fingerprints,
+    diagnostics,
+  }
 }
 
 export async function scanRepository(repository: Repository, rootPath: string): Promise<ScanResult> {
@@ -280,24 +311,60 @@ export async function scanRepository(repository: Repository, rootPath: string): 
   )
 
   const operations: ApiOperation[] = []
+  const diagnostics: ScanDiagnostic[] = []
+  const contentFingerprints: string[] = []
   for (const file of openApiFiles) {
     try {
-      operations.push(...parseOpenApi(repository, file, await readText(root, file)))
-    } catch {
-      // Invalid specifications become visible through a scan-run diagnostic in the API.
+      const content = await readText(root, file)
+      contentFingerprints.push(`${normalize(file)}:${fingerprint(content)}`)
+      operations.push(...parseOpenApi(repository, file, content))
+    } catch (error) {
+      diagnostics.push({
+        sourcePath: normalize(file),
+        category: 'openapi',
+        severity: 'error',
+        code: 'invalid-openapi-document',
+        message: error instanceof Error ? error.message : String(error),
+      })
     }
   }
 
   const tests: TestCase[] = []
   for (const file of testFiles) {
     try {
-      tests.push(...extractTests(repository, normalize(file), await readText(root, file)))
-    } catch {
-      // A single unreadable test file must not abort repository inventory.
+      const content = await readText(root, file)
+      contentFingerprints.push(`${normalize(file)}:${fingerprint(content)}`)
+      tests.push(...extractTests(repository, normalize(file), content))
+    } catch (error) {
+      diagnostics.push({
+        sourcePath: normalize(file),
+        category: 'test',
+        severity: 'error',
+        code: 'unreadable-test-source',
+        message: error instanceof Error ? error.message : String(error),
+      })
     }
   }
 
-  const surfaces = await scanFrontend(root, repository, ignore, storyFiles)
+  for (const file of storyFiles) {
+    try {
+      const content = await readText(root, file)
+      contentFingerprints.push(`${normalize(file)}:${fingerprint(content)}`)
+    } catch (error) {
+      diagnostics.push({
+        sourcePath: normalize(file),
+        category: 'storybook',
+        severity: 'error',
+        code: 'unreadable-story',
+        message: error instanceof Error ? error.message : String(error),
+      })
+    }
+  }
+
+  const frontend = await scanFrontend(root, repository, ignore, storyFiles)
+  const surfaces = frontend.surfaces
+  contentFingerprints.push(...frontend.fingerprints)
+  diagnostics.push(...frontend.diagnostics)
   const expectations = [
     ...operations.flatMap(operation => buildApiExpectations(operation, tests)),
     ...surfaces.flatMap(surface => buildFrontendExpectations(surface, tests)),
@@ -305,9 +372,7 @@ export async function scanRepository(repository: Repository, rootPath: string): 
   const findings = buildFindings(repository.id, operations, surfaces, expectations)
   const revision = digest(
     repository.name,
-    ...openApiFiles.sort(),
-    ...testFiles.sort(),
-    ...[...storyFiles].sort()
+    ...contentFingerprints.sort()
   )
 
   return {
@@ -318,6 +383,7 @@ export async function scanRepository(repository: Repository, rootPath: string): 
     tests,
     expectations,
     findings,
+    diagnostics,
     scannedAt: new Date().toISOString(),
   }
 }

--- a/FuzeQuality/packages/scanner/src/scanner.test.ts
+++ b/FuzeQuality/packages/scanner/src/scanner.test.ts
@@ -98,4 +98,29 @@ paths:
     expect(isCredentialFreeRepositoryUrl('https://github.com/fuze/sample')).toBe(true)
     expect(isCredentialFreeRepositoryUrl('https://token@github.com/fuze/sample')).toBe(false)
   })
+
+  it('changes the revision when inventory content changes without renaming files', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'fuzequality-revision-'))
+    const spec = join(root, 'openapi.yaml')
+    await writeFile(spec, `openapi: 3.0.0\ninfo: { title: Sample, version: 1.0.0 }\npaths: {}`)
+    const first = await scanRepository(repository, root)
+    await writeFile(spec, `openapi: 3.0.0\ninfo: { title: Sample, version: 1.0.1 }\npaths: {}`)
+    const second = await scanRepository(repository, root)
+    expect(second.revision).not.toBe(first.revision)
+  })
+
+  it('reports malformed OpenAPI documents without aborting the repository scan', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'fuzequality-diagnostic-'))
+    await writeFile(join(root, 'openapi.yaml'), 'openapi: [not valid')
+    const result = await scanRepository(repository, root)
+    expect(result.operations).toHaveLength(0)
+    expect(result.diagnostics).toEqual([
+      expect.objectContaining({
+        sourcePath: 'openapi.yaml',
+        category: 'openapi',
+        severity: 'error',
+        code: 'invalid-openapi-document',
+      }),
+    ])
+  })
 })


### PR DESCRIPTION
## Summary
- derive scan revisions from inventory file contents rather than filenames
- change revisions when OpenAPI, tests, packages, frontend sources, or stories change
- report malformed/unreadable source files as structured diagnostics without aborting other inventory
- persist current repository diagnostics in PostgreSQL with a forward-only migration
- include diagnostics in portfolio responses

## Validation
- Docker production build
- TypeScript type-check
- Vitest: 9 passed, 1 live integration skipped
- Vite production build
- git diff --check