### PR TITLE
feat(deploy): give Unleash its own Argo Application (hybrid-Argo)

### DIFF
--- a/deploy/argocd/applications/unleash.yaml
+++ b/deploy/argocd/applications/unleash.yaml
@@ -1,0 +1,31 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: unleash
+  namespace: argocd
+spec:
+  project: fuzefront
+  source:
+    repoURL: https://github.com/izzywdev/FuzeFront.git
+    targetRevision: master
+    path: deploy/helm/unleash
+    helm:
+      valueFiles:
+        - values-prod.yaml
+  destination:
+    server: https://kubernetes.default.svc
+    # Same namespace as the umbrella app — Unleash reads the umbrella chart's
+    # fuzefront-secrets (Postgres superuser password) and the existing
+    # unleash-secrets SealedSecret, both already living in `fuzefront`.
+    namespace: fuzefront
+  syncPolicy:
+    automated:
+      # Unleash itself is stateless (state lives in Postgres, not the pod) —
+      # safe to prune like the umbrella app. The bootstrap Job is a Helm hook
+      # with its own before-hook-creation,hook-succeeded delete-policy, so
+      # pruning here doesn't affect it.
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - PrunePropagationPolicy=foreground

--- a/deploy/helm/fuzefront/values-prod.yaml
+++ b/deploy/helm/fuzefront/values-prod.yaml
@@ -390,44 +390,12 @@ chatService:
                 operator: In
                 values: ["fuzefront-node-2"]
 
-# Unleash (self-hosted OSS feature flags). Synced by the UMBRELLA `fuzefront` Argo
-# Application (gated by unleash.enabled), NOT a separate Application: Unleash's
-# templates live in this umbrella chart, so a second Argo app on the same chart
-# path would DOUBLE-CLAIM the Unleash Deployment (same hybrid-Argo rule that keeps
-# billing in the umbrella). Isolation the hybrid model wants is still satisfied:
-# Unleash has its OWN per-service `unleash-secrets` SealedSecret + its own
-# `unleash_svc` DB role + a DEDICATED `unleash` database, so a pending/crashing
-# Unleash pod CANNOT take down other services or read their secrets.
-#
-# EXTERNAL image (unleashorg/unleash-server) — NOT built by release.yml, so its tag
-# is NOT auto-bumped by CI; bump it deliberately here in a deploy window.
-#
-# Unleash serves only once `unleash-secrets` holds UNLEASH_DB_PASSWORD,
-# INIT_ADMIN_API_TOKENS, UNLEASH_CLIENT_TOKEN (seal real values with
-# deploy/scripts/seal-secret.sh --scope fuzefront/unleash-secrets; placeholders are
-# committed in deploy/contabo/sealed/unleash-secrets.yaml). The unleash_svc role +
-# the `unleash` database are provisioned by the pre-install unleash-db-bootstrap
-# Job. Admin UI is NOT public (port-forward or a CF-Access-gated host only).
-# NEVER hand-deploy — a human flips `enabled` to true via GitOps in a deploy window.
-unleash:
-  # First-light: DISABLED. While false, NEITHER the Unleash Deployment NOR the
-  # pre-install unleash-db-bootstrap hook render — so Unleash adds ZERO freeze
-  # surface to the umbrella sync. GO-LIVE = flip this to true AND seal the real
-  # unleash-secrets keys.
-  enabled: false
-  image:
-    repository: unleashorg/unleash-server
-    tag: "5.12.0"
-  # Steer onto node-2 (keep flag-server load off the DB-heavy node-1).
-  affinity:
-    nodeAffinity:
-      preferredDuringSchedulingIgnoredDuringExecution:
-        - weight: 100
-          preference:
-            matchExpressions:
-              - key: kubernetes.io/hostname
-                operator: In
-                values: ["fuzefront-node-2"]
+# Unleash (self-hosted OSS feature flags) — MOVED to its own chart + Argo
+# Application: deploy/helm/unleash/values-prod.yaml +
+# deploy/argocd/applications/unleash.yaml. It is independently-lifecycled
+# (external image, own release cadence, family-wide flag server FuzeFront
+# hosts) per the hybrid-Argo rule, so it no longer renders from this umbrella
+# chart at all.
 
 # ── Cloudflare cache purge (prod) ────────────────────────────────────────────
 # Sealed for the Contabo k3s cluster; reseal per the template header if the

--- a/deploy/helm/fuzefront/values.yaml
+++ b/deploy/helm/fuzefront/values.yaml
@@ -479,67 +479,14 @@ litellm:
   tolerations: []
 
 # ---------------------------------------------------------------------------
-# Unleash — self-hosted OSS feature-flag server (issue #116, Deliverable 1).
-#
-# EXTERNAL upstream image (unleashorg/unleash-server) — NOT built by release.yml
-# and NOT in its build matrix. Pin a concrete tag below (never :latest).
-#
-# Gated by `unleash.enabled` (default false). When enabled, the umbrella chart
-# renders, in order:
-#   1. a pre-install/pre-upgrade bootstrap Job (unleash-db-bootstrap) that creates
-#      the least-privilege `unleash_svc` role + a DEDICATED `unleash` database it
-#      OWNS on the shared FuzeInfra Postgres (Unleash self-migrates its schema on
-#      boot as unleash_svc — that's why it must own the db).
-#   2. the Unleash Deployment + a cluster-internal Service `fuzefront-unleash`.
-#
-# Admin UI is NOT public: the Service is cluster-internal. Reach the admin UI via
-# `kubectl port-forward svc/fuzefront-unleash 4242:4242`, or (optionally) an
-# admin-gated host under the *.prod.fuzefront.com Cloudflare-Access zone — see
-# `unleash.ingress` below (default off; requires FuzeInfra to wire the CF host).
-#
-# Secrets live in the per-service `unleash-secrets` SealedSecret (keys:
-# UNLEASH_DB_PASSWORD, INIT_ADMIN_API_TOKENS, UNLEASH_CLIENT_TOKEN). Seal real
-# values with:  deploy/scripts/seal-secret.sh <KEY> --scope fuzefront/unleash-secrets
-# Placeholders are committed in deploy/contabo/sealed/unleash-secrets.yaml.
-#
-# Client connection (the @fuzefront/feature-flags package): the unleash API is at
-#   http://fuzefront-unleash.fuzefront.svc.cluster.local:4242/api
-# authenticated with the UNLEASH_CLIENT_TOKEN.
+# Unleash — self-hosted OSS feature-flag server (issue #116) — MOVED OUT of this
+# umbrella chart into its OWN chart + Argo Application: deploy/helm/unleash and
+# deploy/argocd/applications/unleash.yaml. Per the hybrid-Argo rule (CLAUDE.md),
+# an independently-lifecycled service (external image, own release cadence,
+# family-wide flag server hosted by FuzeFront) gets its own Application rather
+# than being folded into this umbrella. See that chart for the full config;
+# nothing here renders Unleash anymore.
 # ---------------------------------------------------------------------------
-unleash:
-  enabled: false
-  image:
-    repository: unleashorg/unleash-server
-    # Concrete, widely-published OSS tag (verified-available fallback per #116).
-    # Bump deliberately in a deploy window (external image — not auto-bumped by CI).
-    tag: "5.12.0"
-  port: 4242
-  replicas: 1
-  # Least-privilege DB role created by the unleash-db-bootstrap Job (NOT the shared
-  # fuzefront_user). Its password is UNLEASH_DB_PASSWORD in unleash-secrets.
-  dbUser: unleash_svc
-  # Dedicated database OWNED by unleash_svc (Unleash self-migrates into it).
-  dbName: unleash
-  # Per-service secret (unleash-only keys). Shared creds stay in fuzefront-secrets.
-  secretName: unleash-secrets
-  # Pre-install Job that creates the unleash_svc role + `unleash` database.
-  dbBootstrap:
-    enabled: true
-  # Unleash needs headroom for its Node runtime + in-memory flag cache.
-  resources:
-    requests: { cpu: 100m, memory: 256Mi }
-    limits:   { cpu: 500m, memory: 512Mi }
-  # OPTIONAL admin-gated ingress for the admin UI (default OFF). Requires the host
-  # to sit under the *.prod.fuzefront.com Cloudflare-Access zone; the CF tunnel
-  # rule + CNAME are FuzeInfra-owned (delegated). See the chart README.
-  ingress:
-    enabled: false
-    className: ""        # defaults to ingress.className when empty
-    host: ""             # e.g. unleash.prod.fuzefront.com (CF-Access gated)
-    annotations: {}
-  nodeSelector: {}
-  affinity: {}
-  tolerations: []
 
 authentik:
   enabled: true

--- a/deploy/helm/unleash/Chart.yaml
+++ b/deploy/helm/unleash/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v2
+name: unleash
+description: >-
+  Self-hosted Unleash (feature-flag) server for the Fuze family. FuzeFront
+  HOSTS this deployment per the family flag-service standard; it is
+  independently-lifecycled from the fuzefront umbrella chart (own release
+  cadence, own external image, own Argo Application) even though it runs in
+  the `fuzefront` namespace and shares the fuzeinfra-postgres instance.
+type: application
+version: 0.1.0
+appVersion: "5.12.0"

--- a/deploy/helm/unleash/templates/_helpers.tpl
+++ b/deploy/helm/unleash/templates/_helpers.tpl
@@ -1,0 +1,48 @@
+{{/* Common labels. */}}
+{{- define "unleash.labels" -}}
+app.kubernetes.io/part-of: fuzefront
+app.kubernetes.io/name: unleash
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version }}
+{{- end -}}
+
+{{/*
+Pod scheduling block (nodeSelector + affinity + tolerations).
+Usage:  {{- include "unleash.scheduling" (dict "svc" .Values.unleash "root" .) | nindent 6 }}
+Falls back to the global placement defaults when the service sets nothing.
+Renders nothing when neither specifies placement.
+*/}}
+{{- define "unleash.scheduling" -}}
+{{- $svc := .svc | default dict -}}
+{{- $g := .root.Values.global.scheduling | default dict -}}
+{{- $nodeSelector := $svc.nodeSelector | default $g.nodeSelector -}}
+{{- $affinity := $svc.affinity | default $g.affinity -}}
+{{- $tolerations := $svc.tolerations | default $g.tolerations -}}
+{{- with $nodeSelector }}
+nodeSelector:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- with $affinity }}
+affinity:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- with $tolerations }}
+tolerations:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Prometheus scrape annotations for a pod template.
+Usage:  {{- include "unleash.metricsAnnotations" (dict "port" .Values.unleash.port "root" .) | nindent 8 }}
+Renders nothing when observability.metrics.enabled is false.
+*/}}
+{{- define "unleash.metricsAnnotations" -}}
+{{- $obs := .root.Values.observability | default dict -}}
+{{- $m := $obs.metrics | default dict -}}
+{{- if $m.enabled -}}
+prometheus.io/scrape: "true"
+prometheus.io/port: {{ .port | quote }}
+prometheus.io/path: {{ .path | default $m.path | default "/metrics" | quote }}
+{{- end -}}
+{{- end -}}

--- a/deploy/helm/unleash/templates/unleash-db-bootstrap-job.yaml
+++ b/deploy/helm/unleash/templates/unleash-db-bootstrap-job.yaml
@@ -4,13 +4,15 @@ kind: Job
 metadata:
   name: fuzefront-unleash-db-bootstrap
   labels:
-    {{- include "fuzefront.labels" . | nindent 4 }}
+    {{- include "unleash.labels" . | nindent 4 }}
     app.kubernetes.io/component: unleash-db-bootstrap
   annotations:
     # Idempotent, privileged provisioning of the least-privilege unleash_svc role
     # and a DEDICATED `unleash` database it OWNS. Runs BEFORE the Unleash server
-    # starts (Unleash self-migrates its own schema on boot as unleash_svc). Runs as
-    # the FuzeInfra Postgres superuser — the only place that has CREATEROLE/CREATEDB.
+    # starts (Unleash self-migrates its own schema on boot as unleash_svc). Runs
+    # as the FuzeInfra Postgres superuser, whose password is read from the
+    # umbrella chart's existing `fuzefront-secrets` Secret in this namespace —
+    # NOT re-declared or re-sealed by this chart.
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-4"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
@@ -24,7 +26,7 @@ spec:
         app.kubernetes.io/component: unleash-db-bootstrap
     spec:
       restartPolicy: Never
-      {{- with .Values.imagePullSecrets }}
+      {{- with .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -36,13 +38,13 @@ spec:
             - |
               export PGPASSWORD="$DB_SUPERUSER_PASSWORD"
               # --- Step 1: role -----------------------------------------------------
-              # Connect to the superuser's MAINTENANCE db ($DB_NAME / postgres) to
-              # ensure the unleash_svc LOGIN role. The password is passed via a psql
-              # ':var' (plain SQL → psql substitutes), stashed into a session GUC, then
-              # read back inside the DO block via current_setting()+format(%L): psql
-              # ':var' interpolation does NOT work inside a dollar-quoted ($do$...$do$)
-              # body, so we must round-trip it through the GUC. (Same pattern as
-              # billing-db-bootstrap — copy it exactly.)
+              # Connect to the superuser's MAINTENANCE db to ensure the unleash_svc
+              # LOGIN role. The password is passed via a psql ':var' (plain SQL ->
+              # psql substitutes), stashed into a session GUC, then read back inside
+              # the DO block via current_setting()+format(%L): psql ':var'
+              # interpolation does NOT work inside a dollar-quoted ($do$...$do$)
+              # body, so we must round-trip it through the GUC. (Same pattern as the
+              # umbrella chart's billing/unleash bootstrap Jobs — copied exactly.)
               psql -h "$DB_HOST" -p "$DB_PORT" -U "$DB_SUPERUSER" -d "$DB_NAME" \
                 -v ON_ERROR_STOP=1 -v unleash_pw="$UNLEASH_DB_PASSWORD" <<'SQL'
               SET fuzefront.unleash_pw TO :'unleash_pw';
@@ -60,26 +62,25 @@ spec:
               # CREATE DATABASE cannot run inside a DO block / transaction and is not
               # idempotent, so guard it with the SELECT ... WHERE NOT EXISTS + \gexec
               # idiom (psql executes the generated statement only when the row is
-              # absent → no-op on pre-upgrade re-run). Connect to the maintenance db.
+              # absent -> no-op on pre-upgrade re-run). Connect to the maintenance db.
               psql -h "$DB_HOST" -p "$DB_PORT" -U "$DB_SUPERUSER" -d "$DB_NAME" \
                 -v ON_ERROR_STOP=1 <<'SQL'
               SELECT 'CREATE DATABASE unleash OWNER unleash_svc'
               WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'unleash')\gexec
               SQL
               # --- Step 3: privileges ----------------------------------------------
-              # unleash_svc OWNS the `unleash` database, so it can run ALL of Unleash's
-              # own migrations (CREATE TABLE/EXTENSION/etc.). Re-affirm full DB-level
-              # privileges + ownership of the public schema inside `unleash` so a
-              # pre-existing db (e.g. created by hand before this Job) is also correct.
-              # Idempotent and safe on pre-upgrade re-run.
+              # unleash_svc OWNS the `unleash` database, so it can run ALL of
+              # Unleash's own migrations (CREATE TABLE/EXTENSION/etc.). Re-affirm
+              # full DB-level privileges + ownership of the public schema inside
+              # `unleash` so a pre-existing db is also correct. Idempotent.
               psql -h "$DB_HOST" -p "$DB_PORT" -U "$DB_SUPERUSER" -d "$DB_NAME" \
                 -v ON_ERROR_STOP=1 <<'SQL'
               GRANT ALL PRIVILEGES ON DATABASE unleash TO unleash_svc;
               ALTER DATABASE unleash OWNER TO unleash_svc;
               SQL
               # Re-own the public schema INSIDE the unleash db (connect to it). On
-              # PG15 the public schema is no longer world-writable; making unleash_svc
-              # its owner lets Unleash create its tables there.
+              # PG15 the public schema is no longer world-writable; making
+              # unleash_svc its owner lets Unleash create its tables there.
               psql -h "$DB_HOST" -p "$DB_PORT" -U "$DB_SUPERUSER" -d "unleash" \
                 -v ON_ERROR_STOP=1 <<'SQL'
               ALTER SCHEMA public OWNER TO unleash_svc;
@@ -93,14 +94,18 @@ spec:
               value: {{ .Values.fuzeinfra.postgres.port | quote }}
             # Superuser maintenance DB (CREATE DATABASE / role ops connect here).
             - name: DB_NAME
-              value: {{ .Values.database.name | default "postgres" | quote }}
+              value: {{ .Values.unleash.dbBootstrap.superuser.maintenanceDb | default "postgres" | quote }}
             - name: DB_SUPERUSER
-              value: {{ .Values.database.bootstrap.superuser.username | quote }}
+              value: {{ .Values.unleash.dbBootstrap.superuser.username | quote }}
             - name: DB_SUPERUSER_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.database.bootstrap.superuser.secretName | default (include "fuzefront.secretName" .) }}
-                  key: {{ .Values.database.bootstrap.superuser.secretKey | quote }}
+                  # Cross-service reference: the umbrella `fuzefront` chart's
+                  # Secret (fuzefront-secrets) already holds the shared FuzeInfra
+                  # Postgres superuser password in this namespace. This chart does
+                  # NOT create or own that Secret — it only reads it.
+                  name: {{ .Values.unleash.dbBootstrap.superuser.secretName }}
+                  key: {{ .Values.unleash.dbBootstrap.superuser.secretKey }}
             # unleash_svc's own password — lives in the per-service unleash-secrets.
             - name: UNLEASH_DB_PASSWORD
               valueFrom:

--- a/deploy/helm/unleash/templates/unleash.yaml
+++ b/deploy/helm/unleash/templates/unleash.yaml
@@ -4,7 +4,7 @@ kind: Deployment
 metadata:
   name: fuzefront-unleash
   labels:
-    {{- include "fuzefront.labels" . | nindent 4 }}
+    {{- include "unleash.labels" . | nindent 4 }}
     app.kubernetes.io/component: unleash
 spec:
   replicas: {{ .Values.unleash.replicas }}
@@ -15,19 +15,20 @@ spec:
     metadata:
       labels:
         app: fuzefront-unleash
-        {{- include "fuzefront.labels" . | nindent 8 }}
+        {{- include "unleash.labels" . | nindent 8 }}
       annotations:
-        {{- include "fuzefront.metricsAnnotations" (dict "port" .Values.unleash.port "root" .) | nindent 8 }}
+        {{- include "unleash.metricsAnnotations" (dict "port" .Values.unleash.port "root" .) | nindent 8 }}
     spec:
-      {{- include "fuzefront.scheduling" (dict "svc" .Values.unleash "root" .) | nindent 6 }}
-      {{- with .Values.imagePullSecrets }}
+      {{- include "unleash.scheduling" (dict "svc" .Values.unleash "root" .) | nindent 6 }}
+      {{- with .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
         - name: unleash
-          # EXTERNAL upstream image (unleashorg/unleash-server) — NOT built by
-          # release.yml. Pinned to a concrete tag in values (never :latest).
+          # EXTERNAL upstream image (unleashorg/unleash-server) — independently
+          # lifecycled from FuzeFront's own release/CI image matrix. Pinned to a
+          # concrete tag in values (never :latest); bump deliberately.
           image: "{{ .Values.unleash.image.repository }}:{{ .Values.unleash.image.tag }}"
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
           ports:
@@ -46,8 +47,9 @@ spec:
             # DB connection: Unleash runs as the least-privilege unleash_svc role
             # which OWNS the dedicated `unleash` database (created by the
             # unleash-db-bootstrap Job) and self-migrates its schema on boot.
-            # UNLEASH_DB_PASSWORD comes from the per-service unleash-secrets Secret;
-            # assembled into DATABASE_URL via $(VAR) interpolation.
+            # UNLEASH_DB_PASSWORD comes from the per-service unleash-secrets
+            # Secret (already sealed in deploy/contabo/sealed/unleash-secrets.yaml
+            # — reused as-is); assembled into DATABASE_URL via $(VAR) interpolation.
             - name: UNLEASH_DB_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -56,16 +58,17 @@ spec:
             - name: DATABASE_URL
               value: "postgresql://{{ .Values.unleash.dbUser }}:$(UNLEASH_DB_PASSWORD)@{{ .Values.fuzeinfra.postgres.host }}:{{ .Values.fuzeinfra.postgres.port }}/{{ .Values.unleash.dbName }}"
             # Bootstrap tokens. Always rendered when Unleash is enabled — the
-            # per-service unleash-secrets SealedSecret provides these at runtime (the
-            # pod stays pending until the keys are sealed). No Helm-values gate.
+            # per-service unleash-secrets SealedSecret provides these at runtime
+            # (the pod stays pending until the keys are sealed). No Helm-values gate.
             # INIT_ADMIN_API_TOKENS: admin/bootstrap token (format `*:*.<hex>`).
             - name: INIT_ADMIN_API_TOKENS
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.unleash.secretName | default "unleash-secrets" }}
                   key: INIT_ADMIN_API_TOKENS
-            # INIT_CLIENT_API_TOKENS: the client/SDK token the @fuzefront/feature-flags
-            # package uses (format `default:development.<hex>` / `[project]:[env].<hex>`).
+            # INIT_CLIENT_API_TOKENS: the client/SDK token the
+            # @fuzefront/feature-flags package uses (format
+            # `default:development.<hex>` / `[project]:[env].<hex>`).
             - name: INIT_CLIENT_API_TOKENS
               valueFrom:
                 secretKeyRef:
@@ -92,11 +95,12 @@ kind: Service
 metadata:
   name: fuzefront-unleash
   labels:
-    {{- include "fuzefront.labels" . | nindent 4 }}
+    {{- include "unleash.labels" . | nindent 4 }}
     app.kubernetes.io/component: unleash
 spec:
-  # Cluster-internal ONLY. The admin UI is NOT publicly exposed (see README +
-  # the optional unleash.ingress stub). Clients connect to:
+  # Cluster-internal ONLY. The admin UI is NOT publicly exposed (see this
+  # chart's README + the optional unleash.ingress stub). Clients (and the
+  # @fuzefront/feature-flags package) connect to:
   #   http://fuzefront-unleash.fuzefront.svc.cluster.local:4242/api
   selector:
     app: fuzefront-unleash
@@ -109,14 +113,14 @@ spec:
 # This does NOT make Unleash public: the host MUST sit under the
 # *.prod.fuzefront.com Cloudflare-Access zone (admin Zero-Trust). The CF tunnel
 # ingress rule (<host> -> traefik.kube-system:80) + the proxied CNAME are
-# FuzeInfra-owned (Terraform) — this Ingress only host-matches once FuzeInfra has
-# wired that. See deploy/helm/fuzefront/README.md (Unleash admin access).
+# FuzeInfra-owned (Terraform) — this Ingress only host-matches once FuzeInfra
+# has wired that (delegated @claude item — NOT done by this chart).
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: fuzefront-unleash
   labels:
-    {{- include "fuzefront.labels" . | nindent 4 }}
+    {{- include "unleash.labels" . | nindent 4 }}
     app.kubernetes.io/component: unleash
   {{- with .Values.unleash.ingress.annotations }}
   annotations:

--- a/deploy/helm/unleash/values-prod.yaml
+++ b/deploy/helm/unleash/values-prod.yaml
@@ -1,0 +1,38 @@
+# Prod overlay for the standalone Unleash chart/Argo Application.
+#
+# Unleash serves only once `unleash-secrets` holds UNLEASH_DB_PASSWORD,
+# INIT_ADMIN_API_TOKENS, UNLEASH_CLIENT_TOKEN (already sealed and committed at
+# deploy/contabo/sealed/unleash-secrets.yaml, applied via the fuzefront-sealed
+# Argo Application — reused as-is, NOT re-sealed by this chart). The
+# unleash_svc role + the `unleash` database are provisioned by the pre-install
+# unleash-db-bootstrap Job, which reads the shared Postgres superuser password
+# from the umbrella chart's `fuzefront-secrets` Secret (same namespace).
+#
+# Admin UI is NOT public (port-forward, or a future CF-Access-gated host via
+# unleash.ingress — FuzeInfra-owned tunnel wiring, delegated).
+#
+# NEVER hand-deploy — a human flips `enabled` to true via GitOps in a deploy
+# window, after confirming unleash-secrets holds real (not placeholder) values.
+observability:
+  metrics:
+    enabled: true
+
+unleash:
+  # First-light: DISABLED. While false, neither the Unleash Deployment nor the
+  # pre-install unleash-db-bootstrap hook render, so Unleash adds ZERO sync
+  # surface to this Argo Application. GO-LIVE = flip this to true (after
+  # confirming the real unleash-secrets values are sealed).
+  enabled: false
+  image:
+    repository: unleashorg/unleash-server
+    tag: "5.12.0"
+  # Steer onto node-2 (keep flag-server load off the DB-heavy node-1).
+  affinity:
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          preference:
+            matchExpressions:
+              - key: kubernetes.io/hostname
+                operator: In
+                values: ["fuzefront-node-2"]

--- a/deploy/helm/unleash/values.yaml
+++ b/deploy/helm/unleash/values.yaml
@@ -1,0 +1,71 @@
+# Default (local/kind) values. Prod overrides live in values-prod.yaml.
+global:
+  imagePullPolicy: IfNotPresent
+  imagePullSecrets: []
+  # Default pod placement (per-service values below override these).
+  scheduling:
+    nodeSelector: {}
+    affinity: {}
+    tolerations: []
+
+observability:
+  metrics:
+    enabled: false
+    path: /metrics
+
+# Shared FuzeInfra Postgres this chart connects to (NOT provisioned here).
+fuzeinfra:
+  namespace: fuzeinfra
+  postgres:
+    host: postgres.fuzeinfra.svc.cluster.local
+    port: 5432
+
+unleash:
+  enabled: false
+  image:
+    repository: unleashorg/unleash-server
+    # Concrete, widely-published OSS tag (verified-available fallback per #116).
+    # Bump deliberately in a deploy window (external image — not auto-bumped by CI).
+    tag: "5.12.0"
+  port: 4242
+  replicas: 1
+  # Least-privilege DB role created by the unleash-db-bootstrap Job (NOT the
+  # shared fuzefront_user). Its password is UNLEASH_DB_PASSWORD in unleash-secrets.
+  dbUser: unleash_svc
+  # Dedicated database OWNED by unleash_svc (Unleash self-migrates into it).
+  dbName: unleash
+  # Per-service secret (unleash-only keys): UNLEASH_DB_PASSWORD,
+  # INIT_ADMIN_API_TOKENS, UNLEASH_CLIENT_TOKEN. Already sealed in
+  # deploy/contabo/sealed/unleash-secrets.yaml — reused as-is, not re-sealed here.
+  secretName: unleash-secrets
+  # Pre-install Job that creates the unleash_svc role + `unleash` database. Runs
+  # as the FuzeInfra Postgres superuser, whose password is read from an
+  # existing Secret in this namespace (default: the umbrella chart's
+  # fuzefront-secrets, which already holds it) — never re-declared here.
+  dbBootstrap:
+    enabled: true
+    superuser:
+      username: fuzeinfra
+      # Maintenance DB the superuser connects to for CREATE ROLE/DATABASE.
+      maintenanceDb: postgres
+      secretName: fuzefront-secrets
+      secretKey: DB_SUPERUSER_PASSWORD
+  # Unleash needs headroom for its Node runtime + in-memory flag cache.
+  resources:
+    requests: { cpu: 100m, memory: 256Mi }
+    limits:   { cpu: 500m, memory: 512Mi }
+  # OPTIONAL admin-gated ingress for the admin UI (default OFF). Requires the
+  # host to sit under the *.prod.fuzefront.com Cloudflare-Access zone; the CF
+  # tunnel rule + CNAME are FuzeInfra-owned (delegated) — see this chart's
+  # README before enabling.
+  ingress:
+    enabled: false
+    className: ""        # defaults to ingress.className when empty
+    host: ""              # e.g. unleash.prod.fuzefront.com (CF-Access gated)
+    annotations: {}
+  nodeSelector: {}
+  affinity: {}
+  tolerations: []
+
+ingress:
+  className: ""


### PR DESCRIPTION
## Summary
- Unleash (self-hosted feature-flag server, family-hosted by FuzeFront) was fully implemented but folded into the umbrella `fuzefront` Helm chart/Argo Application. Per CLAUDE.md's hybrid-Argo rule, an independently-lifecycled service (external image, own release cadence) should get its own Argo Application — this PR does that extraction.
- New standalone chart `deploy/helm/unleash/` (Deployment + Service + optional admin Ingress, gated by `unleash.enabled`; pre-install DB-bootstrap Job) — templates copied verbatim from the umbrella chart's `templates/unleash.yaml` / `templates/unleash-db-bootstrap-job.yaml`.
- New Argo Application `deploy/argocd/applications/unleash.yaml` (`path: deploy/helm/unleash`, `values-prod.yaml`, `namespace: fuzefront`, automated prune+selfHeal) — auto-discovered by the existing app-of-apps (`deploy/argocd/app-of-apps.yaml` recurses `deploy/argocd/applications/`).
- Reuses the **existing** `unleash-secrets` SealedSecret (`deploy/contabo/sealed/unleash-secrets.yaml`, already sealed 2026-07-13) and the umbrella chart's `fuzefront-secrets` (Postgres superuser password) as-is — **no new secrets sealed**.
- Removed the now-superseded unleash blocks from the umbrella `fuzefront` chart (`templates/unleash.yaml`, `templates/unleash-db-bootstrap-job.yaml`, and the `unleash:` values blocks in `values.yaml`/`values-prod.yaml`) so it no longer double-renders Unleash.
- Still disabled by default (`unleash.enabled: false` in both `values.yaml` and `values-prod.yaml`) — go-live remains a deliberate GitOps flip in a deploy window, unchanged from before this PR.

## Validation
- `helm lint deploy/helm/unleash -f deploy/helm/unleash/values-prod.yaml` → 0 failed
- `helm lint deploy/helm/fuzefront -f deploy/helm/fuzefront/values-prod.yaml` → 0 failed (umbrella still lints clean after Unleash extraction)
- `helm template` both charts (enabled + disabled) — renders as expected; disabled = zero resources; umbrella no longer renders any Unleash resources
- `kubeconform -strict -ignore-missing-schemas`: unleash chart → 3/3 valid; umbrella chart → 33/33 valid (3 skipped, expected for unschematized CRDs)

## Test plan
- [ ] CI gate workflows green on this PR
- [ ] (Gated, not part of this PR) Confirm Argo picks up the new Application from app-of-apps and syncs it (no-op while `enabled: false`)
- [ ] (Gated, not part of this PR) Go-live: flip `unleash.enabled: true` in `deploy/helm/unleash/values-prod.yaml` in a deploy window, after confirming `unleash-secrets` holds real (non-placeholder) values

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>