### PR TITLE
fix(deps): resolve ajv major conflict breaking SBOM generation and the security contract tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "rimraf": "^6.0.1"
       },
       "devDependencies": {
+        "ajv": "^8.17.1",
         "concurrently": "^8.2.2",
         "lint-staged": "^16.1.2",
         "prettier": "^3.6.2",
@@ -337,23 +338,6 @@
         }
       }
     },
-    "backend/node_modules/ajv-formats/node_modules/ajv": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
-      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
     "backend/node_modules/eslint": {
       "version": "8.57.1",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
@@ -411,6 +395,23 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "backend/node_modules/eslint/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "backend/node_modules/express-rate-limit": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.2.0.tgz",
@@ -425,6 +426,13 @@
       "peerDependencies": {
         "express": "4 || 5 || ^5.0.0-beta.1"
       }
+    },
+    "backend/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
     },
     "backend/node_modules/pino": {
       "version": "9.14.0",
@@ -550,23 +558,6 @@
         "ts-jest": "^29.1.1",
         "ts-node": "^10.9.1",
         "typescript": "^5.1.6"
-      }
-    },
-    "backend/security/node_modules/ajv": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
-      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "billing-client": {
@@ -782,22 +773,6 @@
       },
       "peerDependencies": {
         "openapi-types": ">=7"
-      }
-    },
-    "node_modules/@apidevtools/swagger-parser/node_modules/ajv": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
-      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/@apidevtools/swagger-parser/node_modules/ajv-draft-04": {
@@ -2219,6 +2194,30 @@
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@eslint/js": {
       "version": "8.57.1",
@@ -5032,23 +5031,6 @@
         "node": "^12.20 || >=14.13"
       }
     },
-    "node_modules/@stoplight/spectral-core/node_modules/ajv": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
-      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
     "node_modules/@stoplight/spectral-core/node_modules/ajv-errors": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-3.0.0.tgz",
@@ -5140,23 +5122,6 @@
       },
       "peerDependencies": {
         "ajv": ">=8"
-      }
-    },
-    "node_modules/@stoplight/spectral-functions/node_modules/ajv": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
-      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/@stoplight/spectral-functions/node_modules/ajv-draft-04": {
@@ -5423,23 +5388,6 @@
       "dev": true,
       "license": "Apache-2.0"
     },
-    "node_modules/@stoplight/spectral-ruleset-migrator/node_modules/ajv": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
-      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
     "node_modules/@stoplight/spectral-rulesets": {
       "version": "1.22.6",
       "resolved": "https://registry.npmjs.org/@stoplight/spectral-rulesets/-/spectral-rulesets-1.22.6.tgz",
@@ -5483,23 +5431,6 @@
       },
       "peerDependencies": {
         "ajv": ">=8"
-      }
-    },
-    "node_modules/@stoplight/spectral-rulesets/node_modules/ajv": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
-      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/@stoplight/spectral-runtime": {
@@ -7458,15 +7389,15 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
-      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
@@ -7490,29 +7421,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/ajv-formats/node_modules/ajv": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
-      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/ajv/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "license": "MIT"
     },
     "node_modules/alien-signals": {
       "version": "0.4.14",
@@ -10174,6 +10082,22 @@
         "url": "https://eslint.org/donate"
       }
     },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/eslint/node_modules/eslint-scope": {
       "version": "8.4.0",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
@@ -10255,6 +10179,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "license": "MIT"
     },
     "node_modules/esm": {
       "version": "3.2.25",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "check:workspace-deps": "node scripts/check-workspace-deps.mjs"
   },
   "devDependencies": {
+    "ajv": "^8.17.1",
     "concurrently": "^8.2.2",
     "lint-staged": "^16.1.2",
     "prettier": "^3.6.2",


### PR DESCRIPTION
## 📋 Description

`Generate SBOM` in `security.yml` has been failing on **every** master push. The job runs `npm install` then `@cyclonedx/cyclonedx-npm`, which shells out to `npm ls --json --long --all`; that exits non-zero with:

```
npm error code ELSPROBLEMS
npm error invalid: ajv@6.15.0 .../node_modules/ajv
```

**Root cause.** Two `ajv` majors are required across the workspace tree. `@eslint/eslintrc` (via eslint 8 in `backend` and eslint 9 at root) needs `ajv@^6.12.4`, while `backend/security` declares `ajv@^8.17.1`. npm hoisted the 6.x copy into the root `node_modules/ajv` slot and never materialised a nested 8.x for the workspace — so the security workspace resolved its own direct dependency to a version outside its declared range. `npm ls` reports that as `invalid` and fails, taking the SBOM job with it.

**This was not only an SBOM problem.** `backend/security/tests/security-api/spec.ts` imports `ajv/dist/2020` — the draft-2020 entrypoint, which exists only in ajv 8. Against the hoisted ajv 6 that specifier does not resolve at all (`MODULE_NOT_FOUND`), so the INDEPENDENT AuthN contract-verification suite could not load its validator.

**Fix.** Declare `ajv@^8.17.1` in the root `devDependencies`. That makes 8.x win the root slot, and npm nests the 6.x copy under `@eslint/eslintrc` where it is actually needed.

## 🔄 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🔨 Build system or dependency update

## 🧪 Testing

- [x] Manual testing (dependency-resolution change; verified against the exact commands CI runs)

**Test Configuration:**

- Node.js version: v22.22.2 (CI job uses Node 20; the conflict and fix are resolver-level, not version-specific)
- npm version: 10.9.7
- OS: Linux

### Test Instructions

```bash
rm -rf node_modules
npm install
npm ls --json --long --all          # exits 0 — the exact command cyclonedx runs
npx @cyclonedx/cyclonedx-npm --output-file sbom.json
```

Verified on a clean tree:

| Check | Before | After |
|---|---|---|
| `npm ls --json --long --all` | exit 1 (`ELSPROBLEMS`) | **exit 0** |
| `npx @cyclonedx/cyclonedx-npm` | fails | **1302-component CycloneDX 1.6 SBOM** |
| `npm ci` | ok | **ok** (lockfile internally consistent) |
| `require.resolve('ajv/dist/2020')` from `backend/security` | `MODULE_NOT_FOUND` | **resolves** |
| root `ajv` | 6.15.0 | **8.20.0** |
| `@eslint/eslintrc/node_modules/ajv` | (none) | **6.15.0** |
| `eslint --version` | 9.39.4 | **9.39.4** |
| `tsc --noEmit` in `backend/security` | clean | **clean** |

## 🔧 Implementation Details

### Changes Made

- **Root `package.json`:** one added line — `"ajv": "^8.17.1"` in `devDependencies`.
- **`package-lock.json`:** regenerated. Churn is confined to `ajv` and its companion `json-schema-traverse` (0.4.x for ajv 6, 1.x for ajv 8). No other package's resolution changes — confirmed by diffing the changed `node_modules/*` keys.

`backend/security/package.json` is deliberately **untouched**: its `^8.17.1` range was already correct, and only the hoisting was wrong. An intermediate probe (`npm install --workspace`) reordered that file's dependencies alphabetically and bumped the range to `^8.20.0`; that churn was reverted so the diff stays minimal.

### Alternatives considered

- **A global `overrides` entry for `ajv`** — rejected: overrides are tree-wide, and forcing a single major would break `@eslint/eslintrc`, which genuinely needs 6.x.
- **Dropping `ajv` from `backend/security`** — rejected: it is genuinely used by the contract-validator test.
- **Making the SBOM step tolerant (`npm ls || true`)** — rejected: it would paper over a real broken resolution and leave the security suite unable to load.

### Code Quality

- [x] Code follows conventional commit format
- [x] TypeScript strict mode passes (`tsc --noEmit` clean in `backend/security`)
- [x] ESLint still loads and runs (9.39.4)
- [x] No security vulnerabilities introduced — `ajv@6.15.0` was verified as a genuinely published registry version, not a typosquat; this change moves the root slot to the current `8.20.0`

## 🚨 Breaking Changes

None. No source files change. Consumers of `backend/security` that were silently getting `ajv@6` now get the `ajv@8` their manifest already asked for, which is the intended behaviour and what the code was written against.

## 📋 Checklist

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] Existing checks pass locally with my changes
- [ ] I have added tests that prove my fix is effective — not applicable; the fix is dependency resolution, and the proof is `npm ls` / cyclonedx exiting 0. It also *unblocks* the existing `backend/security` contract suite, which previously could not load.

## 🔗 Related Issues and PRs

Pre-existing failure, not introduced by any recent PR — confirmed the same `Generate SBOM` job failed on `0bfa724d` (#409) and `9b0b8191`, both before #403 merged.

## 📝 Additional Notes

### Deployment Notes

- [x] Requires dependency updates (lockfile only; no runtime dependency is added to any shipped image — `ajv` is declared as a root **dev** dependency)

Not labelled `auto-merge`: `master` is deploy-on-push in this repo, so per `CLAUDE.md` this should be merged deliberately in a deploy window rather than bot-merged.

### Future Work

The second red check on master — `Deploy FuzeFront Website (SSH)`, failing at `Terraform Plan` with `no matching EC2 VPC found` / missing ALB / empty ASG for the `fuzefront-website` AWS stack — is **not** addressed here. It needs an owner decision first: repair the Terraform data sources, or retire the workflow if the marketing site has moved off AWS.

---
_Generated by [Claude Code](https://claude.ai/code/session_018GwoakPmfmvL4ot86LfFeX)_