### PR TITLE
fix(frontend/test): stub virtual:__federation__ so vitest can transform the host

### DIFF
--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -49,8 +49,35 @@ const stubCss = {
   },
 }
 
+// `virtual:__federation__` is injected at BUILD time by @originjs/vite-plugin-federation
+// (registered in vite.config.ts, deliberately NOT here — tests don't build remotes).
+// Without the plugin the id is unresolvable, so vite:import-analysis fails the whole
+// test file the moment anything reaches src/utils/loadFederatedApp.ts — which
+// FederatedAppLoader.tsx and StandaloneAppSurface.tsx both import. Stub it, exactly as
+// stubCss does for stylesheets: jsdom tests assert host logic, never real remote loading.
+// Tests that care about loading behaviour vi.mock('../utils/loadFederatedApp') anyway.
+const FEDERATION_ID = 'virtual:__federation__'
+const FEDERATION_STUB_ID = '\0federation-stub.js'
+const stubFederation = {
+  name: 'stub-virtual-federation',
+  enforce: 'pre' as const,
+  resolveId(id: string) {
+    return id === FEDERATION_ID ? FEDERATION_STUB_ID : null
+  },
+  load(id: string) {
+    return id === FEDERATION_STUB_ID
+      ? [
+          'export const __federation_method_setRemote = () => {}',
+          'export const __federation_method_getRemote = () => Promise.resolve({})',
+          'export const __federation_method_unwrapDefault = (m) =>',
+          '  m && typeof m === "object" && "default" in m ? m.default : m',
+        ].join('\n')
+      : null
+  },
+}
+
 export default defineConfig({
-  plugins: [stubCss, react()],
+  plugins: [stubCss, stubFederation, react()],
   resolve: {
     alias: {
       '@fuzefront/identity-ui': identityUiSrc,


### PR DESCRIPTION
## The failure

`Lint & Test` has been red on `master` — 4 consecutive runs on 2026-07-26 alone, independent of any PR:

```
Failed to resolve import "virtual:__federation__"
File: frontend/src/utils/loadFederatedApp.ts:10:7
```

## Cause

`virtual:__federation__` is injected at **build time** by `@originjs/vite-plugin-federation`, which is registered in `vite.config.ts` but deliberately **not** in `vitest.config.ts` — tests don't build remotes.

Without that plugin the id is unresolvable, so `vite:import-analysis` fails the **entire test file** the moment anything reaches `src/utils/loadFederatedApp.ts`. Both `FederatedAppLoader.tsx` and `StandaloneAppSurface.tsx` import it, and `App.tsx` imports those — so the blast radius is any test touching the app shell.

## Fix

A `stubFederation` pre-plugin resolving that one id to an inert module exporting the three helpers the host imports.

This mirrors the **`stubCss` plugin already in this same file** — same pattern, same rationale: jsdom unit tests assert host DOM/logic, never real remote loading (tests that care about load behaviour `vi.mock` the loader module anyway).

## Verification

- A temporary spec importing the three helpers from `virtual:__federation__` **resolves and passes**: `setRemote`/`getRemote` are functions, `unwrapDefault({default: 42}) === 42`, `unwrapDefault(7) === 7`. Temp spec removed.
- A full `vitest run` afterwards reports **zero** occurrences of `virtual:__federation__` anywhere in the output.
- `tsc --noEmit` yields **0** errors referencing `vitest.config.ts` on both master's version and this one — no new type error introduced.

## Scope note — read before assuming this unblocked anything

This repairs `Lint & Test`, which is **NOT** one of `master`'s required status checks. The required set is `Security Scan`, `In-repo packages resolve from source`, and the `gate-*` family. So this was never blocking a merge — it was leaving `master` persistently red, which hides real regressions.

Residual local failures are a `react-router-dom` gap in the worktree's `node_modules`, not a code defect, and do not reproduce in CI (CI collects 15 test files; the local worktree only 13).

**Not labelled `auto-merge`** — `master` is deploy-on-push, so per `CLAUDE.md` this belongs in a deploy window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
