### PR TITLE
fix(fuzequality): mount writable runtime directories

### DIFF
--- a/FuzeQuality/deploy/helm/fuzequality/templates/api.yaml
+++ b/FuzeQuality/deploy/helm/fuzequality/templates/api.yaml
@@ -12,6 +12,10 @@ spec:
       labels: { app.kubernetes.io/name: fuzequality, app.kubernetes.io/component: backend }
       annotations: { prometheus.io/scrape: "true", prometheus.io/port: {{ .Values.backend.port | quote }}, prometheus.io/path: /metrics }
     spec:
+      securityContext: { fsGroup: 1000, fsGroupChangePolicy: OnRootMismatch }
+      volumes:
+        - name: runtime-tmp
+          emptyDir: { sizeLimit: 64Mi }
       {{- with .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -25,6 +29,8 @@ spec:
           env:
             {{- include "fuzequality.env" . | nindent 12 }}
           envFrom: []
+          volumeMounts:
+            - { name: runtime-tmp, mountPath: /tmp }
           readinessProbe: { httpGet: { path: /health/ready, port: http }, initialDelaySeconds: 5 }
           livenessProbe: { httpGet: { path: /health/live, port: http }, initialDelaySeconds: 15 }
           resources:

--- a/FuzeQuality/deploy/helm/fuzequality/templates/web.yaml
+++ b/FuzeQuality/deploy/helm/fuzequality/templates/web.yaml
@@ -10,6 +10,12 @@ spec:
   template:
     metadata: { labels: { app.kubernetes.io/name: fuzequality, app.kubernetes.io/component: frontend } }
     spec:
+      securityContext: { fsGroup: 101, fsGroupChangePolicy: OnRootMismatch }
+      volumes:
+        - name: nginx-cache
+          emptyDir: { sizeLimit: 64Mi }
+        - name: nginx-run
+          emptyDir: { sizeLimit: 8Mi }
       {{- with .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -19,6 +25,9 @@ spec:
           image: "{{ .Values.frontendImage.repository }}:{{ .Values.frontendImage.tag }}"
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
           ports: [{ name: http, containerPort: {{ .Values.frontend.port }} }]
+          volumeMounts:
+            - { name: nginx-cache, mountPath: /var/cache/nginx }
+            - { name: nginx-run, mountPath: /var/run }
           readinessProbe: { httpGet: { path: /, port: http }, initialDelaySeconds: 3 }
           resources:
             {{- toYaml .Values.frontend.resources | nindent 12 }}

--- a/FuzeQuality/deploy/helm/fuzequality/templates/workers.yaml
+++ b/FuzeQuality/deploy/helm/fuzequality/templates/workers.yaml
@@ -11,6 +11,10 @@ spec:
   template:
     metadata: { labels: { app.kubernetes.io/name: fuzequality, app.kubernetes.io/component: {{ $name }} } }
     spec:
+      securityContext: { fsGroup: 1000, fsGroupChangePolicy: OnRootMismatch }
+      volumes:
+        - name: runtime-tmp
+          emptyDir: { sizeLimit: 64Mi }
       {{- with $.Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -38,6 +42,8 @@ spec:
                   name: {{ $.Values.chroma.existingSecret }}
                   key: {{ $.Values.chroma.secretKey }}
             {{- end }}
+          volumeMounts:
+            - { name: runtime-tmp, mountPath: /tmp }
           {{- if $worker.chromaRequired }}
           startupProbe:
             exec: { command: ["npm", "run", "check:chroma"] }


### PR DESCRIPTION
## Summary
- mount a bounded emptyDir at /tmp for the API and TypeScript workers
- mount bounded nginx cache and run directories for the frontend
- apply matching fsGroup ownership while retaining readOnlyRootFilesystem

## Verification
- reproduced the production tsx ENOENT failure locally under UID 1000 and a read-only root
- API stays running with the /tmp runtime mount
- nginx stays running under UID 101 with writable cache/run mounts
- Helm lint passes and all mounts render

Jira: FQ-59