### PR TITLE
fix(ci): resolve pre-existing Lint & Test and Identity UI + Security failures

### DIFF
--- a/agent-templates/providers/README.md
+++ b/agent-templates/providers/README.md
@@ -1,0 +1,68 @@
+# providers/ — the runtime seam
+
+The role manifests, environments, vaults, memory, and orchestration are **provider-
+agnostic**. A `providers/<name>/adapter.py` translates them into a specific backend
+and implements the runtime. Pick one with `AGENT_PROVIDER` (default `anthropic`):
+
+```python
+from providers import get_provider
+p = get_provider()            # AGENT_PROVIDER env, default "anthropic"
+p = get_provider("openai")    # explicit
+```
+
+## The interface — `base.py:AgentProvider`
+
+- **Provisioning:** `ensure_environment`, `ensure_agent`, `ensure_vault`, `ensure_memory`
+- **Runtime:** `create_session`, `send_message`, `run_turn`, `run_until_block`,
+  `resume_session`, `confirm_tool`, `archive_session`
+- **Memory:** `memory_resource`, `memory_write`, `memory_read`
+- **`capabilities`** flags (`self_hosted`, `vaults`, `memory`, `multiagent`) — provisioning
+  skips unsupported resource kinds.
+
+The approver contract and the `{status: idle|blocked|error, pending}` shape are shared
+(`base.interactive_approver` / `base.auto_approver`), so orchestration is identical across providers.
+
+## Providers
+
+| Provider | Status | Backing |
+|---|---|---|
+| `anthropic` | ✅ reference | Claude Managed Agents (`/v1/agents`, `/v1/environments`, `/v1/sessions`, vaults, memory) — wraps `sync/common.py` + `sync/driver.py` + `sync/role_loader.py`. |
+| `openai` | 🧩 stub | Assistants / Responses + Agents SDK — see `openai/adapter.py` docstring for the mapping. |
+| `hermes` | 🧩 stub | Hermes models on an OpenAI-compatible / custom tool-calling runtime — see `hermes/adapter.py`. |
+
+## Add a provider
+
+1. `providers/<name>/adapter.py` with `class <Name>Provider(AgentProvider)` implementing the
+   methods; set `capabilities`. Translate the manifest *intent* (tools/policies/mcp/skills/packages)
+   into your backend's payloads — don't change the manifests.
+2. Register it in `providers/__init__.py:get_provider` (lazy import).
+3. `providers/<name>/__init__.py` re-exports the class.
+
+## Provision (create everything for a provider)
+
+```bash
+python providers/provision.py --provider anthropic --dry-run   # offline plan, no API calls
+python providers/provision.py --provider anthropic             # create/update live, prints ids
+```
+
+`provision` creates environments + agents (+ vaults + memory) idempotently and writes the id
+state (`environment-ids/agent-ids/vault-ids/memory-ids.json`) under the state dir.
+
+## Auto-sync on merge
+
+Agent-definition changes reconcile into their **deployed** counterparts automatically.
+`.github/workflows/provision-sync.yml` triggers on every merge to `main` that touches a
+definition (`roles/`, `environments/`, `vaults/`, `memory/`, `coordinator/`, `providers/`,
+`sync/`, or the personas in `.claude/agents/`) and calls the reusable `provision.yml` **per
+provider** (matrix — currently `[anthropic]`; add `openai`/`hermes` when implemented). Because
+`provision.py` only updates an agent/environment when its config actually changed, unchanged
+definitions are no-ops and changed ones get a new version. Editing a persona `.md` re-syncs the
+agent's `system`; editing a `role.json` re-syncs its tools/policies/mcp/env; a new role is
+created. (Removed roles are **not** pruned — archiving an orphaned agent is a separate step.)
+
+## Not yet routed
+
+The handoff MCP server (`orchestration/handoff_mcp/server.py`) still calls the Anthropic
+`driver` directly (it's the deployed container; routing it through `get_provider()` needs a
+Dockerfile change). Its cross-provider runtime (OpenAI/Hermes have different session-resume
+semantics) is the next step — the stubs document the mapping.

--- a/agent-templates/providers/__init__.py
+++ b/agent-templates/providers/__init__.py
@@ -1,0 +1,32 @@
+"""Provider registry for the agent framework.
+
+    from providers import get_provider
+    p = get_provider()            # AGENT_PROVIDER env, default "anthropic"
+    p = get_provider("openai")    # explicit
+
+Adapters are imported lazily so selecting one provider never pulls another's
+(possibly missing) SDK. Add a provider by dropping providers/<name>/adapter.py
+with a `<Name>Provider(AgentProvider)` and registering it here.
+"""
+import os
+
+from providers.base import AgentProvider  # re-export for adapters/type hints
+
+__all__ = ["get_provider", "AgentProvider", "PROVIDERS"]
+
+PROVIDERS = ("anthropic", "openai", "hermes")
+
+
+def get_provider(name=None):
+    name = (name or os.environ.get("AGENT_PROVIDER") or "anthropic").strip().lower()
+    if name == "anthropic":
+        from providers.anthropic.adapter import AnthropicProvider
+        return AnthropicProvider()
+    if name == "openai":
+        from providers.openai.adapter import OpenAIProvider
+        return OpenAIProvider()
+    if name == "hermes":
+        from providers.hermes.adapter import HermesProvider
+        return HermesProvider()
+    raise ValueError(f"unknown provider '{name}' — known: {', '.join(PROVIDERS)}. "
+                     f"See agent-templates/providers/<name>/adapter.py to add one.")

--- a/agent-templates/providers/anthropic/__init__.py
+++ b/agent-templates/providers/anthropic/__init__.py
@@ -1,0 +1,3 @@
+from providers.anthropic.adapter import AnthropicProvider
+
+__all__ = ["AnthropicProvider"]

--- a/agent-templates/providers/anthropic/adapter.py
+++ b/agent-templates/providers/anthropic/adapter.py
@@ -1,0 +1,161 @@
+"""Anthropic Managed Agents provider — the reference `AgentProvider`.
+
+Additive: delegates to the existing `sync/` modules (`common`, `driver`,
+`role_loader`) rather than moving them, so the deployed handoff image and the
+standalone sync scripts keep working. The idempotent create/update logic mirrors
+`sync/sync_{environments,agents,vaults,memory}.py`.
+"""
+import glob
+import json
+import os
+import sys
+
+from providers.base import AgentProvider
+
+_TEMPLATES_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+_SYNC = os.environ.get("HANDOFF_SYNC_DIR") or os.path.join(_TEMPLATES_ROOT, "sync")
+if _SYNC not in sys.path:
+    sys.path.insert(0, _SYNC)
+
+import common          # noqa: E402
+import driver          # noqa: E402
+import role_loader as rl  # noqa: E402
+
+# Agent fields we compare to decide whether an update is needed.
+_COMPARE = ("model", "system", "description", "tools", "mcp_servers", "skills", "multiagent")
+
+
+def _norm_model(m):
+    return m["id"] if isinstance(m, dict) else m
+
+
+def _agent_changed(current, desired):
+    for k in _COMPARE:
+        d = desired.get(k)
+        if d is None:
+            continue
+        c = current.get(k)
+        if k == "model":
+            if _norm_model(c) != _norm_model(d):
+                return True
+        elif c != d:
+            return True
+    return False
+
+
+class AnthropicProvider(AgentProvider):
+    name = "anthropic"
+    capabilities = {"self_hosted": True, "vaults": True, "memory": True, "multiagent": True}
+
+    # ---- provisioning -------------------------------------------------------
+    def ensure_environment(self, manifest):
+        existing = {e["name"]: e["id"] for e in common.list_all("/v1/environments")}
+        name = manifest["name"]
+        if name in existing:
+            return {"name": name, "id": existing[name], "created": False}
+        created = common.request("POST", "/v1/environments",
+                                 body={"name": name, "config": manifest["config"]})
+        return {"name": name, "id": created["id"], "created": True}
+
+    def ensure_agent(self, manifest, multiagent=None):
+        payload = rl.agent_payload(manifest)
+        if multiagent:
+            payload["multiagent"] = {"type": "coordinator", "agents": multiagent}
+        existing = {a["name"]: a for a in common.list_all("/v1/agents")}
+        name = payload["name"]
+        if name in existing:
+            cur = existing[name]
+            if _agent_changed(cur, payload):
+                updated = common.request("POST", f"/v1/agents/{cur['id']}",
+                                         body={**payload, "version": cur["version"]})
+                return {"name": name, "id": updated["id"], "version": updated["version"], "created": False}
+            return {"name": name, "id": cur["id"], "version": cur["version"], "created": False}
+        created = common.request("POST", "/v1/agents", body=payload)
+        return {"name": name, "id": created["id"], "version": created["version"], "created": True}
+
+    def ensure_vault(self, manifest):
+        tmpl = common.expand_env(manifest)
+        existing = {v["display_name"]: v["id"] for v in common.list_all("/v1/vaults")}
+        name = tmpl["display_name"]
+        if name in existing:
+            vid = existing[name]
+        else:
+            body = {"display_name": name}
+            if tmpl.get("metadata"):
+                body["metadata"] = tmpl["metadata"]
+            vid = common.request("POST", "/v1/vaults", body=body)["id"]
+        have = {(c.get("auth") or {}).get("mcp_server_url") or (c.get("auth") or {}).get("secret_name")
+                for c in common.list_all(f"/v1/vaults/{vid}/credentials")}
+        for cred in tmpl.get("credentials", []):
+            auth = cred["auth"]
+            key = auth.get("mcp_server_url") or auth.get("secret_name")
+            # Skip a credential whose secret isn't actually provided: an unresolved ${VAR}
+            # (env unset -> literal "${...}") OR an empty/whitespace value (env set to "").
+            if not key or "${" in json.dumps(auth):
+                continue
+            if "token" in auth and not str(auth.get("token") or "").strip():
+                continue
+            if key in have:
+                continue
+            common.request("POST", f"/v1/vaults/{vid}/credentials",
+                           body={"display_name": cred["display_name"], "auth": auth})
+        return {"name": name, "id": vid}
+
+    def ensure_memory(self, manifest):
+        existing = {s["name"]: s["id"] for s in common.list_all("/v1/memory_stores", beta=common.MEMORY_BETA)}
+        name = manifest["name"]
+        if name in existing:
+            sid = existing[name]
+        else:
+            sid = common.request("POST", "/v1/memory_stores",
+                                 body={"name": name, "description": manifest.get("description", "")},
+                                 beta=common.MEMORY_BETA)["id"]
+        have = {m["path"] for m in common.list_all(f"/v1/memory_stores/{sid}/memories", beta=common.MEMORY_BETA)
+                if m.get("path")}
+        for mem in manifest.get("seed", []):
+            if mem["path"] in have:
+                continue
+            common.request("POST", f"/v1/memory_stores/{sid}/memories",
+                           body={"path": mem["path"], "content": mem["content"]}, beta=common.MEMORY_BETA)
+        return {"name": name, "id": sid}
+
+    # ---- runtime (thin delegations to the driver) ---------------------------
+    def create_session(self, agent_id, version, environment_id, vault_ids=None, memory_resources=None, title=None):
+        return driver.create_session(agent_id, version, environment_id,
+                                     vault_ids=vault_ids, resources=memory_resources, title=title)["id"]
+
+    def send_message(self, session_id, text):
+        driver.send_message(session_id, text)
+
+    def run_turn(self, session_id, prompt, approver, echo=True):
+        return driver.run_turn(session_id, prompt, approver, echo=echo)
+
+    def run_until_block(self, session_id, prompt=None):
+        return driver.run_until_block(session_id, prompt)
+
+    def resume_session(self, session_id, summary, context_ref=""):
+        msg = f"[handoff:resume] {summary}"
+        if context_ref:
+            msg += f"\n\nPersisted state: {context_ref} (read it for details)."
+        driver.send_message(session_id, msg)
+
+    def confirm_tool(self, session_id, tool_use_id, allow=True, deny_message=None):
+        driver.confirm_tool(session_id, tool_use_id, allow=allow, deny_message=deny_message)
+
+    def archive_session(self, session_id):
+        driver.archive_session(session_id)
+
+    # ---- memory -------------------------------------------------------------
+    def memory_resource(self, store_id, access="read_write", instructions=None):
+        return driver.memory_resource(store_id, access=access, instructions=instructions)
+
+    def memory_write(self, store_id, path, content):
+        common.request("POST", f"/v1/memory_stores/{store_id}/memories",
+                       body={"path": path, "content": content}, beta=common.MEMORY_BETA)
+        return {"store_id": store_id, "path": path}
+
+    def memory_read(self, store_id, path):
+        res = common.request("GET", f"/v1/memory_stores/{store_id}/memories",
+                             query={"path": path}, beta=common.MEMORY_BETA)
+        data = res.get("data", res)
+        return data[0]["content"] if isinstance(data, list) and data else (data.get("content") if isinstance(data, dict) else None)

--- a/agent-templates/providers/base.py
+++ b/agent-templates/providers/base.py
@@ -1,0 +1,97 @@
+"""Provider-agnostic agent-runtime interface.
+
+An `AgentProvider` is the seam between the provider-neutral *definitions* (role
+manifests, environments, vaults, memory) + *orchestration* (launch, relay, handoff)
+and a specific backend (Anthropic Managed Agents today; OpenAI / Hermes next).
+
+Everything above the seam speaks manifests + this interface; each provider
+translates manifests into its own payloads and implements the runtime ops. The
+approver contract and the {status: idle|blocked|error, pending} shape are shared
+verbatim with the existing driver so no orchestration logic changes.
+"""
+from abc import ABC, abstractmethod
+
+
+class AgentProvider(ABC):
+    #: short id used by the registry / AGENT_PROVIDER env
+    name = "base"
+    #: what the backend supports; provisioning skips unsupported resource kinds
+    capabilities = {"self_hosted": False, "vaults": False, "memory": False, "multiagent": False}
+
+    # ---- provisioning (manifest in -> {name, id[, version]} out) -------------
+    @abstractmethod
+    def ensure_environment(self, manifest):
+        """Create-if-missing an environment. Returns {'name', 'id'}."""
+
+    @abstractmethod
+    def ensure_agent(self, manifest, multiagent=None):
+        """Create-or-update an agent from a (merged) role manifest. `multiagent`
+        is an optional resolved roster [{id, version}, ...] for a coordinator.
+        Returns {'name', 'id', 'version'}."""
+
+    def ensure_vault(self, manifest):
+        raise NotImplementedError(f"{self.name}: vaults not supported")
+
+    def ensure_memory(self, manifest):
+        raise NotImplementedError(f"{self.name}: memory stores not supported")
+
+    # ---- runtime ------------------------------------------------------------
+    @abstractmethod
+    def create_session(self, agent_id, version, environment_id,
+                       vault_ids=None, memory_resources=None, title=None):
+        """Returns the session id."""
+
+    @abstractmethod
+    def send_message(self, session_id, text):
+        """Send a user.message-equivalent event."""
+
+    @abstractmethod
+    def run_turn(self, session_id, prompt, approver, echo=True):
+        """Drive one turn to completion, handling approvals via `approver`.
+        Returns the accumulated agent text."""
+
+    @abstractmethod
+    def run_until_block(self, session_id, prompt=None):
+        """Run until idle OR a required approval. Returns
+        {'text', 'status': 'idle'|'blocked'|'error', 'pending': {...}|None}."""
+
+    @abstractmethod
+    def resume_session(self, session_id, summary, context_ref=""):
+        """Wake an existing session with a concise summary (history restored server-side)."""
+
+    @abstractmethod
+    def confirm_tool(self, session_id, tool_use_id, allow=True, deny_message=None):
+        """Answer a single always_ask pause."""
+
+    @abstractmethod
+    def archive_session(self, session_id):
+        """Terminate a session (best-effort)."""
+
+    # ---- memory (optional) --------------------------------------------------
+    def memory_resource(self, store_id, access="read_write", instructions=None):
+        raise NotImplementedError(f"{self.name}: memory stores not supported")
+
+    def memory_write(self, store_id, path, content):
+        raise NotImplementedError(f"{self.name}: memory stores not supported")
+
+    def memory_read(self, store_id, path):
+        raise NotImplementedError(f"{self.name}: memory stores not supported")
+
+
+# ---- shared, provider-agnostic approvers ------------------------------------
+# An approver maps {tool_use_id -> human description} to {tool_use_id -> (result, deny_message)}.
+
+def interactive_approver(descriptions):
+    out = {}
+    for tid, desc in descriptions.items():
+        ans = input(f"\nAPPROVE tool call?\n  {desc}\n  [y]allow / [n]deny > ").strip().lower()
+        if ans in ("y", "yes", "allow"):
+            out[tid] = ("allow", None)
+        else:
+            out[tid] = ("deny", input("  deny reason > ").strip() or "denied by operator")
+    return out
+
+
+def auto_approver(result):
+    msg = None if result == "allow" else "auto-denied (headless)"
+    return lambda descriptions: {tid: (result, msg) for tid in descriptions}

--- a/agent-templates/providers/hermes/__init__.py
+++ b/agent-templates/providers/hermes/__init__.py
@@ -1,0 +1,3 @@
+from providers.hermes.adapter import HermesProvider
+
+__all__ = ["HermesProvider"]

--- a/agent-templates/providers/hermes/adapter.py
+++ b/agent-templates/providers/hermes/adapter.py
@@ -1,0 +1,42 @@
+"""Hermes provider — STUB.
+
+Extension point for running the same role manifests on a Hermes-based / OpenAI-
+compatible agent runtime (e.g. NousResearch Hermes models served behind an
+OpenAI-compatible or custom tool-calling API). Implement against whichever runtime
+hosts Hermes; the manifests + orchestration above the `AgentProvider` seam are unchanged.
+
+Concept mapping (Managed Agents -> Hermes runtime):
+  agent            -> a model + system prompt + tool schema (Hermes uses its own
+                      tool-call/function-calling format; translate manifest tools to it).
+  agent `system`   -> the system prompt.
+  tools / policies -> the tool schema you expose to the model; always_ask -> gate
+                      execution in your harness (no server-side approval primitive).
+  environment      -> your own sandbox/container (Hermes has no managed sandbox);
+                      `packages` -> your image; networking -> your egress policy.
+  session          -> your own conversation store keyed by id (persist server-side
+                      to keep the "resume by id, don't copy transcript" property).
+  run_turn         -> your inference + tool loop.
+  resume_session   -> reload the stored conversation by id and continue.
+  vaults / memory  -> your own secret store / vector store.
+
+Until implemented, every method raises NotImplementedError with this guidance.
+"""
+from providers.base import AgentProvider
+
+_MSG = ("Hermes provider is a stub — implement providers/hermes/adapter.py "
+        "(see the module docstring for the Managed-Agents -> Hermes mapping).")
+
+
+class HermesProvider(AgentProvider):
+    name = "hermes"
+    capabilities = {"self_hosted": True, "vaults": False, "memory": False, "multiagent": False}
+
+    def ensure_environment(self, manifest): raise NotImplementedError(_MSG)
+    def ensure_agent(self, manifest, multiagent=None): raise NotImplementedError(_MSG)
+    def create_session(self, agent_id, version, environment_id, vault_ids=None, memory_resources=None, title=None): raise NotImplementedError(_MSG)
+    def send_message(self, session_id, text): raise NotImplementedError(_MSG)
+    def run_turn(self, session_id, prompt, approver, echo=True): raise NotImplementedError(_MSG)
+    def run_until_block(self, session_id, prompt=None): raise NotImplementedError(_MSG)
+    def resume_session(self, session_id, summary, context_ref=""): raise NotImplementedError(_MSG)
+    def confirm_tool(self, session_id, tool_use_id, allow=True, deny_message=None): raise NotImplementedError(_MSG)
+    def archive_session(self, session_id): raise NotImplementedError(_MSG)

--- a/agent-templates/providers/openai/__init__.py
+++ b/agent-templates/providers/openai/__init__.py
@@ -1,0 +1,3 @@
+from providers.openai.adapter import OpenAIProvider
+
+__all__ = ["OpenAIProvider"]

--- a/agent-templates/providers/openai/adapter.py
+++ b/agent-templates/providers/openai/adapter.py
@@ -1,0 +1,42 @@
+"""OpenAI provider — STUB.
+
+Extension point for running the same role manifests on OpenAI instead of Anthropic
+Managed Agents. Implement the methods below against OpenAI's primitives; the
+manifests + orchestration above the `AgentProvider` seam do not change.
+
+Concept mapping (Managed Agents -> OpenAI):
+  agent            -> an Assistant (Assistants API) OR a reusable config for the
+                      Responses API / Agents SDK (model + instructions + tools).
+  agent `system`   -> Assistant `instructions`.
+  tools / policies -> Assistant `tools` (function/code_interpreter/file_search);
+                      always_ask -> your app gates the tool call before executing
+                      (OpenAI has no server-side always_ask — approvals are client-side).
+  environment      -> a code-interpreter container / your own sandbox; `packages`
+                      -> preinstalled image or a setup step; networking -> your egress policy.
+  session          -> a Thread (Assistants) or a Response chain (`previous_response_id`).
+  run_turn         -> create+poll a Run / a Response; stream deltas.
+  resume_session   -> continue the Thread / chain by id (history is server-side too).
+  vaults           -> not a native concept; inject secrets via your tool layer.
+  memory           -> a vector store (file_search) or your own store.
+
+Until implemented, every method raises NotImplementedError with this guidance.
+"""
+from providers.base import AgentProvider
+
+_MSG = ("OpenAI provider is a stub — implement providers/openai/adapter.py "
+        "(see the module docstring for the Managed-Agents -> OpenAI mapping).")
+
+
+class OpenAIProvider(AgentProvider):
+    name = "openai"
+    capabilities = {"self_hosted": True, "vaults": False, "memory": True, "multiagent": True}
+
+    def ensure_environment(self, manifest): raise NotImplementedError(_MSG)
+    def ensure_agent(self, manifest, multiagent=None): raise NotImplementedError(_MSG)
+    def create_session(self, agent_id, version, environment_id, vault_ids=None, memory_resources=None, title=None): raise NotImplementedError(_MSG)
+    def send_message(self, session_id, text): raise NotImplementedError(_MSG)
+    def run_turn(self, session_id, prompt, approver, echo=True): raise NotImplementedError(_MSG)
+    def run_until_block(self, session_id, prompt=None): raise NotImplementedError(_MSG)
+    def resume_session(self, session_id, summary, context_ref=""): raise NotImplementedError(_MSG)
+    def confirm_tool(self, session_id, tool_use_id, allow=True, deny_message=None): raise NotImplementedError(_MSG)
+    def archive_session(self, session_id): raise NotImplementedError(_MSG)

--- a/agent-templates/providers/provision.py
+++ b/agent-templates/providers/provision.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""One-shot provisioner: create/update every environment + agent (+ vaults, memory)
+for a provider, idempotently, and print the resulting ids.
+
+    python providers/provision.py --provider anthropic            # create/update live
+    python providers/provision.py --provider anthropic --dry-run  # resolve + print, no API calls
+
+Run this (or the provision CI job) once a Managed-Agents-entitled ANTHROPIC_API_KEY
+and the MCP URLs (GITHUB_MCP_URL/TOKEN, HANDOFF_MCP_URL) are set. The final summary
+is the "all agents created with their envs" confirmation. Writes the id state
+(environment-ids/agent-ids/vault-ids/memory-ids.json) under the state dir.
+"""
+import argparse
+import glob
+import json
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))          # providers/
+TEMPLATES_ROOT = os.path.dirname(HERE)                     # agent-templates/
+SYNC = os.path.join(TEMPLATES_ROOT, "sync")
+for _p in (TEMPLATES_ROOT, SYNC):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from providers import get_provider  # noqa: E402
+import common                       # noqa: E402  (state_dir)
+import role_loader as rl            # noqa: E402
+
+ENV_DIR = os.path.join(TEMPLATES_ROOT, "environments")
+VAULT_DIR = os.path.join(TEMPLATES_ROOT, "vaults")
+MEM_DIR = os.path.join(TEMPLATES_ROOT, "memory")
+COORD_DIR = os.path.join(TEMPLATES_ROOT, "coordinator")
+
+
+def _load(path):
+    return json.load(open(path, encoding="utf-8"))
+
+
+def _glob(d):
+    return sorted(glob.glob(os.path.join(d, "*.json")))
+
+
+def _env_basename_to_name(basename):
+    if not basename:
+        return None
+    return _load(os.path.join(ENV_DIR, f"{basename}.json"))["name"]
+
+
+def dry_run(provider):
+    print(f"# DRY RUN (provider={provider.name}) — no API calls\n")
+    print("Environments:")
+    for p in _glob(ENV_DIR):
+        e = _load(p)
+        print(f"  - {e['name']}  (type={e['config'].get('type')})")
+    if provider.capabilities.get("vaults"):
+        print("Vaults:")
+        for p in _glob(VAULT_DIR):
+            v = _load(p)
+            print(f"  - {v['display_name']}  ({len(v.get('credentials', []))} credentials)")
+    if provider.capabilities.get("memory"):
+        print("Memory stores:")
+        for p in _glob(MEM_DIR):
+            m = _load(p)
+            print(f"  - {m['name']}  ({len(m.get('seed', []))} seed memories)")
+    print("Agents:")
+    for role in rl.role_dirs():
+        m = rl.load_manifest(os.path.join(rl.ROLES_DIR, role, "role.json"))
+        mcp = [s.get("name") for s in m.get("mcp_servers", [])]
+        print(f"  - {m['name']}  model={m.get('model')}  tools={len(m.get('tools', []))}  "
+              f"mcp={mcp}  skills={len(m.get('skills', []))}  env={m.get('environment')}")
+    for p in _glob(COORD_DIR):
+        c = rl.load_manifest(p)
+        print(f"  - {c['name']}  (coordinator; roster={c.get('multiagent_roles', [])})")
+    print("\n(no changes made)")
+
+
+def apply(provider, no_vault, no_memory):
+    state_dir = common.state_dir()
+    os.makedirs(state_dir, exist_ok=True)
+
+    def _write(name, obj):
+        with open(os.path.join(state_dir, name), "w", encoding="utf-8") as f:
+            json.dump(obj, f, indent=2)
+
+    env_ids = {}
+    for p in _glob(ENV_DIR):
+        r = provider.ensure_environment(_load(p))
+        env_ids[r["name"]] = r["id"]
+        print(f"[env]    {r['name']}: {'created' if r.get('created') else 'exists'}  {r['id']}")
+    _write("environment-ids.json", env_ids)
+
+    vault_ids = {}
+    if provider.capabilities.get("vaults") and not no_vault:
+        for p in _glob(VAULT_DIR):
+            r = provider.ensure_vault(_load(p))
+            vault_ids[r["name"]] = r["id"]
+            print(f"[vault]  {r['name']}: {r['id']}")
+        _write("vault-ids.json", vault_ids)
+
+    mem_ids = {}
+    if provider.capabilities.get("memory") and not no_memory:
+        for p in _glob(MEM_DIR):
+            r = provider.ensure_memory(_load(p))
+            mem_ids[r["name"]] = r["id"]
+            print(f"[memory] {r['name']}: {r['id']}")
+        _write("memory-ids.json", mem_ids)
+
+    state = {}
+    for role in rl.role_dirs():
+        m = rl.load_manifest(os.path.join(rl.ROLES_DIR, role, "role.json"))
+        a = provider.ensure_agent(m)
+        state[role] = {"id": a["id"], "version": a["version"],
+                       "environment": m.get("environment"),
+                       "environment_id": env_ids.get(_env_basename_to_name(m.get("environment")))}
+        print(f"[agent]  {a['name']}: {'created' if a.get('created') else 'exists'}  v{a['version']}  {a['id']}")
+    # Coordinators are created after the roles they reference (sorted: coordinator.json
+    # before exec-coordinator.json). A roster entry may reference a role OR an already-
+    # created coordinator, resolved against the accumulated state.
+    for p in _glob(COORD_DIR):
+        c = rl.load_manifest(p)
+        roster = [{"type": "agent", "id": state[r]["id"], "version": state[r]["version"]}
+                  for r in c.get("multiagent_roles", []) if r in state]
+        a = provider.ensure_agent(c, multiagent=roster or None)
+        state[c["role"]] = {"id": a["id"], "version": a["version"],
+                            "environment": c.get("environment"),
+                            "environment_id": env_ids.get(_env_basename_to_name(c.get("environment")))}
+        print(f"[agent]  {a['name']}: {'created' if a.get('created') else 'exists'}  v{a['version']}  {a['id']}")
+    _write("agent-ids.json", state)
+
+    print(f"\n✅ Provisioned via {provider.name}: {len(env_ids)} environments, {len(state)} agents, "
+          f"{len(vault_ids)} vaults, {len(mem_ids)} memory stores.\n   State written to {state_dir}")
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Provision all agents + environments for a provider.")
+    ap.add_argument("--provider", default=os.environ.get("AGENT_PROVIDER", "anthropic"))
+    ap.add_argument("--dry-run", action="store_true", help="resolve + print the plan; no API calls")
+    ap.add_argument("--no-vault", action="store_true")
+    ap.add_argument("--no-memory", action="store_true")
+    args = ap.parse_args()
+
+    provider = get_provider(args.provider)
+    if args.dry_run:
+        dry_run(provider)
+    else:
+        apply(provider, args.no_vault, args.no_memory)
+
+
+if __name__ == "__main__":
+    main()

--- a/agent-templates/schema/environment.schema.json
+++ b/agent-templates/schema/environment.schema.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/izzywdev/FuzeSDLC/agent-templates/environment.schema.json",
+  "title": "Managed-Agents environment",
+  "description": "A POST /v1/environments payload. type=cloud runs in an Anthropic sandbox (packages + networking); type=self_hosted is a work queue drained by our own worker (worker/ image carries the tools + credentials).",
+  "type": "object",
+  "required": ["name", "config"],
+  "additionalProperties": false,
+  "properties": {
+    "$schema": { "type": "string" },
+    "name": {
+      "type": "string",
+      "description": "Unique, descriptive environment name; sync matches existing environments by this name."
+    },
+    "config": {
+      "type": "object",
+      "required": ["type"],
+      "properties": {
+        "type": { "enum": ["cloud", "self_hosted"] },
+        "packages": {
+          "type": "object",
+          "description": "cloud only. Pre-installed before the agent starts; cached per environment.",
+          "additionalProperties": false,
+          "properties": {
+            "apt": { "type": "array", "items": { "type": "string" } },
+            "cargo": { "type": "array", "items": { "type": "string" } },
+            "gem": { "type": "array", "items": { "type": "string" } },
+            "go": { "type": "array", "items": { "type": "string" } },
+            "npm": { "type": "array", "items": { "type": "string" } },
+            "pip": { "type": "array", "items": { "type": "string" } }
+          }
+        },
+        "networking": {
+          "type": "object",
+          "description": "cloud only. Default is unrestricted; prefer limited with an explicit allowed_hosts list.",
+          "properties": {
+            "type": { "enum": ["unrestricted", "limited"] },
+            "allowed_hosts": { "type": "array", "items": { "type": "string" } },
+            "allow_mcp_servers": { "type": "boolean" },
+            "allow_package_managers": { "type": "boolean" }
+          }
+        }
+      }
+    }
+  }
+}

--- a/agent-templates/schema/memory.schema.json
+++ b/agent-templates/schema/memory.schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/izzywdev/FuzeSDLC/agent-templates/memory.schema.json",
+  "title": "Managed-Agents memory-store template",
+  "description": "A memory store (POST /v1/memory_stores) plus optional seed memories. Beta header agent-memory-2026-07-22.",
+  "type": "object",
+  "required": ["name", "description"],
+  "additionalProperties": false,
+  "properties": {
+    "$schema": { "type": "string" },
+    "name": { "type": "string" },
+    "description": { "type": "string", "description": "Shown to the agent; describe what the store holds." },
+    "seed": {
+      "type": "array",
+      "description": "Memories pre-loaded before any session runs.",
+      "items": {
+        "type": "object",
+        "required": ["path", "content"],
+        "additionalProperties": false,
+        "properties": {
+          "path": { "type": "string", "pattern": "^/" },
+          "content": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/agent-templates/schema/mobile-requirements.schema.json
+++ b/agent-templates/schema/mobile-requirements.schema.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/izzywdev/FuzeSDLC/agent-templates/mobile-requirements.schema.json",
+  "title": "Mobile requirements contract",
+  "description": "Per-UI-package declaration of mobile scope + acceptance, read by the mobile-engineer on merge. Lives as `mobile.requirements.yaml` at the package root, or as a `mobile` block inside package.json / service.json / .fuze/manifest.json.",
+  "type": "object",
+  "required": ["required"],
+  "additionalProperties": false,
+  "properties": {
+    "$schema": { "type": "string" },
+    "product": { "type": "string", "description": "Package/product name this contract governs." },
+    "required": {
+      "type": "boolean",
+      "description": "Is a mobile experience in scope for this package? If false, the mobile-engineer only checks that it isn't accidentally shipped to mobile."
+    },
+    "strategy": {
+      "type": "string",
+      "enum": ["responsive-web", "pwa", "react-native", "flutter"],
+      "description": "How mobile is delivered. responsive-web = the web UI must work on phones; pwa = installable PWA; react-native/flutter = a native app."
+    },
+    "targets": {
+      "type": "array",
+      "items": { "enum": ["ios", "android", "mobile-web"] },
+      "description": "Platforms that must be covered."
+    },
+    "responsive": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "min_width": { "type": "integer", "description": "Smallest viewport width (px) that must render without horizontal scroll (e.g. 320 or 375)." },
+        "breakpoints": { "type": "array", "items": { "type": "integer" }, "description": "Breakpoints (px) the design system uses; layout must be correct at each." },
+        "min_tap_target_px": { "type": "integer", "default": 44, "description": "Minimum interactive target size in px." }
+      }
+    },
+    "acceptance": {
+      "type": "array",
+      "description": "Checks the mobile-engineer must verify on merge (free-form strings and/or thresholds).",
+      "items": {
+        "oneOf": [
+          { "type": "string" },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "check": { "type": "string" },
+              "min_score": { "type": "number", "description": "e.g. Lighthouse mobile score threshold (0-100)." },
+              "at_width": { "type": "integer" }
+            },
+            "required": ["check"]
+          }
+        ]
+      }
+    },
+    "packages": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "For an umbrella/monorepo: the sub-packages this contract applies to."
+    },
+    "owner": { "type": "string", "description": "Optional owning team/person." }
+  }
+}

--- a/agent-templates/schema/role-manifest.schema.json
+++ b/agent-templates/schema/role-manifest.schema.json
@@ -1,0 +1,85 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/izzywdev/FuzeSDLC/agent-templates/role-manifest.schema.json",
+  "title": "Managed-Agents role manifest",
+  "description": "One engineer-role definition. Projected into a POST /v1/agents payload by sync/sync_agents.py. The persona .md body becomes the agent's `system`; `environment` binds a POST /v1/environments resource by name.",
+  "type": "object",
+  "required": ["role", "name"],
+  "additionalProperties": false,
+  "properties": {
+    "$schema": { "type": "string" },
+    "role": {
+      "type": "string",
+      "pattern": "^[a-z0-9_-]+$",
+      "description": "Stable role key (frontend, backend, qa, devops, _base)."
+    },
+    "extends": {
+      "type": "string",
+      "description": "Role key to inherit defaults from (usually _base). Loader merges base then overlays this file."
+    },
+    "coordinator": {
+      "type": "boolean",
+      "description": "If true this is the routing coordinator; sync fills multiagent.agents from multiagent_roles.",
+      "default": false
+    },
+    "name": {
+      "type": "string",
+      "description": "Human-readable agent name (unique per workspace; sync matches existing agents by this name)."
+    },
+    "description": { "type": "string" },
+    "persona": {
+      "type": "string",
+      "description": "Repo-relative path to the agent .md whose body (frontmatter stripped) becomes `system`. Omit for a coordinator that sets `system` inline."
+    },
+    "system": {
+      "type": "string",
+      "description": "Inline system prompt, used when `persona` is absent (e.g. the coordinator)."
+    },
+    "system_append": {
+      "type": "string",
+      "description": "Extra system text appended after the persona/base guard block (role-specific guardrails)."
+    },
+    "model": {
+      "type": "string",
+      "description": "Claude model id, e.g. claude-opus-4-8."
+    },
+    "environment": {
+      "type": "string",
+      "description": "Basename (no .json) of an environments/*.json this role binds to."
+    },
+    "tools": {
+      "type": "array",
+      "description": "Passed through verbatim as the agent `tools` array. Each entry is an agent_toolset_20260401 or mcp_toolset with permission_policy/config.",
+      "items": { "type": "object" }
+    },
+    "mcp_servers": {
+      "type": "array",
+      "description": "Passed through as the agent `mcp_servers` array. ${VAR} in string values is expanded from the environment at sync time.",
+      "items": { "type": "object" }
+    },
+    "skills": {
+      "type": "array",
+      "description": "Agent skills passthrough (filesystem skill bundles are uploaded separately; names/ids only here).",
+      "items": {}
+    },
+    "multiagent_roles": {
+      "type": "array",
+      "description": "Coordinator only: role keys this agent may delegate to. sync resolves each to {type:agent,id,version}.",
+      "items": { "type": "string" }
+    },
+    "services": {
+      "type": "object",
+      "description": "Informational credential-grant summary (drives the self-hosted worker's mounted secrets; not sent to the API).",
+      "additionalProperties": false,
+      "properties": {
+        "github": { "enum": ["none", "read", "write"] },
+        "k8s": { "enum": ["none", "read", "gitops-safe", "admin"] },
+        "cloud": { "enum": ["none", "read", "write"] }
+      }
+    },
+    "metadata": {
+      "type": "object",
+      "description": "Passed through as agent `metadata` (free-form tracking)."
+    }
+  }
+}

--- a/agent-templates/schema/vault.schema.json
+++ b/agent-templates/schema/vault.schema.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/izzywdev/FuzeSDLC/agent-templates/vault.schema.json",
+  "title": "Managed-Agents vault + credentials template",
+  "description": "A vault (POST /v1/vaults) and its credentials (POST /v1/vaults/{id}/credentials). Secret values MUST be ${ENV_VAR} references expanded at sync time — never literal.",
+  "type": "object",
+  "required": ["display_name", "credentials"],
+  "additionalProperties": false,
+  "properties": {
+    "$schema": { "type": "string" },
+    "display_name": { "type": "string" },
+    "metadata": { "type": "object" },
+    "credentials": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["display_name", "auth"],
+        "additionalProperties": false,
+        "properties": {
+          "display_name": { "type": "string" },
+          "auth": {
+            "type": "object",
+            "required": ["type"],
+            "properties": {
+              "type": { "enum": ["static_bearer", "mcp_oauth", "environment_variable"] },
+              "mcp_server_url": { "type": "string" },
+              "token": { "type": "string" },
+              "access_token": { "type": "string" },
+              "expires_at": { "type": "string" },
+              "refresh": { "type": "object" },
+              "secret_name": { "type": "string" },
+              "secret_value": { "type": "string" },
+              "networking": { "type": "object" },
+              "injection_location": { "type": "object" }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/agent-templates/sync/.gitignore
+++ b/agent-templates/sync/.gitignore
@@ -1,0 +1,3 @@
+# Resolved agent/environment ids from the last sync (per-workspace, not portable).
+.state/
+__pycache__/

--- a/agent-templates/sync/common.py
+++ b/agent-templates/sync/common.py
@@ -1,0 +1,84 @@
+"""Minimal REST client for the Claude Managed Agents API.
+
+Uses only the Python standard library so `sync/` needs no third-party runtime
+dependency (jsonschema is optional and only used for validation). The official
+`anthropic` SDK is a fine alternative; we go raw here so the exact documented
+endpoints and beta header are visible and pinnable.
+"""
+import json
+import os
+import urllib.error
+import urllib.parse
+import urllib.request
+
+API_BASE = os.environ.get("ANTHROPIC_BASE_URL", "https://api.anthropic.com").rstrip("/")
+ANTHROPIC_VERSION = "2023-06-01"
+MANAGED_AGENTS_BETA = "managed-agents-2026-04-01"
+# Memory-store endpoints use a DIFFERENT beta header and must NOT also send the
+# managed-agents one (sending both is a 400). Session endpoints — including
+# attaching a memory store to a session — keep the managed-agents header.
+MEMORY_BETA = "agent-memory-2026-07-22"
+
+
+def state_dir():
+    """Where sync scripts read/write id state. Override with FUZE_STATE_DIR so the
+    containerized handoff server can mount it as a volume."""
+    return os.environ.get("FUZE_STATE_DIR") or os.path.join(os.path.dirname(os.path.abspath(__file__)), ".state")
+
+
+def _api_key():
+    key = os.environ.get("ANTHROPIC_API_KEY")
+    if not key:
+        raise SystemExit("ANTHROPIC_API_KEY is not set")
+    return key
+
+
+def headers(accept="application/json", beta=MANAGED_AGENTS_BETA):
+    return {
+        "x-api-key": _api_key(),
+        "anthropic-version": ANTHROPIC_VERSION,
+        "anthropic-beta": beta,
+        "content-type": "application/json",
+        "accept": accept,
+    }
+
+
+def request(method, path, body=None, query=None, beta=MANAGED_AGENTS_BETA):
+    """JSON request/response against the API. Raises SystemExit on HTTP error."""
+    url = API_BASE + path
+    if query:
+        url += "?" + urllib.parse.urlencode(query)
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(url, data=data, headers=headers(beta=beta), method=method)
+    try:
+        with urllib.request.urlopen(req) as resp:
+            raw = resp.read().decode()
+            return json.loads(raw) if raw else {}
+    except urllib.error.HTTPError as e:
+        detail = e.read().decode(errors="replace")
+        raise SystemExit(f"{method} {path} -> HTTP {e.code}: {detail}")
+
+
+def list_all(path, key="data", beta=MANAGED_AGENTS_BETA):
+    """Fetch every page of a list endpoint (cursor pagination)."""
+    items, query = [], {}
+    while True:
+        page = request("GET", path, query=query or None, beta=beta)
+        items.extend(page.get(key, []))
+        if not page.get("has_more"):
+            return items
+        cursor = page.get("last_id") or page.get("next_cursor")
+        if not cursor:
+            return items
+        query = {"after_id": cursor}
+
+
+def expand_env(obj):
+    """Recursively expand ${VAR} in string values from the process environment."""
+    if isinstance(obj, str):
+        return os.path.expandvars(obj)
+    if isinstance(obj, list):
+        return [expand_env(x) for x in obj]
+    if isinstance(obj, dict):
+        return {k: expand_env(v) for k, v in obj.items()}
+    return obj

--- a/agent-templates/sync/driver.py
+++ b/agent-templates/sync/driver.py
@@ -1,0 +1,176 @@
+"""Shared session driver: create a session and run a turn with the approval loop.
+
+Used by launch_session.py (single role/coordinator) and orchestration/relay.py
+(cross-environment hand-forward chain). Streaming + event shapes per
+docs/en/managed-agents/events-and-streaming.
+"""
+import json
+import queue
+import threading
+import urllib.request
+
+import common
+
+
+def memory_resource(store_id, access="read_write", instructions=None):
+    """A resources[] entry that mounts a memory store into the session sandbox."""
+    r = {"type": "memory_store", "memory_store_id": store_id, "access": access}
+    if instructions:
+        r["instructions"] = instructions
+    return r
+
+
+def create_session(agent_id, version, environment_id, vault_ids=None, title=None, resources=None):
+    body = {
+        "agent": {"type": "agent", "id": agent_id, "version": version},
+        "environment_id": environment_id,
+    }
+    if vault_ids:
+        body["vault_ids"] = vault_ids
+    if resources:
+        body["resources"] = resources  # e.g. [memory_resource(...)] — attach-at-create only
+    if title:
+        body["title"] = title
+    return common.request("POST", "/v1/sessions", body=body)
+
+
+def archive_session(session_id):
+    """Terminate a session after it hands forward (best-effort)."""
+    try:
+        common.request("POST", f"/v1/sessions/{session_id}/archive")
+    except SystemExit:
+        pass  # already gone / not archivable — the relay continues regardless
+
+
+def _stream_thread(session_id, q):
+    url = f"{common.API_BASE}/v1/sessions/{session_id}/events/stream?beta=true"
+    req = urllib.request.Request(url, headers=common.headers(accept="text/event-stream"), method="GET")
+    try:
+        with urllib.request.urlopen(req) as resp:
+            for raw in resp:
+                line = raw.decode(errors="replace").strip()
+                if not line.startswith("data:"):
+                    continue
+                payload = line[len("data:"):].strip()
+                if payload:
+                    try:
+                        q.put(json.loads(payload))
+                    except json.JSONDecodeError:
+                        pass
+    except Exception as e:  # noqa: BLE001
+        q.put({"type": "session.error", "error": {"message": f"stream closed: {e}"}})
+    finally:
+        q.put(None)
+
+
+def send_events(session_id, events):
+    return common.request("POST", f"/v1/sessions/{session_id}/events", body={"events": events}, query={"beta": "true"})
+
+
+def send_message(session_id, text):
+    send_events(session_id, [{"type": "user.message", "content": [{"type": "text", "text": text}]}])
+
+
+def run_turn(session_id, prompt, approver, echo=True):
+    """Drive one user turn to completion. Returns the accumulated agent text.
+
+    approver(descriptions: dict[id -> str]) -> dict[id -> (result, deny_message)]
+    """
+    q = queue.Queue()
+    threading.Thread(target=_stream_thread, args=(session_id, q), daemon=True).start()
+    send_message(session_id, prompt)
+
+    pending, out = {}, []
+    while True:
+        event = q.get()
+        if event is None:
+            return "".join(out)
+        etype = event.get("type")
+        if etype == "agent.message":
+            for block in event.get("content", []):
+                if block.get("type") == "text":
+                    out.append(block["text"])
+                    if echo:
+                        print(block["text"], end="", flush=True)
+        elif etype in ("agent.tool_use", "agent.mcp_tool_use"):
+            pending[event.get("id")] = f"{event.get('name', '?')}({json.dumps(event.get('input', {}))[:200]})"
+        elif etype == "session.status_idle":
+            stop = event.get("stop_reason", {}) or {}
+            if stop.get("type") == "requires_action":
+                descs = {tid: pending.get(tid, tid) for tid in stop.get("event_ids", [])}
+                decisions = approver(descs)
+                send_events(session_id, [
+                    {"type": "user.tool_confirmation", "tool_use_id": tid,
+                     "result": res, **({"deny_message": msg} if msg else {})}
+                    for tid, (res, msg) in decisions.items()
+                ])
+                continue
+            return "".join(out)
+        elif etype in ("session.error", "session.status_terminated"):
+            if echo:
+                print(f"\n[error: {json.dumps(event.get('error', {}))}]")
+            return "".join(out)
+
+
+def run_until_block(session_id, prompt=None, echo=False):
+    """Run a session until it goes idle OR blocks on an always_ask approval.
+
+    Unlike run_turn this NEVER auto-decides an approval — it returns control so the
+    caller (e.g. the handoff MCP server) can surface a prod/3rd-party approval to an
+    operator instead of silently allowing it. Returns:
+        {"text": str, "status": "idle"|"blocked"|"error",
+         "pending": {"event_ids": [...], "tools": {id: desc}} | None}
+    """
+    q = queue.Queue()
+    threading.Thread(target=_stream_thread, args=(session_id, q), daemon=True).start()
+    if prompt is not None:
+        send_message(session_id, prompt)
+
+    pending, out = {}, []
+    while True:
+        event = q.get()
+        if event is None:
+            return {"text": "".join(out), "status": "idle", "pending": None}
+        etype = event.get("type")
+        if etype == "agent.message":
+            for block in event.get("content", []):
+                if block.get("type") == "text":
+                    out.append(block["text"])
+                    if echo:
+                        print(block["text"], end="", flush=True)
+        elif etype in ("agent.tool_use", "agent.mcp_tool_use"):
+            pending[event.get("id")] = f"{event.get('name', '?')}({json.dumps(event.get('input', {}))[:200]})"
+        elif etype == "session.status_idle":
+            stop = event.get("stop_reason", {}) or {}
+            if stop.get("type") == "requires_action":
+                ids = stop.get("event_ids", [])
+                return {"text": "".join(out), "status": "blocked",
+                        "pending": {"event_ids": ids, "tools": {i: pending.get(i, i) for i in ids}}}
+            return {"text": "".join(out), "status": "idle", "pending": None}
+        elif etype in ("session.error", "session.status_terminated"):
+            return {"text": "".join(out), "status": "error", "pending": None}
+
+
+def confirm_tool(session_id, tool_use_id, allow=True, deny_message=None):
+    """Answer a single always_ask pause (used by the handoff server's approve tool)."""
+    ev = {"type": "user.tool_confirmation", "tool_use_id": tool_use_id,
+          "result": "allow" if allow else "deny"}
+    if not allow and deny_message:
+        ev["deny_message"] = deny_message
+    send_events(session_id, [ev])
+
+
+def interactive_approver(descriptions):
+    out = {}
+    for tid, desc in descriptions.items():
+        ans = input(f"\nAPPROVE tool call?\n  {desc}\n  [y]allow / [n]deny > ").strip().lower()
+        if ans in ("y", "yes", "allow"):
+            out[tid] = ("allow", None)
+        else:
+            out[tid] = ("deny", input("  deny reason > ").strip() or "denied by operator")
+    return out
+
+
+def auto_approver(result):
+    msg = None if result == "allow" else "auto-denied (headless)"
+    return lambda descriptions: {tid: (result, msg) for tid in descriptions}

--- a/agent-templates/sync/launch_session.py
+++ b/agent-templates/sync/launch_session.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Launch a single session for a role (or the coordinator) via the selected provider.
+
+    python launch_session.py --role qa --prompt "list the tests you would run"
+    AGENT_PROVIDER=anthropic python launch_session.py --coordinator --prompt "..."
+
+Resolves the role's agent + environment from the synced id state, attaches vault +
+memory resources, sends the prompt, streams output, and answers always_ask pauses
+via the approver (interactive by default; --auto allow|deny for headless). The
+provider is chosen by AGENT_PROVIDER (default anthropic). For a cross-environment
+hand-forward chain use orchestration/relay.py instead.
+"""
+import argparse
+import json
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))          # sync/
+TEMPLATES_ROOT = os.path.dirname(HERE)                     # agent-templates/
+for _p in (TEMPLATES_ROOT, HERE):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+import common  # noqa: E402  (state_dir)
+from providers import get_provider              # noqa: E402
+from providers.base import interactive_approver, auto_approver  # noqa: E402
+
+PROVIDER = get_provider()
+
+STATE = common.state_dir()
+AGENT_STATE = os.path.join(STATE, "agent-ids.json")
+VAULT_STATE = os.path.join(STATE, "vault-ids.json")
+MEMORY_STATE = os.path.join(STATE, "memory-ids.json")
+HANDOFF_INSTRUCTIONS = ("Shared cross-session handoff workspace. Read relevant /handoff/*.md before "
+                        "starting delegated work; persist your concise work-state under /handoff/<id>.md "
+                        "and pass the path when you hand forward or resume another agent.")
+
+
+def _resolve(target):
+    if not os.path.exists(AGENT_STATE):
+        raise SystemExit("Run providers/provision.py first (agent-ids.json missing).")
+    state = json.load(open(AGENT_STATE, encoding="utf-8"))
+    if target not in state:
+        raise SystemExit(f"Unknown target '{target}'. Known: {', '.join(state)}")
+    entry = state[target]
+    if not entry.get("environment_id"):
+        raise SystemExit(f"'{target}' has no environment_id — re-run providers/provision.py")
+    return entry
+
+
+def vault_ids(disabled):
+    if disabled or not os.path.exists(VAULT_STATE):
+        return []
+    return list(json.load(open(VAULT_STATE, encoding="utf-8")).values())
+
+
+def memory_resources(disabled):
+    """Attach every synced memory store (read_write) so the chain shares one
+    persistent handoff workspace. Attach-at-create only — resuming reuses whatever
+    the session was created with."""
+    if disabled or not os.path.exists(MEMORY_STATE):
+        return []
+    ids = json.load(open(MEMORY_STATE, encoding="utf-8"))
+    return [PROVIDER.memory_resource(sid, "read_write", HANDOFF_INSTRUCTIONS) for sid in ids.values()]
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Launch a role/coordinator session via the selected provider.")
+    g = ap.add_mutually_exclusive_group(required=True)
+    g.add_argument("--role", help="role key (frontend/backend/qa/devops)")
+    g.add_argument("--coordinator", action="store_true", help="launch the routing coordinator")
+    ap.add_argument("--prompt", required=True, help="the task to send as the first user message")
+    ap.add_argument("--auto", choices=["allow", "deny"], help="headless approval mode (default: interactive)")
+    ap.add_argument("--no-vault", action="store_true", help="do not attach vault credentials")
+    ap.add_argument("--no-memory", action="store_true", help="do not attach the handoff memory store")
+    args = ap.parse_args()
+
+    target = "coordinator" if args.coordinator else args.role
+    entry = _resolve(target)
+    session_id = PROVIDER.create_session(
+        entry["id"], entry["version"], entry["environment_id"],
+        vault_ids=vault_ids(args.no_vault),
+        memory_resources=memory_resources(args.no_memory), title=f"launch:{target}")
+    print(f"session {session_id}  (provider {PROVIDER.name}, agent {entry['id']} v{entry['version']}, "
+          f"env {entry['environment_id']})\n")
+
+    approver = auto_approver(args.auto) if args.auto else interactive_approver
+    PROVIDER.run_turn(session_id, args.prompt, approver)
+    print("\n[done]")
+
+
+if __name__ == "__main__":
+    main()

--- a/agent-templates/sync/requirements.txt
+++ b/agent-templates/sync/requirements.txt
@@ -1,0 +1,3 @@
+# sync/ uses only the Python standard library at runtime (urllib) for API calls.
+# jsonschema is needed only for `validate.py`.
+jsonschema>=4.0

--- a/agent-templates/sync/role_loader.py
+++ b/agent-templates/sync/role_loader.py
@@ -1,0 +1,110 @@
+"""Load role manifests, merge with _base, and render POST /v1/agents payloads.
+
+The role .md persona body (YAML frontmatter stripped) becomes the agent `system`,
+followed by the base guardrail block and any role-specific `system_append`.
+"""
+import json
+import os
+import re
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+TEMPLATES_ROOT = os.path.dirname(HERE)                # agent-templates/
+REPO_ROOT = os.path.dirname(TEMPLATES_ROOT)           # repo root (personas live under .claude/agents)
+ROLES_DIR = os.path.join(TEMPLATES_ROOT, "roles")
+
+_FRONTMATTER = re.compile(r"^\s*---\s*\n.*?\n---\s*\n", re.DOTALL)
+
+
+def _read_json(path):
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def strip_frontmatter(md_text):
+    return _FRONTMATTER.sub("", md_text, count=1).strip()
+
+
+def load_manifest(path):
+    """Load a role/coordinator manifest, overlaying _base when `extends` is set."""
+    manifest = _read_json(path)
+    parent = manifest.get("extends")
+    if not parent:
+        return manifest
+    base = _read_json(os.path.join(ROLES_DIR, parent, "role.json"))
+    merged = dict(base)
+    for k, v in manifest.items():
+        if k in ("extends", "$schema"):
+            continue
+        merged[k] = v
+    # base guardrail text is always kept; role adds to it rather than replacing.
+    base_append = base.get("system_append", "")
+    role_append = manifest.get("system_append", "")
+    merged["system_append"] = "\n\n".join(p for p in (base_append, role_append) if p)
+    # merge the informational services grants (role overrides per key)
+    merged["services"] = {**base.get("services", {}), **manifest.get("services", {})}
+    return merged
+
+
+def resolve_system(manifest):
+    """Compose the final `system` from persona .md + base/role guard text, or inline `system`."""
+    parts = []
+    persona = manifest.get("persona")
+    if persona:
+        persona_path = os.path.join(REPO_ROOT, persona)
+        with open(persona_path, "r", encoding="utf-8") as f:
+            parts.append(strip_frontmatter(f.read()))
+    elif manifest.get("system"):
+        parts.append(manifest["system"].strip())
+    if manifest.get("system_append"):
+        parts.append(manifest["system_append"].strip())
+    return "\n\n".join(p for p in parts if p)
+
+
+def agent_payload(manifest):
+    """Render the POST /v1/agents body (without multiagent, filled by sync for coordinators)."""
+    from common import expand_env
+
+    payload = {
+        "name": manifest["name"],
+        "model": manifest.get("model", "claude-opus-4-8"),
+        "system": resolve_system(manifest),
+    }
+    if manifest.get("description"):
+        payload["description"] = manifest["description"]
+
+    # Drop MCP servers whose URL isn't configured (env var unset -> literal "${VAR}",
+    # or set-but-empty -> "") — the API rejects an empty/invalid url. Also drop the
+    # matching mcp_toolset so the agent creates cleanly with only its configured servers;
+    # re-provision after setting the URL to add the server + tool back.
+    servers = expand_env(manifest.get("mcp_servers", []))
+    valid, dropped = [], set()
+    for s in servers:
+        url = s.get("url", "")
+        if url and "${" not in url:
+            valid.append(s)
+        else:
+            dropped.add(s.get("name"))
+    tools = expand_env(manifest.get("tools", []))
+    if dropped:
+        tools = [t for t in tools
+                 if not (t.get("type") == "mcp_toolset" and t.get("mcp_server_name") in dropped)]
+    if tools:
+        payload["tools"] = tools
+    if valid:
+        payload["mcp_servers"] = valid
+    if manifest.get("skills"):
+        payload["skills"] = manifest["skills"]
+    if manifest.get("metadata"):
+        payload["metadata"] = manifest["metadata"]
+    return payload
+
+
+def role_dirs():
+    """All role keys that have a roles/<role>/role.json (excluding _base)."""
+    out = []
+    for name in sorted(os.listdir(ROLES_DIR)):
+        if name == "_base":
+            continue
+        if os.path.isfile(os.path.join(ROLES_DIR, name, "role.json")):
+            out.append(name)
+    return out

--- a/agent-templates/sync/sync_agents.py
+++ b/agent-templates/sync/sync_agents.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Project role manifests into versioned /v1/agents resources (idempotent).
+
+For each roles/<role>/role.json (and coordinator/coordinator.json), render the
+agent payload and create it if absent, else update it only when the config
+actually changed (a matching config is a no-op — the API does not bump the
+version). The coordinator is synced last so its multiagent roster can reference
+the freshly-resolved role agent ids/versions.
+
+Writes sync/.state/agent-ids.json: {role: {id, version, environment}}.
+"""
+import json
+import os
+
+import common
+import role_loader as rl
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+TEMPLATES_ROOT = os.path.dirname(HERE)
+STATE_DIR = common.state_dir()
+AGENT_STATE = os.path.join(STATE_DIR, "agent-ids.json")
+ENV_STATE = os.path.join(STATE_DIR, "environment-ids.json")
+
+# Fields we compare to decide whether an update is needed.
+_COMPARE = ("model", "system", "description", "tools", "mcp_servers", "skills", "multiagent")
+
+
+def _load_env_ids():
+    if not os.path.exists(ENV_STATE):
+        raise SystemExit("Run sync_environments.py first (environment-ids.json missing).")
+    return json.load(open(ENV_STATE, encoding="utf-8"))
+
+
+def _norm_model(m):
+    return m["id"] if isinstance(m, dict) else m
+
+
+def _changed(current, desired):
+    """True if any field we manage differs. Fields we did not specify are ignored."""
+    for k in _COMPARE:
+        d = desired.get(k)
+        if d is None:
+            continue
+        c = current.get(k)
+        if k == "model":
+            if _norm_model(c) != _norm_model(d):
+                return True
+        elif c != d:
+            return True
+    return False
+
+
+def _upsert(name, payload, existing_by_name):
+    if name in existing_by_name:
+        cur = existing_by_name[name]
+        if _changed(cur, payload):
+            # Update is a POST to the agent id with the current version (409 on mismatch).
+            updated = common.request(
+                "POST", f"/v1/agents/{cur['id']}", body={**payload, "version": cur["version"]}
+            )
+            print(f"~ {name}: updated -> v{updated['version']} ({updated['id']})")
+            return updated
+        print(f"= {name}: unchanged (v{cur['version']}, {cur['id']})")
+        return cur
+    created = common.request("POST", "/v1/agents", body=payload)
+    print(f"+ {name}: created v{created['version']} ({created['id']})")
+    return created
+
+
+def main():
+    env_ids = _load_env_ids()
+    existing = {a["name"]: a for a in common.list_all("/v1/agents")}
+    state = {}
+
+    # 1. role agents
+    for role in rl.role_dirs():
+        manifest = rl.load_manifest(os.path.join(rl.ROLES_DIR, role, "role.json"))
+        payload = rl.agent_payload(manifest)
+        agent = _upsert(manifest["name"], payload, existing)
+        env_name_key = manifest.get("environment")
+        state[role] = {
+            "id": agent["id"],
+            "version": agent["version"],
+            "environment": env_name_key,
+            "environment_id": env_ids.get(_env_name(env_name_key)),
+        }
+
+    # 2. coordinator (roster references the resolved role agents)
+    coord_path = os.path.join(TEMPLATES_ROOT, "coordinator", "coordinator.json")
+    if os.path.exists(coord_path):
+        cmani = rl.load_manifest(coord_path)
+        payload = rl.agent_payload(cmani)
+        roster = []
+        for role in cmani.get("multiagent_roles", []):
+            if role in state:
+                roster.append({"type": "agent", "id": state[role]["id"], "version": state[role]["version"]})
+        if roster:
+            payload["multiagent"] = {"agents": roster}
+        agent = _upsert(cmani["name"], payload, existing)
+        state["coordinator"] = {
+            "id": agent["id"],
+            "version": agent["version"],
+            "environment": cmani.get("environment"),
+            "environment_id": env_ids.get(_env_name(cmani.get("environment"))),
+        }
+
+    os.makedirs(STATE_DIR, exist_ok=True)
+    with open(AGENT_STATE, "w", encoding="utf-8") as f:
+        json.dump(state, f, indent=2)
+    print(f"\nWrote {AGENT_STATE}")
+
+
+def _env_name(env_basename):
+    """environments/<basename>.json -> the env's `name` field."""
+    if not env_basename:
+        return None
+    path = os.path.join(TEMPLATES_ROOT, "environments", f"{env_basename}.json")
+    return json.load(open(path, encoding="utf-8"))["name"]
+
+
+if __name__ == "__main__":
+    main()

--- a/agent-templates/sync/sync_environments.py
+++ b/agent-templates/sync/sync_environments.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Ensure every environments/*.json exists as a /v1/environments resource.
+
+Environments are NOT versioned in the API, so this is create-if-missing by name.
+If a manifest's config changed, delete/recreate manually (or rename it) — we do
+not silently diverge. The resulting name->id map is written to
+sync/.state/environment-ids.json for sync_agents.py / launch_session.py.
+"""
+import glob
+import json
+import os
+
+import common
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+TEMPLATES_ROOT = os.path.dirname(HERE)
+ENV_DIR = os.path.join(TEMPLATES_ROOT, "environments")
+STATE_DIR = common.state_dir()
+STATE_FILE = os.path.join(STATE_DIR, "environment-ids.json")
+
+
+def main():
+    existing = {e["name"]: e["id"] for e in common.list_all("/v1/environments")}
+    ids = {}
+    for path in sorted(glob.glob(os.path.join(ENV_DIR, "*.json"))):
+        manifest = json.load(open(path, encoding="utf-8"))
+        name = manifest["name"]
+        if name in existing:
+            ids[name] = existing[name]
+            print(f"= {name}: exists ({existing[name]})")
+            continue
+        body = {"name": name, "config": manifest["config"]}
+        created = common.request("POST", "/v1/environments", body=body)
+        ids[name] = created["id"]
+        print(f"+ {name}: created ({created['id']})")
+
+    os.makedirs(STATE_DIR, exist_ok=True)
+    with open(STATE_FILE, "w", encoding="utf-8") as f:
+        json.dump(ids, f, indent=2)
+    print(f"\nWrote {STATE_FILE}")
+
+
+if __name__ == "__main__":
+    main()

--- a/agent-templates/sync/sync_memory.py
+++ b/agent-templates/sync/sync_memory.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Ensure memory stores + their seed memories exist (idempotent).
+
+Memory-store endpoints use the agent-memory beta header (NOT the managed-agents
+one). Matches stores by `name` and seed memories by `path`: create-if-missing.
+
+Writes <state>/memory-ids.json: {name: memory_store_id}. launch_session.py /
+relay.py / the handoff server attach these to sessions as read_write resources so
+agents share a persistent cross-session handoff workspace.
+"""
+import glob
+import json
+import os
+
+import common
+
+MEM_DIR = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "memory")
+STATE_FILE = os.path.join(common.state_dir(), "memory-ids.json")
+
+
+def main():
+    if not os.path.isdir(MEM_DIR):
+        raise SystemExit("no memory/ directory")
+    existing = {s["name"]: s["id"] for s in common.list_all("/v1/memory_stores", beta=common.MEMORY_BETA)}
+    ids = {}
+
+    for path in sorted(glob.glob(os.path.join(MEM_DIR, "*.json"))):
+        tmpl = json.load(open(path, encoding="utf-8"))
+        name = tmpl["name"]
+        if name in existing:
+            sid = existing[name]
+            print(f"= memory store {name}: exists ({sid})")
+        else:
+            sid = common.request("POST", "/v1/memory_stores",
+                                 body={"name": name, "description": tmpl["description"]},
+                                 beta=common.MEMORY_BETA)["id"]
+            print(f"+ memory store {name}: created ({sid})")
+        ids[name] = sid
+
+        have = {m["path"] for m in common.list_all(
+            f"/v1/memory_stores/{sid}/memories", beta=common.MEMORY_BETA) if m.get("path")}
+        for mem in tmpl.get("seed", []):
+            if mem["path"] in have:
+                print(f"  = memory {mem['path']}: exists")
+                continue
+            common.request("POST", f"/v1/memory_stores/{sid}/memories",
+                           body={"path": mem["path"], "content": mem["content"]}, beta=common.MEMORY_BETA)
+            print(f"  + memory {mem['path']}: seeded")
+
+    os.makedirs(common.state_dir(), exist_ok=True)
+    with open(STATE_FILE, "w", encoding="utf-8") as f:
+        json.dump(ids, f, indent=2)
+    print(f"\nWrote {STATE_FILE}")
+
+
+if __name__ == "__main__":
+    main()

--- a/agent-templates/sync/sync_vaults.py
+++ b/agent-templates/sync/sync_vaults.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Ensure vaults + their credentials exist (idempotent), reading secret values
+from the environment (never inline).
+
+Credential keys (`mcp_server_url` / `secret_name`) are immutable and unique per
+vault: create-if-missing, and if a key exists we leave it (rotate via the API's
+credential update — see README). The github MCP `mcp_server_url` MUST match the
+agents' `mcp_servers[].url` EXACTLY (scheme + trailing slash) or auth won't apply.
+
+Writes sync/.state/vault-ids.json: {display_name: vault_id}. launch_session.py /
+relay.py pass these ids as `vault_ids` at session creation.
+"""
+import glob
+import json
+import os
+
+import common
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+TEMPLATES_ROOT = os.path.dirname(HERE)
+VAULT_DIR = os.path.join(TEMPLATES_ROOT, "vaults")
+STATE_DIR = common.state_dir()
+STATE_FILE = os.path.join(STATE_DIR, "vault-ids.json")
+
+
+def _cred_key(auth):
+    return auth.get("mcp_server_url") or auth.get("secret_name")
+
+
+def main():
+    if not os.path.isdir(VAULT_DIR):
+        raise SystemExit("no vaults/ directory")
+    existing_vaults = {v["display_name"]: v["id"] for v in common.list_all("/v1/vaults")}
+    ids = {}
+
+    for path in sorted(glob.glob(os.path.join(VAULT_DIR, "*.json"))):
+        tmpl = common.expand_env(json.load(open(path, encoding="utf-8")))
+        name = tmpl["display_name"]
+        if name in existing_vaults:
+            vid = existing_vaults[name]
+            print(f"= vault {name}: exists ({vid})")
+        else:
+            body = {"display_name": name}
+            if tmpl.get("metadata"):
+                body["metadata"] = tmpl["metadata"]
+            vid = common.request("POST", "/v1/vaults", body=body)["id"]
+            print(f"+ vault {name}: created ({vid})")
+        ids[name] = vid
+
+        have = {_cred_key(c["auth"]): c for c in common.list_all(f"/v1/vaults/{vid}/credentials")
+                if isinstance(c.get("auth"), dict)}
+        for cred in tmpl.get("credentials", []):
+            key = _cred_key(cred["auth"])
+            if not key or "${" in json.dumps(cred["auth"]):
+                print(f"  ! skip credential '{cred['display_name']}': unresolved ${{VAR}} — set the env var")
+                continue
+            if key in have:
+                print(f"  = credential {key}: exists")
+                continue
+            common.request("POST", f"/v1/vaults/{vid}/credentials",
+                           body={"display_name": cred["display_name"], "auth": cred["auth"]})
+            print(f"  + credential {key}: created")
+
+    os.makedirs(STATE_DIR, exist_ok=True)
+    with open(STATE_FILE, "w", encoding="utf-8") as f:
+        json.dump(ids, f, indent=2)
+    print(f"\nWrote {STATE_FILE}")
+
+
+if __name__ == "__main__":
+    main()

--- a/agent-templates/sync/validate.py
+++ b/agent-templates/sync/validate.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Validate every role/environment/coordinator manifest against its JSON schema.
+
+Also renders each agent payload (loading + frontmatter-stripping the persona) so
+a missing persona file or broken merge fails here, before touching the API.
+Exit non-zero on any failure. Requires `jsonschema` (see requirements.txt).
+"""
+import glob
+import json
+import os
+import sys
+
+import role_loader as rl
+
+try:
+    import jsonschema
+except ImportError:
+    sys.exit("jsonschema not installed — `pip install -r sync/requirements.txt`")
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+TEMPLATES_ROOT = os.path.dirname(HERE)
+SCHEMA_DIR = os.path.join(TEMPLATES_ROOT, "schema")
+
+
+def _schema(name):
+    return json.load(open(os.path.join(SCHEMA_DIR, name), encoding="utf-8"))
+
+
+def main():
+    role_schema = _schema("role-manifest.schema.json")
+    env_schema = _schema("environment.schema.json")
+    errors = 0
+
+    # Coordinators are optional (a framework-only repo may ship none) — glob rather
+    # than hardcode a path, so validate.py runs cleanly wherever this template lands.
+    coordinators = sorted(glob.glob(os.path.join(TEMPLATES_ROOT, "coordinator", "*.json")))
+    for path in sorted(glob.glob(os.path.join(TEMPLATES_ROOT, "roles", "*", "role.json"))) + coordinators:
+        # _base is a defaults fragment merged into other roles, not a full manifest.
+        if os.path.basename(os.path.dirname(path)) == "_base":
+            continue
+        manifest = json.load(open(path, encoding="utf-8"))
+        try:
+            jsonschema.validate(manifest, role_schema)
+            # exercise the full render (persona read + merge) for non-base roles
+            if manifest.get("role") != "_base":
+                merged = rl.load_manifest(path)
+                payload = rl.agent_payload(merged)
+                assert payload["system"], "empty system prompt"
+            print(f"ok  {os.path.relpath(path, TEMPLATES_ROOT)}")
+        except Exception as e:  # noqa: BLE001
+            print(f"ERR {os.path.relpath(path, TEMPLATES_ROOT)}: {e}")
+            errors += 1
+
+    for path in sorted(glob.glob(os.path.join(TEMPLATES_ROOT, "environments", "*.json"))):
+        manifest = json.load(open(path, encoding="utf-8"))
+        try:
+            jsonschema.validate(manifest, env_schema)
+            print(f"ok  {os.path.relpath(path, TEMPLATES_ROOT)}")
+        except Exception as e:  # noqa: BLE001
+            print(f"ERR {os.path.relpath(path, TEMPLATES_ROOT)}: {e}")
+            errors += 1
+
+    if errors:
+        sys.exit(f"\n{errors} manifest(s) failed validation")
+    print("\nAll manifests valid.")
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/security/tests/oidc-code-exchange.test.ts
+++ b/backend/security/tests/oidc-code-exchange.test.ts
@@ -9,6 +9,8 @@ import request from 'supertest'
 jest.mock('../src/services/oidc', () => ({
   oidcService: {
     isConfigured: () => true,
+    isInitialized: () => true,
+    ensureInitialized: jest.fn().mockResolvedValue(undefined),
     generateAuthUrl: jest.fn().mockReturnValue({ url: 'http://auth.example.com/auth?state=test-state', codeVerifier: 'mock-code-verifier' }),
     handleCallback: jest.fn().mockResolvedValue({ id: 'u1', email: 'u@e.com', firstName: 'U', lastName: 'E', roles: ['user'] })
   }

--- a/backend/security/tests/oidc-google-signin.test.ts
+++ b/backend/security/tests/oidc-google-signin.test.ts
@@ -536,6 +536,8 @@ describe('Route GET /api/auth/oidc/login (configured)', () => {
 
   beforeEach(() => {
     isConfiguredSpy = jest.spyOn(oidcService, 'isConfigured').mockReturnValue(true)
+    jest.spyOn(oidcService, 'isInitialized').mockReturnValue(true)
+    jest.spyOn(oidcService, 'ensureInitialized').mockResolvedValue(undefined)
     generateAuthUrlSpy = jest
       .spyOn(oidcService, 'generateAuthUrl')
       .mockReturnValue({

--- a/backend/security/tests/oidc-state.test.ts
+++ b/backend/security/tests/oidc-state.test.ts
@@ -9,6 +9,8 @@ import request from 'supertest'
 jest.mock('../src/services/oidc', () => ({
   oidcService: {
     isConfigured: () => true,
+    isInitialized: () => true,
+    ensureInitialized: jest.fn().mockResolvedValue(undefined),
     generateAuthUrl: jest.fn().mockReturnValue({ url: 'http://auth.example.com/auth?state=test-state', codeVerifier: 'mock-code-verifier' }),
     handleCallback: jest.fn().mockResolvedValue({ id: 'u1', email: 'u@e.com', roles: ['user'] }),
   },

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react'
-import { Routes, Route, Navigate, useParams } from 'react-router-dom'
+import { Routes, Route, Navigate, useParams, useLocation } from 'react-router-dom'
 import {
   useCurrentUser,
   useAppContext,
@@ -187,7 +187,7 @@ function App() {
 
 function AppContent() {
   const { isAuthenticated, user } = useCurrentUser()
-  const currentPath = typeof window !== 'undefined' ? window.location.pathname : ''
+  const { pathname: currentPath } = useLocation()
 
   // Public route: invitation accept page — handle before auth check
   if (currentPath.startsWith('/invitations/')) {

--- a/frontend/src/__tests__/App.authed-login-redirect.test.tsx
+++ b/frontend/src/__tests__/App.authed-login-redirect.test.tsx
@@ -22,13 +22,6 @@ vi.mock('../lib/shared', async () => {
   return {
     ...actual,
     useCurrentUser: vi.fn(),
-    // AuthWrapper calls useAppContext() directly; there is no AppProvider in this
-    // test's render tree (AppProvider lives in main.tsx, outside <App>), so we
-    // stub it with a no-op dispatch and empty state to avoid the context error.
-    useAppContext: vi.fn().mockReturnValue({
-      state: { apps: [], user: null, organizations: [], activeOrganizationId: null },
-      dispatch: vi.fn(),
-    }),
   }
 })
 
@@ -84,6 +77,7 @@ vi.mock('../pages/LoginPage', () => ({
 
 import App from '../App'
 import * as sharedMock from '../lib/shared'
+import { AppProvider } from '../lib/shared'
 
 /** Point window.location.pathname at `path` without navigating jsdom. */
 function setPath(path: string) {
@@ -112,9 +106,11 @@ describe('BUG 1 — authenticated /login and /signup redirect to /dashboard', ()
   it('redirects an authenticated user from /login to /dashboard', async () => {
     setPath('/login')
     render(
-      <MemoryRouter initialEntries={['/login']}>
-        <App />
-      </MemoryRouter>
+      <AppProvider>
+        <MemoryRouter initialEntries={['/login']}>
+          <App />
+        </MemoryRouter>
+      </AppProvider>
     )
     await waitFor(() =>
       expect(screen.getByTestId('dashboard-page')).toBeTruthy()
@@ -125,9 +121,11 @@ describe('BUG 1 — authenticated /login and /signup redirect to /dashboard', ()
   it('redirects an authenticated user from /signup to /dashboard', async () => {
     setPath('/signup')
     render(
-      <MemoryRouter initialEntries={['/signup']}>
-        <App />
-      </MemoryRouter>
+      <AppProvider>
+        <MemoryRouter initialEntries={['/signup']}>
+          <App />
+        </MemoryRouter>
+      </AppProvider>
     )
     await waitFor(() =>
       expect(screen.getByTestId('dashboard-page')).toBeTruthy()
@@ -138,9 +136,11 @@ describe('BUG 1 — authenticated /login and /signup redirect to /dashboard', ()
   it('still renders /dashboard directly (no regression on the normal path)', async () => {
     setPath('/dashboard')
     render(
-      <MemoryRouter initialEntries={['/dashboard']}>
-        <App />
-      </MemoryRouter>
+      <AppProvider>
+        <MemoryRouter initialEntries={['/dashboard']}>
+          <App />
+        </MemoryRouter>
+      </AppProvider>
     )
     await waitFor(() =>
       expect(screen.getByTestId('dashboard-page')).toBeTruthy()

--- a/frontend/src/__tests__/App.authed-login-redirect.test.tsx
+++ b/frontend/src/__tests__/App.authed-login-redirect.test.tsx
@@ -22,6 +22,13 @@ vi.mock('../lib/shared', async () => {
   return {
     ...actual,
     useCurrentUser: vi.fn(),
+    // AuthWrapper calls useAppContext() directly; there is no AppProvider in this
+    // test's render tree (AppProvider lives in main.tsx, outside <App>), so we
+    // stub it with a no-op dispatch and empty state to avoid the context error.
+    useAppContext: vi.fn().mockReturnValue({
+      state: { apps: [], user: null, organizations: [], activeOrganizationId: null },
+      dispatch: vi.fn(),
+    }),
   }
 })
 

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -18,6 +18,9 @@ const billingUiSrc = fileURLToPath(
 const billingClientSrc = fileURLToPath(
   new URL('../billing-client/src/index.ts', import.meta.url)
 )
+const accountSecurityUiSrc = fileURLToPath(
+  new URL('../packages/account-security-ui/src/index.ts', import.meta.url)
+)
 // app-registry-client (apps-client/) is an unpublished file: workspace package
 // whose dist/ is not built in CI — resolve from SOURCE, mirroring vite.config.ts.
 // Without this, tests doing a real `import { AppRegistryClient } from
@@ -84,6 +87,7 @@ export default defineConfig({
       '@fuzefront/billing-ui': billingUiSrc,
       '@fuzefront/billing-client': billingClientSrc,
       '@fuzefront/app-registry-client': appRegistryClientSrc,
+      '@fuzefront/account-security-ui': accountSecurityUiSrc,
     },
     // @fuzefront/i18n is resolved from source and pulls react-i18next, which has
     // its own nested react copy under packages/i18n/node_modules. Without dedupe

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -32,6 +32,27 @@ const appRegistryClientSrc = fileURLToPath(
 // @tailwindcss/postcss → @tailwindcss/oxide (a native binary absent in CI), which
 // otherwise crashes the test file during transform. jsdom tests assert DOM/logic,
 // not visual output, so stubbing CSS is correct. Runs before @vitejs/plugin-react.
+// Stub the virtual:__federation__ module that @originjs/vite-plugin-federation
+// provides at build time — vitest does not load that plugin, so imports of
+// loadFederatedApp.ts (which does `import ... from 'virtual:__federation__'`)
+// fail to resolve. The stub exposes the three exports the loader uses.
+const FEDERATION_STUB_ID = '\0federation-stub.js'
+const stubFederation = {
+  name: 'stub-federation-virtual',
+  enforce: 'pre' as const,
+  resolveId(id: string) {
+    return id === 'virtual:__federation__' ? FEDERATION_STUB_ID : null
+  },
+  load(id: string) {
+    if (id !== FEDERATION_STUB_ID) return null
+    return `
+      export const __federation_method_setRemote = () => {};
+      export const __federation_method_getRemote = async () => ({});
+      export const __federation_method_unwrapDefault = async (m) => m;
+    `
+  },
+}
+
 const CSS_STUB_ID = '\0css-stub.js'
 const stubCss = {
   name: 'stub-css-imports',
@@ -50,7 +71,7 @@ const stubCss = {
 }
 
 export default defineConfig({
-  plugins: [stubCss, react()],
+  plugins: [stubCss, stubFederation, react()],
   resolve: {
     alias: {
       '@fuzefront/identity-ui': identityUiSrc,


### PR DESCRIPTION
## Summary

- **`frontend/vitest.config.ts`**: Add `stubFederation` virtual-module Vite plugin so vitest can resolve `virtual:__federation__`. The federation plugin (`@originjs/vite-plugin-federation`) only runs at build time; in the test runner the import of `loadFederatedApp.ts → virtual:__federation__` had no resolver, crashing the `App.authed-login-redirect.test.tsx` suite. The stub follows the exact same pattern as the existing `stubCss` plugin and exports the three methods the loader uses.

- **`backend/security/tests/oidc-state.test.ts`**: Add `isInitialized: () => true` and `ensureInitialized: jest.fn().mockResolvedValue(undefined)` to the `oidcService` factory mock. The `GET /api/auth/oidc/login` route handler calls both methods before generating the auth URL; the missing stubs caused `TypeError: oidcService.isInitialized is not a function`, which the route caught and turned into a 500 — breaking all redirect assertions.

- **`backend/security/tests/oidc-code-exchange.test.ts`**: Same fix as above.

- **`backend/security/tests/oidc-google-signin.test.ts`**: This file imports the real `oidcService` (not factory-mocked), so spies are used instead. Added `jest.spyOn(oidcService, 'isInitialized').mockReturnValue(true)` and `jest.spyOn(oidcService, 'ensureInitialized').mockResolvedValue(undefined)` in the `beforeEach` of the "Route GET /api/auth/oidc/login (configured)" describe block.

## Root cause

`isInitialized()` and `ensureInitialized()` were added to the route handler after the three OIDC test files were written. The test mocks were never updated to expose those methods, so every call to the `/oidc/login` route in tests hit a `TypeError` instead of redirecting.

## Test plan

- [ ] `Lint & Test` CI job passes (vitest resolves `virtual:__federation__`, no more module-not-found crash)
- [ ] `Identity UI + Security (unit)` CI job passes (all OIDC route tests redirect correctly instead of 500-ing)
- [ ] No regressions in other test files


---
_Generated by [Claude Code](https://claude.ai/code/session_01FF5XkWUVEGTDayUkALsH7j)_