### PR TITLE
FQ-17: unblock FuzeQuality production release

### DIFF
--- a/FuzeQuality/apps/api/src/repository-onboarding.ts
+++ b/FuzeQuality/apps/api/src/repository-onboarding.ts
@@ -72,7 +72,7 @@ export function createGitHubAccessVerifier(tokenForInstallation: (installationId
         commitSha,
         private: repository.private ?? true,
         permissions: {
-          contents: repository.permissions.admin ? 'admin' : repository.permissions.push ? 'write' : 'read',
+          contents: repository.permissions?.admin ? 'admin' : repository.permissions?.push ? 'write' : 'read',
           metadata: 'read',
         },
       }


### PR DESCRIPTION
## Summary
- handle GitHub App responses that omit the legacy permissions object
- unblock the FuzeQuality frontend verification/release stage

## Verification
- production Docker erify target passes
- TypeScript type-check passes
- 38 tests pass, 1 integration test intentionally skipped
- Vite production build passes

Follow-up to #372.