### PR TITLE
fix(chart): restore the authentik-mendys secret keys dropped from secret.yaml

### DIFF
--- a/deploy/helm/fuzefront/templates/secret.yaml
+++ b/deploy/helm/fuzefront/templates/secret.yaml
@@ -86,4 +86,25 @@ stringData:
   # Read at blueprint-apply time via !Env [AUTHENTIK_MENDYS_PLATFORM_CLIENT_SECRET].
   MENDYS_PLATFORM_CLIENT_SECRET: {{ .Values.secret.mendysPlatformClientSecret | trim | quote }}
   {{- end }}
+  {{- if .Values.authentikMendys.enabled }}
+  # ── MendysRobotics Authentik instance (isolated identity silo) ──────────────
+  # templates/authentik-mendys.yaml mounts all four of these as NON-OPTIONAL
+  # secretKeyRefs. If this block is missing while authentikMendys.enabled is
+  # true, both pods fail with CreateContainerConfigError — so these keys and
+  # that template must be added and removed together.
+  #
+  # These are per-instance credentials and MUST NOT be shared with the
+  # FuzeFront instance: reusing AUTHENTIK_SECRET_KEY across two instances would
+  # make sessions and tokens minted by one verifiable by the other, collapsing
+  # the account boundary the separate instance exists to create.
+  AUTHENTIK_MENDYS_SECRET_KEY: {{ .Values.secret.authentikMendysSecretKey | trim | quote }}
+  AUTHENTIK_MENDYS_BOOTSTRAP_PASSWORD: {{ .Values.secret.authentikMendysBootstrapPassword | quote }}
+  AUTHENTIK_MENDYS_BOOTSTRAP_TOKEN: {{ .Values.secret.authentikMendysBootstrapToken | trim | quote }}
+  # Password for the `authentik_mendys_user` Postgres role. FuzeInfra's
+  # `fuzeinfra-service-db-provision` Job (values entry `authentik-mendys`)
+  # (re)syncs the role to this same value, read from the
+  # `authentik-mendys-db-credentials` Secret sealed for the fuzeinfra
+  # namespace — the two must match or the instance cannot connect.
+  AUTHENTIK_MENDYS_DB_PASSWORD: {{ .Values.secret.authentikMendysDbPassword | trim | quote }}
+  {{- end }}
 {{- end }}


### PR DESCRIPTION
`templates/authentik-mendys.yaml` mounts four **non-optional** `secretKeyRef`s that `templates/secret.yaml` on `master` no longer creates:

- `AUTHENTIK_MENDYS_SECRET_KEY`
- `AUTHENTIK_MENDYS_DB_PASSWORD`
- `AUTHENTIK_MENDYS_BOOTSTRAP_PASSWORD`
- `AUTHENTIK_MENDYS_BOOTSTRAP_TOKEN`

Rendering with `authentikMendys.enabled=true` produces **8 unresolved non-optional secret references** (4 keys × server + worker). Both pods would fail with `CreateContainerConfigError`.

## Latent, not live

The gate is off, so nothing is deployed and nothing is broken right now. It would have failed the moment someone first enabled the silo — which is the worst possible time to find out.

## How it happened

The keys were part of #428, which added the instance. `values.yaml` still carries both the `authentikMendys:` block and all four `secret.authentikMendys*` values, and the instance template is intact — **only this one stanza went missing**, and the comments on the two neighbouring client-secret entries were rewritten at the same time. That points at a conflict resolution over that region of the file rather than a deliberate removal.

Worth a glance at whatever else merged into that file recently, in case anything else was lost the same way.

## Verification

Rather than eyeballing it, I cross-checked **every** `secretKeyRef` in the rendered chart against the keys the chart actually creates:

| | unresolved non-optional refs |
|---|---|
| `master` as merged | **8** |
| with this fix | **0** |

Also adds a comment tying the two files together so they are added and removed as a pair.

Related: #428 (added the instance), #433 (exposure docs), #434 (the broker work that makes the silo usable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)