### PR TITLE
fix(fuzequality): provision Kafka topics before workers

### DIFF
--- a/FuzeQuality/deploy/helm/fuzequality/templates/kafka-topics.yaml
+++ b/FuzeQuality/deploy/helm/fuzequality/templates/kafka-topics.yaml
@@ -6,8 +6,9 @@ metadata:
   labels:
     {{- include "fuzequality.labels" . | nindent 4 }}
   annotations:
-    "helm.sh/hook": post-install,post-upgrade
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/sync-wave: "-1"
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation,HookSucceeded
 spec:
   backoffLimit: 4
   template:


### PR DESCRIPTION
## Summary
- run Kafka topic creation as an Argo Sync hook at wave -1
- complete topic/DLQ provisioning before worker Deployments are evaluated
- remove the Helm PostSync dependency cycle that kept projector/intelligence unhealthy

## Verification
- Helm lint passes
- rendered topic Job uses Sync wave -1 and BeforeHookCreation/HookSucceeded cleanup
- scanner is healthy on the corrected broker while the multi-topic workers still fail before the deferred topic Job can run

Jira: FQ-59