### PR TITLE
ci(chat): build and publish the chat-service image, and bump its tag in values-prod

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,8 +181,19 @@ jobs:
         # Root build context: the Dockerfile runs `npm ci --workspace=
         # services/chat-service`, so it needs the root package.json/lockfile and
         # shared/ — not just services/chat-service/.
+        #
+        # continue-on-error matches the other auxiliary services (a broken
+        # chat build must not block backend/frontend from shipping), but that
+        # alone would let the bump step below pin a tag for an image that was
+        # never pushed. The `id` here is what lets the bump gate on the real
+        # outcome — see "Bump image tags" (review finding).
+        id: chat_image
         continue-on-error: true
-        uses: docker/build-push-action@v7
+        # SHA-pinned (Semgrep github-actions-mutable-action-tag). Same SHA the
+        # already-pinned steps in security.yml use. The other steps in this
+        # file still use the mutable @v7 — pinning the whole file is a separate,
+        # security-owned change, not this PR's scope.
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: services/chat-service/Dockerfile
@@ -231,6 +242,15 @@ jobs:
         run: |
           set -euo pipefail
           SHA="${{ steps.tag.outputs.sha }}"
+          # chat-service builds with continue-on-error, so its image may NOT
+          # exist even though this step runs. Only bump its tag when the build
+          # actually succeeded — otherwise values-prod would pin a tag that was
+          # never pushed (today masked only by chatService.enabled: false).
+          # The expected-rewrite count moves with it so the guard stays exact.
+          CHAT_OK=0
+          if [ "${{ steps.chat_image.outcome }}" = "success" ]; then CHAT_OK=1; fi
+          EXPECTED=$((7 + CHAT_OK))
+          echo "chat-service image built: ${CHAT_OK} — expecting ${EXPECTED} tag rewrites"
           mkdir -p ~/.ssh
           printf '%s\n' "$SSH_KEY" > ~/.ssh/release_bump
           chmod 600 ~/.ssh/release_bump
@@ -260,7 +280,7 @@ jobs:
           # manually restored LF. Rewritten tag lines preserve the line's
           # original ending so a CRLF file round-trips without a spurious
           # whole-file diff.
-          awk -v sha="$SHA" '
+          awk -v sha="$SHA" -v chat="$CHAT_OK" '
             hot {
               hot=0
               if ($0 ~ /^[[:space:]]*tag:/) {
@@ -277,14 +297,16 @@ jobs:
             /repository: ghcr\.io\/izzywdev\/fuzefront-clock-app\r?$/ { hot=1 }
             /repository: ghcr\.io\/izzywdev\/fuzefront-email-service\r?$/ { hot=1 }
             /repository: ghcr\.io\/izzywdev\/fuzefront-sms-service\r?$/ { hot=1 }
-            /repository: ghcr\.io\/izzywdev\/fuzefront-chat-service\r?$/ { hot=1 }
+            chat == 1 && /repository: ghcr\.io\/izzywdev\/fuzefront-chat-service\r?$/ { hot=1 }
             { print }
             END { print n+0 > "/tmp/bump-count" }
           ' /tmp/vp-current.yaml > /tmp/vp-new.yaml
           # Guard against silent no-ops: if the file layout drifts (quoted
           # values, reordered keys, renamed registry path) the awk matches
           # nothing and we would otherwise "succeed" while deploying stale
-          # tags (review finding). Exactly 8 core-app tags must be rewritten.
+          # tags (review finding). Exactly EXPECTED core-app tags must be
+          # rewritten: 7 always-built images, plus chat-service only when its
+          # continue-on-error build actually succeeded.
           # The anchor list MUST cover every image this workflow BUILDS. It
           # previously listed only 5 while the build steps produced 7: the
           # email-service and sms-service images were built and pushed on every
@@ -294,8 +316,8 @@ jobs:
           # sms-service kept tag "" — i.e. it was NEVER deployed at all. If you
           # add a build step above, add its anchor here AND bump this number.
           COUNT=$(cat /tmp/bump-count)
-          if [ "$COUNT" -ne 8 ]; then
-            echo "::error::expected 8 core-app tag rewrites in ${FILE}, got ${COUNT} — file layout changed; update the bump step"
+          if [ "$COUNT" -ne "$EXPECTED" ]; then
+            echo "::error::expected ${EXPECTED} core-app tag rewrites in ${FILE}, got ${COUNT} — file layout changed; update the bump step"
             exit 1
           fi
           if cmp -s /tmp/vp-current.yaml /tmp/vp-new.yaml; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -177,6 +177,22 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      - name: Build & push chat-service
+        # Root build context: the Dockerfile runs `npm ci --workspace=
+        # services/chat-service`, so it needs the root package.json/lockfile and
+        # shared/ — not just services/chat-service/.
+        continue-on-error: true
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: services/chat-service/Dockerfile
+          push: true
+          tags: |
+            ghcr.io/izzywdev/fuzefront-chat-service:${{ steps.tag.outputs.sha }}
+            ghcr.io/izzywdev/fuzefront-chat-service:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
       - name: Build & push clock-app (built-in MF remote)
         # Built-in reference Module-Federation remote, served same-origin at
         # app.fuzefront.com/apps/clock/. Self-contained Dockerfile => context is clock-app/.
@@ -261,13 +277,14 @@ jobs:
             /repository: ghcr\.io\/izzywdev\/fuzefront-clock-app\r?$/ { hot=1 }
             /repository: ghcr\.io\/izzywdev\/fuzefront-email-service\r?$/ { hot=1 }
             /repository: ghcr\.io\/izzywdev\/fuzefront-sms-service\r?$/ { hot=1 }
+            /repository: ghcr\.io\/izzywdev\/fuzefront-chat-service\r?$/ { hot=1 }
             { print }
             END { print n+0 > "/tmp/bump-count" }
           ' /tmp/vp-current.yaml > /tmp/vp-new.yaml
           # Guard against silent no-ops: if the file layout drifts (quoted
           # values, reordered keys, renamed registry path) the awk matches
           # nothing and we would otherwise "succeed" while deploying stale
-          # tags (review finding). Exactly 7 core-app tags must be rewritten.
+          # tags (review finding). Exactly 8 core-app tags must be rewritten.
           # The anchor list MUST cover every image this workflow BUILDS. It
           # previously listed only 5 while the build steps produced 7: the
           # email-service and sms-service images were built and pushed on every
@@ -277,8 +294,8 @@ jobs:
           # sms-service kept tag "" — i.e. it was NEVER deployed at all. If you
           # add a build step above, add its anchor here AND bump this number.
           COUNT=$(cat /tmp/bump-count)
-          if [ "$COUNT" -ne 7 ]; then
-            echo "::error::expected 7 core-app tag rewrites in ${FILE}, got ${COUNT} — file layout changed; update the bump step"
+          if [ "$COUNT" -ne 8 ]; then
+            echo "::error::expected 8 core-app tag rewrites in ${FILE}, got ${COUNT} — file layout changed; update the bump step"
             exit 1
           fi
           if cmp -s /tmp/vp-current.yaml /tmp/vp-new.yaml; then

--- a/deploy/helm/fuzefront/values-prod.yaml
+++ b/deploy/helm/fuzefront/values-prod.yaml
@@ -407,6 +407,17 @@ litellm:
                 values: ["fuzefront-node-2"]
 
 chatService:
+  # The tag: line MUST stay immediately after repository: — release.yml's GitOps
+  # bump step only rewrites a tag: found on the line directly following a matched
+  # repository: anchor. Seeded with the first SHA this image was built at; every
+  # later release rewrites it.
+  #
+  # chatService.enabled is still false (see values.yaml), so nothing pulls this
+  # yet. Flipping enabled on before an LLM endpoint exists gets you a running pod
+  # that fails every turn — see docs/planning/ai-chat-gap-analysis.md blocker 1.
+  image:
+    repository: ghcr.io/izzywdev/fuzefront-chat-service
+    tag: latest
   affinity:
     nodeAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
## 📋 Description

Blocker 2 of `docs/planning/ai-chat-gap-analysis.md`.

`services/chat-service` was absent from the `release.yml` image matrix, so **no image was ever built or pushed**. And `values-prod.yaml` carried no `chatService.image` block at all, so the default `tag: local` applied. Flipping `chatService.enabled` on today gets you `ImagePullBackOff`.

**This PR does not turn chat on.** `chatService.enabled` stays `false`. The service still has no LLM endpoint — blocker 1, the LiteLLM gateway Argo app deleted in `f7c2ad56` whose chart never landed in FuzeInfra — and *every* chat turn and embedding routes through it (`src/llm/litellm.ts`: *"this client never talks to Anthropic/OpenAI directly"*). This change only makes an image exist, so enabling chat later is a one-line flip instead of a build-pipeline project.

## 🔄 Type of Change

- [x] 🔨 Build system or dependency update
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## 🔧 Implementation Details

### Changes Made

**`.github/workflows/release.yml`**

- New `Build & push chat-service` step mirroring the other services. Build context is the repo **root**, not `services/chat-service/` — the Dockerfile runs `npm ci --workspace=services/chat-service` and needs the root `package.json`/`package-lock.json` plus `shared/`. (That workspace membership only became true in #403; before it the image was unbuildable *independently* of being missing from this matrix.)
- Added the matching anchor to the GitOps bump `awk` and raised the count guard **7 → 8**, per that step's own instruction:

  > If you add a build step above, add its anchor here AND bump this number.

  Without the anchor the image would be built and pushed on every release while `values-prod` stayed frozen — the exact silent failure the guard's comment records for `email-service` and `sms-service`.

**`deploy/helm/fuzefront/values-prod.yaml`**

- Added the `chatService.image` block. `tag:` sits **immediately after** `repository:` because the bump `awk` only rewrites a `tag:` line found directly after a matched repository anchor — a comment between them would silently break it. Seeded with `latest` (the workflow pushes that tag too) until the first release run rewrites it to a SHA.

## 🧪 Testing

- [x] Manual testing (CI-config change; verified by simulating the exact production `awk`)

| Check | Result |
|---|---|
| Simulated bump `awk` against edited `values-prod.yaml` | **exactly 8 rewrites** — matches the guard, new chat-service tag among them |
| `chat-service.yaml` (Deployment) image expr | reads `.Values.chatService.image.repository`/`.tag` → picks up the bump |
| `chat-db-migrate-job.yaml` (pre-upgrade hook) image expr | same → migration Job uses the same image |
| `release.yml` parses as YAML | ✅ |
| `values-prod.yaml` parses as YAML | ✅ |

The count guard is the risky part of this diff — a wrong number kills *every* release — so it was verified by extracting the workflow's `awk` verbatim and running it against the modified file, not by reading it.

## 🚨 Breaking Changes

None. No running service changes: `chatService.enabled` is still `false`, so neither the Deployment nor the migrate Job renders. The only behavioural delta is that each release now also builds and pushes one more image.

## 📝 Additional Notes

### Found while editing the anchor list — NOT fixed here

`billing-service` and `provisioning-service` are **built and pushed** by this workflow and **pinned in `values-prod.yaml`**, but have **no bump anchors** — so their tags are never rewritten and both are frozen at stale SHAs. Cross-check:

| | built by release.yml | has bump anchor | in values-prod |
|---|---|---|---|
| backend, frontend, security, applications, clock-app, email, sms | ✅ | ✅ | ✅ |
| **billing-service** | ✅ | ❌ | ✅ (pinned `6135e6b5ed77`) |
| **provisioning-service** | ✅ | ❌ | ✅ |

This is the same defect the guard comment documents for email/sms, recurring. It is deliberately **not** fixed in this PR: adding those two anchors would move two live services to a new image on the next release, which is a deploy decision to make in a deploy window on purpose — not a side effect of a chat-service PR. Happy to do it as a follow-up.

### Deployment Notes

- [x] Requires dependency updates — no; this only adds an image build
- Nothing to do at deploy time. The next release after merge builds `ghcr.io/izzywdev/fuzefront-chat-service:<sha>` and rewrites the seeded `latest` tag to that SHA.

### Future Work — what still gates a working chat UI

1. **An LLM endpoint** (blocker 1, FuzeInfra) — the only true gate. Either land the LiteLLM chart or decide to point `litellm.ts` at an OpenAI-compatible endpoint directly.
2. Flip `chatService.enabled: true` in `values-prod` — after 1, in a deploy window.
3. Degraded-but-not-blocking: ChromaDB disabled (`agent/loop.ts` treats retrieval failure as non-fatal — answers without citations), Kafka off (billing metering), `REDIS_URL` unset (per-pod in-memory rate limits), shared DB creds instead of a least-privilege `chat_svc` role.

---
_Generated by [Claude Code](https://claude.ai/code/session_018GwoakPmfmvL4ot86LfFeX)_