### PR TITLE
feat(security): multi-tenant identity registry, host resolution and tenant context (#434 stage 1)

### DIFF
--- a/backend/security/src/middleware/tenant-context.ts
+++ b/backend/security/src/middleware/tenant-context.ts
@@ -1,0 +1,91 @@
+/**
+ * Resolves the identity tenant for an inbound request and makes it the ambient
+ * tenant for everything downstream.
+ *
+ * security-service fronts several tenants, each backed by its own Authentik
+ * instance and therefore its own account directory. The request host is what
+ * distinguishes them, so this middleware must run BEFORE any handler that
+ * touches identity.
+ *
+ * FAIL CLOSED. If no tenant claims the host, the request is rejected — it is
+ * never served by "the first" or "the default" tenant. Falling back would
+ * authenticate the user against the wrong directory, silently rejoining two
+ * directories that are deliberately separate. That is the exact failure this
+ * design exists to prevent, so it is worth a hard 400.
+ *
+ * In legacy single-tenant mode (`SECURITY_TENANTS` unset) resolution always
+ * succeeds, so mounting this is a no-op for existing deployments.
+ */
+import { NextFunction, Request, Response } from 'express'
+import { logger } from '../lib/logger'
+import {
+  AuthentikTenant,
+  isMultiTenant,
+  normaliseHost,
+  resolveTenantByHost,
+  runWithTenant,
+} from '../providers/authentik/tenants'
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace Express {
+    interface Request {
+      /** The identity tenant serving this request. Set by tenantContext. */
+      identityTenant?: AuthentikTenant
+    }
+  }
+}
+
+/**
+ * Prefer Express's `req.hostname`, which already honours the trust-proxy
+ * setting, and fall back to the raw Host header. X-Forwarded-Host is NOT read
+ * directly: behind the ingress it is caller-supplied, and letting it pick the
+ * tenant would let a client choose which directory to authenticate against.
+ */
+function requestHost(req: Request): string {
+  return normaliseHost(req.hostname || req.headers.host)
+}
+
+export function tenantContext(req: Request, res: Response, next: NextFunction): void {
+  const host = requestHost(req)
+  const tenant = resolveTenantByHost(host)
+
+  if (!tenant) {
+    logger.warn({ host, path: req.path }, 'tenant: rejected request from unclaimed host')
+    res.status(400).json({
+      error: 'unknown_host',
+      message: 'This host is not configured for authentication.',
+    })
+    return
+  }
+
+  req.identityTenant = tenant
+  // Bind for the remainder of the request so code far from the route — which
+  // cannot reasonably take a tenant parameter — reads the right configuration.
+  runWithTenant(tenant, () => next())
+}
+
+/**
+ * Assert that a session/token minted for `tokenTenantId` is being presented to
+ * the tenant that issued it. A session is only valid within its own directory;
+ * accepting one across tenants would let an account in one silo act in another.
+ */
+export function assertTenantMatches(
+  req: Request,
+  tokenTenantId: string | undefined
+): { ok: true } | { ok: false; reason: string } {
+  const expected = req.identityTenant?.id
+  if (!expected) return { ok: false, reason: 'no tenant context on request' }
+
+  if (!tokenTenantId) {
+    // Sessions minted before tenancy existed carry no tenant claim. Accept them
+    // only while single-tenant, where there is nothing to confuse them with.
+    if (!isMultiTenant()) return { ok: true }
+    return { ok: false, reason: 'token carries no tenant claim' }
+  }
+
+  if (tokenTenantId !== expected) {
+    return { ok: false, reason: `token is for tenant "${tokenTenantId}", host serves "${expected}"` }
+  }
+  return { ok: true }
+}

--- a/backend/security/src/providers/authentik/config.ts
+++ b/backend/security/src/providers/authentik/config.ts
@@ -1,13 +1,20 @@
 /**
  * Server-only configuration for the Authentik-backed identity provider.
  *
- * Everything here is env-driven and lives ONLY inside the concrete provider
- * implementation — no vendor name leaks past this boundary into the API surface.
+ * Everything here lives ONLY inside the concrete provider implementation — no
+ * vendor name leaks past this boundary into the API surface.
+ *
+ * Tenant-dependent values are read from the ambient tenant (see tenants.ts),
+ * NOT from process.env, because security-service fronts several tenants and
+ * each is backed by its own Authentik instance and account directory. In legacy
+ * single-tenant mode the ambient tenant is synthesised from the same env vars
+ * these functions used to read, so behaviour is unchanged.
  */
+import { currentTenant } from './tenants'
 
-/** App base origin the browser talks to (same-origin API base). */
+/** App base origin the browser talks to (same-origin API base), per tenant. */
 export function appBaseUrl(): string {
-  return (process.env.FRONTEND_URL || 'http://fuzefront.dev.local').replace(/\/$/, '')
+  return currentTenant('appBaseUrl').appBaseUrl
 }
 
 /**
@@ -47,12 +54,15 @@ export function googleCallbackPath(): string {
 }
 
 /**
- * Whether the SERVER-BROKERED Google path is active (default ON). Set
- * `SECURITY_GOOGLE_BROKERED=false` to fall back to the legacy Authentik
- * `/source/oauth/*` source-redirect path while the brokered path is being proven.
+ * Whether the SERVER-BROKERED Google path is active for the current tenant
+ * (default ON). The fallback is Authentik's `/source/oauth/*` source-redirect,
+ * which sends the BROWSER to Authentik — acceptable for FuzeFront, whose
+ * Authentik paths are routed under its own app host, but NOT for a tenant whose
+ * whole premise is that Authentik is invisible to it. Such a tenant must set
+ * `googleBrokered: true` and keep it there.
  */
 export function googleBrokeredEnabled(): boolean {
-  return process.env.SECURITY_GOOGLE_BROKERED !== 'false'
+  return currentTenant('googleBrokered').googleBrokered
 }
 
 /** Session token lifetime (ms). */

--- a/backend/security/src/providers/authentik/tenants.ts
+++ b/backend/security/src/providers/authentik/tenants.ts
@@ -1,0 +1,280 @@
+/**
+ * Multi-tenant registry for the Authentik-backed identity provider.
+ *
+ * security-service is the single front door for identity across every tenant;
+ * Authentik is an implementation detail behind it (see config.ts — "no vendor
+ * name leaks past this boundary into the API surface"). Each tenant is backed
+ * by its OWN Authentik instance with its own database, so two tenants' account
+ * directories are unrelated: an account in one cannot sign in to the other, and
+ * the same email may exist independently in both.
+ *
+ * This module owns the mapping from an inbound request host to the Authentik
+ * instance that serves it. Nothing else in the service should read
+ * `process.env.AUTHENTIK_*` directly.
+ *
+ * ── Two modes, and why ───────────────────────────────────────────────────────
+ *
+ * LEGACY (default, `SECURITY_TENANTS` unset): a single tenant is synthesised
+ * from the existing `AUTHENTIK_*` environment variables and serves EVERY host.
+ * This reproduces today's single-tenant behaviour exactly — deployments that
+ * have not opted in see no change whatsoever.
+ *
+ * MULTI (`SECURITY_TENANTS` set): hosts are matched against the declared
+ * tenants and an unknown host is REJECTED. The fail-closed rule deliberately
+ * engages only in this mode. Applying it in legacy mode would break FuzeFront
+ * immediately, because requests legitimately arrive on many hosts there
+ * (app.fuzefront.com, fuzefront.dev.local, localhost, in-cluster service DNS).
+ * Once you declare tenants you are asserting the full host list, and at that
+ * point silently falling back to the first tenant would authenticate a user
+ * against the WRONG directory — which is the one failure this whole split
+ * exists to prevent. So: no fallback, no "default tenant", reject.
+ */
+import { AsyncLocalStorage } from 'node:async_hooks'
+
+export interface AuthentikTenant {
+  /** Stable identifier. Embedded in sessions, so changing one invalidates them. */
+  id: string
+  /** Hosts this tenant serves. Compared case-insensitively, port stripped. */
+  hosts: string[]
+  /** Browser-facing issuer used for OIDC discovery. */
+  issuerUrl: string
+  /** In-cluster base for server-side calls (token/userinfo/jwks/flow-executor). */
+  baseUrl: string
+  clientId: string
+  clientSecret: string
+  redirectUri: string
+  /** Admin API token for server-side account operations. */
+  adminToken: string
+  /** Enrollment flow slug inside THIS tenant's Authentik. */
+  enrollmentFlowSlug: string
+  /** Origin the browser talks to for this tenant (same-origin API base). */
+  appBaseUrl: string
+  /** Whether the server-brokered social path is active for this tenant. */
+  googleBrokered: boolean
+}
+
+/** Thrown when a request arrives on a host no tenant claims (MULTI mode). */
+export class UnknownTenantHostError extends Error {
+  readonly host: string
+  constructor(host: string) {
+    super(`No identity tenant is configured for host "${host}"`)
+    this.name = 'UnknownTenantHostError'
+    this.host = host
+  }
+}
+
+/** Thrown when tenant-scoped config is read with no tenant in context. */
+export class NoTenantContextError extends Error {
+  constructor(what: string) {
+    super(
+      `${what} was read outside a tenant context. Wrap non-request callers in ` +
+        `runWithTenant(tenant, fn); request paths get this from tenantContext middleware.`
+    )
+    this.name = 'NoTenantContextError'
+  }
+}
+
+/**
+ * Normalise a Host header for comparison: lowercase, strip the port, strip a
+ * trailing dot (fully-qualified form), strip IPv6 brackets. `Host` is
+ * attacker-influenced, so it is only ever used to LOOK UP a declared tenant —
+ * never to construct a URL we then call.
+ */
+export function normaliseHost(host: string | undefined | null): string {
+  if (!host) return ''
+  let h = host.trim().toLowerCase()
+  if (h.startsWith('[')) {
+    const end = h.indexOf(']')
+    if (end !== -1) return h.slice(1, end)
+  }
+  const colon = h.lastIndexOf(':')
+  if (colon !== -1 && !h.slice(colon + 1).includes(':')) h = h.slice(0, colon)
+  if (h.endsWith('.')) h = h.slice(0, -1)
+  return h
+}
+
+function envHost(url: string | undefined): string[] {
+  if (!url) return []
+  try {
+    return [normaliseHost(new URL(url).host)].filter(Boolean)
+  } catch {
+    return []
+  }
+}
+
+/** Build the implicit single tenant from the pre-multi-tenant env vars. */
+function legacyTenant(): AuthentikTenant {
+  const appBase = (process.env.FRONTEND_URL || 'http://fuzefront.dev.local').replace(/\/$/, '')
+  return {
+    id: process.env.SECURITY_TENANT_ID || 'fuzefront',
+    hosts: envHost(appBase),
+    issuerUrl:
+      process.env.AUTHENTIK_ISSUER_URL || 'http://localhost:9000/application/o/fuzefront/',
+    baseUrl: (process.env.AUTHENTIK_BASE_URL || '').replace(/\/$/, ''),
+    clientId: process.env.AUTHENTIK_CLIENT_ID || '',
+    clientSecret: process.env.AUTHENTIK_CLIENT_SECRET || '',
+    redirectUri:
+      process.env.AUTHENTIK_REDIRECT_URI || 'http://fuzefront.dev.local/api/auth/oidc/callback',
+    adminToken: process.env.AUTHENTIK_ADMIN_TOKEN || '',
+    enrollmentFlowSlug: process.env.AUTHENTIK_ENROLLMENT_FLOW_SLUG || 'fuzefront-enrollment',
+    appBaseUrl: appBase,
+    googleBrokered: process.env.SECURITY_GOOGLE_BROKERED !== 'false',
+  }
+}
+
+interface RawTenant extends Partial<AuthentikTenant> {
+  id?: string
+  hosts?: string[]
+}
+
+function requireField(raw: RawTenant, field: keyof AuthentikTenant, index: number): string {
+  const v = raw[field]
+  if (typeof v !== 'string' || v.trim() === '') {
+    throw new Error(
+      `SECURITY_TENANTS[${index}] (${raw.id ?? 'unnamed'}): "${field}" is required and must be a non-empty string`
+    )
+  }
+  return v
+}
+
+function parseTenants(json: string): AuthentikTenant[] {
+  let raw: unknown
+  try {
+    raw = JSON.parse(json)
+  } catch (e) {
+    throw new Error(`SECURITY_TENANTS is not valid JSON: ${(e as Error).message}`)
+  }
+  if (!Array.isArray(raw) || raw.length === 0) {
+    throw new Error('SECURITY_TENANTS must be a non-empty JSON array of tenant objects')
+  }
+
+  const tenants = (raw as RawTenant[]).map((t, i) => {
+    const hosts = Array.isArray(t.hosts) ? t.hosts.map(normaliseHost).filter(Boolean) : []
+    if (hosts.length === 0) {
+      throw new Error(
+        `SECURITY_TENANTS[${i}] (${t.id ?? 'unnamed'}): "hosts" must list at least one host`
+      )
+    }
+    return {
+      id: requireField(t, 'id', i),
+      hosts,
+      issuerUrl: requireField(t, 'issuerUrl', i),
+      baseUrl: (t.baseUrl || '').replace(/\/$/, ''),
+      clientId: requireField(t, 'clientId', i),
+      clientSecret: t.clientSecret ?? '',
+      redirectUri: requireField(t, 'redirectUri', i),
+      adminToken: t.adminToken ?? '',
+      enrollmentFlowSlug: requireField(t, 'enrollmentFlowSlug', i),
+      appBaseUrl: requireField(t, 'appBaseUrl', i).replace(/\/$/, ''),
+      googleBrokered: t.googleBrokered !== false,
+    } as AuthentikTenant
+  })
+
+  // Reject collisions at BOOT rather than letting whichever tenant happens to
+  // be first silently win a host at request time.
+  const byHost = new Map<string, string>()
+  const byId = new Set<string>()
+  for (const t of tenants) {
+    if (byId.has(t.id)) throw new Error(`SECURITY_TENANTS: duplicate tenant id "${t.id}"`)
+    byId.add(t.id)
+    for (const h of t.hosts) {
+      const owner = byHost.get(h)
+      if (owner) {
+        throw new Error(
+          `SECURITY_TENANTS: host "${h}" is claimed by both "${owner}" and "${t.id}"`
+        )
+      }
+      byHost.set(h, t.id)
+    }
+  }
+  return tenants
+}
+
+let cached: { tenants: AuthentikTenant[]; multi: boolean; byHost: Map<string, AuthentikTenant> } | null =
+  null
+
+function registry() {
+  const json = process.env.SECURITY_TENANTS
+  const multi = typeof json === 'string' && json.trim() !== ''
+
+  // LEGACY mode is rebuilt from the environment on EVERY read, deliberately.
+  // The functions this replaces (appBaseUrl, googleBrokeredEnabled, …) each
+  // read process.env per call, so anything mutating the environment after boot
+  // — notably tests — saw the new value immediately. Memoising would silently
+  // change that for every existing deployment, which is precisely what legacy
+  // mode exists to avoid. Rebuilding one small object is not worth caching.
+  if (!multi) {
+    const tenant = legacyTenant()
+    const byHost = new Map<string, AuthentikTenant>()
+    for (const h of tenant.hosts) byHost.set(h, tenant)
+    return { tenants: [tenant], multi: false, byHost }
+  }
+
+  // MULTI mode IS memoised: SECURITY_TENANTS is static configuration, so
+  // re-parsing and re-validating per call would be waste, and caching makes the
+  // boot-time validation errors surface once rather than on every request.
+  if (cached) return cached
+  const tenants = parseTenants(json as string)
+  const byHost = new Map<string, AuthentikTenant>()
+  for (const t of tenants) for (const h of t.hosts) byHost.set(h, t)
+  cached = { tenants, multi: true, byHost }
+  return cached
+}
+
+/** Drop the memoised registry. Tests only — config is read once at boot. */
+export function resetTenantRegistryForTests(): void {
+  cached = null
+}
+
+export function isMultiTenant(): boolean {
+  return registry().multi
+}
+
+export function allTenants(): AuthentikTenant[] {
+  return registry().tenants
+}
+
+export function getTenantById(id: string): AuthentikTenant | undefined {
+  return registry().tenants.find((t) => t.id === id)
+}
+
+/**
+ * Resolve the tenant serving `host`.
+ *
+ * LEGACY mode: always the single tenant, whatever the host — today's behaviour.
+ * MULTI mode: exact host match, or `undefined`. Callers MUST treat `undefined`
+ * as a rejection and must not substitute a default.
+ */
+export function resolveTenantByHost(host: string | undefined | null): AuthentikTenant | undefined {
+  const reg = registry()
+  if (!reg.multi) return reg.tenants[0]
+  return reg.byHost.get(normaliseHost(host))
+}
+
+const tenantStore = new AsyncLocalStorage<AuthentikTenant>()
+
+/**
+ * Run `fn` with `tenant` as the ambient tenant. Required for callers with no
+ * HTTP request — provisioning scripts, seed jobs, Kafka consumers — which
+ * cannot inherit a request-scoped value.
+ */
+export function runWithTenant<T>(tenant: AuthentikTenant, fn: () => T): T {
+  return tenantStore.run(tenant, fn)
+}
+
+/** The ambient tenant, or `undefined` outside any tenant context. */
+export function currentTenantOrUndefined(): AuthentikTenant | undefined {
+  const t = tenantStore.getStore()
+  if (t) return t
+  // In legacy mode there is exactly one tenant and it serves everything, so
+  // ambient context is unnecessary. In MULTI mode, absence is a real error.
+  const reg = registry()
+  return reg.multi ? undefined : reg.tenants[0]
+}
+
+/** The ambient tenant. Throws rather than guessing. */
+export function currentTenant(what = 'Tenant configuration'): AuthentikTenant {
+  const t = currentTenantOrUndefined()
+  if (!t) throw new NoTenantContextError(what)
+  return t
+}

--- a/backend/security/tests/tenant-registry.test.ts
+++ b/backend/security/tests/tenant-registry.test.ts
@@ -1,0 +1,286 @@
+/**
+ * Tests for the multi-tenant identity registry.
+ *
+ * The claims under test are security claims, not conveniences:
+ *   1. Legacy mode reproduces the pre-tenancy configuration EXACTLY, so
+ *      existing FuzeFront deployments are untouched.
+ *   2. In multi-tenant mode an unclaimed host is REJECTED — never served by a
+ *      default tenant, which would authenticate a user against the wrong
+ *      account directory.
+ *   3. A session minted for one tenant is not accepted by another.
+ */
+import {
+  NoTenantContextError,
+  allTenants,
+  currentTenant,
+  currentTenantOrUndefined,
+  isMultiTenant,
+  normaliseHost,
+  resetTenantRegistryForTests,
+  resolveTenantByHost,
+  runWithTenant,
+} from '../src/providers/authentik/tenants'
+import { assertTenantMatches } from '../src/middleware/tenant-context'
+
+const ENV_KEYS = [
+  'SECURITY_TENANTS',
+  'SECURITY_TENANT_ID',
+  'FRONTEND_URL',
+  'AUTHENTIK_ISSUER_URL',
+  'AUTHENTIK_BASE_URL',
+  'AUTHENTIK_CLIENT_ID',
+  'AUTHENTIK_CLIENT_SECRET',
+  'AUTHENTIK_REDIRECT_URI',
+  'AUTHENTIK_ADMIN_TOKEN',
+  'AUTHENTIK_ENROLLMENT_FLOW_SLUG',
+  'SECURITY_GOOGLE_BROKERED',
+]
+
+let saved: Record<string, string | undefined>
+
+beforeEach(() => {
+  saved = {}
+  for (const k of ENV_KEYS) {
+    saved[k] = process.env[k]
+    delete process.env[k]
+  }
+  resetTenantRegistryForTests()
+})
+
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (saved[k] === undefined) delete process.env[k]
+    else process.env[k] = saved[k]
+  }
+  resetTenantRegistryForTests()
+})
+
+const TWO_TENANTS = JSON.stringify([
+  {
+    id: 'fuzefront',
+    hosts: ['app.fuzefront.com'],
+    issuerUrl: 'https://app.fuzefront.com/application/o/fuzefront/',
+    baseUrl: 'http://authentik-server:9000',
+    clientId: 'fuzefront-oidc-client',
+    clientSecret: 'ff-secret',
+    redirectUri: 'https://app.fuzefront.com/api/auth/oidc/callback',
+    adminToken: 'ff-admin',
+    enrollmentFlowSlug: 'fuzefront-enrollment',
+    appBaseUrl: 'https://app.fuzefront.com',
+  },
+  {
+    id: 'mendys',
+    hosts: ['live.mendysrobotics.com', 'marketplace.mendysrobotics.com'],
+    issuerUrl: 'https://live.mendysrobotics.com/application/o/mendys-platform/',
+    baseUrl: 'http://authentik-mendys-server:9000',
+    clientId: 'mendys-platform-oidc-client',
+    clientSecret: 'mendys-secret',
+    redirectUri: 'https://live.mendysrobotics.com/api/auth/oidc/callback',
+    adminToken: 'mendys-admin',
+    enrollmentFlowSlug: 'mendys-enrollment',
+    appBaseUrl: 'https://live.mendysrobotics.com',
+    googleBrokered: true,
+  },
+])
+
+describe('legacy (single-tenant) mode', () => {
+  it('is the default when SECURITY_TENANTS is unset', () => {
+    expect(isMultiTenant()).toBe(false)
+    expect(allTenants()).toHaveLength(1)
+  })
+
+  it('reproduces the pre-tenancy env configuration exactly', () => {
+    process.env.FRONTEND_URL = 'https://app.fuzefront.com'
+    process.env.AUTHENTIK_ISSUER_URL = 'https://app.fuzefront.com/application/o/fuzefront/'
+    process.env.AUTHENTIK_BASE_URL = 'http://authentik-server:9000'
+    process.env.AUTHENTIK_CLIENT_ID = 'fuzefront-oidc-client'
+    process.env.AUTHENTIK_CLIENT_SECRET = 'shh'
+    process.env.AUTHENTIK_ADMIN_TOKEN = 'admin-token'
+    resetTenantRegistryForTests()
+
+    const t = allTenants()[0]
+    expect(t.id).toBe('fuzefront')
+    expect(t.issuerUrl).toBe('https://app.fuzefront.com/application/o/fuzefront/')
+    expect(t.baseUrl).toBe('http://authentik-server:9000')
+    expect(t.clientId).toBe('fuzefront-oidc-client')
+    expect(t.clientSecret).toBe('shh')
+    expect(t.adminToken).toBe('admin-token')
+    // Unset -> the same defaults the old process.env reads used.
+    expect(t.enrollmentFlowSlug).toBe('fuzefront-enrollment')
+    expect(t.googleBrokered).toBe(true)
+  })
+
+  it('honours SECURITY_GOOGLE_BROKERED=false exactly as before', () => {
+    process.env.SECURITY_GOOGLE_BROKERED = 'false'
+    resetTenantRegistryForTests()
+    expect(allTenants()[0].googleBrokered).toBe(false)
+  })
+
+  it('serves EVERY host, including ones it does not name', () => {
+    process.env.FRONTEND_URL = 'https://app.fuzefront.com'
+    resetTenantRegistryForTests()
+    // Requests legitimately arrive on many hosts in a single-tenant deployment
+    // (dev hostnames, localhost, in-cluster service DNS). Failing closed here
+    // would break FuzeFront, so legacy mode must not.
+    for (const h of ['app.fuzefront.com', 'fuzefront.dev.local', 'localhost', 'security-service']) {
+      expect(resolveTenantByHost(h)?.id).toBe('fuzefront')
+    }
+  })
+
+  it('provides an ambient tenant without middleware', () => {
+    expect(currentTenantOrUndefined()).toBeDefined()
+    expect(() => currentTenant()).not.toThrow()
+  })
+
+  // The functions this registry replaces each read process.env per call, so a
+  // late environment change took effect immediately. Memoising legacy mode
+  // would silently break that for every existing deployment (and for tests
+  // that set env in beforeEach), so it must NOT be cached.
+  it('re-reads the environment on every call, with no memoisation', () => {
+    process.env.FRONTEND_URL = 'https://first.example.com'
+    expect(allTenants()[0].appBaseUrl).toBe('https://first.example.com')
+
+    // Changed AFTER the first read, and deliberately without resetting.
+    process.env.FRONTEND_URL = 'https://second.example.com'
+    expect(allTenants()[0].appBaseUrl).toBe('https://second.example.com')
+
+    process.env.SECURITY_GOOGLE_BROKERED = 'false'
+    expect(allTenants()[0].googleBrokered).toBe(false)
+  })
+})
+
+describe('multi-tenant mode', () => {
+  beforeEach(() => {
+    process.env.SECURITY_TENANTS = TWO_TENANTS
+    resetTenantRegistryForTests()
+  })
+
+  it('routes each declared host to its own tenant', () => {
+    expect(resolveTenantByHost('app.fuzefront.com')?.id).toBe('fuzefront')
+    expect(resolveTenantByHost('live.mendysrobotics.com')?.id).toBe('mendys')
+    expect(resolveTenantByHost('marketplace.mendysrobotics.com')?.id).toBe('mendys')
+  })
+
+  it('matches hosts case-insensitively and ignores the port', () => {
+    expect(resolveTenantByHost('LIVE.MendysRobotics.com:443')?.id).toBe('mendys')
+  })
+
+  // THE central guarantee.
+  it('REJECTS an unclaimed host instead of falling back to a default tenant', () => {
+    expect(resolveTenantByHost('evil.example.com')).toBeUndefined()
+    expect(resolveTenantByHost('')).toBeUndefined()
+    expect(resolveTenantByHost(undefined)).toBeUndefined()
+    // Specifically: not the first tenant.
+    expect(resolveTenantByHost('unknown.host')?.id).not.toBe('fuzefront')
+  })
+
+  it('gives each tenant a DIFFERENT Authentik instance', () => {
+    const ff = resolveTenantByHost('app.fuzefront.com')!
+    const me = resolveTenantByHost('live.mendysrobotics.com')!
+    expect(me.baseUrl).not.toBe(ff.baseUrl)
+    expect(me.issuerUrl).not.toBe(ff.issuerUrl)
+    expect(me.clientId).not.toBe(ff.clientId)
+    expect(me.enrollmentFlowSlug).not.toBe(ff.enrollmentFlowSlug)
+  })
+
+  it('throws rather than guessing when read outside a tenant context', () => {
+    expect(currentTenantOrUndefined()).toBeUndefined()
+    expect(() => currentTenant()).toThrow(NoTenantContextError)
+  })
+
+  it('binds the ambient tenant inside runWithTenant', () => {
+    const me = resolveTenantByHost('live.mendysrobotics.com')!
+    runWithTenant(me, () => {
+      expect(currentTenant().id).toBe('mendys')
+    })
+    expect(currentTenantOrUndefined()).toBeUndefined()
+  })
+})
+
+describe('registry validation at boot', () => {
+  const load = (v: unknown) => {
+    process.env.SECURITY_TENANTS = typeof v === 'string' ? v : JSON.stringify(v)
+    resetTenantRegistryForTests()
+    return () => allTenants()
+  }
+
+  it('rejects two tenants claiming the same host', () => {
+    const dup = JSON.parse(TWO_TENANTS)
+    dup[1].hosts = ['app.fuzefront.com']
+    expect(load(dup)).toThrow(/claimed by both/)
+  })
+
+  it('rejects duplicate tenant ids', () => {
+    const dup = JSON.parse(TWO_TENANTS)
+    dup[1].id = 'fuzefront'
+    expect(load(dup)).toThrow(/duplicate tenant id/)
+  })
+
+  it('rejects a tenant with no hosts', () => {
+    const bad = JSON.parse(TWO_TENANTS)
+    bad[1].hosts = []
+    expect(load(bad)).toThrow(/must list at least one host/)
+  })
+
+  it('rejects a tenant missing a required field', () => {
+    const bad = JSON.parse(TWO_TENANTS)
+    delete bad[1].issuerUrl
+    expect(load(bad)).toThrow(/"issuerUrl" is required/)
+  })
+
+  it('rejects malformed JSON and empty arrays', () => {
+    expect(load('{not json')).toThrow(/not valid JSON/)
+    expect(load([])).toThrow(/non-empty JSON array/)
+  })
+})
+
+describe('normaliseHost', () => {
+  it.each([
+    ['App.FuzeFront.com', 'app.fuzefront.com'],
+    ['app.fuzefront.com:8443', 'app.fuzefront.com'],
+    ['app.fuzefront.com.', 'app.fuzefront.com'],
+    ['[::1]:9000', '::1'],
+    ['  APP.fuzefront.com  ', 'app.fuzefront.com'],
+    [undefined, ''],
+  ])('%s -> %s', (input, expected) => {
+    expect(normaliseHost(input as string | undefined)).toBe(expected)
+  })
+})
+
+describe('cross-tenant session rejection', () => {
+  beforeEach(() => {
+    process.env.SECURITY_TENANTS = TWO_TENANTS
+    resetTenantRegistryForTests()
+  })
+
+  const reqFor = (host: string) => ({ identityTenant: resolveTenantByHost(host) }) as never
+
+  it('accepts a session presented to its own tenant', () => {
+    expect(assertTenantMatches(reqFor('live.mendysrobotics.com'), 'mendys')).toEqual({ ok: true })
+  })
+
+  // THE central guarantee: an account in one silo cannot act in another.
+  it('REJECTS a session minted for another tenant', () => {
+    const r = assertTenantMatches(reqFor('app.fuzefront.com'), 'mendys')
+    expect(r.ok).toBe(false)
+    const r2 = assertTenantMatches(reqFor('live.mendysrobotics.com'), 'fuzefront')
+    expect(r2.ok).toBe(false)
+  })
+
+  it('rejects a claimless token in multi-tenant mode', () => {
+    const r = assertTenantMatches(reqFor('live.mendysrobotics.com'), undefined)
+    expect(r.ok).toBe(false)
+    expect((r as { reason: string }).reason).toMatch(/no tenant claim/)
+  })
+
+  it('accepts a claimless token in legacy mode (pre-tenancy sessions)', () => {
+    delete process.env.SECURITY_TENANTS
+    resetTenantRegistryForTests()
+    expect(assertTenantMatches(reqFor('anything'), undefined)).toEqual({ ok: true })
+  })
+
+  it('rejects when the request has no tenant context at all', () => {
+    const r = assertTenantMatches({} as never, 'mendys')
+    expect(r.ok).toBe(false)
+  })
+})


### PR DESCRIPTION
Stage 1 of #434. Lays the foundation for security-service to front several identity tenants, each backed by its own Authentik instance and therefore its own account directory.

**This does not yet make a MendysRobotics login work** — see *Not done* below. #434 stays open.

## Why

security-service is the single front door for identity; Authentik is an implementation detail behind it (`config.ts`: *"no vendor name leaks past this boundary into the API surface"*). But the implementation was single-tenant, reading `AUTHENTIK_*` straight from `process.env` at ~12 sites with a FuzeFront default at each.

## What's here

- **`providers/authentik/tenants.ts`** — the registry. Host → Authentik instance, carrying per-tenant issuer, in-cluster base URL, client credentials, admin token and enrollment flow slug.
- **`middleware/tenant-context.ts`** — resolves the tenant from the request host, binds it via `AsyncLocalStorage`, and provides `assertTenantMatches` for cross-tenant session rejection.
- **`config.ts`** — `appBaseUrl()` and `googleBrokeredEnabled()` read the ambient tenant instead of `process.env`. Signatures unchanged, so no call site churns.

## Two modes, and the split is the point

| | LEGACY (`SECURITY_TENANTS` unset) | MULTI (set) |
|---|---|---|
| Tenants | one, synthesised from today's env vars | as declared |
| Unknown host | served (today's behaviour) | **REJECTED** |
| Caching | none — rebuilt per read | memoised |

**Fail-closed engages only in MULTI, deliberately.** Applying it in legacy mode would break FuzeFront immediately, because requests legitimately arrive there on `app.fuzefront.com`, `fuzefront.dev.local`, `localhost` and in-cluster service DNS. Once you declare tenants you are asserting the full host list — and at that point falling back to a default would authenticate a user against the **wrong directory**, the single failure this whole split exists to prevent. So: no fallback, no default tenant, reject.

**Legacy is not memoised**, also deliberately. The functions it replaces each read `process.env` per call, so a late env change took effect immediately; caching would silently change that for every existing deployment and for tests that set env per case. There's a test pinning this.

## Design choices worth reviewing

- **`AsyncLocalStorage` over threading a tenant parameter.** The deep callers (`authentikPassword`, `machine-identity`, `accountApi`) are also invoked from provisioning scripts and seed jobs with no request in scope. `runWithTenant()` serves both without a sprawling diff across a live auth path.
- **`X-Forwarded-Host` is deliberately NOT read.** Behind the ingress it is caller-supplied; letting it pick the tenant would let a client choose which directory to authenticate against. Uses `req.hostname` (which honours trust-proxy) falling back to `Host`.
- **Misconfiguration fails at BOOT**, not at request time: duplicate host claims, duplicate tenant ids, missing required fields and malformed JSON all throw on load.

## Verification

- **28 new tests pass** — legacy parity, host routing, fail-closed rejection, boot validation, host normalisation, cross-tenant session rejection.
- `tsc --noEmit` clean for these files. (One pre-existing unrelated error in `eventPublisher.ts`, an artifact of a partial workspace install.)
- **No regression, measured rather than asserted:** the 8 Authentik/OIDC suites give **96 passed / 2 failed both with and without this change** — identical. I ran the same set against a stashed, pristine tree to confirm. Those 2 failures (`google-brokered-signin` extra-arg assertion, `authentik-provider` email verification) reproduce on clean `master` and are **pre-existing**, not caused here — worth a separate look.

## Not done (why #434 stays open)

`oidc.ts`, `authentikPassword.ts`, `machine-identity.ts`, `accountApi.ts` and the routes still read `process.env.AUTHENTIK_*` directly, so the *"no `process.env.AUTHENTIK_*` outside the registry"* criterion is unmet, and the middleware is not yet mounted on the auth routers. `oidc.ts` is a stateful singleton with discovery caching and background retry that must become one instance per tenant — and that is where the `iss`-rewriting subtlety lives, so it deserves its own reviewable change rather than being bolted on here.

Also still open from #434: per-tenant Google client credentials (shared client vs one per tenant — a consent-screen branding decision), tenant-scoped session claims at mint time, and the chart wiring.

Related: #428, #433, #439, izzywdev/FuzeInfra#421, izzywdev/MendysRobotics#253.

🤖 Generated with [Claude Code](https://claude.com/claude-code)