### PR TITLE
fix(frontend): authenticated /login|/signup 404 + org-null app visibility on dashboard

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,11 @@
 import React, { useEffect, useRef, useState } from 'react'
 import { Routes, Route, Navigate, useParams } from 'react-router-dom'
-import { useCurrentUser, useAppContext, MenuItem } from './lib/shared'
+import {
+  useCurrentUser,
+  useAppContext,
+  MenuItem,
+  resetWorkspaceSessionIfUserChanged,
+} from './lib/shared'
 import { installBridge, bridge } from './platform/bridge'
 import { AppRegistryProvider } from './platform/appRegistry'
 import StandaloneAppSurface from './components/StandaloneAppSurface'
@@ -40,6 +45,7 @@ function AuthWrapper({ children }: { children: React.ReactNode }) {
             console.log('Attempting to get current user...')
             const user = await getCurrentUser()
             console.log('Successfully got user:', user.email)
+            resetWorkspaceSessionIfUserChanged(user.id)
             dispatch({ type: 'SET_USER', payload: user })
           } catch (userError) {
             // Token is invalid or expired
@@ -207,6 +213,16 @@ function AppContent() {
         <LoginPage />
       </AppRegistryProvider>
     )
+  }
+
+  // An authenticated user hitting the pre-auth /login or /signup routes must
+  // be redirected to /dashboard (replace, not push, so Back doesn't bounce
+  // them into the auth surface). Without this, those paths simply aren't
+  // registered in the authenticated route tree below and fall through to the
+  // catch-all 404 — this was BUG 1: a signed-in user visiting /login saw a
+  // "404 - Page Not Found" app-shell page instead of being routed home.
+  if (currentPath === '/login' || currentPath === '/signup') {
+    return <Navigate to="/dashboard" replace />
   }
 
   // Standalone apps (mode = "standalone") render WITHOUT any portal chrome —

--- a/frontend/src/__tests__/App.authed-login-redirect.test.tsx
+++ b/frontend/src/__tests__/App.authed-login-redirect.test.tsx
@@ -1,0 +1,142 @@
+/**
+ * App.authed-login-redirect.test.tsx
+ *
+ * Regression cover for the prod BUG 1: an authenticated user who navigated
+ * (or was linked) to /login or /signup saw the app shell's catch-all
+ * "404 - Page Not Found" page instead of being routed to /dashboard. The
+ * authenticated route tree in App.tsx (AppContent) never registered /login
+ * or /signup at all, so both fell through to the `*` NotFoundPage route.
+ *
+ * Fixed by short-circuiting both paths to `<Navigate to="/dashboard" replace />`
+ * before the standalone/portal route tree is evaluated, for any authenticated
+ * session (password or social login alike).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+
+vi.mock('../lib/shared', async () => {
+  const actual = await vi.importActual<typeof import('../lib/shared')>(
+    '../lib/shared'
+  )
+  return {
+    ...actual,
+    useCurrentUser: vi.fn(),
+  }
+})
+
+vi.mock('../services/api', () => ({
+  getCurrentUser: vi.fn().mockResolvedValue({
+    id: 'user-1',
+    email: 'user@example.com',
+    roles: [],
+  }),
+}))
+
+vi.mock('../services/websocket', () => ({
+  default: {
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    on: vi.fn(),
+    off: vi.fn(),
+    onServer: vi.fn(),
+    offServer: vi.fn(),
+    emitServer: vi.fn(),
+    isConnected: vi.fn().mockReturnValue(false),
+  },
+}))
+
+vi.mock('../platform/bridge', () => ({
+  installBridge: vi.fn(),
+  bridge: { setContext: vi.fn() },
+}))
+
+vi.mock('../platform/appRegistry', () => ({
+  AppRegistryProvider: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+}))
+
+vi.mock('../components/WorkspaceProvisioningGate', () => ({
+  WorkspaceProvisioningGate: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+}))
+
+vi.mock('../components/Layout', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+vi.mock('../pages/DashboardPage', () => ({
+  default: () => <div data-testid="dashboard-page">Dashboard</div>,
+}))
+
+vi.mock('../pages/LoginPage', () => ({
+  default: () => <div data-testid="login-page">Login</div>,
+}))
+
+import App from '../App'
+import * as sharedMock from '../lib/shared'
+
+/** Point window.location.pathname at `path` without navigating jsdom. */
+function setPath(path: string) {
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    writable: true,
+    value: { ...window.location, pathname: path, href: `https://app.fuzefront.com${path}` },
+  })
+}
+
+describe('BUG 1 — authenticated /login and /signup redirect to /dashboard', () => {
+  beforeEach(() => {
+    vi.mocked(sharedMock.useCurrentUser).mockReturnValue({
+      user: { id: 'user-1', email: 'user@example.com', roles: [] },
+      currentUser: { id: 'user-1', email: 'user@example.com', roles: [] },
+      isAuthenticated: true,
+      setUser: vi.fn(),
+      setCurrentUser: vi.fn(),
+    } as any)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('redirects an authenticated user from /login to /dashboard', async () => {
+    setPath('/login')
+    render(
+      <MemoryRouter initialEntries={['/login']}>
+        <App />
+      </MemoryRouter>
+    )
+    await waitFor(() =>
+      expect(screen.getByTestId('dashboard-page')).toBeTruthy()
+    )
+    expect(screen.queryByText(/404 - Page Not Found/i)).toBeNull()
+  })
+
+  it('redirects an authenticated user from /signup to /dashboard', async () => {
+    setPath('/signup')
+    render(
+      <MemoryRouter initialEntries={['/signup']}>
+        <App />
+      </MemoryRouter>
+    )
+    await waitFor(() =>
+      expect(screen.getByTestId('dashboard-page')).toBeTruthy()
+    )
+    expect(screen.queryByText(/404 - Page Not Found/i)).toBeNull()
+  })
+
+  it('still renders /dashboard directly (no regression on the normal path)', async () => {
+    setPath('/dashboard')
+    render(
+      <MemoryRouter initialEntries={['/dashboard']}>
+        <App />
+      </MemoryRouter>
+    )
+    await waitFor(() =>
+      expect(screen.getByTestId('dashboard-page')).toBeTruthy()
+    )
+  })
+})

--- a/frontend/src/__tests__/DashboardPage.org-app-visibility.test.tsx
+++ b/frontend/src/__tests__/DashboardPage.org-app-visibility.test.tsx
@@ -1,0 +1,163 @@
+/**
+ * DashboardPage.org-app-visibility.test.tsx
+ *
+ * Regression cover for the prod BUG 2: a Google/social-login user saw
+ * "No applications available" on the dashboard while the sidebar (backed by
+ * the same `@fuzefront/app-registry-client` registry) correctly listed all 3
+ * activated apps. Root cause: DashboardPage read a different, legacy
+ * `fetchApps()` (`GET /apps`) source instead of `useRegisteredApps()`
+ * (`GET /api/v1/app-registry/apps?status=activated`) — the one source that
+ * had actually returned the 3 apps (with `organizationId: null`) live.
+ *
+ * These tests pin:
+ *   1. isAppVisibleForOrg keeps `organizationId: null` (platform-global) apps
+ *      visible regardless of the active org — including when org hydration
+ *      hasn't completed yet (`activeOrganizationId === null`).
+ *   2. DashboardPage renders apps sourced from `useRegisteredApps()` (the
+ *      same registry the sidebar/SidePanel consumes), not the legacy list.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import type { App as RegistryApp } from '@fuzefront/app-registry-client'
+
+vi.mock('../lib/shared', async () => {
+  const actual = await vi.importActual<typeof import('../lib/shared')>(
+    '../lib/shared'
+  )
+  return {
+    ...actual,
+    useCurrentUser: vi.fn(),
+    useOrganizations: vi.fn(),
+  }
+})
+
+const mockUseRegisteredApps = vi.fn()
+vi.mock('../platform/appRegistry', () => ({
+  useRegisteredApps: () => mockUseRegisteredApps(),
+}))
+
+import DashboardPage, { isAppVisibleForOrg } from '../pages/DashboardPage'
+import * as sharedMock from '../lib/shared'
+
+function makeApp(overrides: Partial<RegistryApp> = {}): RegistryApp {
+  return {
+    slug: 'clock',
+    status: 'activated',
+    mode: 'portal',
+    builtin: true,
+    organizationId: null,
+    isHealthy: true,
+    lastSeenAt: null,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    manifest: {
+      manifestVersion: '1',
+      slug: 'clock',
+      name: 'Clock',
+      menuLabel: 'Clock',
+      mode: 'portal',
+      integration: { type: 'module-federation' } as any,
+    } as any,
+    ...overrides,
+  } as RegistryApp
+}
+
+describe('isAppVisibleForOrg (BUG 2 filter unit)', () => {
+  it('shows a platform-global app (organizationId: null) when an org is active', () => {
+    expect(isAppVisibleForOrg({ organizationId: null }, 'org-1')).toBe(true)
+  })
+
+  it('shows a platform-global app when org hydration has not completed yet (activeOrganizationId null)', () => {
+    expect(isAppVisibleForOrg({ organizationId: null }, null)).toBe(true)
+  })
+
+  it('shows an app scoped to the active organization', () => {
+    expect(isAppVisibleForOrg({ organizationId: 'org-1' }, 'org-1')).toBe(true)
+  })
+
+  it('hides an app scoped to a DIFFERENT organization', () => {
+    expect(isAppVisibleForOrg({ organizationId: 'org-2' }, 'org-1')).toBe(false)
+  })
+})
+
+describe('DashboardPage (BUG 2 regression)', () => {
+  beforeEach(() => {
+    vi.mocked(sharedMock.useCurrentUser).mockReturnValue({
+      user: { id: 'user-1', email: 'user@example.com', roles: [], firstName: 'Ada' },
+      currentUser: null,
+      isAuthenticated: true,
+      setUser: vi.fn(),
+      setCurrentUser: vi.fn(),
+    } as any)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('renders platform-global apps (organizationId: null) from the registry even with an active org set', async () => {
+    vi.mocked(sharedMock.useOrganizations).mockReturnValue({
+      organizations: [],
+      activeOrganizationId: '25b9fc00-8a6f-4215-b9bb-002d898b967e',
+      activeOrganization: null,
+      setActiveOrganization: vi.fn(),
+    } as any)
+    mockUseRegisteredApps.mockReturnValue({
+      apps: [
+        makeApp({ slug: 'fuzesocial', manifest: { ...makeApp().manifest, menuLabel: 'FuzeSocial' } as any }),
+        makeApp({ slug: 'fuzeagent', manifest: { ...makeApp().manifest, menuLabel: 'FuzeAgent' } as any }),
+        makeApp({ slug: 'clock', manifest: { ...makeApp().manifest, menuLabel: 'Clock' } as any }),
+      ],
+      loading: false,
+      error: null,
+      refresh: vi.fn(),
+    })
+
+    render(<DashboardPage />)
+
+    await waitFor(() => expect(screen.getByText('FuzeSocial')).toBeTruthy())
+    expect(screen.getByText('FuzeAgent')).toBeTruthy()
+    expect(screen.getByText('Clock')).toBeTruthy()
+    expect(screen.queryByText(/No applications available/i)).toBeNull()
+  })
+
+  it('renders the same apps even before org hydration completes (activeOrganizationId null)', async () => {
+    vi.mocked(sharedMock.useOrganizations).mockReturnValue({
+      organizations: [],
+      activeOrganizationId: null,
+      activeOrganization: null,
+      setActiveOrganization: vi.fn(),
+    } as any)
+    mockUseRegisteredApps.mockReturnValue({
+      apps: [makeApp()],
+      loading: false,
+      error: null,
+      refresh: vi.fn(),
+    })
+
+    render(<DashboardPage />)
+
+    await waitFor(() => expect(screen.getByText('Clock')).toBeTruthy())
+  })
+
+  it('shows the empty state when the registry genuinely has no visible apps', async () => {
+    vi.mocked(sharedMock.useOrganizations).mockReturnValue({
+      organizations: [],
+      activeOrganizationId: 'org-1',
+      activeOrganization: null,
+      setActiveOrganization: vi.fn(),
+    } as any)
+    mockUseRegisteredApps.mockReturnValue({
+      apps: [makeApp({ organizationId: 'org-2' })],
+      loading: false,
+      error: null,
+      refresh: vi.fn(),
+    })
+
+    render(<DashboardPage />)
+
+    await waitFor(() =>
+      expect(screen.getByText(/No applications available/i)).toBeTruthy()
+    )
+  })
+})

--- a/frontend/src/lib/shared.tsx
+++ b/frontend/src/lib/shared.tsx
@@ -36,6 +36,44 @@ function persistActiveOrganizationId(id: string | null): void {
   }
 }
 
+// The session-scoped "workspace provisioned" flag WorkspaceProvisioningGate
+// uses to skip its loading flash on subsequent navigations within a session.
+const WORKSPACE_READY_SESSION_KEY = 'ff.workspaceReady'
+const LAST_AUTHENTICATED_USER_ID_KEY = 'ff.lastAuthenticatedUserId'
+
+/**
+ * BUG 2 fix (org switcher rendering blank for a social/Google login):
+ *
+ * `ff.activeOrganizationId` (localStorage) and `ff.workspaceReady`
+ * (sessionStorage) are keyed per BROWSER, not per account. A user who signs
+ * out and a *different* user signs back in on the same browser/tab inherits
+ * both stale values: `ff.workspaceReady` short-circuits
+ * WorkspaceProvisioningGate straight to "ready" without confirming org
+ * membership for the NEW session, and `ff.activeOrganizationId` may point at
+ * an org the new user does not belong to at all — leaving
+ * `useOrganizations().activeOrganization` unable to resolve (the org list
+ * for the new user never contains that id), which is exactly what renders
+ * the top-bar org switcher blank.
+ *
+ * Call this once the authenticated user is known (after login/session
+ * restore). If the user id differs from the last-seen one on this browser,
+ * clear both stale keys so WorkspaceProvisioningGate performs a full,
+ * un-shortcut org fetch + hydration for the new account — the same path a
+ * fresh native-login session takes.
+ */
+export function resetWorkspaceSessionIfUserChanged(userId: string): void {
+  try {
+    const lastUserId = localStorage.getItem(LAST_AUTHENTICATED_USER_ID_KEY)
+    if (lastUserId && lastUserId !== userId) {
+      sessionStorage.removeItem(WORKSPACE_READY_SESSION_KEY)
+      localStorage.removeItem(ACTIVE_ORG_STORAGE_KEY)
+    }
+    localStorage.setItem(LAST_AUTHENTICATED_USER_ID_KEY, userId)
+  } catch {
+    // localStorage/sessionStorage unavailable (privacy mode) — degrade gracefully.
+  }
+}
+
 // Types
 export interface User {
   id: string

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,43 +1,66 @@
-import { useEffect, useState } from 'react'
-import { useAppContext, useCurrentUser, App } from '../lib/shared'
-import { fetchApps } from '../services/api'
+import { useCurrentUser, useOrganizations } from '../lib/shared'
+import { useRegisteredApps } from '../platform/appRegistry'
+import { iconGlyph, iconImageUrl, integrationTypeOf, appHref } from '../platform/appManifest'
+import type { App as RegistryApp } from '@fuzefront/app-registry-client'
+
+/**
+ * An app is visible on the dashboard when it is platform-global
+ * (`organizationId: null` — owned by no single org, e.g. FuzeSocial/Clock)
+ * OR it belongs to the currently active organization. Never drop a
+ * platform-global app just because org hydration hasn't finished yet /
+ * `activeOrganizationId` is momentarily null — that was the crux of BUG 2.
+ */
+export function isAppVisibleForOrg(
+  app: Pick<RegistryApp, 'organizationId'>,
+  activeOrganizationId: string | null
+): boolean {
+  return (
+    app.organizationId === null ||
+    app.organizationId === undefined ||
+    app.organizationId === activeOrganizationId
+  )
+}
+
+function integrationIcon(type: string) {
+  return type === 'module-federation'
+    ? '🔗'
+    : type === 'iframe'
+      ? '🖼️'
+      : type === 'web-component'
+        ? '🧩'
+        : '📱'
+}
 
 function DashboardPage() {
-  const { dispatch } = useAppContext()
   const { user } = useCurrentUser()
-  const [allApps, setAllApps] = useState<App[]>([])
+  const { activeOrganizationId } = useOrganizations()
+  // BUG 2 root cause: this page previously called the legacy `fetchApps()`
+  // (`GET /apps`) instead of the same `@fuzefront/app-registry-client`
+  // source (`GET /api/v1/app-registry/apps?status=activated`) the sidebar
+  // (SidePanel) already reads via `useRegisteredApps()`. For a Google/social
+  // login, the legacy endpoint came back empty even though the registry API
+  // itself returned all 3 activated apps (confirmed live: 200 + 3 apps,
+  // `organizationId: null`) — the sidebar (registry-backed) showed them, the
+  // dashboard (legacy-backed) did not. Reading the SAME registry hook fixes
+  // the mismatch; `isAppVisibleForOrg` additionally guarantees
+  // platform-global apps always render regardless of which org is active or
+  // whether org hydration has completed yet.
+  const { apps: registeredApps } = useRegisteredApps()
+  const allApps = registeredApps.filter(app =>
+    isAppVisibleForOrg(app, activeOrganizationId)
+  )
 
-  useEffect(() => {
-    const loadApps = async () => {
-      try {
-        const apps = await fetchApps() // Now returns apps with health status
-        setAllApps(apps)
-        dispatch({ type: 'SET_APPS', payload: apps })
-      } catch (error) {
-        console.error('Failed to load apps:', error)
-      }
-    }
-    loadApps()
-  }, [dispatch])
-
-  const handleAppClick = (app: App) => {
-    if (!app.isHealthy) {
+  const handleAppClick = (app: RegistryApp) => {
+    if (app.isHealthy === false) {
       alert(
-        `${app.name} is currently unavailable. Please try again later or contact support.`
+        `${app.manifest.menuLabel} is currently unavailable. Please try again later or contact support.`
       )
       return
     }
-    window.location.href = `/app/${app.id}`
+    const href = appHref(app)
+    if (href.startsWith('http')) window.location.href = href
+    else window.location.href = href
   }
-
-  const integrationIcon = (type: App['integrationType']) =>
-    type === 'module-federation'
-      ? '🔗'
-      : type === 'iframe'
-        ? '🖼️'
-        : type === 'web-component'
-          ? '🧩'
-          : '📱'
 
   return (
     <div className="dashboard">
@@ -54,54 +77,60 @@ function DashboardPage() {
         <div>
           <h2 className="section-title">Available Applications</h2>
           <div className="app-grid">
-            {allApps.map(app => (
-              <div
-                key={app.id}
-                className={`app-card${app.isHealthy ? '' : ' is-offline'}`}
-                onClick={() => handleAppClick(app)}
-              >
-                <div className="app-card-head">
-                  <div className="app-card-icon">
-                    {app.iconUrl ? (
-                      <img
-                        src={app.iconUrl}
-                        alt=""
-                        className="app-icon-img"
-                        onError={e => {
-                          (e.target as HTMLImageElement).style.display = 'none'
-                        }}
-                      />
-                    ) : (
-                      <div
-                        className={`app-icon-fallback type-${app.integrationType || 'other'}`}
-                      >
-                        {integrationIcon(app.integrationType)}
-                      </div>
-                    )}
-
-                    {/* Health Status Indicator */}
-                    <div
-                      className={`health-dot${app.isHealthy ? '' : ' offline'}`}
-                    />
-                  </div>
-
-                  <div>
-                    <h3 className="app-card-title">
-                      {app.name}
-                      {!app.isHealthy && (
-                        <span className="app-offline-tag">(Offline)</span>
+            {allApps.map(app => {
+              const isHealthy = app.isHealthy !== false
+              const integrationType = integrationTypeOf(app)
+              const imageUrl = iconImageUrl(app.manifest.icon)
+              return (
+                <div
+                  key={app.slug}
+                  className={`app-card${isHealthy ? '' : ' is-offline'}`}
+                  onClick={() => handleAppClick(app)}
+                >
+                  <div className="app-card-head">
+                    <div className="app-card-icon">
+                      {imageUrl ? (
+                        <img
+                          src={imageUrl}
+                          alt=""
+                          className="app-icon-img"
+                          onError={e => {
+                            ;(e.target as HTMLImageElement).style.display = 'none'
+                          }}
+                        />
+                      ) : (
+                        <div
+                          className={`app-icon-fallback type-${integrationType || 'other'}`}
+                        >
+                          {iconGlyph(app.manifest.icon) ??
+                            integrationIcon(integrationType)}
+                        </div>
                       )}
-                    </h3>
-                    <span className="app-type-badge mono">
-                      {app.integrationType}
-                    </span>
+
+                      {/* Health Status Indicator */}
+                      <div
+                        className={`health-dot${isHealthy ? '' : ' offline'}`}
+                      />
+                    </div>
+
+                    <div>
+                      <h3 className="app-card-title">
+                        {app.manifest.menuLabel}
+                        {!isHealthy && (
+                          <span className="app-offline-tag">(Offline)</span>
+                        )}
+                      </h3>
+                      <span className="app-type-badge mono">
+                        {integrationType}
+                      </span>
+                    </div>
                   </div>
+                  {app.manifest.description && (
+                    <p className="app-card-desc">{app.manifest.description}</p>
+                  )}
                 </div>
-                {app.description && (
-                  <p className="app-card-desc">{app.description}</p>
-                )}
-              </div>
-            ))}
+              )
+            })}
           </div>
         </div>
       ) : (


### PR DESCRIPTION
## Summary
Two prod frontend bugs found via real-browser e2e of app.fuzefront.com.

**BUG 1 — authenticated user hitting /login or /signup got a 404.**
`AppContent`'s authenticated route tree (frontend/src/App.tsx) never registered `/login` or `/signup` at all, so both fell through to the catch-all `*` -> `NotFoundPage`. Fixed by redirecting both paths to `/dashboard` (`replace`, not `push`) before the standalone/portal route tree is evaluated.

**BUG 2 — Google/social login landed on an empty dashboard while the sidebar correctly listed all 3 apps.**
Root cause: `DashboardPage` read a different, legacy `fetchApps()` (`GET /apps`) source instead of the same `@fuzefront/app-registry-client` registry (`GET /api/v1/app-registry/apps?status=activated`) the sidebar (`SidePanel`) already consumes via `useRegisteredApps()`. Live evidence confirmed the registry endpoint returned 200 + all 3 activated apps (`organizationId: null`) — the sidebar (registry-backed) rendered them, the dashboard (legacy-backed) did not.

Fix: `DashboardPage` now reads `useRegisteredApps()` (same source as the sidebar) and applies a new `isAppVisibleForOrg()` filter so platform-global apps (`organizationId: null`) are always visible regardless of the active org, or whether org hydration has completed yet.

Also addressed the accompanying symptom (blank org switcher for the Google user): `ff.activeOrganizationId` (localStorage) and `ff.workspaceReady` (sessionStorage) are keyed per-browser, not per-account, so a different account signing in on the same browser inherited a previous session's stale org id / skip-ahead flag. Added `resetWorkspaceSessionIfUserChanged()` (frontend/src/lib/shared.tsx), called from `AuthWrapper`'s `initializeAuth`, to clear both when the authenticated user id changes, forcing a full org re-hydration for the new account.

## Files changed
- `frontend/src/App.tsx` — redirect authenticated `/login` and `/signup` to `/dashboard`; call `resetWorkspaceSessionIfUserChanged`
- `frontend/src/lib/shared.tsx` — `resetWorkspaceSessionIfUserChanged()`
- `frontend/src/pages/DashboardPage.tsx` — switch to `useRegisteredApps()`; `isAppVisibleForOrg()`
- `frontend/src/__tests__/App.authed-login-redirect.test.tsx` (new)
- `frontend/src/__tests__/DashboardPage.org-app-visibility.test.tsx` (new)

## Test plan
- [x] RTL unit tests added covering: authenticated `/login`+`/signup` redirect to `/dashboard`; `isAppVisibleForOrg` unit cases (org-null app visible with active org, with org hydration not yet complete, org-matched app visible, cross-org app hidden); `DashboardPage` renders registry apps in all three scenarios plus the genuine-empty-state case.
- [ ] `npx tsc --noEmit` / `vitest run` locally — **BLOCKED**: `frontend/node_modules` is corrupted from concurrent cross-worktree npm installs on this shared machine (`node_modules/typescript/lib/tsc.js` missing, `node_modules/vitest/vitest.mjs` missing, `node_modules/.bin` empty). One clean reinstall attempt (`npm install typescript --no-save`) also failed with `ENOTEMPTY` on `node_modules/async` (concurrent-writer collision). Per repo guidance this is a known shared-cache gotcha (CLAUDE.md "Isolated npm cache per parallel worktree agent") — not re-attempting further per the "one honest attempt" instruction. CI runs in a clean container and will verify tsc + vitest.

## Design-system conformance
No new UI primitives introduced; DashboardPage continues to render via existing `app-card`/`app-grid`/`dashboard-empty` classes already governed by the DS. No raw hex/px/font added.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session-Id: f636c22e-1cd7-401e-8843-97e3e3a4ba01