### PR TITLE
fix(fuzequality): enable API gap implementation dispatch

### DIFF
--- a/FuzeQuality/apps/web/src/App.tsx
+++ b/FuzeQuality/apps/web/src/App.tsx
@@ -401,7 +401,7 @@ function ApiCatalogPage({ data }: { data: Portfolio }) {
       <div className="snapshot-stamp"><span>Policy</span><strong>api-coverage-v1</strong><small>{data.repositories.filter(repository => repository.lastScanAt).length} fresh scan snapshots</small></div>
     </div>
     <CoverageRail expectations={expectations} />
-    <Matrix items={operations} expectations={expectations} kind="api" />
+    <Matrix items={operations} expectations={expectations} kind="api" repositories={data.repositories} />
     <section className="panel catalog-findings">
       <div className="panel-heading"><div><p className="eyebrow">Remediation queue</p><h2>OpenAPI quality and coverage findings</h2></div><span className="header-badge"><AlertTriangle /> {findings.length}</span></div>
       <div className="finding-list">


### PR DESCRIPTION
## Summary
- pass repository inventory into the API coverage matrix
- allow the GAP planner to resolve the exact scanned revision
- enable governed cloud implementation dispatch from API catalog gaps

## Verification
- npm run type-check
- local Vitest start is blocked by npm optional Rollup binary resolution on Windows; CI remains authoritative