### PR TITLE
feat(authentik): MendysRobotics identity silo — separate Authentik instance + platform OIDC client

### DIFF
--- a/deploy/helm/fuzefront/authentik/blueprints-mendys/README.md
+++ b/deploy/helm/fuzefront/authentik/blueprints-mendys/README.md
@@ -1,0 +1,92 @@
+# MendysRobotics Authentik blueprints (isolated identity silo)
+
+Blueprints in this directory are applied **only** to the `authentik-mendys`
+instance (chart values `authentikMendys`), mounted at `/blueprints/mendys/`.
+FuzeFront's own blueprints live one directory up in `../blueprints/` and are
+mounted only on the FuzeFront instance.
+
+**Never mount both sets on one instance.** Authentik's worker applies every
+`*.yaml` it discovers under `/blueprints`, so a shared mount would recreate
+FuzeFront's flows, providers and applications inside the Mendys directory and
+erase the separation this split exists to create.
+
+## Why a separate instance instead of a brand
+
+Authentik has no realm. One instance is one user directory:
+
+- **Brands** (`authentik_brands.brand`) are *soft* multi-tenancy — branding and
+  default flows per domain. Per authentik's own docs, "all objects like
+  applications and providers are still global". A Mendys brand on the FuzeFront
+  instance would still share every account.
+- **Hard tenancy** (a Postgres *schema* per tenant, authentik 2024.2+) does give
+  real separation, but it is Enterprise-only, still alpha, requires a license
+  per tenant, and is created only through the API — so it cannot be expressed
+  as a blueprint in git, which is how every other authentik object here is
+  managed.
+- **A second instance on its own database** gives the same isolation property
+  for free and stays fully declarative. That is what this directory serves.
+
+## The boundary
+
+MendysRobotics accounts exist only in this directory. A FuzeFront account
+cannot sign in to the Mendys apps, a Mendys account cannot sign in to
+FuzeFront, and the same email address may exist independently on both sides as
+two unrelated accounts.
+
+Because the directory *is* the tenant boundary, the applications here use
+`policy_engine_mode: all` with no group bindings — there is no need to police
+who may reach them, since users from the other side have no account here at
+all.
+
+The only applications in this silo are the two MendysRobotics products:
+
+| Blueprint | client_id | Application slug |
+|---|---|---|
+| `provider-oidc-mendys-platform.yaml` | `mendys-platform-oidc-client` | `mendys-platform` |
+| `provider-oidc-mendys-datasets.yaml` | `mendys-datasets-oidc-client` | `mendys-datasets` |
+
+## Flows
+
+`flow-enrollment.yaml` is a deliberate copy of FuzeFront's enrollment flow, not
+a shared file: authentik objects are per-instance, so each directory needs its
+own flow, stages and prompts, and the user-facing copy differs. **If you change
+the security properties of one (password policy, stage order,
+`create_users_as_inactive`), change the other to match.**
+
+## Secrets
+
+Client secrets are never stored here. Each provider reads its secret at
+blueprint-apply time from the worker pod's environment via authentik's `!Env`
+tag:
+
+| Blueprint | env var | chart Secret key |
+|---|---|---|
+| platform | `AUTHENTIK_MENDYS_PLATFORM_CLIENT_SECRET` | `MENDYS_PLATFORM_CLIENT_SECRET` |
+| datasets | `AUTHENTIK_MENDYS_DATASETS_CLIENT_SECRET` | `MENDYS_DATASETS_CLIENT_SECRET` |
+
+The platform secret must be **byte-identical** to `MENDYS_AUTHENTIK_CLIENT_SECRET`
+in the `mendys-secrets` sealed secret (namespace `mendys-prod`) — it is one
+OAuth2 client credential shared by the two sides of the exchange.
+
+**Rotation is not a value change.** The blueprint runner honours
+`client_id`/`client_secret` only at provider *creation*; updating the secret
+requires deleting the provider entry and re-applying the blueprint.
+
+## Browser-facing exposure (open decision)
+
+`authentikMendys.ingress` is **off by default**, matching FuzeFront's posture:
+FuzeFront has no public IdP host — its authentik is ClusterIP-only and reached
+through `app.fuzefront.com/api/auth/idp/*`, so the browser never learns the IdP
+hostname. Two ways to expose this silo, in order of preference:
+
+1. **Mirror FuzeFront (preferred).** Add an `/api/auth/idp/*` path to the
+   MendysRobotics ingress in `mendys-prod` proxying to
+   `authentik-mendys-server.<fuzefront-ns>.svc.cluster.local:9000`. Keeps the
+   IdP host invisible. That change belongs to the MendysRobotics repo.
+2. **A public `auth.mendysrobotics.com` host** via `authentikMendys.ingress`.
+   Simpler, but re-introduces the exposed IdP host, so only do this behind
+   Cloudflare Access.
+
+Either way the issuer is **not** `https://auth.fuzefront.com/application/o/mendys-platform/`
+— that host belongs to the FuzeFront instance, which is a different directory.
+The Mendys side must repoint its issuer at whichever surface is chosen.

--- a/deploy/helm/fuzefront/authentik/blueprints-mendys/brand-mendys.yaml
+++ b/deploy/helm/fuzefront/authentik/blueprints-mendys/brand-mendys.yaml
@@ -1,0 +1,25 @@
+# Authentik Blueprint — MendysRobotics brand
+#
+# Applied to the MendysRobotics Authentik instance only. This is the DEFAULT
+# brand of that instance: it is the sole tenant of its own directory, so unlike
+# the FuzeFront brand it does not share the instance with anything else.
+#
+# Deliberately minimal: title only, no logo/favicon/custom CSS. The FuzeFront
+# brand embeds fuse-seam assets as inline data-URIs; MendysRobotics has no
+# equivalent asset set in this repo, and inventing one here would put made-up
+# branding in front of real users. Add branding_logo / branding_favicon /
+# branding_custom_css once MendysRobotics supplies the assets — the same
+# data-URI approach applies (the /media mount is an emptyDir and is wiped on
+# every pod restart, so file-based assets do not survive).
+version: 1
+metadata:
+  name: MendysRobotics Brand
+entries:
+  - model: authentik_brands.brand
+    state: present
+    identifiers:
+      domain: "mendysrobotics.com"
+    attrs:
+      domain: "mendysrobotics.com"
+      default: true
+      branding_title: "MendysRobotics"

--- a/deploy/helm/fuzefront/authentik/blueprints-mendys/flow-enrollment.yaml
+++ b/deploy/helm/fuzefront/authentik/blueprints-mendys/flow-enrollment.yaml
@@ -1,0 +1,205 @@
+# Authentik Blueprint — MendysRobotics self-service enrollment flow
+#
+# Modeled on the FuzeFront enrollment flow
+# (authentik/blueprints/flow-enrollment.yaml) — same stage design, same
+# password policy — but instantiated as SEPARATE objects in the MendysRobotics
+# directory. It is a copy rather than a shared file because Authentik objects
+# are per-instance: each directory needs its own flow, stages and prompts, and
+# the user-facing copy differs ("MendysRobotics account", not "FuzeFront").
+# If you change the security properties of one (password policy, stage order,
+# create_users_as_inactive), change the other to match.
+#
+# Stages (in order):
+#   1. mendys-enroll-prompt  — email, username, password, password_repeat, ToS
+#   2. mendys-enroll-write   — create the user account (active immediately)
+#   3. mendys-enroll-login   — automatically log the new user in
+#
+# Password policy (12+ chars, upper/lower/digit/symbol) is applied as a
+# validation_policy on the prompt stage.
+#
+# NOTE: as in the FuzeFront flow, the email-verification stage is DEFINED but
+# deliberately NOT bound — without SMTP configured (authentikMendys.smtp.*) the
+# verify stage stalls the flow. Bind it once Mendys SMTP is live.
+#
+# There is intentionally no social/Google enrollment counterpart here: this
+# silo has no Google source, so the FuzeFront `*-source-enrollment` flow and
+# its username-derivation policy have no analogue.
+version: 1
+metadata:
+  name: MendysRobotics Enrollment Flow
+  labels:
+    blueprints.goauthentik.io/instantiate: "true"
+entries:
+  # ── Password policy ─────────────────────────────────────────────────────────
+  - model: authentik_policies_password.passwordpolicy
+    state: present
+    identifiers:
+      name: mendys-password-policy
+    attrs:
+      name: mendys-password-policy
+      length_min: 12
+      amount_uppercase: 1
+      amount_lowercase: 1
+      amount_digits: 1
+      amount_symbols: 1
+      password_field: password
+      error_message: "Password must be at least 12 characters with uppercase, lowercase, digit and symbol."
+
+  # ── Prompt fields ─────────────────────────────────────────────────────────
+  - model: authentik_stages_prompt.prompt
+    state: present
+    identifiers:
+      name: mendys-enroll-email
+    attrs:
+      name: mendys-enroll-email
+      field_key: email
+      label: "Email"
+      type: email
+      required: true
+      placeholder: "you@example.com"
+      order: 10
+
+  - model: authentik_stages_prompt.prompt
+    state: present
+    identifiers:
+      name: mendys-enroll-username
+    attrs:
+      name: mendys-enroll-username
+      field_key: username
+      label: "Username"
+      type: username
+      required: true
+      placeholder: "your-username"
+      order: 20
+
+  - model: authentik_stages_prompt.prompt
+    state: present
+    identifiers:
+      name: mendys-enroll-password
+    attrs:
+      name: mendys-enroll-password
+      field_key: password
+      label: "Password"
+      type: password
+      required: true
+      placeholder: "Password (12+ chars)"
+      order: 30
+
+  - model: authentik_stages_prompt.prompt
+    state: present
+    identifiers:
+      name: mendys-enroll-password-repeat
+    attrs:
+      name: mendys-enroll-password-repeat
+      field_key: password_repeat
+      label: "Confirm Password"
+      type: password
+      required: true
+      placeholder: "Repeat password"
+      order: 40
+
+  # Consent / ToS acceptance field
+  - model: authentik_stages_prompt.prompt
+    state: present
+    identifiers:
+      name: mendys-enroll-tos
+    attrs:
+      name: mendys-enroll-tos
+      field_key: tos_accepted
+      label: "I agree to the Terms of Service"
+      type: checkbox
+      required: true
+      order: 50
+
+  # ── Prompt stage (bundles fields + policy) ──────────────────────────────────
+  - model: authentik_stages_prompt.promptstage
+    state: present
+    identifiers:
+      name: mendys-enroll-prompt
+    attrs:
+      name: mendys-enroll-prompt
+      fields:
+        - !Find [authentik_stages_prompt.prompt, [name, mendys-enroll-email]]
+        - !Find [authentik_stages_prompt.prompt, [name, mendys-enroll-username]]
+        - !Find [authentik_stages_prompt.prompt, [name, mendys-enroll-password]]
+        - !Find [authentik_stages_prompt.prompt, [name, mendys-enroll-password-repeat]]
+        - !Find [authentik_stages_prompt.prompt, [name, mendys-enroll-tos]]
+      validation_policies:
+        - !Find [authentik_policies_password.passwordpolicy, [name, mendys-password-policy]]
+
+  # ── Email verification stage (defined, NOT bound — see header) ───────────────
+  - model: authentik_stages_email.emailstage
+    state: present
+    identifiers:
+      name: mendys-enroll-email-verify
+    attrs:
+      name: mendys-enroll-email-verify
+      use_global_settings: true
+      activate_user_on_success: true
+      from_address: "noreply@mendysrobotics.com"
+      subject: "Verify your MendysRobotics account"
+      template: email/account_confirmation.html
+      token_expiry: minutes=30
+
+  # ── User-write stage ─────────────────────────────────────────────────────────
+  - model: authentik_stages_user_write.userwritestage
+    state: present
+    identifiers:
+      name: mendys-enroll-write
+    attrs:
+      name: mendys-enroll-write
+      create_users_as_inactive: false
+      user_type: internal
+
+  # ── User-login stage ─────────────────────────────────────────────────────────
+  - model: authentik_stages_user_login.userloginstage
+    state: present
+    identifiers:
+      name: mendys-enroll-login
+    attrs:
+      name: mendys-enroll-login
+      session_duration: "seconds=0"  # browser-session (expires on close)
+
+  # ── Enrollment flow ───────────────────────────────────────────────────────────
+  - model: authentik_flows.flow
+    state: present
+    identifiers:
+      slug: mendys-enrollment
+    attrs:
+      name: "MendysRobotics Sign-up"
+      slug: mendys-enrollment
+      title: "Create your MendysRobotics account"
+      designation: enrollment
+      authentication: none
+      layout: stacked
+
+  # ── Flow-stage bindings (order = execution order) ─────────────────────────────
+  - model: authentik_flows.flowstagebinding
+    state: present
+    identifiers:
+      target: !Find [authentik_flows.flow, [slug, mendys-enrollment]]
+      stage: !Find [authentik_stages_prompt.promptstage, [name, mendys-enroll-prompt]]
+    attrs:
+      order: 10
+      evaluate_on_plan: true
+      re_evaluate_policies: false
+
+  - model: authentik_flows.flowstagebinding
+    state: present
+    identifiers:
+      target: !Find [authentik_flows.flow, [slug, mendys-enrollment]]
+      stage: !Find [authentik_stages_user_write.userwritestage, [name, mendys-enroll-write]]
+    attrs:
+      order: 20
+      evaluate_on_plan: true
+      re_evaluate_policies: false
+
+  - model: authentik_flows.flowstagebinding
+    state: present
+    identifiers:
+      target: !Find [authentik_flows.flow, [slug, mendys-enrollment]]
+      stage: !Find [authentik_stages_user_login.userloginstage, [name, mendys-enroll-login]]
+    attrs:
+      order: 30
+      evaluate_on_plan: true
+      re_evaluate_policies: false

--- a/deploy/helm/fuzefront/authentik/blueprints-mendys/provider-oidc-mendys-datasets.yaml
+++ b/deploy/helm/fuzefront/authentik/blueprints-mendys/provider-oidc-mendys-datasets.yaml
@@ -1,0 +1,171 @@
+# Authentik Blueprint — MendysRobotics Datasets OIDC provider + Application
+#
+# Creates the OIDC provider and Application for the `mendys-datasets`
+# consumer product (the MendysRobotics datasets marketplace).
+#
+# ── MIGRATION IN PROGRESS: this file is the MendysRobotics-silo copy ──────────
+# The identical provider still exists in the FuzeFront instance
+# (authentik/blueprints/provider-oidc-mendys-datasets.yaml) and is still the
+# one serving live traffic. Both can coexist: they are different Authentik
+# instances with different databases, so the shared client_id
+# `mendys-datasets-oidc-client` does not collide.
+#
+# Cutover order (do NOT collapse these into one step — deleting the FuzeFront
+# provider before the consumer repoints blacks out datasets sign-in):
+#   1. this instance goes live and this provider is created here;
+#   2. MendysRobotics repoints its datasets issuer at this instance and
+#      re-stamps the client secret (blueprints set client_secret only at
+#      provider CREATION);
+#   3. only then retire authentik/blueprints/provider-oidc-mendys-datasets.yaml
+#      from the FuzeFront instance with an explicit `state: absent` entry —
+#      deleting the file alone does NOT remove the object from that directory.
+#
+# Accounts do not migrate. This directory starts empty: existing datasets users
+# living in the FuzeFront directory have no account here and must enroll.
+#
+# client_id is public/non-sensitive and kept as a literal.
+# client_secret is injected at blueprint-apply time via Authentik's !Env
+# YAML tag — it reads AUTHENTIK_MENDYS_DATASETS_CLIENT_SECRET from the
+# worker pod's environment (sourced from the chart Secret via an OPTIONAL
+# secretKeyRef; key MENDYS_DATASETS_CLIENT_SECRET). No secret value is
+# stored in this file or in the ConfigMap.
+#
+# NOTE: attrs.client_id / attrs.client_secret are respected at *creation time*
+# by Authentik 2024.x blueprint runner. If the provider already exists, these
+# fields are not updated. Rotation requires deleting the provider entry and
+# re-applying.
+#
+# DESIGN: All objects this blueprint needs are defined inline (flow, scope
+# mappings) — no !Find references to system-blueprint objects NOR to another
+# custom blueprint's objects. Authentik's Celery blueprint runner applies
+# blueprints concurrently; a !Find that references an object committed by a
+# DIFFERENT blueprint (e.g. provider-oidc.yaml's scope mappings) would
+# silently abort the entry if that object isn't yet in the DB. Defining
+# everything inline eliminates that race.
+version: 1
+metadata:
+  name: MendysRobotics Datasets OIDC Provider
+  labels:
+    blueprints.goauthentik.io/instantiate: "true"
+entries:
+  # ── Authorization flow (implicit consent) ────────────────────────────────────
+  # An empty authorization flow = implicit consent in Authentik. The blueprint
+  # runner appends OAuthFulfillmentStage automatically; with no ConsentStage in
+  # the flow, consent is bypassed and the code is issued immediately.
+  - model: authentik_flows.flow
+    state: present
+    identifiers:
+      slug: mendys-datasets-authorization-implicit-consent
+    attrs:
+      name: MendysRobotics Datasets Authorization (Implicit Consent)
+      slug: mendys-datasets-authorization-implicit-consent
+      designation: authorization
+      title: MendysRobotics Sign In
+      # require_authenticated: user must already be logged in to run this flow.
+      # all + 0 policy bindings = vacuous truth → flow is always accessible.
+      authentication: require_authenticated
+      policy_engine_mode: all
+
+  # ── Scope mappings (inline — no cross-blueprint dependency) ──────────────────
+  # Defined before the provider so they exist in DB when the provider entry's
+  # !Find tags execute (blueprint entries are applied in order).
+  - model: authentik_providers_oauth2.scopemapping
+    state: present
+    identifiers:
+      name: "Mendys Datasets OIDC scope - openid"
+    attrs:
+      name: "Mendys Datasets OIDC scope - openid"
+      scope_name: openid
+      expression: "return {}"
+
+  - model: authentik_providers_oauth2.scopemapping
+    state: present
+    identifiers:
+      name: "Mendys Datasets OIDC scope - email"
+    attrs:
+      name: "Mendys Datasets OIDC scope - email"
+      scope_name: email
+      expression: |
+        return {
+            "email": request.user.email,
+            "email_verified": True,
+        }
+
+  - model: authentik_providers_oauth2.scopemapping
+    state: present
+    identifiers:
+      name: "Mendys Datasets OIDC scope - profile"
+    attrs:
+      name: "Mendys Datasets OIDC scope - profile"
+      scope_name: profile
+      expression: |
+        return {
+            "name": request.user.name,
+            "given_name": request.user.name,
+            "preferred_username": request.user.username,
+            "nickname": request.user.username,
+            "groups": [g.name for g in request.user.ak_groups.all()],
+        }
+
+  # ── OIDC / OAuth2 provider ────────────────────────────────────────────────────
+  - model: authentik_providers_oauth2.oauth2provider
+    state: present
+    identifiers:
+      name: MendysRobotics Datasets
+    attrs:
+      name: MendysRobotics Datasets
+      client_type: confidential
+      # Required since Authentik 2026.x: fresh providers default to NO allowed
+      # grant types and reject every authorize request ("Invalid grant_type").
+      grant_types:
+        - authorization_code
+        - refresh_token
+      # client_id is public/non-sensitive — kept as a deterministic literal.
+      # client_secret is resolved at apply time from the worker pod env var
+      # AUTHENTIK_MENDYS_DATASETS_CLIENT_SECRET (sourced from the chart
+      # Secret). No secret value is committed to git or stored in the
+      # ConfigMap.
+      client_id: "mendys-datasets-oidc-client"
+      client_secret: !Env [AUTHENTIK_MENDYS_DATASETS_CLIENT_SECRET, ""]
+      # Redirect URIs — the two MendysRobotics apps' backend OIDC callbacks.
+      # Listed statically (the blueprint ConfigMap is a raw file, not
+      # Helm-templated), so the same blueprint works in all envs.
+      redirect_uris:
+        - matching_mode: strict
+          url: "https://marketplace.mendysrobotics.com/api/dsm/auth/oidc/callback"
+        - matching_mode: strict
+          url: "https://live.mendysrobotics.com/api/dsm/auth/oidc/callback"
+      # Scope mappings defined inline above — !Find resolves within this same
+      # blueprint run since those entries are applied before this one.
+      property_mappings:
+        - !Find [authentik_providers_oauth2.scopemapping, [name, "Mendys Datasets OIDC scope - openid"]]
+        - !Find [authentik_providers_oauth2.scopemapping, [name, "Mendys Datasets OIDC scope - email"]]
+        - !Find [authentik_providers_oauth2.scopemapping, [name, "Mendys Datasets OIDC scope - profile"]]
+      # Use email as the `sub` claim — consistent with the FuzeFront provider
+      sub_mode: user_email
+      include_claims_in_id_token: true
+      # Reference the flow defined above. !Find resolves within the same
+      # blueprint run — the flow entry is applied before this provider entry.
+      authorization_flow: !Find [authentik_flows.flow, [slug, mendys-datasets-authorization-implicit-consent]]
+      # REQUIRED since authentik 2024.10 — provider creation fails validation
+      # without it ("invalidation_flow: This field is required"), which is why
+      # the first apply of this blueprint errored and created nothing. The
+      # default system flow ships with every install (default blueprint
+      # flow-default-provider-invalidation.yaml).
+      invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+
+  # ── Application ───────────────────────────────────────────────────────────────
+  - model: authentik_core.application
+    state: present
+    identifiers:
+      slug: mendys-datasets
+    attrs:
+      name: MendysRobotics Datasets
+      slug: mendys-datasets
+      provider: !Find [authentik_providers_oauth2.oauth2provider, [name, MendysRobotics Datasets]]
+      meta_launch_url: "https://marketplace.mendysrobotics.com/"
+      meta_description: "MendysRobotics datasets marketplace"
+      # all + 0 policy bindings = vacuous truth → all authenticated users are
+      # granted access. No policy binding entries needed.
+      policy_engine_mode: all
+      open_in_new_tab: false

--- a/deploy/helm/fuzefront/authentik/blueprints-mendys/provider-oidc-mendys-platform.yaml
+++ b/deploy/helm/fuzefront/authentik/blueprints-mendys/provider-oidc-mendys-platform.yaml
@@ -1,0 +1,155 @@
+# Authentik Blueprint — MendysRobotics Platform OIDC provider + Application
+#
+# Applied to the MendysRobotics Authentik instance (authentik-mendys), NOT the
+# FuzeFront one. Accounts in this directory are unrelated to FuzeFront
+# accounts — see values.yaml `authentikMendys` for why the silo is a separate
+# instance rather than a brand.
+#
+# Serves the shared `mendys-backend` behind BOTH MendysRobotics SPAs:
+#   - https://live.mendysrobotics.com        (platform / backend management)
+#   - https://marketplace.mendysrobotics.com (marketplace)
+# One provider, two redirect URIs — the consumer-side contract is documented in
+# docs/PLATFORM_AUTHN_AUTHZ.md in izzywdev/MendysRobotics (PR #242).
+#
+# client_id is public/non-sensitive and kept as a literal.
+# client_secret is injected at blueprint-apply time via Authentik's !Env YAML
+# tag — it reads AUTHENTIK_MENDYS_PLATFORM_CLIENT_SECRET from the worker pod's
+# environment (sourced from the chart Secret via an OPTIONAL secretKeyRef; key
+# MENDYS_PLATFORM_CLIENT_SECRET). No secret value is stored in this file or in
+# the ConfigMap. That value must be byte-identical to
+# MENDYS_AUTHENTIK_CLIENT_SECRET in the `mendys-secrets` sealed secret in
+# namespace mendys-prod.
+#
+# NOTE: attrs.client_id / attrs.client_secret are respected at *creation time*
+# by the blueprint runner. If the provider already exists, these fields are not
+# updated. Rotation requires deleting the provider entry and re-applying.
+#
+# DESIGN: All objects this blueprint needs are defined inline (flow, scope
+# mappings) — no !Find references to system-blueprint objects NOR to another
+# custom blueprint's objects. Authentik's Celery blueprint runner applies
+# blueprints concurrently; a !Find that references an object committed by a
+# DIFFERENT blueprint would silently abort the entry if that object isn't yet
+# in the DB. Defining everything inline eliminates that race.
+version: 1
+metadata:
+  name: MendysRobotics Platform OIDC Provider
+  labels:
+    blueprints.goauthentik.io/instantiate: "true"
+entries:
+  # ── Authorization flow (implicit consent) ────────────────────────────────────
+  # An empty authorization flow = implicit consent in Authentik. The blueprint
+  # runner appends OAuthFulfillmentStage automatically; with no ConsentStage in
+  # the flow, consent is bypassed and the code is issued immediately.
+  - model: authentik_flows.flow
+    state: present
+    identifiers:
+      slug: mendys-platform-authorization-implicit-consent
+    attrs:
+      name: MendysRobotics Platform Authorization (Implicit Consent)
+      slug: mendys-platform-authorization-implicit-consent
+      designation: authorization
+      title: MendysRobotics Sign In
+      # require_authenticated: user must already be logged in to run this flow.
+      # all + 0 policy bindings = vacuous truth → flow is always accessible.
+      authentication: require_authenticated
+      policy_engine_mode: all
+
+  # ── Scope mappings (inline — no cross-blueprint dependency) ──────────────────
+  # Defined before the provider so they exist in DB when the provider entry's
+  # !Find tags execute (blueprint entries are applied in order).
+  - model: authentik_providers_oauth2.scopemapping
+    state: present
+    identifiers:
+      name: "Mendys Platform OIDC scope - openid"
+    attrs:
+      name: "Mendys Platform OIDC scope - openid"
+      scope_name: openid
+      expression: "return {}"
+
+  - model: authentik_providers_oauth2.scopemapping
+    state: present
+    identifiers:
+      name: "Mendys Platform OIDC scope - email"
+    attrs:
+      name: "Mendys Platform OIDC scope - email"
+      scope_name: email
+      expression: |
+        return {
+            "email": request.user.email,
+            "email_verified": True,
+        }
+
+  - model: authentik_providers_oauth2.scopemapping
+    state: present
+    identifiers:
+      name: "Mendys Platform OIDC scope - profile"
+    attrs:
+      name: "Mendys Platform OIDC scope - profile"
+      scope_name: profile
+      expression: |
+        return {
+            "name": request.user.name,
+            "given_name": request.user.name,
+            "preferred_username": request.user.username,
+            "nickname": request.user.username,
+            "groups": [g.name for g in request.user.ak_groups.all()],
+        }
+
+  # ── OIDC / OAuth2 provider ────────────────────────────────────────────────────
+  - model: authentik_providers_oauth2.oauth2provider
+    state: present
+    identifiers:
+      name: MendysRobotics Platform
+    attrs:
+      name: MendysRobotics Platform
+      client_type: confidential
+      # Required since Authentik 2026.x: fresh providers default to NO allowed
+      # grant types and reject every authorize request ("Invalid grant_type").
+      grant_types:
+        - authorization_code
+        - refresh_token
+      client_id: "mendys-platform-oidc-client"
+      client_secret: !Env [AUTHENTIK_MENDYS_PLATFORM_CLIENT_SECRET, ""]
+      # Redirect URIs — the shared mendys-backend's OIDC callback as reached
+      # through each SPA's host. Both are required: the backend serves both
+      # origins and completes the exchange on whichever host the user started
+      # from. Listed statically (the blueprint ConfigMap is a raw file, not
+      # Helm-templated), so the same blueprint works in all envs.
+      redirect_uris:
+        - matching_mode: strict
+          url: "https://live.mendysrobotics.com/api/auth/oidc/callback"
+        - matching_mode: strict
+          url: "https://marketplace.mendysrobotics.com/api/auth/oidc/callback"
+      # Scope mappings defined inline above — !Find resolves within this same
+      # blueprint run since those entries are applied before this one.
+      property_mappings:
+        - !Find [authentik_providers_oauth2.scopemapping, [name, "Mendys Platform OIDC scope - openid"]]
+        - !Find [authentik_providers_oauth2.scopemapping, [name, "Mendys Platform OIDC scope - email"]]
+        - !Find [authentik_providers_oauth2.scopemapping, [name, "Mendys Platform OIDC scope - profile"]]
+      # Use email as the `sub` claim — consistent with the other providers.
+      sub_mode: user_email
+      include_claims_in_id_token: true
+      authorization_flow: !Find [authentik_flows.flow, [slug, mendys-platform-authorization-implicit-consent]]
+      # REQUIRED since authentik 2024.10 — provider creation fails validation
+      # without it ("invalidation_flow: This field is required"). The default
+      # system flow ships with every install (default blueprint
+      # flow-default-provider-invalidation.yaml).
+      invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+
+  # ── Application ───────────────────────────────────────────────────────────────
+  - model: authentik_core.application
+    state: present
+    identifiers:
+      slug: mendys-platform
+    attrs:
+      name: MendysRobotics Platform
+      slug: mendys-platform
+      provider: !Find [authentik_providers_oauth2.oauth2provider, [name, MendysRobotics Platform]]
+      meta_launch_url: "https://live.mendysrobotics.com/"
+      meta_description: "MendysRobotics platform — live + marketplace SSO"
+      # all + 0 policy bindings = vacuous truth → every account in THIS
+      # directory is granted access. That is the intended semantics here: the
+      # directory itself is the tenant boundary, so no per-app group policy is
+      # needed to keep FuzeFront users out — they have no account here at all.
+      policy_engine_mode: all
+      open_in_new_tab: false

--- a/deploy/helm/fuzefront/templates/authentik-mendys-blueprints.yaml
+++ b/deploy/helm/fuzefront/templates/authentik-mendys-blueprints.yaml
@@ -1,0 +1,29 @@
+{{- /*
+  authentik-mendys-blueprints.yaml — ConfigMap of the MendysRobotics silo's
+  Authentik blueprints, mounted at /blueprints/mendys/ on the authentik-mendys
+  server and worker pods.
+
+  SEPARATE SOURCE DIRECTORY ON PURPOSE. Authentik's worker applies every
+  *.yaml it discovers under /blueprints, so this instance must never mount the
+  FuzeFront set — doing so would recreate FuzeFront's flows, providers and
+  applications inside the Mendys directory and defeat the split.
+
+  Blueprint files live in: deploy/helm/fuzefront/authentik/blueprints-mendys/
+  (FuzeFront's own set stays in authentik/blueprints/ and is mounted only on
+  the FuzeFront instance by authentik-blueprints.yaml.)
+*/}}
+{{- if .Values.authentikMendys.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: authentik-mendys-blueprints
+  labels:
+    {{- include "fuzefront.labels" . | nindent 4 }}
+    app: authentik-mendys
+data:
+  {{- range $path, $content := .Files.Glob "authentik/blueprints-mendys/*.yaml" }}
+  {{- /* Strip the directory prefix so each key is just the filename. */}}
+  {{ base $path }}: |
+    {{- $content | toString | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/fuzefront/templates/authentik-mendys.yaml
+++ b/deploy/helm/fuzefront/templates/authentik-mendys.yaml
@@ -1,0 +1,331 @@
+{{- /*
+  authentik-mendys.yaml — the MendysRobotics identity silo.
+
+  A SECOND, fully separate Authentik (server + worker) backed by its own
+  Postgres database (`authentik_mendys`) on the shared FuzeInfra server, its
+  own Redis logical DB, and its own signing key. See values.yaml
+  `authentikMendys` for why this is a separate instance rather than a brand or
+  an Enterprise schema-tenant.
+
+  ISOLATION INVARIANTS — every one of these is load-bearing; breaking any of
+  them silently re-merges the two directories:
+    1. Different DATABASE      → different user table. This is the boundary.
+    2. Different SECRET_KEY    → neither instance can validate the other's
+                                 sessions/tokens.
+    3. Different REDIS DB      → authentik stores cache + sessions in Redis
+                                 under non-namespaced keys; a shared index
+                                 would cross-talk.
+    4. Different COOKIE_DOMAIN → a shared parent domain would send one
+                                 instance's session cookie to the other.
+    5. Separate blueprint set  → /blueprints/mendys, NOT /blueprints/fuzefront.
+                                 authentik applies every *.yaml it finds under
+                                 /blueprints, so mounting the FuzeFront set
+                                 here would recreate FuzeFront's flows,
+                                 providers and applications inside this silo.
+
+  The env block is deliberately NOT shared with `authentik.commonEnv` in
+  authentik.yaml: almost every entry there is FuzeFront-specific (its secret
+  keys, its Google source, its SMS service, its OIDC provider secret). The
+  generic hardening settings below are duplicated on purpose and each carries a
+  pointer to the incident comment in authentik.yaml that explains it — if you
+  change one of those there, change it here too.
+*/}}
+{{- define "authentikMendys.env" -}}
+{{- $akm := .Values.authentikMendys }}
+# Per-instance signing key. MUST differ from the FuzeFront AUTHENTIK_SECRET_KEY.
+- name: AUTHENTIK_SECRET_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "fuzefront.secretName" . }}
+      key: AUTHENTIK_MENDYS_SECRET_KEY
+# Postgres: shared FuzeInfra server, dedicated database + role. The role and
+# database are provisioned declaratively by FuzeInfra's
+# `fuzeinfra-service-db-provision` hook Job (serviceDatabases entry
+# `authentik-mendys`), which also (re)syncs the role password to the value
+# sealed as `authentik-mendys-db-credentials` in the fuzeinfra namespace.
+- name: AUTHENTIK_POSTGRESQL__HOST
+  value: {{ .Values.fuzeinfra.postgres.host | quote }}
+- name: AUTHENTIK_POSTGRESQL__PORT
+  value: {{ .Values.fuzeinfra.postgres.port | quote }}
+- name: AUTHENTIK_POSTGRESQL__USER
+  value: {{ $akm.dbUser | quote }}
+- name: AUTHENTIK_POSTGRESQL__NAME
+  value: {{ $akm.dbName | quote }}
+- name: AUTHENTIK_POSTGRESQL__PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "fuzefront.secretName" . }}
+      key: AUTHENTIK_MENDYS_DB_PASSWORD
+# Redis: shared instance, dedicated logical DB (see isolation invariant 3).
+- name: AUTHENTIK_REDIS__HOST
+  value: {{ .Values.fuzeinfra.redis.host | quote }}
+- name: AUTHENTIK_REDIS__PORT
+  value: {{ .Values.fuzeinfra.redis.port | quote }}
+- name: AUTHENTIK_REDIS__DB
+  value: {{ $akm.redisDb | quote }}
+- name: AUTHENTIK_LOG_LEVEL
+  value: "info"
+- name: AUTHENTIK_DISABLE_UPDATE_CHECK
+  value: "true"
+- name: AUTHENTIK_ERROR_REPORTING__ENABLED
+  value: "false"
+# "initials" avatars — see authentik.yaml: gravatar does live DNS+HTTPS lookups
+# inside request handling, and cluster DNS stalls turned that into 401s on
+# valid credentials.
+- name: AUTHENTIK_AVATARS
+  value: "initials"
+# Embedded outpost off — see authentik.yaml: it served nothing and its 3s
+# failing poll loop was ~3x the genuine request volume.
+- name: AUTHENTIK_OUTPOSTS__DISABLE_EMBEDDED_OUTPOST
+  value: "true"
+# Pin the web worker pool — authentik derives it from visible CPU, which under
+# a container limit silently shrinks the pool.
+- name: AUTHENTIK_WEB__WORKERS
+  value: {{ $akm.webWorkers | default 2 | quote }}
+- name: AUTHENTIK_COOKIE_DOMAIN
+  value: {{ $akm.cookieDomain | quote }}
+# Bootstrap admin for THIS silo — a separate akadmin from FuzeFront's, in a
+# separate directory. Must be present on the worker (it runs the bootstrap).
+- name: AUTHENTIK_BOOTSTRAP_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "fuzefront.secretName" . }}
+      key: AUTHENTIK_MENDYS_BOOTSTRAP_PASSWORD
+- name: AUTHENTIK_BOOTSTRAP_TOKEN
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "fuzefront.secretName" . }}
+      key: AUTHENTIK_MENDYS_BOOTSTRAP_TOKEN
+- name: AUTHENTIK_BOOTSTRAP_EMAIL
+  value: {{ $akm.bootstrapEmail | quote }}
+# OIDC client secrets for the two applications in this silo, resolved by the
+# blueprints' !Env tag at apply time. OPTIONAL: absent key → the blueprint
+# applies with an empty placeholder; set the key and re-apply to activate.
+#
+# ROTATION: authentik's blueprint runner honours client_id/client_secret only
+# at provider CREATION. Changing these values does not update an existing
+# provider — the provider entry must be deleted and the blueprint re-applied.
+- name: AUTHENTIK_MENDYS_PLATFORM_CLIENT_SECRET
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "fuzefront.secretName" . }}
+      key: MENDYS_PLATFORM_CLIENT_SECRET
+      optional: true
+- name: AUTHENTIK_MENDYS_DATASETS_CLIENT_SECRET
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "fuzefront.secretName" . }}
+      key: MENDYS_DATASETS_CLIENT_SECRET
+      optional: true
+{{- if $akm.smtp.host }}
+# Email backend for this silo (enrollment verification / password reset).
+# Separate sender from FuzeFront so Mendys mail is Mendys-branded.
+- name: AUTHENTIK_EMAIL__HOST
+  value: {{ $akm.smtp.host | quote }}
+- name: AUTHENTIK_EMAIL__PORT
+  value: {{ $akm.smtp.port | quote }}
+- name: AUTHENTIK_EMAIL__USERNAME
+  value: {{ $akm.smtp.username | quote }}
+- name: AUTHENTIK_EMAIL__PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "fuzefront.secretName" . }}
+      key: SMTP_PASSWORD
+      optional: true
+- name: AUTHENTIK_EMAIL__FROM
+  value: {{ $akm.smtp.from | quote }}
+- name: AUTHENTIK_EMAIL__USE_TLS
+  value: {{ $akm.smtp.useTls | quote }}
+- name: AUTHENTIK_EMAIL__USE_SSL
+  value: {{ $akm.smtp.useSSL | quote }}
+- name: AUTHENTIK_EMAIL__TIMEOUT
+  value: {{ $akm.smtp.timeout | quote }}
+{{- end }}
+{{- end -}}
+{{- if .Values.authentikMendys.enabled }}
+{{- $akm := .Values.authentikMendys }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: authentik-mendys-server
+  labels:
+    {{- include "fuzefront.labels" . | nindent 4 }}
+    app: authentik-mendys-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: authentik-mendys-server
+  template:
+    metadata:
+      labels:
+        {{- include "fuzefront.labels" . | nindent 8 }}
+        app: authentik-mendys-server
+      annotations:
+        # Roll the pod when any blueprint changes: labeled blueprints are
+        # applied on startup, so a restart == immediate re-apply.
+        checksum/blueprints: {{ include (print $.Template.BasePath "/authentik-mendys-blueprints.yaml") . | sha256sum }}
+    spec:
+      {{- include "fuzefront.scheduling" (dict "svc" .Values.authentikMendys "root" .) | nindent 6 }}
+      # Bound DNS stalls — same rationale as the FuzeFront authentik-server:
+      # a single CoreDNS replica on another node produced 5s/10s resolver
+      # retries that landed inside login flows.
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
+          - name: timeout
+            value: "1"
+          - name: attempts
+            value: "2"
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: server
+          image: "{{ $akm.image.repository }}:{{ $akm.image.tag }}"
+          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          args: ["server"]
+          env:
+            {{- include "authentikMendys.env" . | nindent 12 }}
+          ports:
+            - containerPort: 9000
+          # PROBE TIMEOUTS ARE EXPLICIT AND MUST STAY THAT WAY — see the long
+          # comment on authentik-server in authentik.yaml. The k8s 1s default
+          # evicted a healthy IdP from its Service 4572 times in 4 days and was
+          # the real cause of "intermittent sign-in failures".
+          startupProbe:
+            httpGet: { path: /-/health/live/, port: 9000 }
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 60 # up to ~5min for first-boot migrations
+          livenessProbe:
+            httpGet: { path: /-/health/live/, port: 9000 }
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 5
+          readinessProbe:
+            httpGet: { path: /-/health/ready/, port: 9000 }
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 3
+          volumeMounts:
+            - { name: media,      mountPath: /media }
+            - { name: blueprints, mountPath: /blueprints/mendys, readOnly: true }
+          # Smaller than the FuzeFront instance (2 web workers, two apps), but
+          # the memory floor is set by the runtime: authentik 2026.5 on Python
+          # 3.14 OOMKilled at 1Gi with 4 workers. Do not trim below 2Gi.
+          resources:
+            requests: { cpu: 150m, memory: 320Mi }
+            limits:   { cpu: "1",  memory: 2Gi }
+      volumes:
+        - name: media
+          emptyDir: {}
+        - name: blueprints
+          configMap:
+            name: authentik-mendys-blueprints
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: authentik-mendys-worker
+  labels:
+    {{- include "fuzefront.labels" . | nindent 4 }}
+    app: authentik-mendys-worker
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: authentik-mendys-worker
+  template:
+    metadata:
+      labels:
+        {{- include "fuzefront.labels" . | nindent 8 }}
+        app: authentik-mendys-worker
+      annotations:
+        checksum/blueprints: {{ include (print $.Template.BasePath "/authentik-mendys-blueprints.yaml") . | sha256sum }}
+    spec:
+      {{- include "fuzefront.scheduling" (dict "svc" .Values.authentikMendys "root" .) | nindent 6 }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: worker
+          image: "{{ $akm.image.repository }}:{{ $akm.image.tag }}"
+          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          args: ["worker"]
+          env:
+            {{- include "authentikMendys.env" . | nindent 12 }}
+          volumeMounts:
+            - { name: media,      mountPath: /media }
+            - { name: blueprints, mountPath: /blueprints/mendys, readOnly: true }
+          resources:
+            requests: { cpu: 100m, memory: 384Mi }
+            limits:   { cpu: "1",  memory: 768Mi }
+      volumes:
+        - name: media
+          emptyDir: {}
+        - name: blueprints
+          configMap:
+            name: authentik-mendys-blueprints
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: authentik-mendys-server
+  labels:
+    {{- include "fuzefront.labels" . | nindent 4 }}
+    app: authentik-mendys-server
+spec:
+  selector:
+    app: authentik-mendys-server
+  ports:
+    - port: 9000
+      targetPort: 9000
+{{- if $akm.ingress.enabled }}
+---
+{{- /*
+  PUBLIC IdP HOST — OFF BY DEFAULT, AND THAT DEFAULT IS DELIBERATE.
+
+  FuzeFront removed its own public `auth.fuzefront.com` Ingress on purpose:
+  its authentik is ClusterIP-only and the sole browser-transitable surface is
+  the reverse-proxied app.fuzefront.com/api/auth/idp/* path, so the browser
+  never learns the IdP hostname. Turning this on for the Mendys silo
+  re-introduces exactly the exposure that boundary exists to prevent.
+
+  Only enable it behind an edge auth gate (Cloudflare Access), or prefer the
+  equivalent of FuzeFront's pattern: a /api/auth/idp/* path on the
+  MendysRobotics ingress in the mendys-prod namespace proxying to
+  authentik-mendys-server.<this-namespace>.svc.cluster.local:9000. That change
+  belongs to the MendysRobotics repo, not this chart.
+*/}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: authentik-mendys
+  labels:
+    {{- include "fuzefront.labels" . | nindent 4 }}
+  {{- with $akm.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with $akm.ingress.className }}
+  ingressClassName: {{ . | quote }}
+  {{- end }}
+  rules:
+    - host: {{ required "authentikMendys.ingress.host is required when authentikMendys.ingress.enabled is true" $akm.ingress.host | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: authentik-mendys-server
+                port:
+                  number: 9000
+{{- end }}
+{{- end }}

--- a/deploy/helm/fuzefront/templates/secret.yaml
+++ b/deploy/helm/fuzefront/templates/secret.yaml
@@ -41,7 +41,40 @@ stringData:
   # provider (blueprint provider-oidc-mendys-datasets.yaml reads it via the
   # worker env var AUTHENTIK_MENDYS_DATASETS_CLIENT_SECRET). Trimmed for the
   # same control-char reason as the authentik credentials above.
+  #
+  # NOTE: this provider now lives in the SEPARATE MendysRobotics Authentik
+  # instance (authentikMendys), not the FuzeFront one — the key is unchanged
+  # but it is consumed by the authentik-mendys pods.
   MENDYS_DATASETS_CLIENT_SECRET: {{ .Values.secret.mendysDatasetsClientSecret | trim | quote }}
+  {{- end }}
+  {{- if .Values.secret.mendysPlatformClientSecret }}
+  # OIDC client secret for the mendys-platform provider — the shared
+  # `mendys-backend` serving BOTH MendysRobotics SPAs (live.mendysrobotics.com
+  # + marketplace.mendysrobotics.com). Read by the authentik-mendys worker as
+  # AUTHENTIK_MENDYS_PLATFORM_CLIENT_SECRET at blueprint-apply time.
+  #
+  # This value MUST be byte-identical to MENDYS_AUTHENTIK_CLIENT_SECRET in the
+  # `mendys-secrets` sealed secret (namespace mendys-prod) — it is one OAuth2
+  # client credential shared by the two sides of the exchange.
+  MENDYS_PLATFORM_CLIENT_SECRET: {{ .Values.secret.mendysPlatformClientSecret | trim | quote }}
+  {{- end }}
+  {{- if .Values.authentikMendys.enabled }}
+  # ── MendysRobotics Authentik instance (isolated identity silo) ──────────────
+  # A SECOND Authentik deployment with its own Postgres database, so Mendys
+  # accounts are unrelated to FuzeFront accounts in both directions. These are
+  # per-instance credentials and MUST NOT be shared with the FuzeFront
+  # instance: reusing AUTHENTIK_SECRET_KEY across two instances would make
+  # sessions/tokens minted by one verifiable by the other, collapsing the very
+  # boundary this split exists to create.
+  AUTHENTIK_MENDYS_SECRET_KEY: {{ .Values.secret.authentikMendysSecretKey | trim | quote }}
+  AUTHENTIK_MENDYS_BOOTSTRAP_PASSWORD: {{ .Values.secret.authentikMendysBootstrapPassword | quote }}
+  AUTHENTIK_MENDYS_BOOTSTRAP_TOKEN: {{ .Values.secret.authentikMendysBootstrapToken | trim | quote }}
+  # Password for the `authentik_mendys_user` Postgres role. FuzeInfra's
+  # `fuzeinfra-service-db-provision` Job (values entry `authentik-mendys`)
+  # (re)syncs the role to this same value, read from the
+  # `authentik-mendys-db-credentials` Secret sealed for the fuzeinfra
+  # namespace — the two must match.
+  AUTHENTIK_MENDYS_DB_PASSWORD: {{ .Values.secret.authentikMendysDbPassword | trim | quote }}
   {{- end }}
   {{- if .Values.secret.sendgridApiKey }}
   SENDGRID_API_KEY: {{ .Values.secret.sendgridApiKey | quote }}

--- a/deploy/helm/fuzefront/values.yaml
+++ b/deploy/helm/fuzefront/values.yaml
@@ -117,6 +117,26 @@ secret:
   # supply via --set / a gitignored values file / the prod SealedSecret.
   # NEVER commit a real secret.
   mendysDatasetsClientSecret: ""
+  # OIDC client secret for the mendys-platform provider (client_id
+  # mendys-platform-oidc-client) — the shared `mendys-backend` behind both
+  # live.mendysrobotics.com and marketplace.mendysrobotics.com.
+  # Must equal MENDYS_AUTHENTIK_CLIENT_SECRET in the mendys-prod
+  # `mendys-secrets` sealed secret. Same rules as above: NEVER commit a real
+  # secret; supply via --set / a gitignored values file / the prod SealedSecret.
+  mendysPlatformClientSecret: ""
+  # ── Credentials for the separate MendysRobotics Authentik instance ──────────
+  # Only consumed when authentikMendys.enabled is true. Each MUST be distinct
+  # from its FuzeFront counterpart — a shared secret key would let either
+  # instance validate the other's sessions and destroy the account boundary.
+  authentikMendysSecretKey: ""
+  authentikMendysBootstrapPassword: ""
+  authentikMendysBootstrapToken: ""
+  # Password of the `authentik_mendys_user` Postgres role, provisioned by
+  # FuzeInfra (serviceDatabases entry `authentik-mendys`). The identical value
+  # must be sealed as `authentik-mendys-db-credentials` (key `password`) into
+  # the `fuzeinfra` namespace, or the provisioning Job will set a password the
+  # Authentik pods do not know.
+  authentikMendysDbPassword: ""
   sendgridApiKey: ""
   # Twilio Verify credentials for SMS MFA. Leave empty to run in mock/inert mode.
   # Supply real values via --set or a gitignored values file. NEVER commit real creds.
@@ -589,6 +609,80 @@ authentik:
     ingressControllerNamespace: kube-system
     # Namespace whose pods may reach authentik-server in-cluster (A2A JWKS fetch).
     fuzeagentNamespace: fuzeagent
+
+# ── MendysRobotics identity silo — a SECOND, fully separate Authentik ─────────
+#
+# WHY A SECOND INSTANCE AND NOT A BRAND: authentik has no realm. One instance
+# is one user directory; `authentik_brands.brand` controls branding + default
+# flows only ("all objects like applications and providers are still global"),
+# so a Mendys brand on the FuzeFront instance would still share every account.
+# authentik's hard tenancy (a Postgres SCHEMA per tenant, 2024.2+) does give
+# real separation, but it is Enterprise-only, still alpha, needs a license per
+# tenant, and is created only through the API — i.e. it cannot be expressed as
+# a blueprint in git, which is how every other authentik object here is
+# managed. A second instance on its own DATABASE gives the same isolation for
+# free and stays declarative.
+#
+# The boundary this buys: MendysRobotics accounts exist only in this instance.
+# A FuzeFront account cannot sign in to the Mendys apps, a Mendys account
+# cannot sign in to FuzeFront, and the same email address may exist
+# independently on both sides as two unrelated accounts.
+#
+# The only applications in this silo are the two MendysRobotics products:
+# the platform backend (mendys-platform) and the datasets marketplace
+# (mendys-datasets).
+authentikMendys:
+  enabled: false
+  # Image is deliberately pinned separately from the FuzeFront instance so the
+  # two can be upgraded independently (one IdP at a time), but defaults to the
+  # same tested tag.
+  image:
+    repository: ghcr.io/goauthentik/server
+    tag: "2026.5.5"
+  # Postgres: same shared FuzeInfra server (fuzeinfra.postgres.*), different
+  # DATABASE and different ROLE. Provisioned by FuzeInfra's
+  # `fuzeinfra-service-db-provision` Job — values entry `authentik-mendys` in
+  # helm/fuzeinfra/values.yaml. Must exist before this instance starts.
+  dbName: authentik_mendys
+  dbUser: authentik_mendys_user
+  # Redis: same shared instance, DIFFERENT logical DB index. Authentik keeps
+  # cache + sessions in Redis; two instances sharing index 0 would collide on
+  # identical key names and leak session state across the silo boundary.
+  # Index 0 is the FuzeFront instance's (authentik's default).
+  redisDb: 2
+  # Cookie domain MUST NOT overlap the FuzeFront one. A shared parent domain
+  # would let one instance's session cookie be sent to the other.
+  cookieDomain: mendysrobotics.com
+  bootstrapEmail: admin@mendysrobotics.com
+  # Fewer web workers than FuzeFront: this silo serves two apps, not the whole
+  # platform. Raise if login latency shows queueing.
+  webWorkers: 2
+  # Browser-facing exposure. OFF by default, matching authentik.adminIngress:
+  # FuzeFront deliberately has NO public IdP host — its authentik is
+  # ClusterIP-only and reached through app.fuzefront.com/api/auth/idp/*, so the
+  # browser never learns the IdP hostname. Enabling this re-introduces a public
+  # IdP host and is only safe behind an edge auth gate (Cloudflare Access).
+  # See the README note in authentik/blueprints-mendys/ for the alternative
+  # (a reverse-proxy path on the MendysRobotics ingress).
+  ingress:
+    enabled: false
+    host: "" # e.g. auth.mendysrobotics.com
+    className: ""
+    annotations: {}
+  # SMTP for this silo's transactional email (enrollment verification, password
+  # reset). Separate from the FuzeFront sender so Mendys mail is Mendys-branded.
+  smtp:
+    host: ""
+    port: 25
+    username: ""
+    from: "noreply@mendysrobotics.com"
+    useTls: false
+    useSSL: false
+    timeout: 10
+  # Placement for the Mendys authentik server + worker (empty → global.scheduling).
+  nodeSelector: {}
+  affinity: {}
+  tolerations: []
 
 ingress:
   enabled: true


### PR DESCRIPTION
Registers the requested per-product Authentik OIDC client for MendysRobotics platform SSO — but as its own **identity silo**, not as another provider on the shared FuzeFront directory.

Companion PR (backing database): izzywdev/FuzeInfra#421

## Why a separate instance and not a brand

The requirement is that MendysRobotics has its own set of accounts: a FuzeFront account must not be recognised by the Mendys apps, a Mendys account must not be recognised by FuzeFront, and the same email may exist independently on both sides.

That cannot be done by adding a blueprint to the existing instance:

- **Authentik has no realm.** One instance is one user directory.
- **Brands are soft only** — branding + default flows per domain. Per authentik's docs, *"all objects like applications and providers are still global"*. A Mendys brand would still share every account.
- **Hard tenancy** (a Postgres *schema* per tenant, 2024.2+) does isolate users, but it is Enterprise-only, still alpha, needs a **license per tenant**, and is managed **only via the API** — it cannot be expressed as a blueprint in git, which is how every other authentik object here is managed.

A **second instance on its own database** gives the same isolation property for free and stays fully declarative.

## What's here

- `templates/authentik-mendys.yaml` — the instance (server + worker + Service), gated on `authentikMendys.enabled`, **default off**.
- `templates/authentik-mendys-blueprints.yaml` — ConfigMap sourced **only** from `authentik/blueprints-mendys/`.
- `blueprints-mendys/provider-oidc-mendys-platform.yaml` — the requested client: `client_type: confidential`, `client_id: mendys-platform-oidc-client`, `client_secret` via `!Env`, `sub_mode: user_email`, `include_claims_in_id_token: true`, openid/email/profile scope mappings, an `invalidation_flow`, and both strict redirect URIs (`live.` and `marketplace.mendysrobotics.com` `/api/auth/oidc/callback`). Application slug `mendys-platform`, launch URL `https://live.mendysrobotics.com/`.
- `blueprints-mendys/{brand-mendys,flow-enrollment}.yaml` — the silo's brand and a self-service enrollment flow mirroring FuzeFront's design.
- `blueprints-mendys/provider-oidc-mendys-datasets.yaml` — the datasets provider's silo-side copy.
- `MENDYS_PLATFORM_CLIENT_SECRET` plus the instance's own secret key, bootstrap credentials and DB password, wired through the chart Secret and env.
- `blueprints-mendys/README.md` — the boundary, the secret contract, and the exposure decision.

## Isolation invariants (each enforced and documented in-file)

| # | Invariant | Why it is load-bearing |
|---|---|---|
| 1 | Separate **database** | Separate user table. This *is* the boundary. |
| 2 | Separate **`AUTHENTIK_SECRET_KEY`** | Otherwise either instance could validate the other's sessions/tokens. |
| 3 | Separate **Redis logical DB** | Authentik stores cache + sessions under non-namespaced keys. |
| 4 | Separate **cookie domain** | A shared parent domain would send one instance's session cookie to the other. |
| 5 | Separate **blueprint mount** | Authentik applies every `*.yaml` under `/blueprints`; a shared mount would recreate FuzeFront's flows/providers/apps inside the Mendys directory. |

Because the directory itself is the tenant boundary, the applications use `policy_engine_mode: all` with no group bindings — there is no need to police who may reach them, since users from the other side have no account here at all.

## Datasets migration is staged, not switched

The FuzeFront-side datasets provider is left **untouched and serving traffic**. Retiring it before MendysRobotics repoints its issuer would black out datasets sign-in, and deleting the blueprint file alone would not remove the objects anyway — that needs an explicit `state: absent` pass. Both copies coexist safely: different instances, different databases, so the shared `client_id` does not collide.

**Accounts do not migrate.** Existing datasets users live in the FuzeFront directory and have no account in the silo until they enroll there.

## Verification

- `helm lint` clean.
- `kubeconform -strict -ignore-missing-schemas`: **16/16 valid, 0 invalid** (1 skip = Traefik CRD).
- Every blueprint parses under authentik's `!Env`/`!Find` tags; provider attributes asserted against the spec above.
- **The FuzeFront render is byte-identical with the silo off** — enabling this cannot disturb the live IdP. (An earlier revision of this branch added a comment to a FuzeFront blueprint; that changed `checksum/blueprints` and would have rolled the live single-replica IdP, so it was reverted.)

One bug caught during review: the new provider initially omitted `grant_types`. On authentik 2026.x a freshly-created provider without it rejects every authorize request (`Invalid grant_type`) — the client would have been dead on arrival. Fixed; both providers now assert `[authorization_code, refresh_token]`.

## Follow-ups (deliberately not in this PR)

- **The issuer URL in izzywdev/MendysRobotics#242 is now wrong.** `https://auth.fuzefront.com/application/o/mendys-platform/` points at the FuzeFront instance, a different directory. The Mendys side must repoint.
- **Browser-facing exposure is undecided.** `authentikMendys.ingress` is off by default because FuzeFront deliberately has no public IdP host. Preferred option is an `/api/auth/idp/*` proxy path on the MendysRobotics ingress; the alternative is a public `auth.mendysrobotics.com` behind Cloudflare Access. See the README.
- The two SealedSecrets, and flipping both `enabled` gates (one PR, once the secrets exist).
- CF tunnel / CF Access for whichever host is chosen.
- Retiring the FuzeFront-side datasets provider, after the repoint.

The client secret is **not** generated here — it must exist only in the destination secret stores. Generate with `openssl rand -hex 32` and place the same value in `MENDYS_PLATFORM_CLIENT_SECRET` (this chart) and `MENDYS_AUTHENTIK_CLIENT_SECRET` in `mendys-secrets` (namespace `mendys-prod`). Note blueprints stamp `client_secret` only at provider *creation* — rotation means deleting and re-applying the provider entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)