### PR TITLE
feat(security): public email-availability endpoint for signup

### DIFF
--- a/backend/security/src/providers/IdentityProvider.ts
+++ b/backend/security/src/providers/IdentityProvider.ts
@@ -292,6 +292,14 @@ export interface IdentityProvider {
   /** Server-brokered account creation. Rejects with CONFLICT if the email exists. */
   signup(input: SignupInput, ctx?: SessionContext): Promise<BrokeredSession>;
 
+  /**
+   * True when an account already exists for `email` (case-insensitive) — the
+   * SAME source of truth `signup` consults to reject a duplicate. Powers the
+   * public inline availability check; never mints a session or reveals anything
+   * beyond a boolean. `email` is expected pre-normalized (trimmed + lowercased).
+   */
+  emailExists(email: string): Promise<boolean>;
+
   /** Normalized identity + user for a presented session token ("me"). */
   getUserInfo(token: string): Promise<{ identity: NormalizedIdentity; user: BrokeredUser }>;
 

--- a/backend/security/src/providers/authentik/AuthentikIdentityProvider.ts
+++ b/backend/security/src/providers/authentik/AuthentikIdentityProvider.ts
@@ -603,6 +603,21 @@ export class AuthentikIdentityProvider implements IdentityProvider {
   }
 
   /**
+   * Existence check against the SAME source of truth `signup` consults — the
+   * synced `users` projection (see signup's fast-path conflict at :569). Matched
+   * case-insensitively so a differently-cased address resolves to the same
+   * account. Returns only a boolean; it never loads or leaks the account row.
+   */
+  async emailExists(email: string): Promise<boolean> {
+    const normalized = (email ?? '').trim().toLowerCase()
+    if (!normalized) return false
+    const existing = await this.db('users')
+      .whereRaw('LOWER(email) = ?', [normalized])
+      .first()
+    return !!existing
+  }
+
+  /**
    * Internal variant of startEmailVerification keyed by a known user id (used at
    * signup, before any bearer exists). Honours the same degrade gate.
    */

--- a/backend/security/src/routes/security.ts
+++ b/backend/security/src/routes/security.ts
@@ -10,6 +10,7 @@
  * are intentionally not implemented in this AuthN slice.
  */
 import express, { Request, Response } from 'express'
+import rateLimit from 'express-rate-limit'
 import { getIdentityProvider } from '../providers/factory'
 import {
   MfaRequiredError,
@@ -27,6 +28,29 @@ import type {
 } from '../providers/IdentityProvider'
 
 const router = express.Router()
+
+// ── Public email-availability rate limiter ───────────────────────────────────
+//
+// `/email-available` intentionally reveals whether an email is already
+// registered — product wants inline "available / already registered" feedback
+// on the signup form, which is impossible without disclosing existence. That
+// makes the endpoint an enumeration oracle by design, so per-IP rate limiting
+// is the deliberate mitigation: it keeps the interactive signup use fluid while
+// making bulk address harvesting impractical. 20 requests / minute / IP.
+// `req.ip` honours the service's `trust proxy` setting (see index.ts) so the
+// key is the real client behind the ingress, not the ingress hop.
+const emailAvailableRateLimiter = rateLimit({
+  windowMs: 60_000,
+  limit: 20,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { error: 'Too many requests, please try again later', code: 'RATE_LIMITED' },
+})
+
+// RFC-5322-lite: one @, no whitespace, a dotted domain. Deliberately simple —
+// the goal is to reject obvious garbage (400), not to fully validate deliver-
+// ability (that is the verification flow's job).
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
 function bearer(req: Request): string | null {
@@ -317,6 +341,29 @@ router.post('/signup', async (req: Request, res: Response) => {
       sessionContext(req)
     )
     res.status(201).json({ token: session.token, sessionId: session.sessionId, user: toApiUser(session.user) })
+  } catch (err) {
+    sendError(res, err)
+  }
+})
+
+// ── Public email availability ─────────────────────────────────────────────
+// GET /v1/security/email-available?email=<addr>
+//
+// Real-time signup feedback: is this email free to register? Checks the SAME
+// source of truth signup consults (`emailExists`), so the answer can never
+// disagree with what signup itself would do. Normalizes (trim + lowercase)
+// before checking and echoes the normalized address back. Rate-limited above —
+// the enumeration exposure is an accepted product tradeoff, not an oversight.
+router.get('/email-available', emailAvailableRateLimiter, async (req: Request, res: Response) => {
+  const raw = typeof req.query.email === 'string' ? req.query.email : ''
+  const email = raw.trim().toLowerCase()
+  if (!email || !EMAIL_RE.test(email)) {
+    res.status(400).json({ error: 'A valid email is required', code: 'MALFORMED' })
+    return
+  }
+  try {
+    const exists = await getIdentityProvider().emailExists(email)
+    res.status(200).json({ available: !exists, email })
   } catch (err) {
     sendError(res, err)
   }

--- a/backend/security/tests/email-available.test.ts
+++ b/backend/security/tests/email-available.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Unit tests for GET /api/v1/security/email-available.
+ *
+ * The public inline signup-availability check. Tested against a FAKE
+ * `IdentityProvider` injected via `setIdentityProvider`, so these assert the
+ * HTTP contract (normalization, validation, the { available, email } envelope,
+ * and the per-IP rate-limit guard) independent of the concrete provider.
+ */
+import express from 'express'
+import request from 'supertest'
+import securityRouter from '../src/routes/security'
+import { setIdentityProvider } from '../src/providers/factory'
+import type { IdentityProvider } from '../src/providers/IdentityProvider'
+
+function fakeProvider(exists: boolean | ((email: string) => boolean)): IdentityProvider {
+  const emailExists = jest.fn(async (email: string) =>
+    typeof exists === 'function' ? exists(email) : exists
+  )
+  return { emailExists } as unknown as IdentityProvider
+}
+
+function makeApp(p: IdentityProvider) {
+  setIdentityProvider(p)
+  const app = express()
+  app.use(express.json())
+  app.use('/api/v1/security', securityRouter)
+  return app
+}
+
+afterEach(() => setIdentityProvider(null))
+
+describe('GET /email-available', () => {
+  it('200 { available:true } when no account exists', async () => {
+    const p = fakeProvider(false)
+    const res = await request(makeApp(p)).get('/api/v1/security/email-available?email=fresh@example.com')
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual({ available: true, email: 'fresh@example.com' })
+  })
+
+  it('200 { available:false } when an account already exists', async () => {
+    const p = fakeProvider(true)
+    const res = await request(makeApp(p)).get('/api/v1/security/email-available?email=taken@example.com')
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual({ available: false, email: 'taken@example.com' })
+  })
+
+  it('normalizes (trims + lowercases) before checking and echoes the normalized email', async () => {
+    const p = fakeProvider(false)
+    const res = await request(makeApp(p)).get(
+      `/api/v1/security/email-available?email=${encodeURIComponent('  Alice@Example.COM  ')}`
+    )
+    expect(res.status).toBe(200)
+    expect(res.body.email).toBe('alice@example.com')
+    expect(p.emailExists).toHaveBeenCalledWith('alice@example.com')
+  })
+
+  it('400 on a malformed email', async () => {
+    const p = fakeProvider(false)
+    const res = await request(makeApp(p)).get('/api/v1/security/email-available?email=not-an-email')
+    expect(res.status).toBe(400)
+    expect(res.body.code).toBe('MALFORMED')
+    expect(p.emailExists).not.toHaveBeenCalled()
+  })
+
+  it('400 when the email param is missing', async () => {
+    const p = fakeProvider(false)
+    const res = await request(makeApp(p)).get('/api/v1/security/email-available')
+    expect(res.status).toBe(400)
+    expect(res.body.code).toBe('MALFORMED')
+  })
+
+  it('429 once the per-IP rate limit is exceeded (enumeration guard)', async () => {
+    // Limit is 20/min/IP. supertest reuses one ephemeral client port per call,
+    // but req.ip resolves to the loopback address for all of them, so the 21st
+    // request within the window trips the limiter.
+    const app = makeApp(fakeProvider(false))
+    let sawRateLimit = false
+    for (let i = 0; i < 25; i++) {
+      const res = await request(app).get('/api/v1/security/email-available?email=loop@example.com')
+      if (res.status === 429) {
+        sawRateLimit = true
+        expect(res.body.code).toBe('RATE_LIMITED')
+        break
+      }
+    }
+    expect(sawRateLimit).toBe(true)
+  })
+})

--- a/backend/security/tests/security-api/mockIdentityProvider.ts
+++ b/backend/security/tests/security-api/mockIdentityProvider.ts
@@ -232,6 +232,10 @@ export class MockIdentityProvider implements IdentityProvider {
     return this.mint(u)
   }
 
+  async emailExists(email: string): Promise<boolean> {
+    return this.users.has((email ?? '').trim().toLowerCase())
+  }
+
   async getUserInfo(
     token: string
   ): Promise<{ identity: NormalizedIdentity; user: BrokeredUser }> {

--- a/packages/security/openapi.yaml
+++ b/packages/security/openapi.yaml
@@ -631,6 +631,52 @@ paths:
                 $ref: '#/components/schemas/AuthMethods'
       x-pagination: exempt
       x-pagination-reason: Singleton capability descriptor.
+  # ────────────────────────── AuthN: email availability ─────────────────────
+  /v1/security/email-available:
+    get:
+      tags: [signup]
+      summary: Check whether an email is available to register
+      operationId: getEmailAvailable
+      description: >-
+        Public, unauthenticated inline check for the signup form: is this email
+        free to register? Consults the SAME source of truth `signup` uses to
+        reject a duplicate, so the answer cannot disagree with signup. The email
+        is normalized (trimmed + lowercased) before checking and echoed back.
+
+
+        This endpoint intentionally reveals whether an address is registered
+        (product requires inline "available / already registered" feedback), so
+        it is per-IP rate-limited (20/min/IP) as the deliberate mitigation for
+        the resulting enumeration exposure. Exceeding the limit returns 429.
+      parameters:
+        - name: email
+          in: query
+          required: true
+          description: The email address to check. Normalized (trim + lowercase) server-side.
+          schema:
+            type: string
+            format: email
+      responses:
+        '200':
+          description: Availability result.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EmailAvailability'
+        '400':
+          description: The email is missing or malformed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorBody'
+        '429':
+          description: Rate limit exceeded (per-IP enumeration guard).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorBody'
+      x-pagination: exempt
+      x-pagination-reason: Singleton boolean availability check.
   # ─────────────────────────────── AuthZ: checks ────────────────────────────
   /v1/security/authz/check:
     post:
@@ -1559,6 +1605,21 @@ components:
         user:
           $ref: '#/components/schemas/User'
       required: [identity, user]
+    EmailAvailability:
+      type: object
+      description: >-
+        Result of the public inline email-availability check. `available` is the
+        negation of "an account already exists"; `email` is the normalized
+        (trimmed + lowercased) address that was actually checked.
+      properties:
+        available:
+          type: boolean
+          description: True when no account exists for the email and it is free to register.
+        email:
+          type: string
+          format: email
+          description: The normalized address that was checked (echoed back).
+      required: [available, email]
     AuthMethods:
       type: object
       description: >-


### PR DESCRIPTION
## What
Adds a public, unauthenticated inline availability check to the **security** service so the signup form can show real-time "available / already registered" feedback.

`GET /api/v1/security/email-available?email=<addr>` → `200 { "available": boolean, "email": "<normalized>" }`

- `available:true` = no account with that email; `false` = one exists.
- 400 `{ error, code:"MALFORMED" }` on missing/malformed email.
- Email is normalized (trim + lowercase) before checking and echoed back.
- **Source of truth:** new `IdentityProvider.emailExists()` consults the SAME synced `users` projection that `signup` checks for a duplicate (case-insensitive `LOWER(email)`), so the answer can never disagree with signup. No second source invented.

## Abuse / enumeration hardening
This endpoint intentionally reveals whether an email is registered (product requires inline availability), so it is an enumeration oracle **by design**. Mitigation: per-IP rate limit (20/min/IP via `express-rate-limit`, keyed on `req.ip` which honours the service's `trust proxy`). 21st+ request in the window → `429 { code:"RATE_LIMITED" }`. A code comment documents the deliberate tradeoff.

## Contract-first
Added `GET /v1/security/email-available` + `EmailAvailability` schema to `packages/security/openapi.yaml` (frontend + product-designer reference this exact shape).

## Tests
Backend unit tests in `backend/security/tests/email-available.test.ts`: available, taken, normalization, malformed, missing, rate-limited(429). Injected via the `setIdentityProvider` fake seam.

> NOTE: local `npm install` could not complete in this worktree (Windows ENOTEMPTY on a killed prior install corrupting node_modules), so the unit suite was not run locally — CI runs it here.

## Out of scope (NOT done)
- Signup UI consuming this (frontend-engineer, in parallel).
- Independent contract/acceptance tests (test-engineer).
- Deploy image tag bump / Helm (devops-engineer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session-Id: f636c22e-1cd7-401e-8843-97e3e3a4ba01