### PR TITLE
ci: add the missing billing-service and provisioning-service tag-bump anchors

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -249,7 +249,7 @@ jobs:
           # The expected-rewrite count moves with it so the guard stays exact.
           CHAT_OK=0
           if [ "${{ steps.chat_image.outcome }}" = "success" ]; then CHAT_OK=1; fi
-          EXPECTED=$((7 + CHAT_OK))
+          EXPECTED=$((9 + CHAT_OK))
           echo "chat-service image built: ${CHAT_OK} — expecting ${EXPECTED} tag rewrites"
           mkdir -p ~/.ssh
           printf '%s\n' "$SSH_KEY" > ~/.ssh/release_bump
@@ -297,6 +297,8 @@ jobs:
             /repository: ghcr\.io\/izzywdev\/fuzefront-clock-app\r?$/ { hot=1 }
             /repository: ghcr\.io\/izzywdev\/fuzefront-email-service\r?$/ { hot=1 }
             /repository: ghcr\.io\/izzywdev\/fuzefront-sms-service\r?$/ { hot=1 }
+            /repository: ghcr\.io\/izzywdev\/fuzefront-billing-service\r?$/ { hot=1 }
+            /repository: ghcr\.io\/izzywdev\/fuzefront-provisioning-service\r?$/ { hot=1 }
             chat == 1 && /repository: ghcr\.io\/izzywdev\/fuzefront-chat-service\r?$/ { hot=1 }
             { print }
             END { print n+0 > "/tmp/bump-count" }
@@ -305,8 +307,19 @@ jobs:
           # values, reordered keys, renamed registry path) the awk matches
           # nothing and we would otherwise "succeed" while deploying stale
           # tags (review finding). Exactly EXPECTED core-app tags must be
-          # rewritten: 7 always-built images, plus chat-service only when its
+          # rewritten: 9 always-built images, plus chat-service only when its
           # continue-on-error build actually succeeded.
+          #
+          # billing-service and provisioning-service were added to this list
+          # late: both were BUILT on every release and pinned in values-prod,
+          # but had no anchor here, so their tags were never rewritten —
+          # billing froze at 6135e6b5ed77 (2026-06-30) while enabled: true in
+          # prod, and provisioning sat at tag "" having never been deployed.
+          # Same defect as the email/sms one recorded above, third occurrence.
+          # The lesson keeps repeating because the count guard cannot detect a
+          # MISSING anchor (fewer anchors == fewer rewrites == "pass"); it only
+          # catches layout drift. If you add a build step, you MUST add the
+          # anchor and bump this number by hand.
           # The anchor list MUST cover every image this workflow BUILDS. It
           # previously listed only 5 while the build steps produced 7: the
           # email-service and sms-service images were built and pushed on every

--- a/deploy/helm/fuzefront/values-prod.yaml
+++ b/deploy/helm/fuzefront/values-prod.yaml
@@ -176,10 +176,15 @@ smsService:
 # IMPORTANT: Before setting provisioningService.enabled: true in production, ensure
 # the SealedSecret `fuzefront-secrets` contains the key INTERNAL_PROVISION_SECRET.
 # Without it the provisioning-service pod will fail to start (missing env var).
+# provisioning-service — image IS built by release.yml, but until this change it
+# had no anchor in that workflow's bump step, so the tag below was never written
+# and stayed "". It is enabled: false (inherited from values.yaml), so nothing
+# rendered and the empty tag was inert rather than an InvalidImageName. The
+# anchor exists now, so the next release writes a real SHA here.
 provisioningService:
   image:
     repository: ghcr.io/izzywdev/fuzefront-provisioning-service
-    tag: ""  # CI's release sed writes the real image SHA here
+    tag: ""
 
 # Billing-service (Stripe). Synced by the UMBRELLA `fuzefront` Argo Application
 # (gated by billingService.enabled), NOT a separate Application: billing's
@@ -202,8 +207,15 @@ billingService:
   # surface on the umbrella sync (no InvalidImageName, no PreSync-hook gate).
   # Billing is a backend microservice, not part of the MF platform shell, and the
   # host backend's billing proxy degrades gracefully without it — so it must not
-  # gate go-live. GO-LIVE = flip this to true (the image tag below is already
-  # auto-bumped to the built SHA by release.yml) AND seal the real STRIPE_* keys.
+  # gate go-live. GO-LIVE = flip this to true AND seal the real STRIPE_* keys.
+  #
+  # The claim that once stood here — "the image tag below is already auto-bumped
+  # to the built SHA by release.yml" — was FALSE for the life of this file. The
+  # image was built on every release, but billing-service had no anchor in that
+  # workflow's bump step, so this tag never moved: it sat at 6135e6b5ed77
+  # (2026-06-30, 142 commits behind) while enabled: true, i.e. prod ran a
+  # month-old billing image. The anchor exists as of this change, so the next
+  # release DOES rewrite this tag — do not hand-pin it.
   enabled: true
   image:
     repository: ghcr.io/izzywdev/fuzefront-billing-service


### PR DESCRIPTION
## 📋 Description

`release.yml` **builds** both images on every release and `values-prod.yaml` **pins** both — but neither had an anchor in the GitOps bump step, so their tags were never rewritten. This is the **third occurrence** of the same defect that step's own comment records for `email-service` and `sms-service`.

### Live impact

| Service | `enabled` in prod | Pinned tag | Reality |
|---|---|---|---|
| **billing-service** | **true** | `6135e6b5ed77` (2026-06-30) | **142 commits behind HEAD** — prod has been running a month-old billing image while every release built and pushed a current one nothing referenced |
| **provisioning-service** | false | `""` | **never deployed at all** — the exact `sms-service` failure mode; harmless only because the Deployment doesn't render, so the empty tag never became an `InvalidImageName` |

## 🔄 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🔨 Build system or dependency update

## 🚨 Breaking Changes / Deploy impact — read before merging

**The next release after this lands moves `billing-service` from `6135e6b5ed77` to the current SHA — 142 commits of billing changes deploying at once into a service that is `enabled: true` in prod.**

That is the correction working as intended, but it is a **real deploy, not a no-op**. Merge in a deploy window with someone watching billing. `provisioning-service` is `enabled: false`, so its bump is inert.

## 🔧 Implementation Details

- Added both `repository:` anchors to the bump `awk`.
- `EXPECTED` 7 → 9 (plus chat-service when its `continue-on-error` build succeeds, so 9 or 10).
- Documented **why the guard never caught this**: it counts *rewrites*, so a missing anchor is invisible to it — fewer anchors means fewer rewrites means "pass". It detects layout drift, not omission. Adding a build step still requires adding the anchor and bumping the number by hand.

### Comments corrected

Two comments in `values-prod.yaml` asserted the opposite of the truth and are fixed:

- `billingService`: *"the image tag below is already auto-bumped to the built SHA by release.yml"* — false for the life of the file.
- `provisioningService`: `tag: ""  # CI's release sed writes the real image SHA here` — it never did.

### `payment-service` deliberately NOT anchored

`release.yml` does not build it yet (`deploy/PENDING-WORKFLOW-CHANGES-payment-service.md`). Anchoring it would pin a tag for an image that is never produced. Verified it stays untouched.

## 🧪 Testing

- [x] Manual testing — verified by extracting the production `awk` verbatim and running it against the modified `values-prod.yaml`

| Path | Rewrites | Expected | |
|---|---|---|---|
| chat build succeeded | 10 | 10 | ✅ |
| chat build failed | 9 | 9 | ✅ |

Also asserted: `billing`, `provisioning` and `chat` tags all rewritten; **`payment-service` untouched**; both files parse as YAML.

The count guard is the dangerous part of this diff — a wrong number blocks *every* release, including backend/frontend — so it was verified by execution, not by reading.

## 📋 Checklist

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective — not applicable; this is CI config. The proof is the awk simulation above, and the next release run.

## 📝 Additional Notes

### Why this keeps happening

Three times now, the same shape: a build step is added, the anchor isn't, and the service silently freezes or never deploys. The guard cannot catch it by construction. If this recurs, the durable fix is to derive the anchor list from the build steps rather than maintaining it by hand — out of scope here, but worth considering.

### Related

Follows #432, which added the chat-service build and anchor and surfaced these two while editing the same list.

---
_Generated by [Claude Code](https://claude.ai/code/session_018GwoakPmfmvL4ot86LfFeX)_