### PR TITLE
fix(ci): dispatch the release after a merge so merging actually deploys

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -2,7 +2,9 @@ name: Auto Merge PR
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    # `closed` is required for the dispatch-release job below — it is the only
+    # event that tells us a PR actually merged.
+    types: [opened, synchronize, reopened, ready_for_review, closed]
   check_suite:
     types: [completed]
 
@@ -10,7 +12,9 @@ jobs:
   auto-merge:
     name: Auto Merge PR
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
+    # Skip on `closed`: the PR is already merged/abandoned by then, and
+    # `gh pr merge --auto` against it just errors.
+    if: github.event.pull_request.draft == false && github.event.action != 'closed'
     permissions:
       contents: write
       pull-requests: write
@@ -25,3 +29,78 @@ jobs:
           gh pr merge ${{ github.event.pull_request.number }} --auto --squash --delete-branch
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # ---------------------------------------------------------------------------
+  # Merging is not deploying. `release.yml` builds the images and bumps the
+  # values-prod tags that Argo rolls out — but its `push: branches: [master]`
+  # trigger does NOT fire after a merge here, for TWO independent reasons:
+  #
+  #   1. Auto-merge pushes to master under GITHUB_TOKEN, and GitHub deliberately
+  #      does not start push-triggered workflows for GITHUB_TOKEN pushes (its
+  #      recursion guard). release.yml's own header documents this.
+  #   2. A squash merge concatenates EVERY commit message in the PR, and GitHub
+  #      scans the whole message — not just the subject. One WIP commit using
+  #      the CI-suppression token (or merely quoting it in prose) poisons the
+  #      squash commit and suppresses the push trigger for everyone.
+  #
+  # Either alone yields a PR that merges green and ships nothing — the failure
+  # mode that left the flag client unbuilt in prod after PR #400. workflow_dispatch
+  # is explicitly EXEMPT from the GITHUB_TOKEN recursion guard, and is immune to
+  # the suppression token, so dispatching is the one path that survives both.
+  # ---------------------------------------------------------------------------
+  dispatch-release:
+    name: Dispatch release after merge
+    runs-on: ubuntu-latest
+    if: github.event.action == 'closed' && github.event.pull_request.merged == true
+    permissions:
+      contents: read
+      pull-requests: read
+      actions: write # required to call workflow_dispatch
+
+    steps:
+      - name: Dispatch release if the merge touched deployable paths
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+          SHA: ${{ github.event.pull_request.merge_commit_sha }}
+        run: |
+          set -euo pipefail
+
+          # Mirror of release.yml's `push.paths`. Keep the two in sync — a path
+          # here that release.yml ignores just wastes a build; a path release.yml
+          # watches but this omits means that change silently never deploys.
+          PATTERN='^(backend/|shared/|frontend/|packages/|services/email-service/|services/sms-service/|services/provisioning-service/|services/billing-service/|clock-app/|deploy/helm/fuzefront/|\.github/workflows/release\.yml)'
+
+          if ! gh pr diff "$PR" --name-only | grep -qE "$PATTERN"; then
+            echo "No deployable paths in PR #$PR — no release needed."
+            exit 0
+          fi
+
+          # Idempotence: a human (non-GITHUB_TOKEN) merge with a clean squash
+          # message DOES fire the push trigger. Don't queue a second identical
+          # build on top of it — release.yml serializes on `concurrency: release`,
+          # so a duplicate would just delay the next real one.
+          sleep 30
+          if [ -n "$SHA" ] && gh run list --workflow=release.yml --limit 20 \
+               --json headSha -q '.[].headSha' | grep -q "^${SHA}$"; then
+            echo "Release already running/ran for ${SHA} (push trigger fired) — not dispatching."
+            exit 0
+          fi
+
+          echo "Dispatching release.yml for merged PR #$PR (${SHA:-unknown sha})"
+          gh workflow run release.yml --ref master \
+            -f reason="auto-dispatch after merge of PR #$PR (push trigger suppressed by GITHUB_TOKEN merge and/or a CI-suppression token in the squash message)"
+
+      - name: Warn if the squash message carries a CI-suppression token
+        if: always()
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SHA: ${{ github.event.pull_request.merge_commit_sha }}
+        run: |
+          set -euo pipefail
+          [ -n "${SHA:-}" ] || exit 0
+          MSG=$(gh api "repos/${{ github.repository }}/commits/${SHA}" -q '.commit.message' || echo '')
+          # Split the token so this very check cannot suppress workflows on itself.
+          if printf '%s' "$MSG" | grep -qiE "\[(skip[ -]ci|ci[ -]skip)\]"; then
+            echo "::warning::Squash commit ${SHA} contains a CI-suppression token inherited from a PR commit message. Push-triggered workflows on master were suppressed for it; the release was dispatched explicitly, but any OTHER push-triggered workflow silently did not run. Keep that token out of commit subjects on PRs that will be squashed."
+          fi


### PR DESCRIPTION
## Problem

`release.yml`'s `push: branches: [master]` trigger **does not fire after a merge in this repo**, for two independent reasons. Either alone yields a PR that merges green and ships nothing.

1. **Auto-merge pushes under `GITHUB_TOKEN`.** GitHub deliberately does not start push-triggered workflows for `GITHUB_TOKEN` pushes (recursion guard). `release.yml`'s own header documents this and points at `workflow_dispatch` as the remedy — but nothing was calling it.
2. **A squash merge concatenates every commit message in the PR**, and GitHub scans the whole message, not just the subject. One WIP commit using the CI-suppression token — or merely *quoting* it in prose — poisons the squash commit and suppresses the trigger for everyone.

This is not hypothetical: after #400 merged, **no release run existed for the merge SHA at all**. The feature-flag client stayed unbuilt in prod until the release was dispatched by hand. Its squash message carried the suppression token 5×, inherited from WIP commit subjects.

## Fix

`workflow_dispatch` is explicitly **exempt** from the `GITHUB_TOKEN` recursion guard and is immune to the suppression token, so it is the one path that survives both causes. A new `dispatch-release` job fires on `pull_request: closed` with `merged == true` and calls it.

- **Path-filtered** against a mirror of `release.yml`'s `push.paths`, so docs-only merges don't trigger an image build. Verified: #400's file list matches (29 hits), a docs-only list and this PR's own file list both correctly produce 0.
- **Idempotent.** A human merge with a clean squash message still fires the push trigger, so the job waits and skips if a release run already exists for the merge SHA — `release.yml` serializes on `concurrency: release`, so a duplicate would only delay the next real build.
- **Warns** when the squash message carries the suppression token, because dispatching the release does *not* fix the other push-triggered workflows it silently disabled.
- The existing `auto-merge` job is now skipped on `closed`, where `gh pr merge --auto` would just error.

## Verification

- `auto-merge.yml` parses as YAML; both jobs' `if`/`permissions` confirmed
- Both `run` blocks pass `bash -n` with `${{ }}` stubbed
- Path regex tested against real file lists (see above)

This PR itself touches only `.github/workflows/auto-merge.yml`, so by its own filter it will **not** trigger a release — which is the correct behaviour and a live test of the filter.

## Note on deploy windows

This makes every auto-merge of deployable paths deploy to prod automatically. That is what `master` being deploy-on-push already implies, but `CLAUDE.md` also asks for merges in a deploy window. If you'd rather keep a human in the loop, the alternative is to have this job **notify** instead of dispatch — say the word and I'll flip it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)