### PR TITLE
fix(login): always render sign-in form (fail-open on slow auth-methods)

### DIFF
--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -65,7 +65,13 @@ function LoginPage() {
   const loading = pending !== null
   const [error, setError] = useState('')
   const [notice, setNotice] = useState('')
-  const [authMethods, setAuthMethods] = useState<AuthMethods | null>(null)
+  // Start from the password-only fallback so the sign-in form is ALWAYS
+  // rendered immediately — never gated on the auth-methods fetch. `getAuthMethods`
+  // is progressive enhancement: when it resolves it upgrades this to advertise
+  // Google/MFA. Previously this was `null` and the whole form was hidden until the
+  // fetch resolved; when that request HUNG (its 30s timeout, not a rejection, so
+  // the catch never ran) the login page rendered blank and was unusable.
+  const [authMethods, setAuthMethods] = useState<AuthMethods>(FALLBACK_METHODS)
   const { setUser } = useCurrentUser()
 
   // Route an authenticated Security-API session into the app: hydrate the
@@ -300,7 +306,7 @@ function LoginPage() {
       {/* Credentials form — the DEFAULT sign-in/sign-up UI, brokered entirely by
           FuzeFront's own Security API (same-origin /api/v1/security). No identity
           provider is named or contacted by the browser. */}
-      {authMethods && passwordEnabled && (
+      {passwordEnabled && (
         <form onSubmit={handleCredentialsSubmit}>
           {mode === 'signup' && (
             <div style={{ display: 'flex', gap: 'var(--space-3, 12px)' }}>


### PR DESCRIPTION
## Problem
Prod login rendered a **blank form** (no email/password/Sign-in) — only the "Welcome to FuzeFront" header + "Create an account" footer. Diagnosed live: the page calls `getAuthMethods()` (`GET /api/v1/security/methods`) on mount and **gates the entire credentials form on it** (`authMethods !== null`, LoginPage.tsx). That endpoint is intermittently slow and sometimes **hangs to its 30s axios timeout** — a hang, not a rejection, so the `catch` that sets `FALLBACK_METHODS` never fired. Result: 30s of blank, unusable login.

## Fix
Initialize `authMethods` to the existing password-only `FALLBACK_METHODS` so the email/password form **always renders immediately**. `getAuthMethods()` becomes progressive enhancement — it upgrades the UI (Google/MFA/signup checks) when it resolves, and a slow/failed fetch can no longer hide the form.

2-line behavioral change (+ comment): `useState(FALLBACK_METHODS)` instead of `useState(null)`, and drop the `authMethods &&` gate on the form.

## Out of scope
- Backend `/api/v1/security/methods` intermittent latency → #366 (same Authentik-hairpin class).
- `app-registry listApps` 10s timeout (post-login launcher) — separate pre-existing gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)