### PR TITLE
fix(security): self-heal OIDC init instead of permanent failure

### DIFF
--- a/backend/security/src/index.ts
+++ b/backend/security/src/index.ts
@@ -109,28 +109,20 @@ async function startServer() {
     }
 
     // If OIDC is configured but the initial discovery failed (e.g. Authentik
-    // blueprints not yet applied at startup), retry in the background every
-    // 10 seconds for up to 5 minutes. This makes the E2E stack reliable:
-    // the backend starts before OIDC is ready, but self-heals once it is.
+    // blueprints not yet applied at startup, or Authentik briefly down), keep
+    // retrying in the background for the LIFE OF THE PROCESS with capped
+    // exponential backoff (1s -> 60s) — not a bounded window. A bounded retry
+    // (previously 30 attempts / 5 min) meant that if Authentik was still down
+    // 5 minutes after boot, OIDC init failed PERMANENTLY: every subsequent
+    // signup/login 401'd with "OIDC is not configured/initialized" until a
+    // human ran `kubectl rollout restart`. This self-heals on its own once
+    // Authentik comes back, with zero request traffic required. Requests
+    // arriving in the meantime also get a lazy re-init attempt via
+    // oidcService.ensureInitialized() (see routes/auth.ts, authentikPassword.ts,
+    // AuthentikIdentityProvider.ts) — both paths share the same in-flight
+    // promise + cooldown so they never double-fire against Authentik.
     if (oidcService.isConfigured() && !oidcService.isInitialized()) {
-      const oidcRetry = async () => {
-        const MAX_ATTEMPTS = 30 // 30 × 10s = 5 min
-        for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
-          await new Promise(resolve => setTimeout(resolve, 10_000))
-          try {
-            await oidcService.initialize()
-            console.log(`✅ OIDC service initialized on retry (attempt ${attempt})`)
-            return
-          } catch {
-            if (attempt < MAX_ATTEMPTS) {
-              console.log(`⚠️  OIDC retry ${attempt}/${MAX_ATTEMPTS} failed — will try again`)
-            } else {
-              console.error('❌ OIDC service failed to initialize after all retries')
-            }
-          }
-        }
-      }
-      oidcRetry() // fire-and-forget; server is already listening
+      oidcService.startBackgroundRetry()
     }
 
     const portNumber = typeof PORT === 'string' ? parseInt(PORT, 10) : PORT

--- a/backend/security/src/providers/authentik/AuthentikIdentityProvider.ts
+++ b/backend/security/src/providers/authentik/AuthentikIdentityProvider.ts
@@ -441,7 +441,7 @@ export class AuthentikIdentityProvider implements IdentityProvider {
   /** Legacy Authentik source-redirect start (fallback; browser transits `/if/*`). */
   private async startSocialLoginViaSource(provider: string, redirectTo = '/'): Promise<SocialLoginStart> {
     if (!this.oidc.isInitialized()) {
-      await this.oidc.initialize()
+      await this.oidc.ensureInitialized()
     }
     const state = crypto.randomBytes(24).toString('hex')
     const { url, codeVerifier } = this.oidc.generateAuthUrl(state)
@@ -1227,7 +1227,7 @@ export class AuthentikIdentityProvider implements IdentityProvider {
       mode = 'brokered'
     } else {
       if (!this.oidc.isInitialized()) {
-        await this.oidc.initialize()
+        await this.oidc.ensureInitialized()
       }
       const { url, codeVerifier: cv } = this.oidc.generateAuthUrl(state)
       const authorize = new URL(url)

--- a/backend/security/src/routes/auth.ts
+++ b/backend/security/src/routes/auth.ts
@@ -380,6 +380,10 @@ router.get('/oidc/login', async (req, res) => {
       })
     }
 
+    if (!oidcService.isInitialized()) {
+      await oidcService.ensureInitialized()
+    }
+
     const state = uuidv4()
     const { url, codeVerifier } = oidcService.generateAuthUrl(state)
 
@@ -434,6 +438,10 @@ router.get('/oidc/signup', signupRedirectRateLimiter, async (req, res) => {
       return res.status(500).json({
         error: 'OIDC authentication not configured. Please set AUTHENTIK_CLIENT_ID and AUTHENTIK_CLIENT_SECRET.',
       })
+    }
+
+    if (!oidcService.isInitialized()) {
+      await oidcService.ensureInitialized()
     }
 
     const state = uuidv4()
@@ -536,7 +544,10 @@ router.post('/oidc/password', passwordLoginRateLimiter, async (req, res) => {
     // 503ing until an SSO request happens to re-initialize the client.
     if (!oidcService.isInitialized()) {
       try {
-        await oidcService.initialize()
+        // ensureInitialized() dedupes concurrent callers onto one in-flight
+        // attempt and fails fast during the post-failure cooldown, instead
+        // of firing a fresh discovery call per request.
+        await oidcService.ensureInitialized()
       } catch (initErr) {
         console.error('❌ OIDC lazy init failed', JSON.stringify({ requestId, message: (initErr as Error).message?.replace(/[\r\n]+/g, ' ') }))
         return res

--- a/backend/security/src/services/authentikPassword.ts
+++ b/backend/security/src/services/authentikPassword.ts
@@ -302,8 +302,18 @@ async function authentikPasswordLoginInner(
   email: string,
   password: string
 ): Promise<User> {
-  if (!oidcService.isConfigured() || !oidcService.isInitialized()) {
+  if (!oidcService.isConfigured()) {
     throw new AuthentikUnavailableError('OIDC is not configured/initialized')
+  }
+  if (!oidcService.isInitialized()) {
+    // Lazy re-init: dedupes concurrent callers onto one in-flight attempt and
+    // fails fast during the post-failure cooldown (see oidc.ts). Preserves
+    // the original error type/message on failure.
+    try {
+      await oidcService.ensureInitialized()
+    } catch {
+      throw new AuthentikUnavailableError('OIDC is not configured/initialized')
+    }
   }
 
   const base = authentikBaseUrl()
@@ -524,8 +534,15 @@ export async function authentikSignup(input: AuthentikSignupInput): Promise<User
 }
 
 async function authentikSignupInner(input: AuthentikSignupInput): Promise<User> {
-  if (!oidcService.isConfigured() || !oidcService.isInitialized()) {
+  if (!oidcService.isConfigured()) {
     throw new AuthentikUnavailableError('OIDC is not configured/initialized')
+  }
+  if (!oidcService.isInitialized()) {
+    try {
+      await oidcService.ensureInitialized()
+    } catch {
+      throw new AuthentikUnavailableError('OIDC is not configured/initialized')
+    }
   }
   if (!input.email || !input.password) {
     throw new InvalidCredentialsError('email and password are required')

--- a/backend/security/src/services/oidc.ts
+++ b/backend/security/src/services/oidc.ts
@@ -12,6 +12,22 @@ import { logger } from '../lib/logger';
  */
 const OIDC_HTTP_TIMEOUT_MS = Number(process.env.OIDC_HTTP_TIMEOUT_MS) || 15000;
 
+/**
+ * Cooldown between init ATTEMPTS once one has failed. Without this, every
+ * request that lands while Authentik is down would each kick off a fresh
+ * discovery call — a self-inflicted retry storm against a service that is
+ * already struggling. A short cooldown lets the lazy re-init in
+ * ensureInitialized() fail fast (throwing the same error callers already
+ * handle) between attempts, while the background loop below keeps making
+ * slower, backed-off attempts in parallel.
+ */
+const OIDC_INIT_COOLDOWN_MS = Number(process.env.OIDC_INIT_COOLDOWN_MS) || 7000;
+
+/** Background re-init backoff bounds: starts fast, caps so a hard-down
+ * Authentik doesn't get hammered for the life of the process. */
+const OIDC_BACKGROUND_RETRY_INITIAL_MS = Number(process.env.OIDC_BACKGROUND_RETRY_INITIAL_MS) || 1000;
+const OIDC_BACKGROUND_RETRY_MAX_MS = Number(process.env.OIDC_BACKGROUND_RETRY_MAX_MS) || 60_000;
+
 interface OIDCConfig {
   issuerUrl: string;
   clientId: string;
@@ -22,6 +38,14 @@ interface OIDCConfig {
 class OIDCService {
   private client: Client | null = null;
   private config: OIDCConfig;
+
+  // Lazy/background re-init bookkeeping. `initPromise` is shared by every
+  // caller currently attempting init (request path AND background loop) so a
+  // burst of concurrent requests against an uninitialized client produces
+  // exactly ONE discovery call, not one per request.
+  private initPromise: Promise<void> | null = null;
+  private lastInitAttemptAt = 0;
+  private backgroundRetryStarted = false;
 
   constructor() {
     this.config = {
@@ -109,6 +133,111 @@ class OIDCService {
     }
   }
 
+  /**
+   * Kick off (or join) a single init attempt, honoring the cooldown. Shared by
+   * both the on-demand lazy path (ensureInitialized) and the background retry
+   * loop (startBackgroundRetry) so the two never race each other into a
+   * double discovery call.
+   *
+   * Returns the in-flight/most-recent attempt's promise, or `null` if no
+   * attempt was made because we're still within the cooldown window from the
+   * last failure (caller decides what to do — lazy path fails fast, the
+   * background loop just waits for the next tick).
+   */
+  private attemptInit(): Promise<void> | null {
+    if (this.client) {
+      return Promise.resolve();
+    }
+    if (this.initPromise) {
+      return this.initPromise;
+    }
+    const now = Date.now();
+    if (now - this.lastInitAttemptAt < OIDC_INIT_COOLDOWN_MS) {
+      return null;
+    }
+    this.lastInitAttemptAt = now;
+    const attemptStart = now;
+    this.initPromise = this.initialize()
+      .then(() => {
+        logger.info(
+          { elapsedMs: Date.now() - attemptStart },
+          'oidc: re-init succeeded'
+        );
+      })
+      .catch(error => {
+        logger.warn(
+          { err: (error as Error).message, elapsedMs: Date.now() - attemptStart },
+          'oidc: re-init attempt failed'
+        );
+        throw error;
+      })
+      .finally(() => {
+        this.initPromise = null;
+      });
+    return this.initPromise;
+  }
+
+  /**
+   * Lazy re-init on demand: called by request-path callers that find the
+   * client uninitialized. Multiple concurrent callers share the same
+   * in-flight promise (no stampede). If we're within the post-failure
+   * cooldown, this fails fast with the existing error rather than issuing a
+   * fresh discovery call per request — the background loop is what keeps
+   * trying between requests.
+   */
+  async ensureInitialized(): Promise<void> {
+    if (this.client) return;
+    const attempt = this.attemptInit();
+    if (!attempt) {
+      throw new Error('OIDC client not initialized');
+    }
+    await attempt;
+  }
+
+  /**
+   * Background self-heal: capped exponential backoff (1s -> 60s) for the life
+   * of the process, so the service recovers within about a minute of
+   * Authentik coming back even with zero request traffic. Idempotent — safe
+   * to call from multiple boot paths. Stops once initialized; nothing in this
+   * service currently un-initializes the client, so there's nothing further
+   * to self-heal after that.
+   */
+  startBackgroundRetry(): void {
+    if (this.backgroundRetryStarted) return;
+    this.backgroundRetryStarted = true;
+
+    const run = async () => {
+      let delayMs = OIDC_BACKGROUND_RETRY_INITIAL_MS;
+      while (!this.client) {
+        await new Promise(resolve => setTimeout(resolve, delayMs));
+        if (this.client) return;
+
+        const attempt = this.attemptInit();
+        if (!attempt) {
+          // Still cooling down from a very recent attempt (e.g. a request
+          // triggered one moments ago) — just wait for the next tick rather
+          // than busy-looping.
+          continue;
+        }
+        try {
+          await attempt;
+          logger.info('oidc: background re-init succeeded, self-heal complete');
+          return;
+        } catch {
+          delayMs = Math.min(delayMs * 2, OIDC_BACKGROUND_RETRY_MAX_MS);
+          logger.warn({ nextRetryMs: delayMs }, 'oidc: background re-init failed, backing off');
+        }
+      }
+    };
+
+    run().catch(error => {
+      // Should be unreachable (the loop only throws are caught internally),
+      // but never let a rejected background promise become an unhandled
+      // rejection that could crash the process.
+      logger.error({ err: (error as Error).message }, 'oidc: background retry loop crashed');
+    });
+  }
+
   generateAuthUrl(state?: string): { url: string; codeVerifier: string } {
     if (!this.client) {
       throw new Error('OIDC client not initialized');
@@ -139,7 +268,11 @@ class OIDCService {
     codeVerifier: string
   ): Promise<User> {
     if (!this.client) {
-      throw new Error('OIDC client not initialized');
+      // Lazy re-init: the callback can legitimately land after the client
+      // dropped/never came up (Authentik was briefly down). Preserve the
+      // exact error type/message on failure so callers' existing handling
+      // is unchanged.
+      await this.ensureInitialized();
     }
     if (!codeVerifier) {
       throw new Error('Code verifier not found');

--- a/backend/security/tests/oidc-lazy-reinit.test.ts
+++ b/backend/security/tests/oidc-lazy-reinit.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Unit tests for OIDCService's self-heal resilience.
+ *
+ * Bug being guarded against: boot-time OIDC init retried a BOUNDED number of
+ * times (30 attempts / 5 min); once exhausted with Authentik still down,
+ * every subsequent signup/login 401'd with "OIDC is not configured/initialized"
+ * for the life of the process — requiring a manual `kubectl rollout restart`.
+ * This took prod auth down twice.
+ *
+ * ensureInitialized() now:
+ *  (a) dedupes concurrent callers onto exactly ONE in-flight discovery call
+ *      (no stampede against a struggling/recovering Authentik),
+ *  (b) lets a LATER request succeed once Authentik recovers, without a
+ *      process restart,
+ *  (c) respects a cooldown between attempts so a hard-down Authentik isn't
+ *      hammered once per request.
+ *
+ * Each test gets a fresh OIDCService instance (via jest.resetModules() +
+ * re-require) so in-flight-promise/cooldown state never leaks between cases.
+ */
+
+jest.mock('../src/config/database', () => ({
+  db: Object.assign(jest.fn(), { transaction: jest.fn() }),
+}))
+
+jest.mock('../src/services/eventPublisher', () => ({
+  defaultEventPublisher: {
+    publishIdentityUserCreated: jest.fn().mockResolvedValue(undefined),
+    publishNotifyEmailRequested: jest.fn().mockResolvedValue(undefined),
+  },
+}))
+
+/** A minimal fake `Issuer` shape sufficient for `new effectiveIssuer.Client(...)`. */
+function fakeIssuer() {
+  return {
+    metadata: { issuer: 'https://auth.example.com/application/o/fuzefront/' },
+    Client: function FakeClient(this: any, cfg: any) {
+      Object.assign(this, cfg)
+    },
+  }
+}
+
+/** Mocks `openid-client` with a caller-supplied `Issuer.discover` implementation. */
+function mockOpenidClient(discoverImpl: () => Promise<any>) {
+  jest.doMock('openid-client', () => ({
+    Issuer: { discover: jest.fn(discoverImpl) },
+    generators: {
+      codeVerifier: jest.fn().mockReturnValue('mock-verifier'),
+      codeChallenge: jest.fn().mockReturnValue('mock-challenge'),
+      state: jest.fn().mockReturnValue('mock-state'),
+    },
+    custom: { setHttpOptionsDefaults: jest.fn() },
+  }))
+}
+
+describe('OIDCService.ensureInitialized — lazy re-init resilience', () => {
+  const ORIGINAL_ENV = process.env
+
+  beforeEach(() => {
+    jest.resetModules()
+    process.env = {
+      ...ORIGINAL_ENV,
+      AUTHENTIK_CLIENT_ID: 'test-client-id',
+      AUTHENTIK_CLIENT_SECRET: 'test-client-secret',
+    }
+  })
+
+  afterEach(() => {
+    process.env = ORIGINAL_ENV
+    jest.dontMock('openid-client')
+  })
+
+  it('(a) N concurrent requests while uninitialized trigger exactly ONE init attempt', async () => {
+    let discoverCalls = 0
+    mockOpenidClient(async () => {
+      discoverCalls++
+      // Simulate a real network round-trip so concurrent callers actually
+      // overlap in time (a synchronous resolve wouldn't exercise the race).
+      await new Promise(resolve => setTimeout(resolve, 25))
+      return fakeIssuer()
+    })
+
+    const { oidcService } = require('../src/services/oidc')
+    expect(oidcService.isInitialized()).toBe(false)
+
+    const concurrentCallers = Array.from({ length: 8 }, () => oidcService.ensureInitialized())
+    await Promise.all(concurrentCallers)
+
+    expect(discoverCalls).toBe(1)
+    expect(oidcService.isInitialized()).toBe(true)
+  })
+
+  it('(b) fail-then-succeed discovery — a later request succeeds without a restart', async () => {
+    let attempt = 0
+    mockOpenidClient(async () => {
+      attempt++
+      if (attempt === 1) {
+        throw new Error('discovery unreachable: Authentik down')
+      }
+      return fakeIssuer()
+    })
+
+    process.env.OIDC_INIT_COOLDOWN_MS = '10' // short, so the 2nd attempt below isn't blocked
+    const { oidcService } = require('../src/services/oidc')
+
+    // First request lands while Authentik is down — fails, but the process
+    // stays up and does NOT permanently latch a "never try again" state.
+    await expect(oidcService.ensureInitialized()).rejects.toThrow(
+      'discovery unreachable: Authentik down'
+    )
+    expect(oidcService.isInitialized()).toBe(false)
+
+    // Wait out the (short, test-only) cooldown — this stands in for
+    // Authentik recovering some time later with zero code change needed.
+    await new Promise(resolve => setTimeout(resolve, 30))
+
+    // A later request (no process restart) now succeeds.
+    await expect(oidcService.ensureInitialized()).resolves.toBeUndefined()
+    expect(oidcService.isInitialized()).toBe(true)
+    expect(attempt).toBe(2)
+  })
+
+  it('(c) cooldown prevents per-request hammering of a hard-down Authentik', async () => {
+    let discoverCalls = 0
+    mockOpenidClient(async () => {
+      discoverCalls++
+      throw new Error('discovery unreachable')
+    })
+
+    process.env.OIDC_INIT_COOLDOWN_MS = '10000' // long cooldown for this case
+    const { oidcService } = require('../src/services/oidc')
+
+    await expect(oidcService.ensureInitialized()).rejects.toThrow('discovery unreachable')
+    expect(discoverCalls).toBe(1)
+
+    // Three more requests arrive immediately after, still within the cooldown
+    // window — none of them should re-invoke discovery.
+    await expect(oidcService.ensureInitialized()).rejects.toThrow(
+      'OIDC client not initialized'
+    )
+    await expect(oidcService.ensureInitialized()).rejects.toThrow(
+      'OIDC client not initialized'
+    )
+    await expect(oidcService.ensureInitialized()).rejects.toThrow(
+      'OIDC client not initialized'
+    )
+    expect(discoverCalls).toBe(1)
+    expect(oidcService.isInitialized()).toBe(false)
+  })
+
+  it('preserves the fail-fast contract: generateAuthUrl still throws while uninitialized', () => {
+    mockOpenidClient(async () => fakeIssuer())
+    const { oidcService } = require('../src/services/oidc')
+    expect(() => oidcService.generateAuthUrl()).toThrow('OIDC client not initialized')
+  })
+})


### PR DESCRIPTION
## Summary
- Boot-time OIDC init retry was bounded (30 attempts / 5 min). Once exhausted with Authentik still down, every subsequent signup/login 401'd with `OIDC is not configured/initialized` until a human ran `kubectl rollout restart deploy/fuzefront-security`. This took prod auth down twice.
- `oidcService` (`backend/security/src/services/oidc.ts`) gains:
  - `ensureInitialized()` — lazy re-init on demand, shared in-flight promise (dedupes concurrent callers into ONE discovery attempt) + a short cooldown (`OIDC_INIT_COOLDOWN_MS`, default 7s) so a hard-down Authentik isn't hammered per request.
  - `startBackgroundRetry()` — capped exponential backoff (1s -> 60s, env-tunable) for the life of the process, replacing the old bounded 30-attempt/5-min loop in `index.ts`.
- All existing lazy re-init call sites (`routes/auth.ts`, `services/authentikPassword.ts`, `providers/authentik/AuthentikIdentityProvider.ts`) now go through `ensureInitialized()` instead of calling `initialize()` directly, so concurrent requests against a down Authentik share one attempt.
- Fail-fast contract preserved: `ensureInitialized()` still throws the same error types/messages callers already handle; `OIDC_HTTP_TIMEOUT_MS` is untouched.
- Structured pino logging on each attempt/success/failure (elapsed ms, no secrets).

## Test plan
- [x] `backend/security/tests/oidc-lazy-reinit.test.ts` (new): (a) N concurrent requests trigger exactly one init attempt, (b) fail-then-succeed discovery mock — a later request succeeds without a restart, (c) cooldown prevents per-request hammering, (d) fail-fast sanity check on `generateAuthUrl()`.
- [ ] `npx tsc --noEmit` and the full `backend/security` jest suite — **could not run locally**: this worktree's `node_modules/typescript` install is stuck/corrupted (heavy concurrent npm/node activity across ~60 parallel worktree processes on the box). CI is the verification of record for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)