### PR TITLE
fix(auth): eliminate DNS-stall login failures (avatars=initials + bounded dnsConfig)

### DIFF
--- a/deploy/helm/fuzefront/templates/authentik.yaml
+++ b/deploy/helm/fuzefront/templates/authentik.yaml
@@ -34,6 +34,16 @@
   value: "true"
 - name: AUTHENTIK_ERROR_REPORTING__ENABLED
   value: "false"
+# Avatars: the default is "gravatar,initials", which performs live gravatar.com
+# DNS + HTTPS lookups inside request handling. Cluster DNS intermittently
+# stalls 5-10s (single CoreDNS replica reached over the node overlay — measured
+# in-pod: gravatar.com resolution 79ms -> 5086ms -> 10101ms), and those stalls
+# landed inside login flows: the security service's 10s flow-hop timeout then
+# turned them into 401s on VALID credentials. "initials" is computed locally —
+# zero egress and zero DNS in the auth path. Do not re-enable gravatar without
+# NodeLocal DNSCache (or equivalent) in place.
+- name: AUTHENTIK_AVATARS
+  value: "initials"
 # Disable the embedded (proxy) outpost. FuzeFront uses OAuth2/OIDC providers
 # only — verified in prod: 3 oauth2 providers, 0 proxy providers, and the
 # "authentik Embedded Outpost" had 0 providers attached, i.e. it served nothing.
@@ -187,6 +197,19 @@ spec:
       # vmi3383846 taint is PreferNoSchedule (soft) so no toleration is needed.
       nodeSelector:
         kubernetes.io/hostname: vmi3383846
+      # Bound DNS stalls. The cluster runs a single CoreDNS replica on another
+      # node; intermittent loss on that path produced 5s/10s resolver-retry
+      # stalls (glibc timeout defaults) measured from this pod, which blocked
+      # login flows. timeout:1/attempts:2 caps any DNS hiccup at ~2s, and
+      # ndots:1 stops the ndots:5 search-domain amplification for dotted names.
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
+          - name: timeout
+            value: "1"
+          - name: attempts
+            value: "2"
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/deploy/helm/fuzefront/templates/security.yaml
+++ b/deploy/helm/fuzefront/templates/security.yaml
@@ -21,6 +21,18 @@ spec:
         {{- include "fuzefront.metricsAnnotations" (dict "port" .Values.securityService.port "root" .) | nindent 8 }}
     spec:
       {{- include "fuzefront.scheduling" (dict "svc" .Values.securityService "root" .) | nindent 6 }}
+      # Bound DNS stalls (same rationale as authentik-server): single CoreDNS
+      # replica over the overlay intermittently stalls lookups in 5s/10s retry
+      # multiples; this service resolves authentik-server on every auth flow.
+      # timeout:1/attempts:2 caps a DNS hiccup at ~2s instead of 5-10s.
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
+          - name: timeout
+            value: "1"
+          - name: attempts
+            value: "2"
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
## Root cause (measured live)
Login intermittently took 16–30s and **401'd on valid credentials**. Authentik's own Django runtimes were ≤1s throughout — the stall was **DNS**. From inside the authentik pod: `gravatar.com` 79ms → 5086ms → **10101ms**, and even `fuzeinfra-postgres` 5074ms — exact 5s/10s glibc resolver-retry multiples = packet loss to the **single CoreDNS replica** (vmi3396106) reached over the node overlay from vmi3383846.

`AUTHENTIK_AVATARS` was unset ⇒ default `gravatar,initials` ⇒ live gravatar lookups inside auth handling. The DNS stalls landed inside login flow hops; the security service's 10s hop timeout (#362/#366) then converted them into 401s.

## Change
- **`AUTHENTIK_AVATARS=initials`** — zero egress/DNS in the auth path.
- **`dnsConfig` (timeout:1, attempts:2, ndots:1)** on authentik-server + security-service — caps any residual DNS hiccup at ~2s instead of 5–10s.

## Verification plan (post-deploy)
- In-pod `getaddrinfo` probe: no 5s/10s outliers.
- 10× `POST /api/v1/security/session`: 0 × 401-on-valid-creds, no `hop timed out` pino entries.

## Out of scope
CoreDNS redundancy (≥2 replicas / NodeLocal DNSCache) + overlay-loss re-verification → delegated to FuzeInfra via @claude issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)