### PR TITLE
FQ-22–25: build OpenAPI coverage intelligence core

### DIFF
--- a/FuzeQuality/packages/contracts/src/index.ts
+++ b/FuzeQuality/packages/contracts/src/index.ts
@@ -66,6 +66,7 @@ export type ApiOperation = {
   summary: string
   tags: string[]
   security: boolean
+  securitySchemes?: string[]
   parameters: Array<{
     name: string
     location: string
@@ -73,6 +74,10 @@ export type ApiOperation = {
     schema?: Record<string, unknown>
   }>
   responses: string[]
+  requestContentTypes?: string[]
+  responseContentTypes?: string[]
+  idempotencyHeader?: string
+  supportsCrudSequence?: boolean
 }
 
 export type FrontendSurface = {
@@ -97,6 +102,9 @@ export type TestCase = {
   sourcePath: string
   assertionCount: number
   targets: string[]
+  explicitTargets?: string[]
+  operationIds?: string[]
+  routes?: Array<{ method?: string; path: string }>
 }
 
 export type TestExpectation = {

--- a/FuzeQuality/packages/core/src/coverage.mapping.test.ts
+++ b/FuzeQuality/packages/core/src/coverage.mapping.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import type { ApiOperation, TestCase } from '@fuzequality/contracts'
+import { buildApiExpectations, mappingMethod } from './coverage'
+
+const operation: ApiOperation = {
+  id: 'api:sample:document:getUser',
+  repositoryId: 'repository',
+  documentPath: 'openapi.yaml',
+  operationId: 'getUser',
+  method: 'get',
+  path: '/users/{id}',
+  summary: 'Get user',
+  tags: [],
+  security: false,
+  parameters: [],
+  responses: ['200'],
+}
+
+function testCase(overrides: Partial<TestCase>): TestCase {
+  return {
+    id: String(overrides.id ?? 'test'),
+    repositoryId: 'repository',
+    framework: 'vitest',
+    level: 'integration',
+    title: 'unrelated title',
+    sourcePath: 'users.test.ts',
+    assertionCount: 1,
+    targets: [],
+    ...overrides,
+  }
+}
+
+describe('API test evidence mapping', () => {
+  it('uses explicit annotation before operationId, method/route, and title evidence', () => {
+    expect(mappingMethod(operation, testCase({ explicitTargets: [operation.id] }))).toBe('explicit')
+    expect(mappingMethod(operation, testCase({ operationIds: ['getUser'] }))).toBe('operation-id')
+    expect(mappingMethod(operation, testCase({ routes: [{ method: 'get', path: '/users/{userId}' }] }))).toBe('method-route')
+    expect(mappingMethod(operation, testCase({ title: 'getUser returns a user' }))).toBe('title')
+  })
+
+  it('does not credit assertion-free or ambiguous route evidence', () => {
+    expect(mappingMethod(operation, testCase({ assertionCount: 0, explicitTargets: [operation.id] }))).toBeUndefined()
+    expect(mappingMethod(operation, testCase({ routes: [{ method: 'post', path: '/users/{id}' }] }))).toBeUndefined()
+    const expectations = buildApiExpectations(operation, [
+      testCase({ id: 'no-assertion', assertionCount: 0, title: 'getUser returns 200' }),
+    ])
+    expect(expectations.find(item => item.kind === 'happy-path')?.coverage).toBe('gap')
+  })
+})

--- a/FuzeQuality/packages/core/src/coverage.ts
+++ b/FuzeQuality/packages/core/src/coverage.ts
@@ -10,21 +10,42 @@ import type {
 const id = (...parts: string[]) =>
   createHash('sha256').update(parts.join('\u0000')).digest('hex').slice(0, 24)
 
+function normalizeRoute(value: string) {
+  return `/${value}`.replace(/\/+/g, '/').replace(/:[^/]+|\{[^}]+\}/g, '{}').replace(/\/$/, '') || '/'
+}
+
+export type EvidenceMethod = 'explicit' | 'operation-id' | 'method-route' | 'title'
+
+export function mappingMethod(subject: ApiOperation | FrontendSurface, test: TestCase): EvidenceMethod | undefined {
+  if (test.assertionCount <= 0) return undefined
+  const explicit = test.explicitTargets ?? []
+  if (explicit.some(target => target === subject.id || ('operationId' in subject && target === subject.operationId))) {
+    return 'explicit'
+  }
+  if ('method' in subject) {
+    if (subject.operationId && (test.operationIds ?? []).includes(subject.operationId)) return 'operation-id'
+    if ((test.routes ?? []).some(route =>
+      (!route.method || route.method.toLowerCase() === subject.method.toLowerCase()) &&
+      normalizeRoute(route.path) === normalizeRoute(subject.path)
+    )) return 'method-route'
+    if (subject.operationId && test.title.toLowerCase().includes(subject.operationId.toLowerCase())) return 'title'
+    return undefined
+  }
+  const title = test.title.toLowerCase()
+  return [subject.name, subject.routePath, subject.sourcePath]
+    .filter((token): token is string => Boolean(token))
+    .some(token => title.includes(token.toLowerCase())) ? 'title' : undefined
+}
+
 function matchingEvidence(subject: ApiOperation | FrontendSurface, tests: TestCase[]) {
-  const tokens =
-    'method' in subject
-      ? [subject.operationId, subject.path, `${subject.method} ${subject.path}`]
-      : [subject.name, subject.routePath, subject.sourcePath]
-  return tests.filter(test =>
-    test.assertionCount > 0 &&
-    tokens
-      .filter((token): token is string => Boolean(token))
-      .some(token =>
-        `${test.title} ${test.targets.join(' ')}`
-          .toLowerCase()
-          .includes(token.toLowerCase())
-      )
-  )
+  return tests
+    .map(test => ({ test, method: mappingMethod(subject, test) }))
+    .filter((candidate): candidate is { test: TestCase; method: EvidenceMethod } => Boolean(candidate.method))
+    .sort((a, b) =>
+      ['explicit', 'operation-id', 'method-route', 'title'].indexOf(a.method) -
+      ['explicit', 'operation-id', 'method-route', 'title'].indexOf(b.method)
+    )
+    .map(candidate => candidate.test)
 }
 
 function scenarioEvidence(
@@ -112,6 +133,19 @@ export function buildApiExpectations(operation: ApiOperation, tests: TestCase[])
     )
   }
 
+  if ((operation.securitySchemes ?? []).some(scheme => /oauth|scope|role|permission/i.test(scheme))) {
+    result.push(
+      expectation(
+        'api-operation',
+        operation.id,
+        'authorization-variation',
+        'Declared roles or scopes have permitted and denied cases',
+        'api.security.role-variation',
+        scenarioEvidence(matchedTests, ['role', 'scope', 'permission', '403'])
+      )
+    )
+  }
+
   for (const parameter of operation.parameters.filter(item => item.required)) {
     result.push(
       expectation(
@@ -180,6 +214,60 @@ export function buildApiExpectations(operation: ApiOperation, tests: TestCase[])
     )
   }
 
+  if ((operation.requestContentTypes ?? []).length > 0) {
+    result.push(
+      expectation(
+        'api-operation',
+        operation.id,
+        'request-content-type',
+        'Every declared request content type is exercised',
+        'api.content-type.request',
+        scenarioEvidence(matchedTests, operation.requestContentTypes ?? []),
+        'recommended'
+      )
+    )
+  }
+
+  if ((operation.responseContentTypes ?? []).length > 0) {
+    result.push(
+      expectation(
+        'api-operation',
+        operation.id,
+        'response-content-type',
+        'Declared response media types and schemas are asserted',
+        'api.content-type.response',
+        scenarioEvidence(matchedTests, operation.responseContentTypes ?? []),
+        'recommended'
+      )
+    )
+  }
+
+  if (operation.idempotencyHeader) {
+    result.push(
+      expectation(
+        'api-operation',
+        operation.id,
+        'idempotency-replay',
+        `${operation.idempotencyHeader} replay does not duplicate the operation`,
+        'api.idempotency.replay',
+        scenarioEvidence(matchedTests, ['idempotent', 'replay', operation.idempotencyHeader])
+      )
+    )
+  }
+
+  if (operation.supportsCrudSequence) {
+    result.push(
+      expectation(
+        'api-operation',
+        operation.id,
+        'crud-sequence',
+        'The operation participates in a stateful resource lifecycle',
+        'api.resource.crud-sequence',
+        scenarioEvidence(matchedTests, ['crud', 'lifecycle', 'create read update delete']),
+        'recommended'
+      )
+    )
+  }
 
   for (const response of operation.responses) {
     const successful = /^2\d\d$/.test(response)
@@ -259,6 +347,29 @@ export function buildFindings(
       detail: 'Add a stable operationId so coverage history survives route refactors.',
       status: 'open',
     })
+  }
+
+  const duplicateOperationIds = new Map<string, ApiOperation[]>()
+  for (const operation of operations) {
+    if (!operation.operationId) continue
+    const matches = duplicateOperationIds.get(operation.operationId) ?? []
+    matches.push(operation)
+    duplicateOperationIds.set(operation.operationId, matches)
+  }
+  for (const [operationId, duplicates] of duplicateOperationIds) {
+    if (duplicates.length < 2) continue
+    for (const operation of duplicates) {
+      findings.push({
+        id: id(operation.id, 'duplicate-operation-id'),
+        repositoryId,
+        subjectId: operation.id,
+        type: 'duplicate-operation-id',
+        severity: 'high',
+        title: `operationId “${operationId}” is duplicated`,
+        detail: `The identifier is shared by ${duplicates.length} operations and cannot provide an unambiguous coverage identity.`,
+        status: 'open',
+      })
+    }
   }
 
   for (const surface of surfaces.filter(item => item.kind === 'component' && !item.hasStory)) {

--- a/FuzeQuality/packages/scanner/src/index.ts
+++ b/FuzeQuality/packages/scanner/src/index.ts
@@ -1,8 +1,7 @@
 import { createHash } from 'node:crypto'
 import { readFile } from 'node:fs/promises'
-import { relative, resolve, sep } from 'node:path'
+import { dirname, relative, resolve, sep } from 'node:path'
 import fg from 'fast-glob'
-import YAML from 'yaml'
 import type {
   ApiOperation,
   FrontendSurface,
@@ -16,6 +15,7 @@ import {
   buildFindings,
   buildFrontendExpectations,
 } from '@fuzequality/core'
+import { parseOpenApiDocument, referencedOpenApiPaths } from './openapi'
 
 const digest = (...parts: string[]) =>
   createHash('sha256').update(parts.join('\u0000')).digest('hex').slice(0, 24)
@@ -42,6 +42,11 @@ const OPENAPI_GLOBS = [
   '**/*swagger*.{yaml,yml,json}',
 ]
 
+const OPENAPI_CONFIG_GLOBS = [
+  '**/*openapi*.{ts,js,mjs,cjs}',
+  '**/*swagger*.{ts,js,mjs,cjs}',
+]
+
 const TEST_GLOBS = [
   '**/*.{test,spec}.{ts,tsx,js,jsx,mjs,cjs,py}',
   '**/tests/**/*.{ts,tsx,js,jsx,mjs,cjs,py}',
@@ -62,74 +67,6 @@ async function readText(root: string, file: string) {
   return value
 }
 
-function operationSecurity(document: Record<string, unknown>, value: Record<string, unknown>) {
-  if ('security' in value) return Array.isArray(value.security) && value.security.length > 0
-  return Array.isArray(document.security) && document.security.length > 0
-}
-
-function parseParameters(value: unknown) {
-  if (!Array.isArray(value)) return []
-  return value
-    .filter(item => item && typeof item === 'object' && !('$ref' in item))
-    .map(item => {
-      const parameter = item as Record<string, unknown>
-      return {
-        name: String(parameter.name ?? 'unnamed'),
-        location: String(parameter.in ?? 'unknown'),
-        required: Boolean(parameter.required),
-        schema:
-          parameter.schema && typeof parameter.schema === 'object'
-            ? (parameter.schema as Record<string, unknown>)
-            : undefined,
-      }
-    })
-}
-
-function parseOpenApi(
-  repository: Repository,
-  file: string,
-  content: string
-): ApiOperation[] {
-  const parsed = file.endsWith('.json') ? JSON.parse(content) : YAML.parse(content)
-  if (!parsed || typeof parsed !== 'object') return []
-  const document = parsed as Record<string, unknown>
-  const paths = document.paths
-  if (!paths || typeof paths !== 'object') return []
-  const operations: ApiOperation[] = []
-  const methods = new Set(['get', 'post', 'put', 'patch', 'delete', 'head', 'options', 'trace'])
-
-  for (const [path, rawPath] of Object.entries(paths as Record<string, unknown>)) {
-    if (!rawPath || typeof rawPath !== 'object') continue
-    const pathItem = rawPath as Record<string, unknown>
-    for (const [method, rawOperation] of Object.entries(pathItem)) {
-      if (!methods.has(method.toLowerCase()) || !rawOperation || typeof rawOperation !== 'object') continue
-      const operation = rawOperation as Record<string, unknown>
-      const operationId = typeof operation.operationId === 'string' ? operation.operationId : undefined
-      const stablePart = operationId ?? `${method.toUpperCase()}:${path}`
-      operations.push({
-        id: `api:${repository.name}:${digest(file)}:${stablePart}`,
-        repositoryId: repository.id,
-        documentPath: normalize(file),
-        operationId,
-        method: method.toLowerCase(),
-        path,
-        summary: String(operation.summary ?? operation.description ?? stablePart),
-        tags: Array.isArray(operation.tags) ? operation.tags.map(String) : [],
-        security: operationSecurity(document, operation),
-        parameters: [
-          ...parseParameters(pathItem.parameters),
-          ...parseParameters(operation.parameters),
-        ],
-        responses:
-          operation.responses && typeof operation.responses === 'object'
-            ? Object.keys(operation.responses)
-            : [],
-      })
-    }
-  }
-  return operations
-}
-
 function frameworkFor(file: string, source: string) {
   if (file.endsWith('.py')) return source.includes('schemathesis') ? 'schemathesis' : 'pytest'
   if (source.includes('@playwright/test')) return 'playwright'
@@ -148,17 +85,31 @@ function levelFor(file: string, source: string): TestCase['level'] {
 function extractTests(repository: Repository, file: string, source: string): TestCase[] {
   const cases: TestCase[] = []
   const titlePattern = /\b(?:it|test)\s*\(\s*(['"`])([^\n]+?)\1/g
-  const targets = [
-    ...source.matchAll(/(?:get|post|put|patch|delete)\s*\(\s*(['"`])([^'"`]+)\1/gi),
-    ...source.matchAll(/(?:page\.goto|request\.(?:get|post|put|patch|delete))\s*\(\s*(['"`])([^'"`]+)\1/gi),
-  ].map(match => match[2])
-  const annotations = [...source.matchAll(/(?:api|flow|jira)['"]?\s*[,):]\s*(?:description:\s*)?['"]([^'"]+)['"]/gi)].map(
-    match => match[1]
-  )
-  const assertionCount = (source.match(/\bexpect\s*\(/g) ?? []).length + (source.match(/\bassert\b/g) ?? []).length
-  let match: RegExpExecArray | null
-  while ((match = titlePattern.exec(source))) {
+  const titleMatches = [...source.matchAll(titlePattern)]
+  const metadata = (segment: string) => {
+    const routeMatches = [
+      ...segment.matchAll(/\b(get|post|put|patch|delete)\s*\(\s*(['"`])([^'"`]+)\2/gi),
+      ...segment.matchAll(/\brequest\.(get|post|put|patch|delete)\s*\(\s*(['"`])([^'"`]+)\2/gi),
+    ]
+    const routes = routeMatches.map(match => ({ method: match[1].toLowerCase(), path: match[3] }))
+    const explicitTargets = [...segment.matchAll(/@fuzequality\s+(?:api|target)\s+([^\s*]+)/gi)].map(match => match[1])
+    const annotations = [...segment.matchAll(/(?:api|flow|jira)['"]?\s*[,):]\s*(?:description:\s*)?['"]([^'"]+)['"]/gi)].map(
+      match => match[1]
+    )
+    const operationIds = [...segment.matchAll(/\boperationId\s*[:=]\s*['"]([^'"]+)['"]/gi)].map(match => match[1])
+    return {
+      routes,
+      explicitTargets,
+      operationIds,
+      assertionCount: (segment.match(/\bexpect\s*\(/g) ?? []).length + (segment.match(/\bassert\b/g) ?? []).length,
+      targets: [...new Set([...routes.map(route => route.path), ...annotations, ...explicitTargets, ...operationIds])],
+    }
+  }
+  for (const [index, match] of titleMatches.entries()) {
     const title = match[2].trim()
+    const start = match.index ?? 0
+    const end = titleMatches[index + 1]?.index ?? source.length
+    const evidence = metadata(source.slice(start, end))
     cases.push({
       id: `test:${repository.name}:${digest(file, title)}`,
       repositoryId: repository.id,
@@ -166,11 +117,15 @@ function extractTests(repository: Repository, file: string, source: string): Tes
       level: levelFor(file, source),
       title,
       sourcePath: normalize(file),
-      assertionCount,
-      targets: [...new Set([...targets, ...annotations])],
+      assertionCount: evidence.assertionCount,
+      targets: evidence.targets,
+      explicitTargets: evidence.explicitTargets,
+      operationIds: evidence.operationIds,
+      routes: evidence.routes,
     })
   }
   if (!cases.length) {
+    const evidence = metadata(source)
     cases.push({
       id: `test:${repository.name}:${digest(file)}`,
       repositoryId: repository.id,
@@ -178,8 +133,11 @@ function extractTests(repository: Repository, file: string, source: string): Tes
       level: levelFor(file, source),
       title: file.split('/').at(-1) ?? file,
       sourcePath: normalize(file),
-      assertionCount,
-      targets: [...new Set([...targets, ...annotations])],
+      assertionCount: evidence.assertionCount,
+      targets: evidence.targets,
+      explicitTargets: evidence.explicitTargets,
+      operationIds: evidence.operationIds,
+      routes: evidence.routes,
     })
   }
   return cases
@@ -296,10 +254,26 @@ async function scanFrontend(
 export async function scanRepository(repository: Repository, rootPath: string): Promise<ScanResult> {
   const root = safeRoot(rootPath)
   const ignore = [...DEFAULT_IGNORES, ...repository.excludeGlobs]
-  const openApiFiles = await fg(
-    repository.includeGlobs.length ? repository.includeGlobs : OPENAPI_GLOBS,
+  const configuredOpenApiGlobs = repository.includeGlobs.length ? repository.includeGlobs : OPENAPI_GLOBS
+  const directOpenApiFiles = await fg(
+    configuredOpenApiGlobs,
     { cwd: root, ignore, onlyFiles: true, followSymbolicLinks: false }
   )
+  const configFiles = await fg(OPENAPI_CONFIG_GLOBS, {
+    cwd: root, ignore, onlyFiles: true, followSymbolicLinks: false,
+  })
+  const referencedFiles: string[] = []
+  for (const configFile of configFiles) {
+    try {
+      const source = await readText(root, configFile)
+      for (const referenced of referencedOpenApiPaths(source)) {
+        referencedFiles.push(normalize(relative(root, resolve(root, dirname(configFile), referenced))))
+      }
+    } catch {
+      // Config parsing is best-effort; candidate documents still receive diagnostics below.
+    }
+  }
+  const openApiFiles = [...new Set([...directOpenApiFiles, ...referencedFiles])]
   const testFiles = await fg(TEST_GLOBS, { cwd: root, ignore, onlyFiles: true, followSymbolicLinks: false })
   const storyFiles = new Set(
     await fg('**/*.stories.{ts,tsx,js,jsx,mdx}', {
@@ -317,7 +291,9 @@ export async function scanRepository(repository: Repository, rootPath: string): 
     try {
       const content = await readText(root, file)
       contentFingerprints.push(`${normalize(file)}:${fingerprint(content)}`)
-      operations.push(...parseOpenApi(repository, file, content))
+      const parsed = await parseOpenApiDocument(root, repository, file, content)
+      operations.push(...parsed.operations)
+      diagnostics.push(...parsed.diagnostics)
     } catch (error) {
       diagnostics.push({
         sourcePath: normalize(file),

--- a/FuzeQuality/packages/scanner/src/openapi.ts
+++ b/FuzeQuality/packages/scanner/src/openapi.ts
@@ -1,0 +1,164 @@
+import { dirname, extname, isAbsolute, join, normalize as normalizePath, relative, resolve, sep } from 'node:path'
+import { readFile } from 'node:fs/promises'
+import YAML from 'yaml'
+import type { ApiOperation, Repository, ScanDiagnostic } from '@fuzequality/contracts'
+
+const METHODS = new Set(['get', 'post', 'put', 'patch', 'delete', 'head', 'options', 'trace'])
+const digestPath = (value: string) =>
+  value.split(sep).join('/').replace(/\/+/g, '/').replace(/\/$/, '')
+const normalizedRoute = (value: string) =>
+  `/${value}`.replace(/\/+/g, '/').replace(/\{[^}]+\}/g, '{}').replace(/\/$/, '') || '/'
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined
+}
+
+function within(root: string, candidate: string) {
+  const rel = relative(root, candidate)
+  return rel === '' || (!rel.startsWith(`..${sep}`) && rel !== '..' && !isAbsolute(rel))
+}
+
+async function validateRefs(
+  root: string,
+  documentPath: string,
+  value: unknown,
+  diagnostics: ScanDiagnostic[],
+  visited = new Set<string>()
+): Promise<void> {
+  if (!value || typeof value !== 'object') return
+  if (Array.isArray(value)) {
+    for (const item of value) await validateRefs(root, documentPath, item, diagnostics, visited)
+    return
+  }
+  const record = value as Record<string, unknown>
+  if (typeof record.$ref === 'string' && !record.$ref.startsWith('#')) {
+    const [referencePath] = record.$ref.split('#')
+    const target = resolve(root, dirname(documentPath), referencePath)
+    if (!within(root, target)) {
+      diagnostics.push({
+        sourcePath: digestPath(documentPath),
+        category: 'openapi',
+        severity: 'error',
+        code: 'openapi-ref-outside-repository',
+        message: `Refusing OpenAPI reference outside repository: ${record.$ref}`,
+      })
+    } else if (!visited.has(target)) {
+      visited.add(target)
+      try {
+        const source = await readFile(target, 'utf8')
+        const parsed = extname(target).toLowerCase() === '.json' ? JSON.parse(source) : YAML.parse(source)
+        await validateRefs(root, digestPath(relative(root, target)), parsed, diagnostics, visited)
+      } catch (error) {
+        diagnostics.push({
+          sourcePath: digestPath(documentPath),
+          category: 'openapi',
+          severity: 'error',
+          code: 'unresolved-openapi-ref',
+          message: `Cannot resolve ${record.$ref}: ${error instanceof Error ? error.message : String(error)}`,
+        })
+      }
+    }
+  }
+  for (const child of Object.values(record)) {
+    await validateRefs(root, documentPath, child, diagnostics, visited)
+  }
+}
+
+function parameters(value: unknown) {
+  if (!Array.isArray(value)) return []
+  return value.flatMap(item => {
+    const parameter = asRecord(item)
+    if (!parameter || '$ref' in parameter) return []
+    return [{
+      name: String(parameter.name ?? 'unnamed'),
+      location: String(parameter.in ?? 'unknown'),
+      required: Boolean(parameter.required),
+      schema: asRecord(parameter.schema),
+    }]
+  })
+}
+
+function contentTypes(value: unknown) {
+  return Object.keys(asRecord(asRecord(value)?.content) ?? {})
+}
+
+function securityNames(document: Record<string, unknown>, operation: Record<string, unknown>) {
+  const security = 'security' in operation ? operation.security : document.security
+  if (!Array.isArray(security)) return []
+  return [...new Set(security.flatMap(item => Object.keys(asRecord(item) ?? {})))]
+}
+
+export async function parseOpenApiDocument(
+  root: string,
+  repository: Repository,
+  file: string,
+  content: string
+): Promise<{ operations: ApiOperation[]; diagnostics: ScanDiagnostic[] }> {
+  const diagnostics: ScanDiagnostic[] = []
+  const parsed = extname(file).toLowerCase() === '.json' ? JSON.parse(content) : YAML.parse(content)
+  const document = asRecord(parsed)
+  if (!document) throw new Error('OpenAPI document must be an object')
+  const version = typeof document.openapi === 'string'
+    ? document.openapi
+    : typeof document.swagger === 'string' ? document.swagger : undefined
+  if (!version || !(version === '2.0' || /^3\.(?:0|1)\.\d+(?:[-+].*)?$/.test(version))) {
+    throw new Error(`Unsupported or missing OpenAPI version: ${version ?? 'none'}`)
+  }
+  const paths = asRecord(document.paths)
+  if (!paths) throw new Error('OpenAPI document has no paths object')
+  await validateRefs(root, file, document, diagnostics)
+
+  const operations: ApiOperation[] = []
+  for (const [route, rawPathItem] of Object.entries(paths)) {
+    const pathItem = asRecord(rawPathItem)
+    if (!pathItem) continue
+    for (const [rawMethod, rawOperation] of Object.entries(pathItem)) {
+      const method = rawMethod.toLowerCase()
+      const operation = asRecord(rawOperation)
+      if (!METHODS.has(method) || !operation) continue
+      const operationId = typeof operation.operationId === 'string' && operation.operationId.trim()
+        ? operation.operationId.trim()
+        : undefined
+      const stablePart = operationId ?? `${method.toUpperCase()}:${normalizedRoute(route)}`
+      const responses = asRecord(operation.responses) ?? {}
+      const securitySchemes = securityNames(document, operation)
+      const allParameters = [...parameters(pathItem.parameters), ...parameters(operation.parameters)]
+      const idempotency = allParameters.find(item =>
+        item.location === 'header' && /idempotency/i.test(item.name)
+      )
+      operations.push({
+        id: `api:${repository.name}:${digestPath(file)}:${stablePart}`,
+        repositoryId: repository.id,
+        documentPath: digestPath(file),
+        operationId,
+        method,
+        path: route,
+        summary: String(operation.summary ?? operation.description ?? stablePart),
+        tags: Array.isArray(operation.tags) ? operation.tags.map(String) : [],
+        security: securitySchemes.length > 0,
+        securitySchemes,
+        parameters: allParameters,
+        responses: Object.keys(responses),
+        requestContentTypes: version === '2.0'
+          ? (Array.isArray(operation.consumes ?? document.consumes) ? ((operation.consumes ?? document.consumes) as unknown[]).map(String) : [])
+          : contentTypes(operation.requestBody),
+        responseContentTypes: version === '2.0'
+          ? (Array.isArray(operation.produces ?? document.produces) ? ((operation.produces ?? document.produces) as unknown[]).map(String) : [])
+          : [...new Set(Object.values(responses).flatMap(response => contentTypes(response)))],
+        idempotencyHeader: idempotency?.name,
+        supportsCrudSequence: /\/\{[^}]+\}$/.test(route) && ['get', 'put', 'patch', 'delete'].includes(method),
+      })
+    }
+  }
+  return { operations, diagnostics }
+}
+
+export function referencedOpenApiPaths(source: string) {
+  return [...new Set(
+    [...source.matchAll(/['"`]([^'"`\r\n]+\.(?:ya?ml|json))['"`]/gi)]
+      .map(match => normalizePath(match[1]).split(sep).join('/'))
+      .filter(path => !path.includes('://') && !path.startsWith('/'))
+  )]
+}

--- a/FuzeQuality/packages/scanner/src/scanner.test.ts
+++ b/FuzeQuality/packages/scanner/src/scanner.test.ts
@@ -124,4 +124,89 @@ paths:
       }),
     ])
   })
+
+  it.each([
+    ['Swagger 2.0', `swagger: '2.0'\ninfo: { title: Legacy, version: 1.0.0 }\npaths: { /health: { get: { responses: { '200': { description: ok } } } } }`],
+    ['OpenAPI 3.0', `openapi: 3.0.3\ninfo: { title: Current, version: 1.0.0 }\npaths: { /health: { get: { responses: { '200': { description: ok } } } } }`],
+    ['OpenAPI 3.1', `openapi: 3.1.1\ninfo: { title: Modern, version: 1.0.0 }\npaths: { /health: { get: { responses: { '200': { description: ok } } } } }`],
+  ])('discovers and validates %s documents', async (_label, document) => {
+    const root = await mkdtemp(join(tmpdir(), 'fuzequality-versions-'))
+    await writeFile(join(root, 'swagger.yaml'), document)
+    const result = await scanRepository(repository, root)
+    expect(result.operations).toHaveLength(1)
+    expect(result.diagnostics).toHaveLength(0)
+  })
+
+  it('discovers a statically referenced specification without executing its config', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'fuzequality-static-ref-'))
+    await mkdir(join(root, 'config'), { recursive: true })
+    await mkdir(join(root, 'specs'), { recursive: true })
+    await writeFile(join(root, 'config', 'swagger.config.ts'), `throw new Error('must not execute'); export const spec = '../specs/service.yaml'`)
+    await writeFile(join(root, 'specs', 'service.yaml'), `openapi: 3.1.0\ninfo: { title: Service, version: 1.0.0 }\npaths: { /ready: { get: { operationId: readiness, responses: { '200': { description: ok } } } } }`)
+    const result = await scanRepository(repository, root)
+    expect(result.operations.map(operation => operation.operationId)).toContain('readiness')
+  })
+
+  it('isolates unresolved and escaping references as findings without losing valid operations', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'fuzequality-refs-'))
+    await writeFile(join(root, 'openapi.yaml'), `openapi: 3.1.0
+info: { title: Refs, version: 1.0.0 }
+paths:
+  /safe:
+    get:
+      operationId: safe
+      responses:
+        '200': { description: ok, content: { application/json: { schema: { $ref: './missing.yaml#/Thing' } } } }
+  /escape:
+    get:
+      responses:
+        '200': { description: no, content: { application/json: { schema: { $ref: '../secret.yaml' } } } }
+`)
+    const result = await scanRepository(repository, root)
+    expect(result.operations).toHaveLength(2)
+    expect(result.diagnostics.map(diagnostic => diagnostic.code)).toEqual(
+      expect.arrayContaining(['unresolved-openapi-ref', 'openapi-ref-outside-repository'])
+    )
+  })
+
+  it('normalizes fallback identities and reports missing and duplicate operation identifiers', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'fuzequality-identities-'))
+    await writeFile(join(root, 'openapi.yaml'), `openapi: 3.0.0
+info: { title: Identities, version: 1.0.0 }
+paths:
+  /users/{userId}/:
+    get: { responses: { '200': { description: ok } } }
+    post: { operationId: duplicate, responses: { '201': { description: ok } } }
+  /groups:
+    get: { operationId: duplicate, responses: { '200': { description: ok } } }
+`)
+    const result = await scanRepository(repository, root)
+    expect(result.operations.find(operation => !operation.operationId)?.id).toContain('GET:/users/{}')
+    expect(result.findings.filter(finding => finding.type === 'duplicate-operation-id')).toHaveLength(2)
+    expect(result.findings.some(finding => finding.type === 'missing-operation-id')).toBe(true)
+  })
+
+  it('creates deterministic content, idempotency, response, and lifecycle expectations', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'fuzequality-policy-'))
+    await writeFile(join(root, 'openapi.yaml'), `openapi: 3.0.0
+info: { title: Policy, version: 1.0.0 }
+paths:
+  /orders/{id}:
+    put:
+      operationId: replaceOrder
+      parameters:
+        - { name: Idempotency-Key, in: header, required: true, schema: { type: string } }
+      requestBody: { content: { application/json: { schema: { type: object } } } }
+      responses:
+        '200': { description: ok, content: { application/json: { schema: { type: object } } } }
+        '404': { description: missing }
+`)
+    const result = await scanRepository(repository, root)
+    const kinds = result.expectations.map(expectation => expectation.kind)
+    expect(kinds).toEqual(expect.arrayContaining([
+      'invalid-content-type', 'request-content-type', 'response-content-type',
+      'idempotency-replay', 'crud-sequence', 'response-200', 'response-404',
+    ]))
+  })
+
 })


### PR DESCRIPTION
## Summary
- discover Swagger 2.0 and OpenAPI 3.0/3.1 documents from conventional/configured globs and static JS/TS references without executing repository code
- enforce repository-bounded external references and isolate malformed/unresolved documents as diagnostics
- create stable operation identities plus missing/duplicate operationId findings
- expand deterministic API expectations for security, parameters, content types, responses, idempotency, not-found, and CRUD lifecycles
- map assertion-bearing tests using explicit annotation > operationId > method/normalized route > title precedence

## Verification
- tsc --noEmit
- vitest run --reporter=dot — 34 passed, 1 opt-in Chroma integration test skipped

## Jira
- FQ-22
- FQ-23
- FQ-24
- FQ-25