### PR TITLE
docs(authentik): correct the Mendys silo exposure model — security-service is the front door

### DIFF
--- a/deploy/helm/fuzefront/authentik/blueprints-mendys/README.md
+++ b/deploy/helm/fuzefront/authentik/blueprints-mendys/README.md
@@ -72,20 +72,51 @@ OAuth2 client credential shared by the two sides of the exchange.
 `client_id`/`client_secret` only at provider *creation*; updating the secret
 requires deleting the provider entry and re-applying the blueprint.
 
-## Browser-facing exposure (open decision)
+## Browser-facing exposure — there is none, by design
 
-`authentikMendys.ingress` is **off by default**, matching FuzeFront's posture:
-FuzeFront has no public IdP host — its authentik is ClusterIP-only and reached
-through `app.fuzefront.com/api/auth/idp/*`, so the browser never learns the IdP
-hostname. Two ways to expose this silo, in order of preference:
+**This instance is never reachable from outside FuzeFront's boundary.**
+`authentikMendys.ingress` is off, and it should stay off.
 
-1. **Mirror FuzeFront (preferred).** Add an `/api/auth/idp/*` path to the
-   MendysRobotics ingress in `mendys-prod` proxying to
-   `authentik-mendys-server.<fuzefront-ns>.svc.cluster.local:9000`. Keeps the
-   IdP host invisible. That change belongs to the MendysRobotics repo.
-2. **A public `auth.mendysrobotics.com` host** via `authentikMendys.ingress`.
-   Simpler, but re-introduces the exposed IdP host, so only do this behind
-   Cloudflare Access.
+Authentik is an implementation detail of FuzeFront's **security-service**, which
+is the single front door for every tenant. MendysRobotics does not talk to
+Authentik, does not know its hostname, and holds no Authentik configuration —
+its users reach `live.` / `marketplace.mendysrobotics.com`, those hosts route
+`/api/v1/security/*` and `/api/auth/*` to security-service, and security-service
+drives the correct Authentik instance in-cluster over ClusterIP
+(`authentik-mendys-server:9000`).
+
+This is the module's stated contract, not a new invention — see
+`backend/security/src/providers/authentik/config.ts`: *"no vendor name leaks
+past this boundary into the API surface"* and *"the browser is ALWAYS sent to a
+same-host path … so the browser never sees an internal identity host."*
+
+Consequences for this directory:
+
+- **Password + enrollment** use the **server-side flow driver** — security-service
+  calls Authentik's `/api/v3` flow-executor server-side and issues its own
+  session. The browser never touches Authentik, so no Authentik paths are routed
+  on the Mendys hosts at all (unlike `app.fuzefront.com`, which does route
+  Authentik's native paths).
+- **Social login** uses the **server-brokered** path, which already exists:
+  Google redirects to `/api/v1/security/social/google/callback` on the tenant
+  host — a security-service route — and security-service exchanges the code with
+  Google itself and provisions the account into this silo via the admin API. It
+  must never fall back to Authentik's `/source/oauth/*`, so
+  `securityService.googleBrokered` must be `"true"` for this tenant. It
+  currently defaults to `"false"`.
+- **The issuer is not a MendysRobotics-facing value.** It is internal to
+  security-service. Nothing in the MendysRobotics repo should contain an
+  Authentik URL.
+
+### Not yet true
+
+security-service is currently **single-tenant**: it reads `AUTHENTIK_ISSUER_URL`,
+`AUTHENTIK_BASE_URL`, `AUTHENTIK_CLIENT_ID/SECRET`, `AUTHENTIK_ADMIN_TOKEN` and
+`AUTHENTIK_ENROLLMENT_FLOW_SLUG` directly from `process.env` at ~12 call sites
+across 7 files, each defaulting to FuzeFront (`…/application/o/fuzefront/`,
+`fuzefront-enrollment`). Until it resolves a tenant per request and threads that
+through, **this silo cannot actually serve a login** — the blueprints here are
+correct and inert, waiting on that work.
 
 Either way the issuer is **not** `https://auth.fuzefront.com/application/o/mendys-platform/`
 — that host belongs to the FuzeFront instance, which is a different directory.

--- a/deploy/helm/fuzefront/templates/authentik-mendys.yaml
+++ b/deploy/helm/fuzefront/templates/authentik-mendys.yaml
@@ -288,19 +288,24 @@ spec:
 {{- if $akm.ingress.enabled }}
 ---
 {{- /*
-  PUBLIC IdP HOST — OFF BY DEFAULT, AND THAT DEFAULT IS DELIBERATE.
+  DEBUG ESCAPE HATCH — NOT A PRODUCTION PATH.
 
-  FuzeFront removed its own public `auth.fuzefront.com` Ingress on purpose:
-  its authentik is ClusterIP-only and the sole browser-transitable surface is
-  the reverse-proxied app.fuzefront.com/api/auth/idp/* path, so the browser
-  never learns the IdP hostname. Turning this on for the Mendys silo
-  re-introduces exactly the exposure that boundary exists to prevent.
+  This silo is an implementation detail of FuzeFront's security-service, which
+  is the single front door for every tenant. MendysRobotics users reach
+  live./marketplace.mendysrobotics.com; those hosts route /api/v1/security/*
+  and /api/auth/* to security-service, which drives THIS Authentik in-cluster
+  over ClusterIP. Nothing outside FuzeFront's boundary addresses Authentik —
+  not end-users, not the MendysRobotics apps. See
+  backend/security/src/providers/authentik/config.ts: "no vendor name leaks
+  past this boundary into the API surface".
 
-  Only enable it behind an edge auth gate (Cloudflare Access), or prefer the
-  equivalent of FuzeFront's pattern: a /api/auth/idp/* path on the
-  MendysRobotics ingress in the mendys-prod namespace proxying to
-  authentik-mendys-server.<this-namespace>.svc.cluster.local:9000. That change
-  belongs to the MendysRobotics repo, not this chart.
+  Do NOT reach for Cloudflare Access to make an exposed IdP host safe. A host
+  carrying live OIDC traffic cannot be gated — per templates/ingress.yaml,
+  putting an auth gate in front of the OIDC path "would break sign-in for every
+  user". Access only works on an admin host carrying no OIDC traffic.
+
+  Enable this only for temporary debugging of the instance itself, and turn it
+  back off.
 */}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress

--- a/deploy/helm/fuzefront/values.yaml
+++ b/deploy/helm/fuzefront/values.yaml
@@ -657,13 +657,19 @@ authentikMendys:
   # Fewer web workers than FuzeFront: this silo serves two apps, not the whole
   # platform. Raise if login latency shows queueing.
   webWorkers: 2
-  # Browser-facing exposure. OFF by default, matching authentik.adminIngress:
-  # FuzeFront deliberately has NO public IdP host — its authentik is
-  # ClusterIP-only and reached through app.fuzefront.com/api/auth/idp/*, so the
-  # browser never learns the IdP hostname. Enabling this re-introduces a public
-  # IdP host and is only safe behind an edge auth gate (Cloudflare Access).
-  # See the README note in authentik/blueprints-mendys/ for the alternative
-  # (a reverse-proxy path on the MendysRobotics ingress).
+  # Browser-facing exposure. OFF, and it should STAY off.
+  #
+  # This instance is an implementation detail of FuzeFront's security-service,
+  # which is the single front door for every tenant. MendysRobotics reaches
+  # security-service on its own hosts; security-service drives this Authentik
+  # in-cluster over ClusterIP. Nothing outside FuzeFront's boundary — not
+  # end-users, not the MendysRobotics apps — ever addresses Authentik.
+  #
+  # Do NOT reach for Cloudflare Access to make an exposed IdP host safe: a host
+  # carrying live OIDC traffic cannot be gated. Per templates/ingress.yaml,
+  # putting an auth gate in front of the OIDC path "would break sign-in for
+  # every user". Access is only usable on an admin host carrying no OIDC
+  # traffic. The escape hatch below exists for debugging, not for production.
   ingress:
     enabled: false
     host: "" # e.g. auth.mendysrobotics.com


### PR DESCRIPTION
Follow-up to #428. The exposure guidance that shipped with the MendysRobotics silo was wrong in two ways, one of them actively dangerous.

## 1. Wrong architecture

It framed the browser-facing surface as a choice between exposing `auth.mendysrobotics.com` and proxying Authentik's paths on the MendysRobotics ingress. **Neither is the architecture.**

Authentik is an implementation detail of FuzeFront's **security-service**, which is the single front door for every tenant. MendysRobotics users reach `live.` / `marketplace.mendysrobotics.com`; those hosts route `/api/v1/security/*` and `/api/auth/*` to security-service, and security-service drives the correct Authentik instance in-cluster over ClusterIP. Nothing outside FuzeFront's boundary addresses Authentik — not end-users, not the MendysRobotics apps, which hold no Authentik configuration at all.

This is the module's own stated contract, not a new invention — `backend/security/src/providers/authentik/config.ts`:

> *"no vendor name leaks past this boundary into the API surface"*
> *"the browser is ALWAYS sent to a same-host path … so the browser never sees an internal identity host"*

## 2. Dangerous advice

It said an exposed IdP host is *"only safe behind an edge auth gate (Cloudflare Access)"*. **That is false and would have broken sign-in.** A host carrying live OIDC traffic cannot be gated — `templates/ingress.yaml` already says so:

> *"Putting an auth gate in front of it would break sign-in for every user."*

Access is only usable on an admin host that carries no OIDC traffic. The `authentikMendys.ingress` block is now documented as a debug escape hatch, not a production path.

## Login mechanisms for this tenant, now documented

- **Password + enrollment** → the **server-side flow driver**. security-service calls Authentik's `/api/v3` flow-executor server-side and issues its own session; the browser never touches Authentik, so no Authentik paths are routed on the Mendys hosts at all (unlike `app.fuzefront.com`, which does route them).
- **Social** → the **server-brokered** path, which already exists: Google redirects to `/api/v1/security/social/google/callback` on the tenant host — a security-service route — and security-service exchanges the code with Google itself. It must never fall back to Authentik's `/source/oauth/*`, so `securityService.googleBrokered` must be `"true"` for this tenant. **It currently defaults to `"false"`.**

## What is NOT yet true

Recorded honestly in the README: security-service is **single-tenant**. It reads `AUTHENTIK_ISSUER_URL`, `AUTHENTIK_BASE_URL`, `AUTHENTIK_CLIENT_ID/SECRET`, `AUTHENTIK_ADMIN_TOKEN` and `AUTHENTIK_ENROLLMENT_FLOW_SLUG` straight from `process.env` at ~12 call sites across 7 files, each defaulting to FuzeFront (`…/application/o/fuzefront/`, `fuzefront-enrollment`). **Until it resolves a tenant per request, this silo cannot serve a login** — the blueprints are correct and inert, waiting on that work. Tracked separately.

## Verification

Comments and README only. `helm lint` clean, `kubeconform -strict` 16/16 valid, and the rendered manifests are **byte-identical to the merged state** — no Kubernetes spec change, so this cannot disturb anything running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)