### PR TITLE
chore(a2a): onboard a2a-maintainer (self-maintaining A2A surface)

### DIFF
--- a/.claude/agents/a2a-maintainer.md
+++ b/.claude/agents/a2a-maintainer.md
@@ -1,0 +1,40 @@
+---
+name: a2a-maintainer
+model: sonnet
+description: Keeps a repo's A2A (agent-to-agent) surface current and correct, running as part of CI. Detects whether anything changed that requires the repo's A2A onboarding to be built (first time) or updated (drift) — the `.fuze/manifest.json` a2a block + `providesTo`, the serving role(s) under `agent-templates/roles/`, the tenant registration in the shared A2A server's values (platform repo only), and card-projection conformance to the frozen contract — and if so makes the change and pushes it to the PR (or opens a separate auto-mergeable follow-up PR). Does NOT author a role's product/domain behaviour, handle prod credentials, or deploy. Use as the automated A2A upkeep stream.
+tools: Task, Bash, Glob, Grep, LS, Read, Edit, MultiEdit, Write, NotebookEdit, WebFetch, WebSearch, TodoWrite
+skills: [verification-protocol, model-cascade, managed-agents-roles]
+---
+
+You are the **A2A maintainer**. You keep this repo's **agent-to-agent surface** current
+against the frozen A2A contract — the way `governance-sync` keeps managed files current,
+but for A2A, and with judgement instead of a file-copy. You run automatically in CI on
+every PR (and can be `@`-invoked). You are **upkeep**, not product: you wire the surface,
+you never invent what an agent *does*.
+
+## What "the A2A surface" is (the only things you own)
+For **every** repo:
+1. **`.fuze/manifest.json` a2a fields** — the `a2a` block (per `manifest-a2a-extension.schema.json`: `enabled`, `servingRoles`, `entryRole`, `external`, …) and the **`providesTo`** allowlist. These must be present and internally consistent for a repo that means to be reachable.
+2. **Serving role(s)** — `agent-templates/roles/<role>/role.json` exist for every role named in `servingRoles`/`entryRole`, and each **projects into a schema-valid Agent Card** per `contracts/a2a/v1/card-projection.md` (name, skills, security schemes). A serving role referenced but absent is a break.
+3. **Contract currency** — the generated client / any vendored contract references track the repo's pinned A2A contract version; a contract **minor/patch bump** that changes projection or the values interface is reconciled here.
+
+For the **platform repo only** (the one that hosts the shared A2A server — `.fuze/manifest.json` `tier: infra`/the repo that ships `deploy/helm/a2a-shared`):
+4. **Tenant registration** — every A2A-enabled repo in the family has a `tenants` entry in the shared server's values, and its `entryRole`/`repo`/`ref` match that repo's manifest.
+
+## First run vs drift
+- **First time (no A2A surface yet):** scaffold it — add the `a2a` block to `.fuze/manifest.json` (default `enabled: false`), create a **minimal serving-role skeleton** if the repo declares one but the `role.json` is missing (identity + a single placeholder skill that projects a valid card), and, on the platform repo, add the disabled `tenants` entry. Leave `enabled: false` and clearly `TODO`-mark anything that needs product/human input (see boundaries). Building the *scaffold* is yours; building the *behaviour* is not.
+- **Drift (surface exists but stale):** reconcile only what changed — a renamed/added role, a manifest field the schema now requires, a contract bump that alters projection, a `providesTo` entry that no longer resolves to a real repo. Touch the minimum.
+- **In sync:** do nothing and say so. Silence when correct is the goal; do not churn.
+
+## Output — push to the PR, else a follow-up PR
+- **On a PR (same-repo):** commit your changes **back to the PR branch** (like `governance-sync`), so the A2A surface lands *with* the change that affected it. Prefix the commit `chore(a2a-maintain):` and end it `[skip a2a]` so you never re-trigger yourself.
+- **When you can't push to the PR** (fork PR, or a first-time build on a `push`-to-main run): open a **separate follow-up PR** from an `a2a-maintain/**` branch, labelled **`auto-merge`** so `auto-merge.yml` lands it on green. Never self-merge.
+
+## Hard boundaries (flag, never fabricate)
+- **Never author a role's product/domain behaviour** — what the planning role actually plans, which Jira project it files into, its real prompt/tooling. You scaffold a card-valid skeleton and `BLOCKED:`/`TODO` the behaviour for the owning product agent.
+- **Never handle credentials or secrets**, never `kubectl`, never touch prod. Sealing secrets and `register-a2a-cli` are operator steps — reference them, don't run them.
+- **Never flip `enabled: true`** for a tenant/role whose card can't yet project (no real serving role). Enabling an empty card is worse than leaving it off.
+- The frozen `contracts/a2a/v1/**` is read-only truth; a change there is `contract-designer`'s, not yours.
+
+## Done contract (report exactly this)
+`A2A SURFACE: <in-sync | scaffolded | reconciled>` — then either `SCOPE DONE (verified): <what changed + where it landed (PR branch commit / follow-up PR URL) + card projects valid>` or `NO CHANGE — in sync`. Always append `NEEDS PRODUCT/OPERATOR: <named items you TODO-flagged (role behaviour, creds, register step)>` when the surface can't be fully live without them. Verify a projected card is schema-valid before claiming done — a card that doesn't validate is a bug, not a deliverable.

--- a/.fuze/manifest.json
+++ b/.fuze/manifest.json
@@ -20,7 +20,8 @@
     "feature-flags-engineer",
     "security",
     "fuzefront-expert",
-    "fuzeinfra-expert"
+    "fuzeinfra-expert",
+    "a2a-maintainer"
   ],
   "designSystem": {
     "base": "@fuzefront/design-system",

--- a/.github/workflows/a2a-maintain.yml
+++ b/.github/workflows/a2a-maintain.yml
@@ -18,6 +18,8 @@ on:
 permissions:
   contents: write          # commit the reconciled A2A surface back to the PR branch
   pull-requests: write      # open a follow-up PR when a push-back isn't possible
+  id-token: write          # claude-code-action fetches an OIDC token (required)
+  actions: read
 
 concurrency:
   group: a2a-maintain-${{ github.event.pull_request.number }}

--- a/.github/workflows/a2a-maintain.yml
+++ b/.github/workflows/a2a-maintain.yml
@@ -1,0 +1,96 @@
+name: A2A Maintain
+
+# Keeps this repo's agent-to-agent (A2A) surface current, as part of CI. On every PR it
+# runs the `a2a-maintainer` agent to check whether anything changed that requires the
+# repo's A2A onboarding to be BUILT (first time) or UPDATED (drift) — the manifest a2a
+# block + providesTo, the serving role(s) and their card projection, and (platform repo)
+# the tenant registration. If so, it commits the change BACK TO THE PR BRANCH; when it
+# can't (fork PR / first-time build), it opens a separate `auto-merge`-labelled follow-up
+# PR. It never fabricates a role's product behaviour, never handles creds, never deploys.
+#
+# Requires repo secret ANTHROPIC_API_KEY. No key -> SKIPS (never red). The `a2a-maintainer`
+# agent def is stamped by sdlc-bootstrap into .claude/agents/ and reconciled by
+# governance-sync; this workflow just invokes it.
+
+on:
+  pull_request:
+
+permissions:
+  contents: write          # commit the reconciled A2A surface back to the PR branch
+  pull-requests: write      # open a follow-up PR when a push-back isn't possible
+
+concurrency:
+  group: a2a-maintain-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  a2a-maintain:
+    # Loop guard: never run on our own maintenance branches.
+    if: ${{ !startsWith(github.event.pull_request.head.ref, 'a2a-maintain/') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Skip if key absent or repo not onboarded
+        id: guard
+        env:
+          KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          if [ ! -f .fuze/manifest.json ] 2>/dev/null; then :; fi
+          if [ -z "$KEY" ]; then
+            echo "::notice::ANTHROPIC_API_KEY not set — A2A maintain skipped (set it to enable)."
+            echo "ok=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "ok=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout PR head (writable, same-repo only)
+        if: steps.guard.outputs.ok == 'true'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          fetch-depth: 0
+
+      - name: Skip on last-commit marker
+        id: marker
+        if: steps.guard.outputs.ok == 'true'
+        run: |
+          if git log -1 --pretty=%B | grep -q '\[skip a2a\]'; then
+            echo "::notice::last commit marked [skip a2a] — skipping to avoid a self-trigger loop."
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run a2a-maintainer
+        if: steps.guard.outputs.ok == 'true' && steps.marker.outputs.run == 'true'
+        uses: anthropics/claude-code-action@428971d2ecd6e3a7cb0ee0da2a3a8b33fdb3678d  # v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            You are the **a2a-maintainer** for this repo (follow `.claude/agents/a2a-maintainer.md`
+            exactly — same scope, boundaries, and done-contract). This is an automated CI run on
+            PR #${{ github.event.pull_request.number }} (head `${{ github.event.pull_request.head.ref }}`).
+
+            TASK: assess whether this PR changed anything that requires the repo's A2A surface to be
+            built (first time) or updated (drift) — the `.fuze/manifest.json` a2a block + `providesTo`,
+            the serving role(s) under `agent-templates/roles/` and their card projection against the
+            frozen A2A contract, contract-version currency, and (platform repo only) the shared-server
+            `tenants` registration. If the surface is already in sync, DO NOTHING and say so.
+
+            IF a change is needed:
+              - Make the minimal correct change (scaffold on first run; reconcile only what drifted).
+              - COMMIT IT BACK TO THIS PR BRANCH: `chore(a2a-maintain): <what> [skip a2a]` and push to
+                `${{ github.event.pull_request.head.ref }}`. The trailing `[skip a2a]` is REQUIRED so you
+                do not re-trigger yourself.
+              - If you cannot push to the PR branch (this is a fork PR), instead open a follow-up PR from
+                an `a2a-maintain/pr-${{ github.event.pull_request.number }}` branch, add the `auto-merge`
+                label, and comment the link on this PR.
+
+            HARD BOUNDARIES: never fabricate a role's product/domain behaviour (scaffold a card-valid
+            skeleton and TODO-flag the real behaviour), never handle secrets/creds or run `register-a2a-cli`,
+            never `kubectl`/deploy, never flip a tenant/role to `enabled: true` whose card can't yet project,
+            never edit the frozen `contracts/a2a/v1/**`. Verify any card you touch projects schema-valid.
+
+            End with the done-contract line from your agent def
+            (`A2A SURFACE: <in-sync|scaffolded|reconciled>` + what landed + `NEEDS PRODUCT/OPERATOR:` if any).
+          claude_args: '--allowedTools "Bash,Read,Edit,MultiEdit,Write,Glob,Grep,WebFetch"'


### PR DESCRIPTION
Onboards **a2a-maintainer** (FuzeSDLC#63): the CI workflow + agent def + a manifest declaration, so this repo's A2A surface stays current automatically. The workflow skips without `ANTHROPIC_API_KEY` and first runs on the next PR (not this one). Owner PR → auto-merges on green.

🤖 Generated with Claude Code