### PR TITLE
FQ-164: Fix Storybook preview release types

### DIFF
--- a/FuzeQuality/apps/web/src/lucide-react.d.ts
+++ b/FuzeQuality/apps/web/src/lucide-react.d.ts
@@ -13,6 +13,8 @@ declare module 'lucide-react' {
   export const Database: LucideIcon
   export const FileCode2: LucideIcon
   export const GitBranch: LucideIcon
+  export const Eye: LucideIcon
+  export const ExternalLink: LucideIcon
   export const Layers3: LucideIcon
   export const Network: LucideIcon
   export const Plus: LucideIcon


### PR DESCRIPTION
Release hotfix for FQ-164. The frontend's local lucide-react declaration shim did not include the two icons used by the preview drawer. This adds the missing declarations so the production Docker type-check can complete.\n\nTriggered by failed release run 30254522665.