### PR TITLE
fix(fuzequality): pin Kubernetes runtime identities

### DIFF
--- a/FuzeQuality/deploy/helm/fuzequality/templates/api.yaml
+++ b/FuzeQuality/deploy/helm/fuzequality/templates/api.yaml
@@ -29,7 +29,7 @@ spec:
           livenessProbe: { httpGet: { path: /health/live, port: http }, initialDelaySeconds: 15 }
           resources:
             {{- toYaml .Values.backend.resources | nindent 12 }}
-          securityContext: { allowPrivilegeEscalation: false, readOnlyRootFilesystem: true, runAsNonRoot: true }
+          securityContext: { allowPrivilegeEscalation: false, readOnlyRootFilesystem: true, runAsNonRoot: true, runAsUser: 1000, runAsGroup: 1000 }
 ---
 apiVersion: v1
 kind: Service

--- a/FuzeQuality/deploy/helm/fuzequality/templates/jobs.yaml
+++ b/FuzeQuality/deploy/helm/fuzequality/templates/jobs.yaml
@@ -28,7 +28,7 @@ spec:
           command: ["npm", "run", "migrate"]
           env:
             {{- include "fuzequality.env" . | nindent 12 }}
-          securityContext: { allowPrivilegeEscalation: false, runAsNonRoot: true }
+          securityContext: { allowPrivilegeEscalation: false, runAsNonRoot: true, runAsUser: 1000, runAsGroup: 1000 }
 ---
 apiVersion: batch/v1
 kind: CronJob
@@ -65,4 +65,4 @@ spec:
               resources:
                 requests: { cpu: 10m, memory: 16Mi }
                 limits: { cpu: 100m, memory: 64Mi }
-              securityContext: { allowPrivilegeEscalation: false, readOnlyRootFilesystem: true, runAsNonRoot: true }
+              securityContext: { allowPrivilegeEscalation: false, readOnlyRootFilesystem: true, runAsNonRoot: true, runAsUser: 101, runAsGroup: 102 }

--- a/FuzeQuality/deploy/helm/fuzequality/templates/web.yaml
+++ b/FuzeQuality/deploy/helm/fuzequality/templates/web.yaml
@@ -22,7 +22,7 @@ spec:
           readinessProbe: { httpGet: { path: /, port: http }, initialDelaySeconds: 3 }
           resources:
             {{- toYaml .Values.frontend.resources | nindent 12 }}
-          securityContext: { allowPrivilegeEscalation: false, readOnlyRootFilesystem: true, runAsNonRoot: true }
+          securityContext: { allowPrivilegeEscalation: false, readOnlyRootFilesystem: true, runAsNonRoot: true, runAsUser: 101, runAsGroup: 101 }
 ---
 apiVersion: v1
 kind: Service

--- a/FuzeQuality/deploy/helm/fuzequality/templates/workers.yaml
+++ b/FuzeQuality/deploy/helm/fuzequality/templates/workers.yaml
@@ -52,6 +52,6 @@ spec:
           {{- end }}
           resources:
             {{- toYaml $worker.resources | nindent 12 }}
-          securityContext: { allowPrivilegeEscalation: false, readOnlyRootFilesystem: true, runAsNonRoot: true }
+          securityContext: { allowPrivilegeEscalation: false, readOnlyRootFilesystem: true, runAsNonRoot: true, runAsUser: 1000, runAsGroup: 1000 }
 ---
 {{- end }}


### PR DESCRIPTION
## Summary
- pin the backend, worker, and migration containers to the Node image's numeric 1000:1000 identity
- pin the nginx frontend to 101:101
- pin the curl reconciler to 101:102
- retain runAsNonRoot and existing filesystem/privilege restrictions

## Verification
- helm lint FuzeQuality/deploy/helm/fuzequality
- helm template confirms every FuzeQuality workload renders a numeric UID and GID

Unblocks the live FQ-59 migration hook, which currently fails Kubernetes runAsNonRoot validation because the image declares the named user node.

Jira: FQ-59