### PR TITLE
FQ-17: sustain Kafka membership throughout long scans

### DIFF
--- a/FuzeQuality/apps/workers/src/runtime.ts
+++ b/FuzeQuality/apps/workers/src/runtime.ts
@@ -22,7 +22,11 @@ export async function runConsumer(
   const brokers = process.env.KAFKA_BROKERS?.split(',').filter(Boolean)
   if (!brokers?.length) throw new Error('KAFKA_BROKERS is required for worker processes')
   const kafka = new Kafka({ clientId: groupId, brokers })
-  const consumer = kafka.consumer({ groupId })
+  const consumer = kafka.consumer({
+    groupId,
+    sessionTimeout: 240_000,
+    heartbeatInterval: 3_000,
+  })
   const producer = kafka.producer()
   await consumer.connect()
   await producer.connect()

--- a/FuzeQuality/apps/workers/src/scanner.ts
+++ b/FuzeQuality/apps/workers/src/scanner.ts
@@ -24,11 +24,25 @@ await runConsumer(
       temporary = true
     }
     try {
-      const result = await scanRepository(repository, root, { onProgress: heartbeat })
-      await apiRequest<ScanResult>('/api/v1/internal/scans/results', {
-        method: 'POST',
-        body: JSON.stringify(result),
-      })
+      const heartbeatTimer = setInterval(() => {
+        void heartbeat().catch(error => {
+          console.warn(JSON.stringify({
+            event: 'repository_scan_heartbeat',
+            outcome: 'failed',
+            repository: `${repository.owner}/${repository.name}`,
+            error: error instanceof Error ? error.message : String(error),
+          }))
+        })
+      }, 3_000)
+      try {
+        const result = await scanRepository(repository, root, { onProgress: heartbeat })
+        await apiRequest<ScanResult>('/api/v1/internal/scans/results', {
+          method: 'POST',
+          body: JSON.stringify(result),
+        })
+      } finally {
+        clearInterval(heartbeatTimer)
+      }
     } finally {
       if (temporary) await rm(root, { recursive: true, force: true })
     }


### PR DESCRIPTION
## Summary
- configure a four-minute Kafka consumer session window
- send background heartbeats during asynchronous discovery and API persistence
- retain cooperative heartbeats inside CPU-heavy scanner loops

This closes the remaining production retry observed after PR #375.