### PR TITLE
chore(governance): backfill A2A providesTo/dependsOn (approved graph)

### DIFF
--- a/.fuze/manifest.json
+++ b/.fuze/manifest.json
@@ -29,9 +29,21 @@
       "workflow": ".github/workflows/ds-propagate.yml",
       "trigger": "push:master:design-system/**",
       "agents": [
-        { "role": "frontend-engineer", "job": "propagate-frontend", "branch": "ds-propagate/frontend-{run}" },
-        { "role": "mobile-frontend-engineer", "job": "propagate-mobile", "branch": "ds-propagate/mobile-{run}" },
-        { "role": "frontend-test-engineer", "job": "ui-tests", "branch": "ds-propagate/e2e-{run}" }
+        {
+          "role": "frontend-engineer",
+          "job": "propagate-frontend",
+          "branch": "ds-propagate/frontend-{run}"
+        },
+        {
+          "role": "mobile-frontend-engineer",
+          "job": "propagate-mobile",
+          "branch": "ds-propagate/mobile-{run}"
+        },
+        {
+          "role": "frontend-test-engineer",
+          "job": "ui-tests",
+          "branch": "ds-propagate/e2e-{run}"
+        }
       ]
     }
   },
@@ -39,5 +51,32 @@
     "ruleset": true,
     "requireSignatures": true,
     "deployOnPush": true
-  }
+  },
+  "providesTo": [
+    "FuzeAgent",
+    "FuzeBI",
+    "FuzeCall",
+    "FuzeContact",
+    "FuzeDeploy",
+    "FuzeExecutive",
+    "FuzeHub",
+    "FuzeKeys",
+    "FuzeMarket",
+    "FuzeMerchandize",
+    "FuzePicker",
+    "FuzePlan",
+    "FuzeSales",
+    "FuzeService",
+    "FuzeSocial",
+    "FuzeX",
+    "MendysRobotics",
+    "MendysRoboticsWP"
+  ],
+  "dependsOn": [
+    "FuzeAgent",
+    "FuzeBI",
+    "FuzeDeploy",
+    "FuzeKeys",
+    "FuzePlan"
+  ]
 }


### PR DESCRIPTION
Applies the approved **A2A dependency graph** ([FuzeSDLC governance/a2a-dependency-graph.json](https://github.com/izzywdev/FuzeSDLC/blob/main/governance/a2a-dependency-graph.json)) to `.fuze/manifest.json`.

- **providesTo** (authoritative A2A authZ allowlist; absent = DENY): `(absent)` → `['FuzeAgent', 'FuzeBI', 'FuzeCall', 'FuzeContact', 'FuzeDeploy', 'FuzeExecutive', 'FuzeHub', 'FuzeKeys', 'FuzeMarket', 'FuzeMerchandize', 'FuzePicker', 'FuzePlan', 'FuzeSales', 'FuzeService', 'FuzeSocial', 'FuzeX', 'MendysRobotics', 'MendysRoboticsWP']`  — added: `['FuzeAgent', 'FuzeBI', 'FuzeCall', 'FuzeContact', 'FuzeDeploy', 'FuzeExecutive', 'FuzeHub', 'FuzeKeys', 'FuzeMarket', 'FuzeMerchandize', 'FuzePicker', 'FuzePlan', 'FuzeSales', 'FuzeService', 'FuzeSocial', 'FuzeX', 'MendysRobotics', 'MendysRoboticsWP']`
- **dependsOn** (advisory): `(absent)` → `['FuzeAgent', 'FuzeBI', 'FuzeDeploy', 'FuzeKeys', 'FuzePlan']`

**UNION semantics** — no existing grant removed; only approved grants added. A2A stays disabled until this repo's rollout, so this is inert data until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)