### PR TITLE
fix(security): forward RFC 9207 iss through the Google brokered callback

### DIFF
--- a/backend/security/src/providers/IdentityProvider.ts
+++ b/backend/security/src/providers/IdentityProvider.ts
@@ -90,6 +90,8 @@ export interface SocialCallbackInput {
   code: string;
   /** Anti-forgery state issued at start. */
   state: string;
+  /** RFC 9207 issuer identifier echoed by the provider (Google sends it; required by the client). */
+  iss?: string;
 }
 
 /**

--- a/backend/security/src/providers/authentik/AuthentikIdentityProvider.ts
+++ b/backend/security/src/providers/authentik/AuthentikIdentityProvider.ts
@@ -510,7 +510,8 @@ export class AuthentikIdentityProvider implements IdentityProvider {
       const identity = await this.googleClient.handleCallback(
         input.code,
         input.state,
-        st.codeVerifier
+        st.codeVerifier,
+        input.iss
       )
       await this.provisionSocialUserFn(identity, 'google')
       user = await this.syncUserFn({
@@ -1283,7 +1284,8 @@ export class AuthentikIdentityProvider implements IdentityProvider {
       const identity = await this.googleClient.handleCallback(
         input.code,
         input.state,
-        link.codeVerifier
+        link.codeVerifier,
+        input.iss
       )
       identityEmail = identity.email
       // Safety: the returned identity must be the SAME account that started the

--- a/backend/security/src/providers/authentik/AuthentikIdentityProvider.ts
+++ b/backend/security/src/providers/authentik/AuthentikIdentityProvider.ts
@@ -229,7 +229,7 @@ export interface AuthentikProviderDeps {
     isInitialized(): boolean
     initialize(): Promise<void>
     generateAuthUrl(state: string): { url: string; codeVerifier: string }
-    handleCallback(code: string, state: string, codeVerifier: string): Promise<GoogleIdentity>
+    handleCallback(code: string, state: string, codeVerifier: string, iss?: string): Promise<GoogleIdentity>
   }
   /** Projects validated social claims into the local `users` row (+ event). */
   syncUser: (userinfo: any) => Promise<BrokeredUser>

--- a/backend/security/src/routes/security.ts
+++ b/backend/security/src/routes/security.ts
@@ -275,8 +275,11 @@ router.get('/social/callback', async (req: Request, res: Response) => {
   try {
     const code = typeof req.query.code === 'string' ? req.query.code : ''
     const state = typeof req.query.state === 'string' ? req.query.state : ''
+    // Google echoes its issuer in the redirect (RFC 9207); the OIDC client
+    // validates it, so it must survive the trip through the broker input.
+    const iss = typeof req.query.iss === 'string' ? req.query.iss : undefined
     if (!code || !state) throw new InvalidInputError('code and state are required')
-    const result = await getIdentityProvider().brokerCallback({ code, state }, sessionContext(req))
+    const result = await getIdentityProvider().brokerCallback({ code, state, iss }, sessionContext(req))
     // Clear the state cookie; append the FuzeFront opaque code (never a token).
     res.setHeader('Set-Cookie', ['sec_social_state=; HttpOnly; Secure; SameSite=Lax; Max-Age=0; Path=/'])
     const sep = result.redirectTo.includes('?') ? '&' : '?'
@@ -312,8 +315,11 @@ router.get('/social/google/callback', async (req: Request, res: Response) => {
   try {
     const code = typeof req.query.code === 'string' ? req.query.code : ''
     const state = typeof req.query.state === 'string' ? req.query.state : ''
+    // Google echoes its issuer in the redirect (RFC 9207); the OIDC client
+    // validates it, so it must survive the trip through the broker input.
+    const iss = typeof req.query.iss === 'string' ? req.query.iss : undefined
     if (!code || !state) throw new InvalidInputError('code and state are required')
-    const result = await getIdentityProvider().brokerCallback({ code, state }, sessionContext(req))
+    const result = await getIdentityProvider().brokerCallback({ code, state, iss }, sessionContext(req))
     const sep = result.redirectTo.includes('?') ? '&' : '?'
     // A LINK handshake mints no session (no code to redeem) — return a neutral
     // confirmation instead.

--- a/backend/security/src/services/googleOidc.ts
+++ b/backend/security/src/services/googleOidc.ts
@@ -124,7 +124,7 @@ export class GoogleOidcService {
    * Exchange the code SERVER-TO-SERVER and return the VALIDATED identity claims.
    * Never logs tokens. Throws on any protocol/validation failure (fail-closed).
    */
-  async handleCallback(code: string, state: string, codeVerifier: string): Promise<GoogleIdentity> {
+  async handleCallback(code: string, state: string, codeVerifier: string, iss?: string): Promise<GoogleIdentity> {
     const start = Date.now()
     logger.info('googleOidc: callback start')
     try {
@@ -132,7 +132,10 @@ export class GoogleOidcService {
       if (!codeVerifier) throw new Error('code_verifier missing for Google callback')
       const tokenSet = await this.client.callback(
         this.config.redirectUri,
-        { code, state },
+        // Google sends `iss` in the redirect (RFC 9207) and openid-client
+        // REQUIRES it when discovery advertises the parameter — dropping it
+        // fails the callback with "iss missing from the response".
+        { code, state, ...(iss ? { iss } : {}) },
         { code_verifier: codeVerifier, state }
       )
       const claims = tokenSet.claims()


### PR DESCRIPTION
## Problem
Google sign-in fails 100% server-side: `googleOidc: callback failed — \"iss missing from the response\"` (verified live, 31ms fast-fail) → browser bounced to `/?error=authentication_failed`.

Google echoes `iss=https://accounts.google.com` in its authorization redirect (RFC 9207), and openid-client REQUIRES that parameter when the issuer's discovery advertises `authorization_response_iss_parameter_supported`. Our callback route rebuilt the params as only `{code, state}`, dropping `iss`.

## Fix
Thread `iss` from the callback query through `SocialCallbackInput` and both provider call sites (sign-in + account-link) into `client.callback()`. Optional field — Authentik-source path unaffected. Never fabricated locally: it comes from the real redirect, preserving the OAuth mix-up protection the check exists for.

Files: `routes/security.ts` (both social callback routes), `providers/IdentityProvider.ts`, `providers/authentik/AuthentikIdentityProvider.ts` (2 call sites), `services/googleOidc.ts`.

## Verification
Live repro + server log evidence above; CI validates types/tests. Post-merge: real browser Google sign-in with the owner's account click (final e2e leg).

🤖 Generated with [Claude Code](https://claude.com/claude-code)