### PR TITLE
FQ-164: Render Storybook component previews in inventory

### DIFF
--- a/FuzeQuality/apps/web/src/App.tsx
+++ b/FuzeQuality/apps/web/src/App.tsx
@@ -12,6 +12,8 @@ import {
   Database,
   FileCode2,
   GitBranch,
+  Eye,
+  ExternalLink,
   Layers3,
   Network,
   Plus,
@@ -27,10 +29,13 @@ import type {
   CoverageState,
   FrontendSurface,
   Portfolio,
+  Repository,
+  StorybookStory,
   TestExpectation,
 } from '@fuzequality/contracts'
 import { api } from './api'
 import { planGap } from './testPlan'
+import { storybookPreviewUrl } from './storybook'
 
 type View = 'overview' | 'repositories' | 'api' | 'frontend' | 'requirements' | 'review'
 
@@ -120,6 +125,40 @@ function GapPlanDrawer({ subject, expectations, selectedId, onClose }: {
           </div>
         </article>
       })}</div>
+    </aside>
+  </div>
+}
+
+function ComponentPreviewDrawer({ surface, repository, onClose }: {
+  surface: FrontendSurface
+  repository?: Repository
+  onClose: () => void
+}) {
+  const closeButton = useRef<HTMLButtonElement>(null)
+  const [story, setStory] = useState<StorybookStory | undefined>(surface.stories[0])
+  const previewUrl = story && storybookPreviewUrl(repository?.storybookBaseUrl, story)
+  useEffect(() => {
+    closeButton.current?.focus()
+    const close = (event: KeyboardEvent) => event.key === 'Escape' && onClose()
+    window.addEventListener('keydown', close)
+    return () => window.removeEventListener('keydown', close)
+  }, [onClose])
+  return <div className="drawer-backdrop" role="presentation" onMouseDown={event => event.target === event.currentTarget && onClose()}>
+    <aside className="preview-drawer" role="dialog" aria-modal="true" aria-labelledby="component-preview-title">
+      <header className="drawer-header">
+        <div><p className="eyebrow">Storybook visual reference</p><h2 id="component-preview-title">{surface.name}</h2><code>{surface.packageName} · {surface.sourcePath}</code></div>
+        <button ref={closeButton} className="icon-button" onClick={onClose} aria-label="Close component preview"><X /></button>
+      </header>
+      {surface.stories.length > 0 ? <>
+        <div className="preview-toolbar">
+          <label>Story<select value={story?.id} onChange={event => setStory(surface.stories.find(item => item.id === event.target.value))}>{surface.stories.map(item => <option key={item.id} value={item.id}>{item.name}</option>)}</select></label>
+          {previewUrl && <a href={previewUrl} target="_blank" rel="noreferrer">Open Storybook <ExternalLink size={14} /></a>}
+        </div>
+        {previewUrl
+          ? <div className="storybook-frame"><iframe title={`${surface.name}: ${story?.name}`} src={previewUrl} sandbox="allow-scripts allow-forms" referrerPolicy="no-referrer" /></div>
+          : <div className="preview-empty"><Eye /><strong>Story discovered; preview host not configured</strong><span>Add this repository’s HTTPS Storybook URL to render its isolated story here.</span><code>{story?.sourcePath} · {story?.exportName}</code></div>}
+        <footer className="preview-provenance"><BookOpen size={14} /> Static CSF metadata from the scanned commit. The iframe runs sandboxed without same-origin, navigation, or popup privileges.</footer>
+      </> : <div className="preview-empty"><Eye /><strong>No Storybook visual reference found</strong><span>Add a co-located <code>*.stories.tsx</code> file and publish Storybook to make this component renderable.</span></div>}
     </aside>
   </div>
 }
@@ -223,11 +262,12 @@ function Repositories({ data, reload }: { data: Portfolio; reload: () => Promise
     defaultBranch: 'main',
     kind: 'mixed',
     installationId: '',
+    storybookBaseUrl: '',
   })
   async function submit(event: FormEvent) {
     event.preventDefault(); setBusy(true); setError('')
     try {
-      const payload = { ...form, includeGlobs: [], excludeGlobs: [], jiraProjects: [] }
+      const payload = { ...form, storybookBaseUrl: form.storybookBaseUrl || undefined, includeGlobs: [], excludeGlobs: [], jiraProjects: [] }
       await api.verifyRepository(payload)
       await api.addRepository(payload)
       setOpen(false); await reload()
@@ -254,28 +294,29 @@ function Repositories({ data, reload }: { data: Portfolio; reload: () => Promise
           </article>
         })}
       </section>
-      {open && <div className="modal-backdrop" role="presentation"><form className="modal" onSubmit={submit}><div className="modal-title"><div><p className="eyebrow">GitHub App source</p><h2>Add repository</h2></div><button type="button" className="icon-button" onClick={() => setOpen(false)}><X /></button></div><label>Owner<input value={form.owner} onChange={event => setForm({ ...form, owner: event.target.value })} required /></label><label>Repository name<input value={form.name} onChange={event => setForm({ ...form, name: event.target.value })} placeholder="FuzeService" required /></label><label>GitHub App installation ID<input value={form.installationId} onChange={event => setForm({ ...form, installationId: event.target.value.trim() })} inputMode="numeric" placeholder="148577461" required /><small>The read-only FuzeQuality GitHub App installation that can access this repository.</small></label><div className="form-row"><label>Default branch<input value={form.defaultBranch} onChange={event => setForm({ ...form, defaultBranch: event.target.value })} /></label><label>Kind<select value={form.kind} onChange={event => setForm({ ...form, kind: event.target.value })}><option value="mixed">Mixed</option><option value="service">Service</option><option value="application">Application</option><option value="library">Library</option><option value="infrastructure">Infrastructure</option></select></label></div>{error && <p className="form-error" role="alert">{error}</p>}<div className="modal-actions"><button type="button" className="secondary-button" onClick={() => setOpen(false)}>Cancel</button><button className="primary-button" disabled={busy}>{busy ? 'Verifying…' : 'Verify and add'}</button></div></form></div>}
+      {open && <div className="modal-backdrop" role="presentation"><form className="modal" onSubmit={submit}><div className="modal-title"><div><p className="eyebrow">GitHub App source</p><h2>Add repository</h2></div><button type="button" className="icon-button" onClick={() => setOpen(false)}><X /></button></div><label>Owner<input value={form.owner} onChange={event => setForm({ ...form, owner: event.target.value })} required /></label><label>Repository name<input value={form.name} onChange={event => setForm({ ...form, name: event.target.value })} placeholder="FuzeService" required /></label><label>GitHub App installation ID<input value={form.installationId} onChange={event => setForm({ ...form, installationId: event.target.value.trim() })} inputMode="numeric" placeholder="148577461" required /><small>The read-only FuzeQuality GitHub App installation that can access this repository.</small></label><label>Storybook URL (optional)<input type="url" value={form.storybookBaseUrl} onChange={event => setForm({ ...form, storybookBaseUrl: event.target.value.trim() })} placeholder="https://storybook.example.com" /><small>HTTPS host for sandboxed component previews. Story metadata is cataloged even without it.</small></label><div className="form-row"><label>Default branch<input value={form.defaultBranch} onChange={event => setForm({ ...form, defaultBranch: event.target.value })} /></label><label>Kind<select value={form.kind} onChange={event => setForm({ ...form, kind: event.target.value })}><option value="mixed">Mixed</option><option value="service">Service</option><option value="application">Application</option><option value="library">Library</option><option value="infrastructure">Infrastructure</option></select></label></div>{error && <p className="form-error" role="alert">{error}</p>}<div className="modal-actions"><button type="button" className="secondary-button" onClick={() => setOpen(false)}>Cancel</button><button className="primary-button" disabled={busy}>{busy ? 'Verifying…' : 'Verify and add'}</button></div></form></div>}
     </>
   )
 }
 
-function Matrix({ items, expectations, kind }: { items: Array<ApiOperation | FrontendSurface>; expectations: TestExpectation[]; kind: 'api' | 'frontend' }) {
+function Matrix({ items, expectations, kind, repositories = [] }: { items: Array<ApiOperation | FrontendSurface>; expectations: TestExpectation[]; kind: 'api' | 'frontend'; repositories?: Repository[] }) {
   const [query, setQuery] = useState('')
   const [selection, setSelection] = useState<{ subject: ApiOperation | FrontendSurface; expectationId: string }>()
+  const [preview, setPreview] = useState<FrontendSurface>()
   const trigger = useRef<HTMLButtonElement | null>(null)
   const filtered = items.filter(item => JSON.stringify(item).toLowerCase().includes(query.toLowerCase()))
   function closePlan() {
     setSelection(undefined)
     requestAnimationFrame(() => trigger.current?.focus())
   }
-  return <><div className="filter-bar"><Search size={16} /><input value={query} onChange={event => setQuery(event.target.value)} placeholder={`Filter ${kind === 'api' ? 'operations' : 'surfaces'}…`} /><span>{filtered.length} shown</span></div><div className="matrix"><div className="matrix-head"><span>{kind === 'api' ? 'Operation' : 'Surface'}</span><span>Expected evidence</span><span>Status</span></div>{filtered.map(item => { const rows = expectations.filter(expectation => expectation.subjectId === item.id); return <div className="matrix-group" key={item.id}><div className="matrix-subject">{kind === 'api' ? <code><b>{(item as ApiOperation).method.toUpperCase()}</b> {(item as ApiOperation).path}</code> : <><strong>{(item as FrontendSurface).name}</strong><small>{(item as FrontendSurface).packageName} · {(item as FrontendSurface).kind}</small></>}</div><div className="matrix-expectations">{rows.map(row => <div key={row.id}><span>{row.label}</span><small>{row.rule}</small></div>)}</div><div className="matrix-states">{rows.map(row => row.coverage === 'gap' ? <button key={row.id} className="gap-button state-gap" onClick={event => { trigger.current = event.currentTarget; setSelection({ subject: item, expectationId: row.id }) }} aria-label={`Gap: ${row.label}. Show ${rows.filter(candidate => candidate.coverage === 'gap').length} tests to add.`}>Gap <ChevronRight size={14} /></button> : <StatusPill key={row.id} state={row.coverage} />)}</div></div> })}{!filtered.length && <div className="empty-state roomy"><FileCode2 /><strong>No catalog entries match</strong><span>Adjust the filter or scan a repository.</span></div>}</div>{selection && <GapPlanDrawer subject={selection.subject} expectations={expectations.filter(item => item.subjectId === selection.subject.id)} selectedId={selection.expectationId} onClose={closePlan} />}</>
+  return <><div className="filter-bar"><Search size={16} /><input value={query} onChange={event => setQuery(event.target.value)} placeholder={`Filter ${kind === 'api' ? 'operations' : 'surfaces'}…`} /><span>{filtered.length} shown</span></div><div className="matrix"><div className="matrix-head"><span>{kind === 'api' ? 'Operation' : 'Surface'}</span><span>Expected evidence</span><span>Status</span></div>{filtered.map(item => { const rows = expectations.filter(expectation => expectation.subjectId === item.id); const surface = kind === 'frontend' ? item as FrontendSurface : undefined; return <div className="matrix-group" key={item.id}><div className="matrix-subject">{kind === 'api' ? <code><b>{(item as ApiOperation).method.toUpperCase()}</b> {(item as ApiOperation).path}</code> : <><strong>{surface?.name}</strong><small>{surface?.packageName} · {surface?.kind}</small><button className="preview-button" onClick={() => setPreview(surface)}><Eye size={14} /> {surface?.stories.length ? `${surface.stories.length} visual ${surface.stories.length === 1 ? 'state' : 'states'}` : 'Visual reference'}</button></>}</div><div className="matrix-expectations">{rows.map(row => <div key={row.id}><span>{row.label}</span><small>{row.rule}</small></div>)}</div><div className="matrix-states">{rows.map(row => row.coverage === 'gap' ? <button key={row.id} className="gap-button state-gap" onClick={event => { trigger.current = event.currentTarget; setSelection({ subject: item, expectationId: row.id }) }} aria-label={`Gap: ${row.label}. Show ${rows.filter(candidate => candidate.coverage === 'gap').length} tests to add.`}>Gap <ChevronRight size={14} /></button> : <StatusPill key={row.id} state={row.coverage} />)}</div></div> })}{!filtered.length && <div className="empty-state roomy"><FileCode2 /><strong>No catalog entries match</strong><span>Adjust the filter or scan a repository.</span></div>}</div>{selection && <GapPlanDrawer subject={selection.subject} expectations={expectations.filter(item => item.subjectId === selection.subject.id)} selectedId={selection.expectationId} onClose={closePlan} />}{preview && <ComponentPreviewDrawer surface={preview} repository={repositories.find(item => item.id === preview.repositoryId)} onClose={() => setPreview(undefined)} />}</>
 }
 
 function CatalogPage({ type, data }: { type: 'api' | 'frontend'; data: Portfolio }) {
   const isApi = type === 'api'
   const expectations = data.expectations.filter(item => item.subjectType === (isApi ? 'api-operation' : 'frontend-surface'))
   const items: Array<ApiOperation | FrontendSurface> = isApi ? data.operations : data.surfaces
-  return <><PageHeading eyebrow={isApi ? 'Contract inventory' : 'Implemented surface'} title={isApi ? 'API coverage matrix' : 'Frontend coverage matrix'} detail={isApi ? 'Every operation measured against schema-derived test expectations.' : 'Routes, pages, components, states, Storybook documentation, and test evidence.'} action={<div className="header-badge">{isApi ? <Braces /> : <Code2 />} {items.length} indexed</div>} /><CoverageRail expectations={expectations} /><Matrix items={items} expectations={expectations} kind={type} /></>
+  return <><PageHeading eyebrow={isApi ? 'Contract inventory' : 'Implemented surface'} title={isApi ? 'API coverage matrix' : 'Frontend coverage matrix'} detail={isApi ? 'Every operation measured against schema-derived test expectations.' : 'Routes, pages, components, states, Storybook documentation, and test evidence.'} action={<div className="header-badge">{isApi ? <Braces /> : <Code2 />} {items.length} indexed</div>} /><CoverageRail expectations={expectations} /><Matrix items={items} expectations={expectations} kind={type} repositories={data.repositories} /></>
 }
 
 function ApiCatalogPage({ data }: { data: Portfolio }) {

--- a/FuzeQuality/apps/web/src/storybook.test.ts
+++ b/FuzeQuality/apps/web/src/storybook.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { storybookPreviewUrl } from './storybook'
+
+const story = {
+  id: 'design-button--primary',
+  title: 'Design/Button',
+  name: 'Primary',
+  exportName: 'Primary',
+  sourcePath: 'src/Button.stories.tsx',
+  hasPlay: false,
+  previewPath: 'iframe.html?id=design-button--primary&viewMode=story',
+}
+
+describe('storybook preview URL', () => {
+  it('builds a same-origin HTTPS iframe URL', () => {
+    expect(storybookPreviewUrl('https://storybook.example.test/ui', story))
+      .toBe('https://storybook.example.test/ui/iframe.html?id=design-button--primary&viewMode=story')
+  })
+
+  it('rejects non-HTTPS and cross-origin preview paths', () => {
+    expect(storybookPreviewUrl('http://storybook.example.test', story)).toBeUndefined()
+    expect(storybookPreviewUrl('https://storybook.example.test', {
+      ...story,
+      previewPath: 'https://attacker.example/iframe.html',
+    })).toBeUndefined()
+  })
+})

--- a/FuzeQuality/apps/web/src/storybook.ts
+++ b/FuzeQuality/apps/web/src/storybook.ts
@@ -1,0 +1,14 @@
+import type { StorybookStory } from '@fuzequality/contracts'
+
+export function storybookPreviewUrl(baseUrl: string | undefined, story: StorybookStory) {
+  if (!baseUrl) return undefined
+  try {
+    const base = new URL(baseUrl)
+    if (base.protocol !== 'https:') return undefined
+    const preview = new URL(story.previewPath, `${base.toString().replace(/\/+$/, '')}/`)
+    if (preview.origin !== base.origin) return undefined
+    return preview.toString()
+  } catch {
+    return undefined
+  }
+}

--- a/FuzeQuality/apps/web/src/styles.css
+++ b/FuzeQuality/apps/web/src/styles.css
@@ -149,3 +149,26 @@ button:disabled { cursor: wait; opacity: .55; }
 @media (max-width: 720px) { .app-shell { display: block; }.sidebar { position: fixed; z-index: 10; top: auto; bottom: 0; width: 100%; height: 64px; padding: 7px; border: 0; border-top: 1px solid var(--line); }.brand, .sidebar-footer { display: none; }.sidebar nav { display: flex; justify-content: space-around; padding: 0; }.sidebar nav button { width: auto; }.topbar { padding: 0 18px; }.content { padding: 28px 18px 90px; }.page-header, .page-header.compact { display: block; }.coverage-dial { display: none; }.stats-grid { grid-template-columns: 1fr 1fr; }.stat { padding: 15px; }.catalog-filters { grid-template-columns: 1fr; }.matrix { overflow-x: auto; }.matrix-head, .matrix-group { min-width: 760px; }.review-card { grid-template-columns: 74px 1fr; }.review-actions { grid-column: 1 / -1; justify-content: flex-end; padding-top: 0; }.form-row { grid-template-columns: 1fr; } }
 @media (max-width: 720px) { .gap-drawer { padding: 21px 16px; }.drawer-header h2 { font-size: 25px; }.planned-test { grid-template-columns: 36px 1fr; }.plan-body { padding: 15px 13px; }.aaa-grid { grid-template-columns: 1fr; }.aaa-grid section:last-child { grid-column: auto; }.plan-heading { display: block; }.plan-heading b { display: inline-block; margin-top: 8px; } }
 @media (prefers-reduced-motion: reduce) { *, *::before, *::after { animation-duration: .01ms !important; transition-duration: .01ms !important; } }
+
+.preview-button { display: inline-flex; align-items: center; gap: 6px; margin-top: 11px; padding: 6px 8px; border: 1px solid #2e5268; background: #0d2231; color: var(--cyan); cursor: pointer; font: 9px 'IBM Plex Mono'; text-transform: uppercase; }
+.preview-button:hover { border-color: var(--cyan); background: #123042; }
+.preview-drawer { width: min(980px, 100vw); height: 100vh; overflow: auto; padding: 30px; border-left: 1px solid #34536a; background: #081522; box-shadow: -28px 0 90px rgba(0,0,0,.48); }
+.preview-toolbar { display: flex; align-items: end; justify-content: space-between; gap: 14px; margin: 20px 0 14px; }
+.preview-toolbar label { display: grid; gap: 6px; color: var(--muted); font: 10px 'IBM Plex Mono'; text-transform: uppercase; }
+.preview-toolbar select { min-width: 230px; padding: 8px 10px; border: 1px solid var(--line); background: #07131e; color: var(--text); }
+.preview-toolbar a { display: inline-flex; align-items: center; gap: 6px; color: var(--cyan); font-size: 11px; }
+.storybook-frame { height: min(660px, 70vh); border: 1px solid var(--line); background: #fff; }
+.storybook-frame iframe { width: 100%; height: 100%; border: 0; }
+.preview-empty { min-height: 420px; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 9px; padding: 35px; border: 1px dashed #31536a; background: #091724; color: var(--muted); text-align: center; }
+.preview-empty svg { width: 32px; height: 32px; color: var(--cyan); }
+.preview-empty strong { color: var(--text); font: 600 20px 'Space Grotesk'; }
+.preview-empty span { max-width: 520px; line-height: 1.5; }
+.preview-empty code { color: #8cb4cc; font-size: 10px; }
+.preview-provenance { display: flex; align-items: center; gap: 7px; margin-top: 13px; color: #657f93; font: 9px 'IBM Plex Mono'; }
+
+@media (max-width: 720px) {
+  .preview-drawer { padding: 21px 16px; }
+  .preview-toolbar { align-items: stretch; flex-direction: column; }
+  .preview-toolbar select { width: 100%; }
+  .storybook-frame { height: 60vh; }
+}

--- a/FuzeQuality/db/migrations/007_storybook_previews.sql
+++ b/FuzeQuality/db/migrations/007_storybook_previews.sql
@@ -1,0 +1,2 @@
+ALTER TABLE fuzequality.frontend_surfaces
+  ADD COLUMN IF NOT EXISTS stories jsonb NOT NULL DEFAULT '[]'::jsonb;

--- a/FuzeQuality/packages/contracts/src/index.ts
+++ b/FuzeQuality/packages/contracts/src/index.ts
@@ -26,6 +26,10 @@ export const repositoryInputSchema = z.object({
     team: z.string().trim().min(1).max(100),
     contact: z.string().trim().email().optional(),
   }).optional(),
+  storybookBaseUrl: z.string().trim().url().refine(
+    value => new URL(value).protocol === 'https:',
+    'Storybook base URL must use HTTPS'
+  ).optional(),
 }).superRefine((value, context) => {
   for (const glob of [...value.includeGlobs, ...value.excludeGlobs]) {
     if (glob.includes('..') || glob.includes('://') || /[\r\n]/.test(glob)) {
@@ -121,6 +125,17 @@ export type FrontendSurface = {
   public: boolean
   states: string[]
   hasStory: boolean
+  stories: StorybookStory[]
+}
+
+export type StorybookStory = {
+  id: string
+  title: string
+  name: string
+  exportName: string
+  sourcePath: string
+  hasPlay: boolean
+  previewPath: string
 }
 
 export type TestCase = {

--- a/FuzeQuality/packages/core/src/store.ts
+++ b/FuzeQuality/packages/core/src/store.ts
@@ -185,13 +185,14 @@ export class PostgresCatalogStore implements CatalogStore {
         jiraBindings: row.config?.jiraBindings ?? [],
         ownership: row.config?.ownership,
         localPath: row.config?.localPath,
+        storybookBaseUrl: row.config?.storybookBaseUrl,
         lastScanAt: row.last_scan_at?.toISOString(),
         lastScanRevision: row.last_scan_revision ?? undefined,
         lastScanStatus: row.last_scan_status,
         lastScanDetails: row.last_scan_details ?? undefined,
       })),
       operations: operations.rows.map(row => ({ id: row.id, repositoryId: row.repository_id, documentPath: row.document_path, operationId: row.operation_id ?? undefined, method: row.method, path: row.path, summary: row.summary, tags: row.tags, security: row.security, parameters: row.parameters, responses: row.responses, ...(row.details ?? {}) })),
-      surfaces: surfaces.rows.map(row => ({ id: row.id, repositoryId: row.repository_id, packageName: row.package_name, kind: row.kind, name: row.name, sourcePath: row.source_path, routePath: row.route_path ?? undefined, public: row.is_public, states: row.states, hasStory: row.has_story })),
+      surfaces: surfaces.rows.map(row => ({ id: row.id, repositoryId: row.repository_id, packageName: row.package_name, kind: row.kind, name: row.name, sourcePath: row.source_path, routePath: row.route_path ?? undefined, public: row.is_public, states: row.states, hasStory: row.has_story, stories: row.stories ?? [] })),
       tests: tests.rows.map(row => ({ id: row.id, repositoryId: row.repository_id, framework: row.framework, level: row.test_level, title: row.title, sourcePath: row.source_path, assertionCount: row.assertion_count, targets: row.targets })),
       expectations: expectations.rows.map(row => ({ id: row.id, subjectType: row.subject_type, subjectId: row.subject_id, kind: row.kind, label: row.label, priority: row.priority, rule: row.rule, coverage: row.coverage, evidenceIds: row.evidence_ids })),
       findings: findings.rows.map(row => ({ id: row.id, repositoryId: row.repository_id ?? undefined, subjectId: row.subject_id ?? undefined, type: row.type, severity: row.severity, title: row.title, detail: row.detail, owner: row.owner ?? undefined, remediation: row.remediation ?? undefined, sourceRevision: row.source_revision ?? undefined, status: row.status })),
@@ -243,7 +244,7 @@ export class PostgresCatalogStore implements CatalogStore {
         const { id, repositoryId, documentPath, operationId, method, path, summary, tags, security, parameters, responses, ...details } = item
         await client.query(`INSERT INTO fuzequality.api_operations (id,repository_id,document_path,operation_id,method,path,summary,tags,security,parameters,responses,details) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12) ON CONFLICT (id) DO UPDATE SET operation_id=EXCLUDED.operation_id,summary=EXCLUDED.summary,tags=EXCLUDED.tags,security=EXCLUDED.security,parameters=EXCLUDED.parameters,responses=EXCLUDED.responses,details=EXCLUDED.details,active=true,updated_at=now()`, [id,repositoryId,documentPath,operationId,method,path,summary,JSON.stringify(tags),security,JSON.stringify(parameters),JSON.stringify(responses),JSON.stringify(details)])
       }
-      for (const item of result.surfaces) await client.query(`INSERT INTO fuzequality.frontend_surfaces (id,repository_id,package_name,kind,name,source_path,route_path,is_public,states,has_story) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10) ON CONFLICT (id) DO UPDATE SET name=EXCLUDED.name,source_path=EXCLUDED.source_path,route_path=EXCLUDED.route_path,is_public=EXCLUDED.is_public,states=EXCLUDED.states,has_story=EXCLUDED.has_story,active=true,updated_at=now()`, [item.id,item.repositoryId,item.packageName,item.kind,item.name,item.sourcePath,item.routePath,item.public,JSON.stringify(item.states),item.hasStory])
+      for (const item of result.surfaces) await client.query(`INSERT INTO fuzequality.frontend_surfaces (id,repository_id,package_name,kind,name,source_path,route_path,is_public,states,has_story,stories) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11) ON CONFLICT (id) DO UPDATE SET name=EXCLUDED.name,source_path=EXCLUDED.source_path,route_path=EXCLUDED.route_path,is_public=EXCLUDED.is_public,states=EXCLUDED.states,has_story=EXCLUDED.has_story,stories=EXCLUDED.stories,active=true,updated_at=now()`, [item.id,item.repositoryId,item.packageName,item.kind,item.name,item.sourcePath,item.routePath,item.public,JSON.stringify(item.states),item.hasStory,JSON.stringify(item.stories)])
       for (const item of result.tests) await client.query(`INSERT INTO fuzequality.test_cases (id,repository_id,framework,test_level,title,source_path,assertion_count,targets) VALUES ($1,$2,$3,$4,$5,$6,$7,$8) ON CONFLICT (id) DO UPDATE SET framework=EXCLUDED.framework,test_level=EXCLUDED.test_level,title=EXCLUDED.title,source_path=EXCLUDED.source_path,assertion_count=EXCLUDED.assertion_count,targets=EXCLUDED.targets,active=true,updated_at=now()`, [item.id,item.repositoryId,item.framework,item.level,item.title,item.sourcePath,item.assertionCount,JSON.stringify(item.targets)])
       for (const item of result.expectations) await client.query(`INSERT INTO fuzequality.test_expectations (id,subject_type,subject_id,kind,label,priority,rule,coverage,evidence_ids) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9) ON CONFLICT (id) DO UPDATE SET label=EXCLUDED.label,priority=EXCLUDED.priority,rule=EXCLUDED.rule,coverage=EXCLUDED.coverage,evidence_ids=EXCLUDED.evidence_ids,active=true,updated_at=now()`, [item.id,item.subjectType,item.subjectId,item.kind,item.label,item.priority,item.rule,item.coverage,JSON.stringify(item.evidenceIds)])
       await client.query('DELETE FROM fuzequality.findings WHERE repository_id=$1', [result.repository.id])
@@ -318,6 +319,7 @@ export function demoPortfolio(): Partial<Portfolio> {
       public: true,
       states: ['default', 'loading', 'error'],
       hasStory: false,
+      stories: [],
     },
     {
       id: 'ui:FuzeFront:billing-ui:component:PlanPicker',
@@ -329,6 +331,7 @@ export function demoPortfolio(): Partial<Portfolio> {
       public: true,
       states: ['default', 'loading', 'error', 'empty'],
       hasStory: false,
+      stories: [],
     },
   ] satisfies Portfolio['surfaces']
   const tests = [

--- a/FuzeQuality/packages/scanner/src/index.ts
+++ b/FuzeQuality/packages/scanner/src/index.ts
@@ -5,6 +5,7 @@ import fg from 'fast-glob'
 import type {
   ApiOperation,
   FrontendSurface,
+  StorybookStory,
   Repository,
   RepositoryScanCandidate,
   ScanDiagnostic,
@@ -160,10 +161,49 @@ function stateHints(source: string) {
   return [...states]
 }
 
+function storySlug(value: string) {
+  return value
+    .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
+    .replace(/[^A-Za-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '')
+    .toLowerCase()
+}
+
+function storyDisplayName(exportName: string, source: string) {
+  const assignment = source.match(new RegExp(`${exportName}\\.storyName\\s*=\\s*['"]([^'"]+)['"]`))
+  return assignment?.[1] ?? exportName.replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+}
+
+function extractStories(sourcePath: string, source: string): Array<StorybookStory & { componentName?: string }> {
+  const title = source.match(/\btitle\s*:\s*['"]([^'"]+)['"]/)?.[1]
+    ?? sourcePath.replace(/\.stories\.[^.]+$/, '').split('/').pop()
+    ?? 'Component'
+  const componentName = source.match(/\bcomponent\s*:\s*([A-Z][A-Za-z0-9_]*)/)?.[1]
+  const exports = [...source.matchAll(/export\s+(?:const|function)\s+([A-Z][A-Za-z0-9_]*)/g)]
+    .map(match => ({ name: match[1], index: match.index ?? 0 }))
+    .filter(item => !['Meta', 'Story', 'StoryObj'].includes(item.name))
+  return exports.map((item, index) => {
+    const exportName = item.name
+    const id = `${storySlug(title)}--${storySlug(exportName)}`
+    const exportBlock = source.slice(item.index, exports[index + 1]?.index ?? source.length)
+    return {
+      id,
+      title,
+      name: storyDisplayName(exportName, source),
+      exportName,
+      sourcePath: normalize(sourcePath),
+      hasPlay: /\bplay\s*:/.test(exportBlock) || new RegExp(`${exportName}\\.play\\s*=`).test(source),
+      previewPath: `iframe.html?id=${encodeURIComponent(id)}&viewMode=story`,
+      componentName,
+    }
+  })
+}
+
 async function scanFrontend(
   root: string,
   repository: Repository,
   ignore: string[],
+  stories: Array<StorybookStory & { componentName?: string }>,
   storyFiles: Set<string>,
   onProgress: () => Promise<void>
 ) {
@@ -195,6 +235,7 @@ async function scanFrontend(
       ignore,
     })
     for (const file of sourceFiles) {
+      if (storyFiles.has(normalize(file))) continue
       await onProgress()
       let source: string
       try {
@@ -227,6 +268,7 @@ async function scanFrontend(
           public: true,
           states: stateHints(source),
           hasStory: false,
+          stories: [],
         })
       }
 
@@ -236,7 +278,12 @@ async function scanFrontend(
       for (const componentMatch of componentMatches) {
         const name = componentMatch[1]
         const base = normalize(file).replace(/\.[^.]+$/, '')
-        const hasStory = [...storyFiles].some(story => story.replace(/\.stories\.[^.]+$/, '') === base)
+        const componentStories = stories
+          .filter(story =>
+            story.componentName === name ||
+            story.sourcePath.replace(/\.stories\.[^.]+$/, '') === base
+          )
+          .map(({ componentName: _componentName, ...story }) => story)
         surfaces.push({
           id: `ui:${repository.name}:${packageName}:component:${name}`,
           repositoryId: repository.id,
@@ -246,7 +293,8 @@ async function scanFrontend(
           sourcePath: normalize(file),
           public: /(?:index\.|exports|export\s+)/.test(`${file} ${source}`),
           states: stateHints(source),
-          hasStory,
+          hasStory: componentStories.length > 0,
+          stories: componentStories,
         })
       }
     }
@@ -338,11 +386,13 @@ export async function scanRepository(
     }
   }
 
+  const stories: Array<StorybookStory & { componentName?: string }> = []
   for (const file of storyFiles) {
     await onProgress()
     try {
       const content = await readText(root, file)
       contentFingerprints.push(`${normalize(file)}:${fingerprint(content)}`)
+      stories.push(...extractStories(normalize(file), content))
     } catch (error) {
       diagnostics.push({
         sourcePath: normalize(file),
@@ -354,7 +404,7 @@ export async function scanRepository(
     }
   }
 
-  const frontend = await scanFrontend(root, repository, ignore, storyFiles, onProgress)
+  const frontend = await scanFrontend(root, repository, ignore, stories, storyFiles, onProgress)
   const surfaces = frontend.surfaces
   contentFingerprints.push(...frontend.fingerprints)
   diagnostics.push(...frontend.diagnostics)

--- a/FuzeQuality/packages/scanner/src/scanner.test.ts
+++ b/FuzeQuality/packages/scanner/src/scanner.test.ts
@@ -79,6 +79,41 @@ paths:
     ]))
   })
 
+  it('catalogs Storybook CSF stories and maps their visual states to components', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'fuzequality-storybook-'))
+    await mkdir(join(root, 'src'), { recursive: true })
+    await writeFile(join(root, 'package.json'), JSON.stringify({ name: '@fuze/design' }))
+    await writeFile(join(root, 'src', 'Button.tsx'), `export function Button() { return <button>Save</button> }`)
+    await writeFile(join(root, 'src', 'Button.stories.tsx'), `
+      import { Button } from './Button'
+      export default { title: 'Design/Button', component: Button }
+      export const Primary = { args: { children: 'Save' } }
+      export const Loading = { args: { loading: true }, play: async () => {} }
+      Loading.storyName = 'Saving'
+    `)
+
+    const result = await scanRepository(repository, root)
+    const button = result.surfaces.find(surface => surface.name === 'Button')
+
+    expect(button).toEqual(expect.objectContaining({
+      hasStory: true,
+      stories: [
+        expect.objectContaining({
+          id: 'design-button--primary',
+          name: 'Primary',
+          previewPath: 'iframe.html?id=design-button--primary&viewMode=story',
+          hasPlay: false,
+        }),
+        expect.objectContaining({
+          id: 'design-button--loading',
+          name: 'Saving',
+          hasPlay: true,
+        }),
+      ],
+    }))
+    expect(result.expectations.find(item => item.kind === 'storybook')?.coverage).toBe('covered-explicit')
+  })
+
   it('credits scenario coverage only to assertion-bearing tests that name the scenario', async () => {
     const root = await mkdtemp(join(tmpdir(), 'fuzequality-evidence-'))
     await mkdir(join(root, 'tests'), { recursive: true })


### PR DESCRIPTION
## Outcome
- discovers Storybook CSF story identities and interaction metadata without executing repository code
- persists stories on frontend surfaces and accepts an HTTPS Storybook host per repository
- renders selected stories in a restricted sandbox iframe from the frontend inventory
- shows actionable missing-host and missing-story states

## Security
- preview URLs must remain HTTPS and same-origin with the configured Storybook host
- iframe omits same-origin, navigation, and popup privileges
- referrer data is suppressed

## Verification
- scanner fixture covers component/story mapping, stable IDs, labels, and play functions
- URL tests cover valid same-origin construction and rejected HTTP/cross-origin input
- full repository CI is the authoritative build/test gate (local dependency installation was unavailable)

Jira: FQ-164, FQ-169, FQ-170, FQ-171