### PR TITLE
fix(fuzequality): avoid rollout surge capacity

### DIFF
--- a/FuzeQuality/deploy/helm/fuzequality/templates/api.yaml
+++ b/FuzeQuality/deploy/helm/fuzequality/templates/api.yaml
@@ -6,6 +6,9 @@ metadata:
     {{- include "fuzequality.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.backend.replicas }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate: { maxSurge: 0, maxUnavailable: 1 }
   selector: { matchLabels: { app.kubernetes.io/name: fuzequality, app.kubernetes.io/component: backend } }
   template:
     metadata:

--- a/FuzeQuality/deploy/helm/fuzequality/templates/web.yaml
+++ b/FuzeQuality/deploy/helm/fuzequality/templates/web.yaml
@@ -6,6 +6,9 @@ metadata:
     {{- include "fuzequality.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.frontend.replicas }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate: { maxSurge: 0, maxUnavailable: 1 }
   selector: { matchLabels: { app.kubernetes.io/name: fuzequality, app.kubernetes.io/component: frontend } }
   template:
     metadata: { labels: { app.kubernetes.io/name: fuzequality, app.kubernetes.io/component: frontend } }

--- a/FuzeQuality/deploy/helm/fuzequality/templates/workers.yaml
+++ b/FuzeQuality/deploy/helm/fuzequality/templates/workers.yaml
@@ -7,6 +7,9 @@ metadata:
     {{- include "fuzequality.labels" $ | nindent 4 }}
 spec:
   replicas: {{ $worker.replicas }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate: { maxSurge: 0, maxUnavailable: 1 }
   selector: { matchLabels: { app.kubernetes.io/name: fuzequality, app.kubernetes.io/component: {{ $name }} } }
   template:
     metadata: { labels: { app.kubernetes.io/name: fuzequality, app.kubernetes.io/component: {{ $name }} } }


### PR DESCRIPTION
## Summary
- configure singleton FuzeQuality Deployments with maxSurge 0 and maxUnavailable 1
- free the old Pod's requested resources before scheduling its replacement
- avoid the production rollout deadlock caused by insufficient capacity for duplicate replicas

## Verification
- production diagnostics show every pending replacement is Unschedulable for CPU/memory while the old crash-loop Pod remains allocated
- Helm lint passes and all five Deployments render the zero-surge strategy

Jira: FQ-59