### PR TITLE
feat(design): restore design/frames/_template scaffold + manifest JSON Schema

### DIFF
--- a/design/frames/_template/README.md
+++ b/design/frames/_template/README.md
@@ -1,0 +1,95 @@
+# `design/frames/_template/` — scaffold for a feature's approval frames
+
+Copy this directory to `design/frames/<feature-slug>/` and replace the placeholders.
+**Reference implementations:** [`design/frames/billing-invoices/`](../billing-invoices/) (smallest
+complete example) and [`design/frames/password-reset/`](../password-reset/) (multi-flow, per-flow
+approval). Match them; don't invent a second convention.
+
+`_template` is scaffolding, not a feature: the leading `_` excludes it from `scripts/stamp-frames.mjs`
+(`discoverFeatures()` skips `_`/`.`-prefixed directories) and from the published frames index
+(`scripts/build-frames-site.mjs`), so it never appears as something awaiting review and never needs
+a stamp of its own.
+
+## Who owns this
+
+`design/frames/<feature>/**` is authored **only** by the **`product-designer`** agent, from product
+requirements and user stories. A `frontend-engineer` authoring the frames is the bias problem
+`contract-designer` exists to prevent on the backend: the implementer must not write the spec they
+are measured against.
+
+Frames are always **their own PR, and its only content**.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `index.html` | Navigable entry point. Links every frame **and renders the build inventory**. |
+| `frame.html` | Scaffold for one frame — copy to `01-<flow>.html`, `02-states.html`, … |
+| `tokens.css` | fuse-seam token subset, inlined so frames are self-contained/portable. Copy verbatim — every feature on master uses byte-identical `tokens.css`. |
+| `manifest.json` | The approval + build contract. |
+| `manifest.schema.json` | The JSON Schema describing `manifest.json`. Reference documentation — not copied per-feature. |
+
+A feature may add one extra stylesheet (e.g. `frame.css`, `auth.css`) for shared frame chrome when
+several frames repeat the same layout — see `api-tokens/frame.css`. Feature-specific `DESIGN.md`
+notes are also fine (`federated-apps`, `locked-app-mode`).
+
+## Steps
+
+1. `cp -r design/frames/_template design/frames/<feature-slug>` — then delete `README.md` and
+   `manifest.schema.json` from the copy (the schema is referenced, not duplicated per feature).
+2. Rename `frame.html` → `01-<flow>.html`, `02-states.html`, … in flow order, and update the links
+   and cards in `index.html`.
+3. Fill `manifest.json`: `name`, `description`, `frames[]`, `contract`, `build`.
+4. **Stamp it** — `node scripts/stamp-frames.mjs --write --feature <feature-slug>` — and commit the
+   stamp.
+5. Open the frames-only PR. `gate-frames-stamped` must be green.
+
+## The rules that are load-bearing
+
+- **States are contract, not decoration.** Cover loading / empty / error *and* the real fail-closed
+  cases (e.g. unlink-last-method → 409; `hasPassword: null` → "set a password first"). Frames
+  showing only the happy path produce UI that only handles the happy path.
+- **The build inventory is approved with the frames.** `build.flows/components/packages` is the
+  architectural contract — approving the frames approves the component/package plan, so the
+  implementation can't quietly build something else. Keep `index.html`'s inventory and
+  `manifest.json`'s `build` in agreement.
+- **Design-system-first.** Tokens only — no raw hex/spacing/type. A missing primitive gets **added
+  to the design system** by `frontend-engineer`, never one-offed in a frame. Name the gap in the
+  manifest (`build.designSystemAdditions`) so it becomes a foundation PR.
+- **`testHooks` are the seam to QA.** The `data-*` selectors here are what Playwright drives, and
+  merging approved frames triggers **RED** specs (TDD) before implementation exists. Keep the
+  frame's hooks and the manifest's `testHooks` identical.
+- **Feature flags default OFF** — target the **builders audience** (owner + QA synthetic accounts),
+  or prod-smoke can never see the feature and its e2e can never go green.
+
+## The stamp (why `--check` exists)
+
+`stamp` is a content hash of `design/frames/<feature>/**`, **derived** by
+`scripts/stamp-frames.mjs` — never hand-written, and stored as bare lowercase sha256 hex. It makes
+an approval provably bind to the exact frames the approver saw: if the frames change afterwards, the
+stamp no longer matches and the approval doesn't silently carry over to frames nobody looked at.
+
+`gate-frames-stamped` recomputes it in CI (`node scripts/stamp-frames.mjs --check`). Without that
+recomputation the stamp would be just another hand-maintained mirror — the drift pattern behind
+several defects in this repo.
+
+```bash
+node scripts/stamp-frames.mjs --check                      # every feature
+node scripts/stamp-frames.mjs --check --feature <feature>
+node scripts/stamp-frames.mjs --write --feature <feature>
+node scripts/stamp-frames.mjs --json                       # {feature: stamp}, no writes
+```
+
+Re-run `--write` after **any** edit to the feature dir, and commit the result.
+
+The approval bookkeeping keys (`approved` / `approvedBy` / `approvedAt`) are **excluded** from the
+hash at every level, so approving a flow does not change the stamp that approval binds to.
+
+## Approval
+
+Approval is **per flow**: `approved` / `approvedBy` / `approvedAt` live on each `build.flows[]`
+entry, so approving one flow unblocks that flow's implementation while the others iterate. The
+`design-approval` workflow writes them onto the **frames PR head branch, never `master`**
+(`master` is deploy-on-push + review-required). Don't hand-edit them.
+
+**Reject ≠ close** — a rejection re-dispatches `product-designer` for an improving iteration.

--- a/design/frames/_template/frame.html
+++ b/design/frames/_template/frame.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>TEMPLATE — Frame</title>
+<link rel="stylesheet" href="tokens.css" />
+<style>
+  .wrap { max-width: 960px; margin: 0 auto; padding: var(--space-10) var(--space-8) var(--space-16); }
+  .crumb { font-family: var(--font-mono); font-size: var(--text-2xs); letter-spacing: var(--tracking-wide);
+    text-transform: uppercase; color: var(--text-tertiary); margin-bottom: var(--space-4); }
+  .crumb a { color: var(--cyan-400); text-decoration: none; }
+  .crumb a:hover { text-decoration: underline; }
+  h1 { font-family: var(--font-display); font-size: var(--text-xl); letter-spacing: var(--tracking-display); margin: 0 0 var(--space-2); }
+  .lead { color: var(--text-secondary); margin: 0 0 var(--space-8); max-width: 64ch; }
+  .panel { background: var(--bg-tertiary); border: 1px solid var(--border-color); border-radius: var(--radius-lg);
+    padding: var(--space-6); position: relative; overflow: hidden; }
+  .panel::before { content: ''; position: absolute; top: 0; left: 0; right: 0; height: 2px; background: var(--seam); }
+  .panel h2 { font-size: var(--text-lg); margin: 0 0 var(--space-4); }
+  .row { display: flex; align-items: center; justify-content: space-between; gap: var(--space-4);
+    padding: var(--space-4) 0; border-bottom: 1px solid var(--border-color); }
+  .row:last-child { border-bottom: 0; }
+  .btn { font-family: var(--font-sans); font-size: var(--text-sm); background: var(--accent-color); color: #fff;
+    border: 0; border-radius: var(--radius-md); padding: var(--space-3) var(--space-5); cursor: pointer; }
+  .btn:hover { background: var(--accent-hover); }
+  .btn.secondary { background: transparent; color: var(--text-secondary); border: 1px solid var(--border-strong); }
+  .pill { display: inline-block; font-family: var(--font-mono); font-size: var(--text-2xs); padding: 2px 8px;
+    border-radius: var(--radius-pill); text-transform: uppercase; letter-spacing: var(--tracking-wide); }
+  .pill.success { color: var(--success-color); background: rgba(52,211,153,0.12); border: 1px solid rgba(52,211,153,0.35); }
+  .pill.error { color: var(--error-color); background: rgba(243,105,127,0.12); border: 1px solid rgba(243,105,127,0.35); }
+  .notes { margin-top: var(--space-8); font-size: var(--text-sm); color: var(--text-tertiary); }
+  .notes code { font-family: var(--font-mono); color: var(--text-secondary); }
+</style>
+</head>
+<body>
+<!-- Every frame carries data-frame="<id>" matching its manifest frames[].id.
+     The data-* hooks below are the CONTRACT Playwright drives — they must match
+     the frame's manifest `testHooks` exactly. Renaming a hook here without
+     updating the manifest is drift; the manifest is the list QA reads. -->
+<div class="wrap" data-frame="01-example-flow">
+  <div class="crumb"><a href="index.html">← All frames</a> · Frame (a)</div>
+  <h1>Example flow</h1>
+  <p class="lead">Replace: what this frame shows and the decision it freezes.</p>
+
+  <section class="panel" data-panel="example">
+    <h2>Example panel</h2>
+    <div class="row" data-example-row="1">
+      <span>Replace with real, representative content — never lorem ipsum.</span>
+      <span class="pill success" data-status="ok">ok</span>
+    </div>
+    <div class="row" data-example-row="2">
+      <span>A second row showing the populated state.</span>
+      <span class="pill error" data-status="failed">failed</span>
+    </div>
+    <div class="row">
+      <button class="btn" data-action="submit">Primary action</button>
+      <button class="btn secondary" data-action="cancel">Cancel</button>
+    </div>
+  </section>
+
+  <p class="notes">
+    Test hooks: <code>[data-frame='01-example-flow']</code> · <code>[data-panel='example']</code> ·
+    <code>[data-action='submit']</code> — keep in sync with <code>manifest.json</code> → <code>frames[].testHooks</code>.<br />
+    Tokens only: no raw hex, spacing or type outside <code>tokens.css</code>.
+  </p>
+</div>
+</body>
+</html>

--- a/design/frames/_template/index.html
+++ b/design/frames/_template/index.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>TEMPLATE — Approval Frames</title>
+<link rel="stylesheet" href="tokens.css" />
+<style>
+  .wrap { max-width: 880px; margin: 0 auto; padding: var(--space-12) var(--space-8) var(--space-16); }
+  .eyebrow { font-family: var(--font-mono); font-size: var(--text-2xs); letter-spacing: var(--tracking-wide);
+    text-transform: uppercase; color: var(--cyan-400); margin-bottom: var(--space-3); }
+  h1 { font-family: var(--font-display); font-size: var(--text-2xl); letter-spacing: var(--tracking-display); margin: 0 0 var(--space-2); }
+  .lead { color: var(--text-secondary); margin: 0; max-width: 64ch; }
+  .grid { display: grid; grid-template-columns: 1fr 1fr; gap: var(--space-5); margin-top: var(--space-8); }
+  @media (max-width: 640px){ .grid { grid-template-columns: 1fr; } }
+  .frame-link { display: block; text-decoration: none; color: inherit; background: var(--bg-tertiary);
+    border: 1px solid var(--border-color); border-radius: var(--radius-lg); padding: var(--space-6);
+    position: relative; overflow: hidden; transition: transform var(--duration-base) var(--ease-standard); }
+  .frame-link:hover { transform: translateY(-2px); box-shadow: var(--shadow-md); border-color: var(--border-strong); }
+  .frame-link .seam { position: absolute; top: 0; left: 0; right: 0; height: 2px; background: var(--seam); opacity: 0; transition: opacity var(--duration-base); }
+  .frame-link:hover .seam { opacity: 1; }
+  .frame-link .step { font-family: var(--font-mono); font-size: var(--text-2xs); color: var(--text-tertiary); letter-spacing: var(--tracking-wide); }
+  .frame-link h3 { margin: var(--space-2) 0; font-size: var(--text-lg); }
+  .frame-link p { margin: 0; color: var(--text-tertiary); font-size: var(--text-sm); }
+  .build { margin-top: var(--space-10); background: var(--bg-secondary); border: 1px solid var(--border-color);
+    border-radius: var(--radius-lg); padding: var(--space-6); }
+  .build h2 { font-family: var(--font-display); font-size: var(--text-lg); margin: 0 0 var(--space-2); }
+  .build p.note { margin: 0 0 var(--space-4); color: var(--text-tertiary); font-size: var(--text-sm); max-width: 64ch; }
+  .build dt { font-family: var(--font-mono); font-size: var(--text-2xs); text-transform: uppercase;
+    letter-spacing: var(--tracking-wide); color: var(--cyan-400); margin-top: var(--space-4); }
+  .build dd { margin: var(--space-2) 0 0; }
+  .chip { display: inline-block; font-family: var(--font-mono); font-size: var(--text-2xs);
+    background: var(--bg-quaternary); border: 1px solid var(--border-color); border-radius: var(--radius-pill);
+    padding: 2px 8px; margin: 0 var(--space-2) var(--space-2) 0; color: var(--text-secondary); }
+  .meta { margin-top: var(--space-10); font-size: var(--text-sm); color: var(--text-tertiary); }
+  .meta code { font-family: var(--font-mono); color: var(--text-secondary); }
+  .pending { display: inline-flex; align-items: center; gap: 6px; font-family: var(--font-mono);
+    font-size: var(--text-2xs); padding: 2px 8px; border-radius: var(--radius-pill);
+    color: var(--warning-color); border: 1px solid rgba(245,185,80,0.4); text-transform: uppercase;
+    letter-spacing: var(--tracking-wide); margin-top: var(--space-4); }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <div class="eyebrow">Contract-freeze · UX approval</div>
+  <h1>TEMPLATE — Approval Frames</h1>
+  <p class="lead">Replace this lead: what these frames demonstrate, before any feature UI is implemented.
+    Approving them freezes the visual contract that the implementation and
+    <code>frontend-test-engineer</code>'s Playwright pre-production checks are verified against.
+    Built in the fuse-seam design system (tokens only).</p>
+
+  <div class="grid">
+    <a href="01-example-flow.html" class="frame-link" data-frame-link>
+      <div class="seam"></div>
+      <div class="step">Frame (a)</div>
+      <h3>Example flow</h3>
+      <p>Replace: the populated, primary path of the flow.</p>
+    </a>
+    <a href="02-states.html" class="frame-link" data-frame-link>
+      <div class="seam"></div>
+      <div class="step">Frame (b)</div>
+      <h3>States</h3>
+      <p>Loading skeleton, empty state, error+retry, and the fail-closed cases.</p>
+    </a>
+  </div>
+
+  <!-- The build inventory is APPROVED WITH THE FRAMES: it is the architectural
+       contract, not a note. Keep it in sync with manifest.json `build`. -->
+  <section class="build" data-build-inventory>
+    <h2>What approving this builds</h2>
+    <p class="note">Approving these frames approves this inventory. The implementation builds
+      exactly these flows, components and packages — it cannot quietly invent a different architecture.</p>
+    <dl>
+      <dt>Flows</dt>
+      <dd><span class="chip" data-build-flow="01-example-flow">ExampleFlow → /example</span></dd>
+      <dt>Components</dt>
+      <dd><span class="chip" data-build-component>ExamplePanel</span><span class="chip" data-build-component>ExampleRow</span></dd>
+      <dt>Packages</dt>
+      <dd><span class="chip" data-build-package>@fuzefront/example-ui</span></dd>
+    </dl>
+  </section>
+
+  <span class="pending" data-approval-status="pending">● Awaiting approval</span>
+
+  <p class="meta">
+    Design system: <code>@fuzefront/design-system</code> (fuse-seam) ·
+    Contract: <code>services/example-service/openapi.yaml</code> → <code>@fuzefront/example-client</code> ·
+    Component: <code>@fuzefront/example-ui → ExamplePanel</code> ·
+    Flag: <code>fuzefront.example.feature</code> (default OFF).<br />
+    Approval is written per-flow into <code>manifest.json</code> by the design-approval workflow —
+    reply <code>@claude approve</code> / <code>@claude reject: &lt;reason&gt;</code>.
+    Re-stamp after any edit: <code>node scripts/stamp-frames.mjs --write &lt;feature&gt;</code>.
+  </p>
+</div>
+</body>
+</html>

--- a/design/frames/_template/manifest.json
+++ b/design/frames/_template/manifest.json
@@ -1,0 +1,58 @@
+{
+  "name": "TEMPLATE — replace with the feature name",
+  "description": "Replace: what these frames freeze, and what approving them commits to. Approving = approving the visual model AND the build inventory below.",
+  "designSystem": "fuse-seam (@fuzefront/design-system)",
+  "entry": "index.html",
+  "contract": {
+    "openapi": "services/example-service/openapi.yaml",
+    "client": "@fuzefront/example-client",
+    "schemas": ["components.schemas.Example"],
+    "endpoints": ["GET /api/v1/example"],
+    "component": "@fuzefront/example-ui → ExamplePanel",
+    "featureFlag": "fuzefront.example.feature"
+  },
+  "build": {
+    "flows": [
+      {
+        "id": "01-example-flow",
+        "orchestrator": "ExampleFlow",
+        "route": "/example",
+        "approved": false
+      }
+    ],
+    "components": ["ExamplePanel", "ExampleRow"],
+    "packages": ["@fuzefront/example-ui"]
+  },
+  "frames": [
+    {
+      "id": "01-example-flow",
+      "file": "01-example-flow.html",
+      "label": "(a) Example flow",
+      "route": "/example",
+      "flow": "01-example-flow",
+      "summary": "Replace: what this frame shows — the populated, primary path of the flow.",
+      "acceptanceNotes": "Replace: the behavioural contract QA writes RED specs against. Name the real fail-closed cases, not just the happy path.",
+      "testHooks": [
+        "[data-frame='01-example-flow']",
+        "[data-panel='example']",
+        "[data-action='submit']"
+      ]
+    },
+    {
+      "id": "02-states",
+      "file": "02-states.html",
+      "label": "(b) States",
+      "route": "/example",
+      "flow": "01-example-flow",
+      "summary": "Loading skeleton, empty state, error+retry, and the feature's fail-closed cases.",
+      "acceptanceNotes": "States are contract, not decoration. Frames showing only the happy path produce UI that only handles the happy path.",
+      "testHooks": [
+        "[data-frame='02-states']",
+        "[data-state='loading']",
+        "[data-state='empty']",
+        "[data-state='error']",
+        "[data-action='retry']"
+      ]
+    }
+  ]
+}

--- a/design/frames/_template/manifest.schema.json
+++ b/design/frames/_template/manifest.schema.json
@@ -1,0 +1,144 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/izzywdev/FuzeFront/design/frames/_template/manifest.schema.json",
+  "title": "Design frames manifest",
+  "description": "The approval + build contract for one feature's design frames (design/frames/<feature>/manifest.json). Approving these frames approves BOTH the visual model and the build inventory (flows / components / packages), so an implementation cannot quietly invent a different architecture. NOTE: `additionalProperties` is deliberately permissive at every level — the 12 manifests on master carry feature-specific extras (`epics`, `plan`, `precedent`, `honestDegrade`, `commissionedByApproval`, `designSystemAdditions`, `missingDesignSystemPrimitives`, …). This schema pins the load-bearing shape that stamping, approval and QA depend on; it does not forbid a feature from saying more.",
+  "type": "object",
+  "required": ["name", "description", "designSystem", "entry", "frames"],
+  "properties": {
+    "name": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Human-readable feature name. Shown as the card title on the frames index."
+    },
+    "description": {
+      "type": "string",
+      "minLength": 1,
+      "description": "What these frames freeze, and what approving them commits to."
+    },
+    "designSystem": {
+      "type": "string",
+      "description": "The design system the frames are built in. Frames use tokens only — no raw hex/spacing/type.",
+      "default": "fuse-seam (@fuzefront/design-system)"
+    },
+    "plan": {
+      "type": "string",
+      "description": "Optional path/link to the planning doc this feature derives from."
+    },
+    "stamp": {
+      "type": "string",
+      "description": "Content stamp of design/frames/<feature>/**, DERIVED by scripts/stamp-frames.mjs — never hand-edited. Binds an approval to the exact frames the approver saw; gate-frames-stamped recomputes it, and design-approval refuses to bind to a stale stamp. Bare lowercase sha256 hex, no algorithm prefix.",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "entry": {
+      "type": "string",
+      "description": "The navigable entry point for the frame set, relative to the feature dir.",
+      "default": "index.html",
+      "pattern": "\\.html$"
+    },
+    "frames": {
+      "type": "array",
+      "description": "The ordered frame sequence. Each frame belongs to a flow; approval is PER FLOW (see build.flows), so one flow can be approved and implemented while its siblings still iterate.",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["id", "file", "label", "summary", "testHooks"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Stable frame id, matching the file stem (e.g. '01-invoice-history')."
+          },
+          "file": {
+            "type": "string",
+            "pattern": "\\.html$",
+            "description": "Frame file, relative to the feature dir."
+          },
+          "label": { "type": "string", "minLength": 1, "description": "Short label, e.g. '(a) Invoice history'." },
+          "route": { "type": "string", "description": "The app route this frame lands on, e.g. '/billing'." },
+          "flow": { "type": "string", "description": "The build.flows[].id this frame belongs to, when a flow spans several frames." },
+          "summary": { "type": "string", "minLength": 1, "description": "What the frame shows." },
+          "acceptanceNotes": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The behavioural contract QA writes RED specs against. States are contract, not decoration — cover loading/empty/error and the real fail-closed cases, not just the happy path."
+          },
+          "testHooks": {
+            "type": "array",
+            "description": "The data-* selectors Playwright drives. These are the stable handles between frames and specs, and must match the frame HTML exactly.",
+            "minItems": 1,
+            "items": { "type": "string", "minLength": 1 }
+          }
+        }
+      }
+    },
+    "contract": {
+      "type": "object",
+      "description": "The API/type contract these frames render against — the seam to contract-first.",
+      "properties": {
+        "openapi": { "type": "string", "description": "Path to the OpenAPI spec, e.g. 'services/billing-service/openapi.yaml'." },
+        "client": { "type": "string", "description": "Generated client package, e.g. '@fuzefront/billing-client'." },
+        "schemas": {
+          "type": "array",
+          "description": "The OpenAPI schema components the frames bind to.",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "endpoints": {
+          "type": "array",
+          "description": "Endpoints the flows call, e.g. 'GET /api/v1/billing/invoices'.",
+          "items": { "type": "string", "pattern": "^(GET|POST|PUT|PATCH|DELETE) /" }
+        },
+        "component": { "type": "string", "minLength": 1, "description": "Target component, e.g. '@fuzefront/billing-ui → InvoiceHistoryPanel'." },
+        "featureFlag": {
+          "type": "string",
+          "description": "Flag gating the feature, taxonomy '<repo>.<domain>.<flag>'. Default OFF; the builders audience must be targeted or prod-smoke can never see it.",
+          "pattern": "^[a-z0-9-]+\\.[a-z0-9-]+\\.[a-z0-9-]+$"
+        }
+      }
+    },
+    "build": {
+      "type": "object",
+      "description": "The build inventory, rendered in index.html and mirrored here. Approving the frames approves this plan.",
+      "properties": {
+        "flows": {
+          "type": "array",
+          "description": "Flow orchestrators to be built. Per-flow approval bookkeeping lives on these entries.",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "required": ["id", "orchestrator", "route"],
+            "properties": {
+              "id": { "type": "string", "minLength": 1, "description": "Flow id; frames[].flow references it." },
+              "orchestrator": { "type": "string", "minLength": 1, "description": "Component that orchestrates the flow, e.g. 'PasswordResetFlow'." },
+              "route": { "type": "string", "pattern": "^/", "description": "Route the flow mounts at." },
+              "approved": {
+                "type": "boolean",
+                "description": "Per-flow approval. Written by the design-approval workflow onto the frames PR head branch — never hand-set on master. Excluded from the stamp (see scripts/stamp-frames.mjs APPROVAL_KEYS) so approving does not invalidate the stamp it binds to."
+              },
+              "approvedBy": { "type": ["string", "null"], "description": "GitHub login of the approver (must be owner/CODEOWNER). null while unapproved." },
+              "approvedAt": {
+                "type": ["string", "null"],
+                "description": "ISO-8601 date (YYYY-MM-DD) or full timestamp of the approval. null while unapproved.",
+                "anyOf": [{ "format": "date" }, { "format": "date-time" }]
+              }
+            },
+            "dependencies": {
+              "approvedBy": ["approved"],
+              "approvedAt": ["approved"]
+            }
+          }
+        },
+        "components": {
+          "type": "array",
+          "description": "React components to be created. Design-system-first: missing primitives are added to the DS, not one-offed here.",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "packages": {
+          "type": "array",
+          "description": "npm packages to be created/extended. Private: publishConfig → GitHub Packages, access restricted.",
+          "items": { "type": "string", "pattern": "^@fuzefront/" }
+        }
+      }
+    }
+  }
+}

--- a/design/frames/_template/tokens.css
+++ b/design/frames/_template/tokens.css
@@ -1,0 +1,235 @@
+/* fuse-seam design-system tokens (subset), inlined so these approval frames are
+   self-contained / portable. Mirrors design-system/tokens/*.css. These frames are
+   contract-freeze UX artifacts — approve the frames = approve the model. */
+:root {
+  /* brand / accent */
+  --indigo-500: #6e5cff;
+  --cyan-400: #29d3e6;
+  --accent-color: var(--indigo-500);
+  --accent-hover: #5a48e6;
+  --accent-soft: rgba(110, 92, 255, 0.14);
+  --accent-2: var(--cyan-400);
+  --seam: linear-gradient(90deg, var(--accent-color) 0%, var(--accent-2) 100%);
+
+  /* graphite surfaces (dark default) */
+  --bg-primary: #0f131c;
+  --bg-secondary: #11161f;
+  --bg-tertiary: #141a26;
+  --bg-quaternary: #1b2230;
+  --border-color: #232b3a;
+  --border-strong: #313b4d;
+
+  --text-primary: #e7ebf2;
+  --text-secondary: #aab3c2;
+  --text-tertiary: #6b7585;
+
+  --success-color: #34d399;
+  --warning-color: #f5b950;
+  --error-color: #f3697f;
+
+  /* type */
+  --font-display: "Space Grotesk", "Inter", system-ui, sans-serif;
+  --font-sans: "Inter", system-ui, -apple-system, sans-serif;
+  --font-mono: "JetBrains Mono", ui-monospace, "SF Mono", monospace;
+  --text-2xs: 11px;
+  --text-xs: 12px;
+  --text-sm: 13px;
+  --text-md: 14px;
+  --text-lg: 16px;
+  --text-xl: 20px;
+  --text-2xl: 26px;
+  --weight-regular: 400;
+  --weight-medium: 500;
+  --weight-semibold: 600;
+  --tracking-wide: 0.04em;
+  --tracking-display: -0.01em;
+
+  /* spacing / radii / shadow */
+  --space-1: 4px; --space-2: 8px; --space-3: 12px; --space-4: 16px;
+  --space-5: 20px; --space-6: 24px; --space-7: 28px; --space-8: 32px;
+  --space-10: 40px; --space-12: 48px; --space-16: 64px;
+  --radius-sm: 6px; --radius-md: 10px; --radius-lg: 14px; --radius-xl: 20px;
+  --radius-pill: 999px;
+  --shadow-xs: 0 1px 2px rgba(0,0,0,0.3);
+  --shadow-md: 0 6px 20px rgba(0,0,0,0.4);
+  --shadow-lg: 0 16px 48px rgba(0,0,0,0.5);
+  --shadow-accent: 0 8px 24px rgba(110,92,255,0.35);
+
+  --top-bar-height: 60px;
+  --side-panel-width: 240px;
+  --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+  --duration-fast: 120ms;
+  --duration-base: 200ms;
+}
+
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  font-family: var(--font-sans);
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  -webkit-font-smoothing: antialiased;
+}
+.mono { font-family: var(--font-mono); }
+
+/* ---- shared portal-shell chrome used across frames ---- */
+.shell { display: flex; flex-direction: column; height: 100vh; }
+.topbar {
+  height: var(--top-bar-height);
+  flex: none;
+  display: flex; align-items: center; gap: var(--space-4);
+  padding: 0 var(--space-6);
+  background: var(--bg-secondary);
+  border-bottom: 1px solid var(--border-color);
+  position: relative;
+}
+.topbar::after {
+  content: ""; position: absolute; left: 0; right: 0; bottom: -1px;
+  height: 2px; background: var(--seam); opacity: 0.7;
+}
+.wordmark {
+  font-family: var(--font-display); font-weight: var(--weight-semibold);
+  font-size: var(--text-lg); letter-spacing: var(--tracking-display);
+}
+.wordmark .fuse {
+  background: var(--seam); -webkit-background-clip: text;
+  background-clip: text; color: transparent;
+}
+.topbar .spacer { flex: 1; }
+.launch-btn {
+  width: 34px; height: 34px; border-radius: var(--radius-md);
+  display: grid; place-items: center; cursor: pointer;
+  background: var(--bg-quaternary); border: 1px solid var(--border-color);
+}
+.avatar {
+  width: 32px; height: 32px; border-radius: var(--radius-pill);
+  background: var(--seam); display: grid; place-items: center;
+  font-weight: var(--weight-semibold); font-size: var(--text-sm); color: #0b0e15;
+}
+.body { flex: 1; display: flex; min-height: 0; }
+
+.side {
+  width: var(--side-panel-width); flex: none;
+  background: var(--bg-secondary);
+  border-right: 1px solid var(--border-color);
+  padding: var(--space-4) var(--space-3);
+  display: flex; flex-direction: column; gap: var(--space-1);
+  overflow-y: auto;
+}
+.side .section-label {
+  font-family: var(--font-mono); font-size: var(--text-2xs);
+  letter-spacing: var(--tracking-wide); text-transform: uppercase;
+  color: var(--text-tertiary); margin: var(--space-4) var(--space-2) var(--space-2);
+}
+.nav-item {
+  display: flex; align-items: center; gap: var(--space-3);
+  padding: var(--space-2) var(--space-3); border-radius: var(--radius-md);
+  color: var(--text-secondary); font-size: var(--text-md); cursor: pointer;
+  text-decoration: none;
+}
+.nav-item:hover { background: var(--bg-quaternary); color: var(--text-primary); }
+.nav-item.active {
+  background: var(--accent-soft); color: var(--text-primary);
+  box-shadow: inset 2px 0 0 var(--accent-color);
+}
+.nav-item .ico { width: 18px; text-align: center; }
+
+.content { flex: 1; overflow: auto; padding: var(--space-8); min-width: 0; }
+.page-title {
+  font-family: var(--font-display); font-size: var(--text-2xl);
+  letter-spacing: var(--tracking-display); margin: 0 0 var(--space-2);
+}
+.page-sub { color: var(--text-secondary); margin: 0 0 var(--space-6); }
+
+.btn {
+  font-family: var(--font-sans); font-size: var(--text-md);
+  font-weight: var(--weight-medium); border-radius: var(--radius-md);
+  padding: var(--space-2) var(--space-4); cursor: pointer; border: 1px solid transparent;
+}
+.btn-primary { background: var(--accent-color); color: #0b0e15; box-shadow: var(--shadow-accent); }
+.btn-primary:hover { background: var(--accent-hover); }
+.btn-ghost { background: transparent; color: var(--text-secondary); border-color: var(--border-color); }
+.btn-ghost:hover { color: var(--text-primary); border-color: var(--border-strong); }
+
+.badge {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-family: var(--font-mono); font-size: var(--text-2xs);
+  padding: 2px 8px; border-radius: var(--radius-pill);
+  border: 1px solid var(--border-color); color: var(--text-secondary);
+  text-transform: uppercase; letter-spacing: var(--tracking-wide);
+}
+.badge.activated { color: var(--success-color); border-color: rgba(52,211,153,0.4); }
+.badge.registered { color: var(--warning-color); border-color: rgba(245,185,80,0.4); }
+.badge.mf { color: var(--cyan-400); border-color: rgba(41,211,230,0.4); }
+.badge.builtin { color: var(--accent-color); border-color: rgba(110,92,255,0.4); }
+.badge.standalone { color: var(--text-primary); border-color: var(--border-strong); }
+
+.dot { width: 9px; height: 9px; border-radius: var(--radius-pill); display: inline-block; }
+.dot.healthy { background: var(--success-color); }
+.dot.down { background: var(--error-color); }
+
+/* approval-frame footer nav */
+.frame-nav {
+  position: fixed; bottom: 0; left: 0; right: 0;
+  display: flex; align-items: center; justify-content: space-between;
+  gap: var(--space-4); padding: var(--space-3) var(--space-6);
+  background: rgba(17,22,31,0.92); backdrop-filter: blur(8px);
+  border-top: 1px solid var(--border-color); z-index: 50;
+}
+.frame-nav .caption { font-size: var(--text-sm); color: var(--text-tertiary); }
+.frame-nav .caption b { color: var(--text-secondary); font-weight: var(--weight-semibold); }
+.frame-nav a { text-decoration: none; }
+.content { padding-bottom: 72px; }
+
+/* ---- invoice status pill soft tokens (mirror @fuzefront/design-system semantic *-soft) ---- */
+:root {
+  --success-soft: rgba(52, 211, 153, 0.14);
+  --warning-soft: rgba(245, 185, 80, 0.14);
+  --error-soft:   rgba(243, 105, 127, 0.14);
+  --neutral-soft: rgba(170, 179, 194, 0.12);
+}
+
+/* ---- InvoiceHistoryPanel (design-system-first; tokens only) ---- */
+.ffb-invoices { background: var(--bg-tertiary); border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg); position: relative; overflow: hidden; max-width: 720px; }
+.ffb-invoices__seam { height: 2px; background: var(--seam); }
+.ffb-invoices__head { display: flex; align-items: baseline; justify-content: space-between;
+  gap: var(--space-3); padding: var(--space-5) var(--space-5) var(--space-3); }
+.ffb-invoices__title { margin: 0; font-family: var(--font-display); font-size: var(--text-lg);
+  font-weight: var(--weight-semibold); color: var(--text-primary); }
+.ffb-invoices__count { color: var(--text-tertiary); font-size: var(--text-sm);
+  font-variant-numeric: tabular-nums; }
+.ffb-invoices__list { display: flex; flex-direction: column; }
+.ffb-invoice-row { display: grid; grid-template-columns: 1fr auto; gap: var(--space-1) var(--space-4);
+  padding: var(--space-4) var(--space-5); border-top: 1px solid var(--border-color); align-items: center; }
+.ffb-invoice-row__main { display: flex; flex-direction: column; gap: var(--space-1); min-width: 0; }
+.ffb-invoice-row__top { display: flex; align-items: center; gap: var(--space-3); flex-wrap: wrap; }
+.ffb-invoice-row__num { font-weight: var(--weight-medium); color: var(--text-primary);
+  font-variant-numeric: tabular-nums; }
+.ffb-invoice-row__date { color: var(--text-secondary); font-size: var(--text-sm); }
+.ffb-invoice-row__side { display: flex; align-items: center; gap: var(--space-4); justify-content: flex-end; }
+.ffb-invoice-row__amount { color: var(--text-primary); font-weight: var(--weight-semibold);
+  font-variant-numeric: tabular-nums; text-align: end; }
+.ffb-pill { display: inline-flex; align-items: center; gap: var(--space-1);
+  padding: 2px var(--space-2); border-radius: var(--radius-pill); font-size: var(--text-2xs);
+  font-weight: var(--weight-semibold); text-transform: capitalize; white-space: nowrap; }
+.ffb-pill__dot { width: 6px; height: 6px; border-radius: var(--radius-pill); background: currentColor; }
+.ffb-pill--paid { background: var(--success-soft); color: var(--success-color); }
+.ffb-pill--open { background: var(--warning-soft); color: var(--warning-color); }
+.ffb-pill--void { background: var(--neutral-soft); color: var(--text-secondary); }
+.ffb-pill--uncollectible { background: var(--error-soft); color: var(--error-color); }
+.ffb-dl { display: inline-flex; align-items: center; gap: var(--space-1); color: var(--accent-color);
+  text-decoration: none; font-size: var(--text-sm); font-weight: var(--weight-medium);
+  padding: var(--space-1) var(--space-2); border-radius: var(--radius-sm); min-height: 32px; }
+.ffb-dl:hover { background: var(--accent-soft); }
+.ffb-dl svg { width: 14px; height: 14px; }
+.ffb-invoices__foot { padding: var(--space-4) var(--space-5); border-top: 1px solid var(--border-color);
+  display: flex; justify-content: center; }
+.ffb-skel { height: 14px; border-radius: var(--radius-pill); background:
+  linear-gradient(90deg, var(--bg-quaternary), var(--border-color), var(--bg-quaternary));
+  background-size: 200% 100%; animation: ffbsh 1.3s ease-in-out infinite; }
+@keyframes ffbsh { 0%{background-position:200% 0} 100%{background-position:-200% 0} }
+@media (prefers-reduced-motion: reduce){ .ffb-skel{ animation: none; } }
+.ffb-empty { padding: var(--space-8) var(--space-5); text-align: center; color: var(--text-secondary); }
+.ffb-empty__icon { width: 40px; height: 40px; margin: 0 auto var(--space-3); color: var(--text-tertiary); }
+.ffb-note { font-size: var(--text-sm); color: var(--text-secondary); }

--- a/docs/planning/design-first-ui-pipeline.md
+++ b/docs/planning/design-first-ui-pipeline.md
@@ -19,10 +19,19 @@
 > - **`product-designer` exists** — landed with the `contract-designer` /
 >   `frontend-engineer` corrections (PR #300).
 >
-> **Not yet built** (sequencing step 1 remainder): `design/frames/_template/`,
-> `scripts/stamp-frames.mjs`, `gate-frames-first`, `gate-frames-stamped`, the
-> design-approval issue form + workflow, and Pages publishing for
-> `design/frames/**`.
+> **Built since** (sequencing step 1): `scripts/stamp-frames.mjs` +
+> `.github/workflows/gate-frames-stamped.yml`, `.github/workflows/design-approval.yml`,
+> `scripts/build-frames-site.mjs` + `.github/workflows/pages-frames.yml`, and
+> `design/frames/_template/` — `index.html`, `frame.html`, `tokens.css`,
+> `manifest.json`, `manifest.schema.json`, `README.md`. Note: **no
+> `approval-bar.html`**; the approval banner lives inline in `index.html` as
+> `[data-approval-status]`, which is what all 12 feature frame sets actually do.
+>
+> **Still not built**: `gate-frames-first` (UI code requires approved frames),
+> `gate-frames-schema` (validate manifests against `manifest.schema.json` in CI —
+> the schema exists and all 12 feature manifests validate against it, but nothing
+> enforces it yet), `gate-ds-conformance`, and the design-approval **issue form**
+> (`.github/ISSUE_TEMPLATE/design-approval.yml`).
 
 ## Context
 
@@ -113,7 +122,7 @@ Flags default OFF ⇒ **prod-smoke and Playwright would never see the feature, s
 ## Template → FuzeSDLC (the part that outlives this feature)
 
 ```
-design/frames/_template/{index.html,frame.html,approval-bar.html,manifest.schema.json,README.md}
+design/frames/_template/{index.html,frame.html,tokens.css,manifest.json,manifest.schema.json,README.md}
 .github/ISSUE_TEMPLATE/design-approval.yml
 .github/workflows/design-approval.yml      # workflow_call — lives in FuzeSDLC
 .github/workflows/gate-frames-first.yml    # UI code requires approved frames


### PR DESCRIPTION
## Why

Resolving the UNCERTAIN branch `origin/claude/design-first-enforcement`. The design-first frames pipeline landed on `master` (12 feature frame sets, `scripts/stamp-frames.mjs`, `gate-frames-stamped`, `design-approval.yml`, `pages-frames.yml`) — but the **`design/frames/_template/` scaffold it was built around never merged**. It existed only on that abandoned branch.

**Verdict: lost, not deliberately dropped.** Evidence:

- `docs/planning/design-first-ui-pipeline.md` (the plan of record) still lists `design/frames/_template/` as an unbuilt deliverable and as the artifact to promote to FuzeSDLC — a dangling reference to a directory that does not exist.
- `scripts/stamp-frames.mjs` **and** `scripts/build-frames-site.mjs` both skip `_`-prefixed dirs, and `build-frames-site.mjs` names `_template` explicitly in a comment. The skip logic exists to accommodate a template that was absent.
- `_template/tokens.css` is **byte-identical** to the `tokens.css` in every one of the 12 shipped feature dirs — the shipped features were copied from it.
- No `manifest.schema.json` for frames exists anywhere on `master`.

## What changed vs the original branch content

The template was ported **reconciled with how the 12 feature dirs are actually structured today**, not with its original design:

| Original (branch) | Corrected (this PR) | Why |
|---|---|---|
| `manifest.feature` | `manifest.name` | All 12 real manifests use `name` |
| approval on `frames[]` | approval on `build.flows[]` | Where every real manifest carries it |
| `stamp` pattern `^sha256:[0-9a-f]{64}$` | `^[0-9a-f]{64}$` | Real stamps are bare hex |
| `additionalProperties: false` | permissive + documented | Real manifests carry `epics`, `plan`, `precedent`, `honestDegrade`, `designSystemAdditions`, … |
| `approvedBy`/`approvedAt` string | nullable | Real unapproved flows use `null` |
| `contract`/`build` required | optional | `billing-invoices`, `federated-apps`, `locked-app-mode` have no `build` |
| README: `stamp-frames.mjs --write <slug>` | `--write --feature <slug>` | Actual CLI |
| README: `gate-frames-schema` must be green | removed | That workflow does not exist |
| plan doc: `approval-bar.html` | `tokens.css` + `manifest.json` | Real frames put the approval banner inline in `index.html` as `[data-approval-status]` |

## Verification

- `node scripts/stamp-frames.mjs --check` → **`All 12 feature stamp(s) up to date.`** with `_template` present. The scaffold is correctly ignored by stamping (and by the published frames index).
- **All 12 real manifests + the template validate** against the new `manifest.schema.json` (ajv, draft-07, `strict:false`, `ajv-formats`). 13/13 PASS.

## Also

Corrects the plan-of-record's stale "Not yet built" list to what actually landed vs what genuinely remains: `gate-frames-first`, `gate-frames-schema`, `gate-ds-conformance`, and `.github/ISSUE_TEMPLATE/design-approval.yml`.

Nothing else on `claude/design-first-enforcement` is unique — its only other file, `scripts/stamp-frames.mjs`, is already on `master` (in a later, improved form).

🤖 Generated with [Claude Code](https://claude.com/claude-code)