### PR TITLE
fix(ingress)!: disable *.fuzefront.com wildcard — it shadowed plan.fuzefront.com (PROD REGRESSION from #431)

### DIFF
--- a/deploy/helm/fuzefront/values-prod.yaml
+++ b/deploy/helm/fuzefront/values-prod.yaml
@@ -314,15 +314,35 @@ ingress:
   enabled: true
   className: traefik
   host: app.fuzefront.com
-  # Tenant subdomains (FF-EPIC-16). Cloudflare Universal SSL already covers
-  # *.fuzefront.com, and the wildcard proxied CNAME → the existing tunnel is
-  # gated on FuzeInfra's `tenant_wildcard_enabled` Terraform var. Emitting the
-  # rule before that is harmless: with no DNS record nothing resolves here.
+  # Tenant subdomains (FF-EPIC-16) — DISABLED. Do not re-enable on Traefik
+  # without the router-priority fix; see below.
   #
-  # app.fuzefront.com, auth, plan, prod and *.prod.fuzefront.com all keep
-  # winning — exact hosts beat wildcards in both DNS and Ingress matching, so
-  # the admin OTP wall is untouched.
-  wildcardHost: '*.fuzefront.com'
+  # This was set to '*.fuzefront.com' in #431 and IMMEDIATELY BROKE FuzePlan:
+  # plan.fuzefront.com started serving the FuzeFront shell instead of
+  # fuzeplan-frontend. Two wrong assumptions compounded:
+  #
+  #  1. "Nothing resolves here yet." False. The wildcard proxied CNAME already
+  #     existed at Cloudflare, so every *.fuzefront.com host went live the
+  #     moment this rule rendered — there was no DNS gate to wait behind.
+  #  2. "Exact hosts beat wildcards, order does not matter." True for the
+  #     Kubernetes Ingress spec and for ingress-nginx (local), but NOT for
+  #     Traefik, which is what prod runs. Traefik orders routers by RULE
+  #     LENGTH, not host specificity. The generated HostRegexp rule for the
+  #     wildcard is longer than Host(`plan.fuzefront.com`), so the wildcard
+  #     wins and shadows every single-label host in the cluster.
+  #
+  # app.fuzefront.com hid the bug because it fans out to the same backends
+  # either way. plan.fuzefront.com did not.
+  #
+  # *.prod.fuzefront.com hosts (argocd, grafana, authentik-admin, the CF Access
+  # OTP wall, ...) were NEVER at risk — they carry two labels and a k8s
+  # wildcard matches exactly one.
+  #
+  # To re-enable safely: put the wildcard rule in its OWN Ingress object
+  # carrying `traefik.ingress.kubernetes.io/router.priority` set LOW, so every
+  # exact-host router outranks it, and verify against plan.fuzefront.com in a
+  # deploy window before trusting it.
+  wildcardHost: ''
   annotations: {}
   tls:
     enabled: false


### PR DESCRIPTION
## Prod regression, mine, from #431

`plan.fuzefront.com` is currently serving the **FuzeFront shell** instead of FuzePlan.

Verified in-cluster:
- `fuzeplan-frontend` (ClusterIP, probed from inside the namespace) returns `<title>FuzePlan</title>`
- `https://plan.fuzefront.com/` returns `<title>FuzeFront — Runtime Microfrontend Platform</title>`, **byte-identical** to `app.fuzefront.com`

## Two wrong assumptions, each hiding the other

**1. "With no DNS record nothing resolves here."**

False. The wildcard proxied CNAME already existed at Cloudflare, so every `*.fuzefront.com` host went live the moment the rule rendered. There was no DNS gate to wait behind:

```
tenant-probe.fuzefront.com   /  200   /api/health  200
corpabc.fuzefront.com        /  200   /api/health  200
```

**2. "Exact hosts beat wildcards, order does not matter."**

True for the Kubernetes Ingress spec and for **ingress-nginx** — which is what `values-local.yaml` uses, so it validated cleanly locally. **Not** true for **Traefik**, which is what prod runs: Traefik orders routers by *rule length*, not host specificity. The generated `HostRegexp` for the wildcard is longer than the exact `Host(...)` rule for `plan.fuzefront.com`, so it outranks it and shadows every single-label host.

`app.fuzefront.com` masked the bug because it fans out to the same backends either way. `plan.fuzefront.com` is a different app, so it did not.

## Blast radius — bounded, and checked rather than assumed

I enumerated every Ingress host in the cluster. `plan.fuzefront.com` was the **only** single-label host besides `app.fuzefront.com`.

**Not affected:** every `*.prod.fuzefront.com` host — argocd, grafana, prometheus, kafka-ui, neo4j, authentik-admin and the Cloudflare Access OTP wall. Those carry two labels, and a Kubernetes wildcard host matches exactly one. The admin surface was never exposed.

## What this does

Sets `ingress.wildcardHost: ''` in `values-prod.yaml`, restoring the known-good single-rule Ingress:

```
hosts: ['app.fuzefront.com']   rule count: 1   paths: 8
helm lint: 0 charts failed
```

The chart mechanism (fanout helper + YAML anchor + `wildcardHost`) is **retained** and still renders for local (`*.fuzefront.local` on nginx).

## Re-enabling later

The wildcard needs its **own Ingress object** with `traefik.ingress.kubernetes.io/router.priority` set low so exact-host routers outrank it — plus a verification against `plan.fuzefront.com` before it is trusted. Deliberately not attempted in this PR: prod is wrong right now, and the restore should not wait on a change that can only be verified after deploying it.

Refs #431, FFRNT-91.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
