### PR TITLE
fix(fuzequality): restore authenticated portfolio bootstrap

### DIFF
--- a/FuzeQuality/apps/api/src/authentication.test.ts
+++ b/FuzeQuality/apps/api/src/authentication.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+import { isPublicRequest } from './authentication'
+
+describe('FuzeQuality API authentication allowlist', () => {
+  it('allows the read-only portfolio used by the Cloudflare-protected web application', () => {
+    expect(isPublicRequest('GET', '/api/v1/portfolio')).toBe(true)
+  })
+
+  it('does not allow portfolio mutations or privileged catalog operations', () => {
+    expect(isPublicRequest('POST', '/api/v1/portfolio')).toBe(false)
+    expect(isPublicRequest('GET', '/api/v1/repositories')).toBe(false)
+    expect(isPublicRequest('POST', '/api/v1/repositories')).toBe(false)
+    expect(isPublicRequest('POST', '/api/v1/repositories/id/scans')).toBe(false)
+  })
+})

--- a/FuzeQuality/apps/api/src/authentication.ts
+++ b/FuzeQuality/apps/api/src/authentication.ts
@@ -1,0 +1,8 @@
+export function isPublicRequest(method: string, path: string) {
+  return (
+    path.startsWith('/health/') ||
+    path === '/metrics' ||
+    path.startsWith('/api/v1/webhooks/') ||
+    (method === 'GET' && path === '/api/v1/portfolio')
+  )
+}

--- a/FuzeQuality/apps/api/src/index.ts
+++ b/FuzeQuality/apps/api/src/index.ts
@@ -19,6 +19,7 @@ import {
 import { githubInstallationToken } from '../../workers/src/github'
 import { createGitHubAccessVerifier, publicAccessError } from './repository-onboarding'
 import { requestIdentity, requirePlatformPermission } from './platform-authorization'
+import { isPublicRequest } from './authentication'
 
 const app = express()
 const store = createCatalogStore()
@@ -41,9 +42,7 @@ app.use((request, response, next) => {
   const configuredToken = process.env.FUZEQUALITY_API_TOKEN
   if (
     !configuredToken ||
-    request.path.startsWith('/health/') ||
-    request.path === '/metrics' ||
-    request.path.startsWith('/api/v1/webhooks/') ||
+    isPublicRequest(request.method, request.path) ||
     request.headers.authorization === `Bearer ${configuredToken}`
   ) {
     next()


### PR DESCRIPTION
## Root cause

Cloudflare Access authenticates the browser successfully, but the FuzeQuality API globally requires the internal service bearer token for `GET /api/v1/portfolio`. The static browser client cannot and should not receive that internal credential, so its initial catalog request returns 401.

## Change

- Allow only `GET /api/v1/portfolio` through the public-request classifier.
- Keep repository administration, scans, mutations, and all other catalog endpoints behind the existing FuzeFront security-service authorization path.
- Add focused regression tests for the public and protected request classifications.

The portfolio endpoint is the deliberately read-only bootstrap endpoint exposed behind the existing Cloudflare-protected production ingress.

## Verification

- `git diff --check` passes.
- Regression tests are committed for CI.
- Local Vitest execution could not complete because the workspace dependency installation was interrupted/incomplete (`fdir` missing after npm stalled); no test success is claimed locally.