### PR TITLE
feat(contract): app suites + multi-surface modes

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -31,7 +31,7 @@ jobs:
           POSTGRES_USER: postgres
           POSTGRES_DB: fuzefront_platform_test
         options: >-
-          --health-cmd pg_isready
+          --health-cmd "pg_isready -U postgres"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
@@ -192,7 +192,7 @@ jobs:
           POSTGRES_USER: postgres
           POSTGRES_DB: fuzefront_platform_test
         options: >-
-          --health-cmd pg_isready
+          --health-cmd "pg_isready -U postgres"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5

--- a/.github/workflows/billing-service-tests.yml
+++ b/.github/workflows/billing-service-tests.yml
@@ -41,7 +41,7 @@ jobs:
           POSTGRES_USER: postgres
           POSTGRES_DB: fuzefront_platform_test
         options: >-
-          --health-cmd pg_isready
+          --health-cmd "pg_isready -U postgres"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,7 +258,7 @@ jobs:
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: frontfuse_test
         options: >-
-          --health-cmd pg_isready
+          --health-cmd "pg_isready -U postgres"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5

--- a/apps-client/src/schema.ts
+++ b/apps-client/src/schema.ts
@@ -207,10 +207,10 @@ export interface components {
          */
         Slug: string;
         /**
-         * @description `portal` — mounted inside the host shell at `/app/:slug` with chrome. `standalone` — rendered without portal chrome on its own host/path.
+         * @description A surface the app can be served on. NOT mutually exclusive — see `AppManifest.modes`, which is the multi-valued form. `portal` — mounted inside the host shell at `/app/:slug` with chrome. `standalone` — rendered without portal chrome on its own host/path (`routing.host`). This is the surface a mobile TWA/APK wraps, and the only one that can be, because an app store needs a URL that stands on its own. `embed` — rendered inside a THIRD-PARTY page via an SDK, with neither portal chrome nor FuzeFront navigation. An embed-only product is not a portal destination and may not register a menu entry at all.
          * @enum {string}
          */
-        AppMode: "portal" | "standalone";
+        AppMode: "portal" | "standalone" | "embed";
         /**
          * @description Lifecycle status. registered → activated → suspended.
          * @enum {string}
@@ -265,7 +265,23 @@ export interface components {
         Nav: {
             section?: components["schemas"]["NavSection"];
             /**
-             * @description Rank WITHIN the section, ascending. Ties break on `slug` so ordering is always total and stable. Leave unset (999) to sort after apps that care.
+             * @description Rank WITHIN the section — or within the suite, when `suite` is declared. Ascending. Ties break on `slug` so ordering is always total and stable. Leave unset (999) to sort after apps that care.
+             * @default 999
+             */
+            order: number;
+            suite?: components["schemas"]["Suite"];
+        };
+        /**
+         * @description Groups sibling apps that are surfaces of ONE product into a single named menu group. A repo that ships several independently-mountable surfaces — FuzeHub's talent / recruiter / ventures / marketplace / admin remotes — must register one app per surface, because `roles`, `visibility`, `integration` and `nav` are all per-surface and a single row cannot hold five of each. Without this key those five register as five unrelated top-level entries and the product disappears as a concept.
+         *     Each sibling carries its own copy rather than the platform holding a central suite table, for the same reason `nav.section` is self-declared: onboarding a product must never require a FuzeFront edit. Siblings are expected to agree; the host resolves disagreement deterministically (lowest `order` wins, ties on the alphabetically-first `slug`) instead of picking arbitrarily.
+         */
+        Suite: {
+            /** @description Stable group key, shared verbatim by every sibling. Apps with the same `id` in the same `section` render as one group. */
+            id: components["schemas"]["Slug"];
+            /** @description Display name of the group (e.g. "FuzeHub"). */
+            label: string;
+            /**
+             * @description Rank of the GROUP within its section — distinct from `nav.order`, which ranks this app within the group. Sorting is section → suite.order → nav.order.
              * @default 999
              */
             order: number;
@@ -326,7 +342,13 @@ export interface components {
             menuLabel: string;
             description?: string;
             icon?: components["schemas"]["Icon"];
+            /**
+             * @deprecated
+             * @description DEPRECATED — single-surface form, superseded by `modes`. A product can genuinely serve more than one surface (portal in the browser, standalone for its own host and for a mobile wrapper), which this scalar cannot say. Still REQUIRED so existing manifests keep validating; when both are present `modes` wins and `mode` MUST be its first entry.
+             */
             mode: components["schemas"]["AppMode"];
+            /** @description Every surface this app supports, in preference order — the first entry is how the host serves it by default. `["portal", "standalone"]` is the common case: mounted in the shell on desktop/web, and separately reachable on its own host so a mobile build has something to wrap. Omit to fall back to `[mode]`. */
+            modes?: components["schemas"]["AppMode"][];
             /**
              * @description Shipped with the platform; cannot be deleted, only suspended.
              * @default false

--- a/apps-client/src/schema.ts
+++ b/apps-client/src/schema.ts
@@ -309,6 +309,42 @@ export interface components {
             /** @description Standalone-only: a dedicated host (e.g. `clock.fuzefront.com`). When omitted, standalone apps are path-based under the main app host. */
             host?: string;
         };
+        /** @description Identity the app needs the platform to provision for it. Today an Authentik application + OIDC provider is created by hand-writing a blueprint under FuzeFront's `deploy/helm/fuzefront/authentik/blueprints/`, which means onboarding a product's identity requires an edit INSIDE FuzeFront — the same coupling that `nav` removed for the side menu and `policy` removed for authz. Declaring it here lets the product own it. */
+        Auth: {
+            oidc?: components["schemas"]["AuthOidc"];
+        };
+        /** @description An OIDC client for this app. Describes only what the PRODUCT knows; every secret stays on the platform side. */
+        AuthOidc: {
+            /** @description Authentik application slug. Defaults to the app's own `slug` when omitted. The server MUST reject a value claimed by a different app — a manifest is self-declared at registration, so an unchecked slug would let one product bind itself to another product's identity. */
+            applicationSlug?: components["schemas"]["Slug"];
+            /**
+             * @description `public` (PKCE, no secret) is for clients that cannot hold one — a browser-only SPA or a mobile/TWA build. Anything with a server keeps `confidential`.
+             * @default confidential
+             * @enum {string}
+             */
+            clientType: "confidential" | "public";
+            /** @description Exact callback URIs. HTTPS only, except loopback for local dev. NO wildcards: a redirect URI is where the authorization code is delivered, so a permissive entry is a token-theft primitive, not a convenience. The server SHOULD additionally require each host to be one the app already declares (`routing.host`, or its integration URL). */
+            redirectUris: string[];
+            postLogoutRedirectUris?: string[];
+            /**
+             * @description Scopes the client requests. `openid` is implied and always granted.
+             * @default [
+             *       "openid",
+             *       "email",
+             *       "profile"
+             *     ]
+             */
+            scopes: string[];
+            /** @description Maps an OIDC claim to the field the app expects, e.g. `{ "sub": "userId", "groups": "roles" }`. */
+            claims?: {
+                [key: string]: string;
+            };
+            /** @description Where the platform finds this client's secret — a (Sealed)Secret reference, NEVER the value. The manifest is committed to a product repo AND served back on read, so a literal secret here would be published twice over. There is deliberately no field to put one in. */
+            secretRef?: {
+                name: string;
+                key: string;
+            };
+        };
         /** @description Platform infrastructure the (typically standalone) app opts into. Portal apps implicitly get auth + api; this block is mainly meaningful for standalone apps that selectively use FuzeFront infra. */
         Infra: {
             /**
@@ -357,6 +393,7 @@ export interface components {
             integration: components["schemas"]["Integration"];
             chrome?: components["schemas"]["Chrome"];
             nav?: components["schemas"]["Nav"];
+            auth?: components["schemas"]["Auth"];
             routing?: components["schemas"]["Routing"];
             infra?: components["schemas"]["Infra"];
             visibility?: components["schemas"]["Visibility"];

--- a/apps-client/src/types.ts
+++ b/apps-client/src/types.ts
@@ -16,6 +16,8 @@ export type MenuItem = components['schemas']['MenuItem'];
 /** Side-menu placement: which lifecycle section the app sits in, and its rank there. */
 export type Nav = components['schemas']['Nav'];
 export type NavSection = components['schemas']['NavSection'];
+/** Groups sibling apps that are surfaces of one product into a single menu group. */
+export type Suite = components['schemas']['Suite'];
 /** Self-declared onboarding surfaces submitted by the app at registration. */
 export type ProductPolicy = components['schemas']['ProductPolicy'];
 export type ProductResourceDecl = components['schemas']['ProductResourceDecl'];

--- a/docs/planning/app-suites-and-modes.md
+++ b/docs/planning/app-suites-and-modes.md
@@ -205,6 +205,73 @@ real auth wiring (`SimpleAuthProvider`) and no data fetching. They share no code
 neither is finished. So this is duplicated *product surface*, not duplicated
 implementation — cheap to reconcile now, expensive once both are real.
 
+## The bar for a product that needs BOTH portal and standalone
+
+FuzeHub gets a pass because its portal surfaces already exist as Vite MF remotes and
+its Next.js app can simply be the standalone one. **Most products will not be that
+lucky**, so this is the standard for everyone else. It is a requirement, not a
+suggestion: `iframe` is not an acceptable portal integration for a product that has a
+real UI.
+
+**1. One implementation, two entry points — never two implementations.**
+
+The failure mode is building the portal surface and the standalone surface separately
+and letting them drift, which is exactly the state FuzeHub is in (`frontend/app/marketplace/`
+vs `packages/fuzehub-marketplace/`). The app itself is one component tree:
+
+```
+src/App.tsx              ← the product. Knows nothing about how it is mounted.
+src/entry.remote.ts      ← exposes <App/> via Module Federation  (portal)
+src/entry.standalone.tsx ← mounts <App/> into #root with a router (standalone)
+```
+
+Both entries import the *same* `App`. If a behaviour exists in one and not the other,
+it is a bug, not a variant.
+
+**2. The shared-dependency contract is fixed by the host, not negotiated.**
+
+The host shares React as a **singleton at `^18.3.1`**. A remote on React 19 cannot
+share that singleton — you get two Reacts, and hooks break in ways that look like
+random state loss. Match the host, or you are not federating.
+
+```ts
+shared: {
+  react:       { singleton: true, requiredVersion: '^18.3.1' },
+  'react-dom': { singleton: true, requiredVersion: '^18.3.1' },
+}
+```
+
+**3. Auth differs per surface, and that difference belongs behind one interface.**
+
+In portal mode the host injects the token (`window.__FUZE_AUTH__`); standalone must
+acquire it itself via Authentik. Do not scatter that fork through the app — resolve it
+once, at the entry:
+
+```ts
+// auth.ts — the app calls getToken(); it never knows which surface it is on.
+export const getToken = () =>
+  window.__FUZE_AUTH__?.token ?? standaloneSession()?.token ?? null
+```
+
+**4. Same-origin API base, both ways.** Never hard-code an absolute API host; it breaks
+under local TLS and prod ingress differently, and mixed-content blocks it under the
+portal.
+
+**5. Routing is prefix-relative.** Portal mounts at `/app/:slug`, standalone at `/`. The
+app must take a `basename` from its entry rather than assuming either.
+
+**6. Next.js App Router is not a federation host or remote — do not try.** React 19 +
+RSC + `@module-federation/nextjs-mf` (a Pages-Router story) is not a paved path. If a
+product is Next.js and needs a portal surface, extract the UI into a Vite MF package
+and let Next import it, rather than federating Next itself.
+
+### Definition of done
+
+- One `App`, two entries, no duplicated screens.
+- Remote loads in the host with **no console errors** (the `ui-runtime-validation` gate).
+- Standalone URL renders with no portal chrome — that is what the APK wraps.
+- Both surfaces exercised in tests; a portal-only test suite hides standalone breakage.
+
 ## Follow-ups
 
 Not in the contract PR, each independently shippable:

--- a/docs/planning/app-suites-and-modes.md
+++ b/docs/planning/app-suites-and-modes.md
@@ -1,0 +1,222 @@
+# App suites, multi-surface modes, and where "mobile" is declared
+
+Status: contract landed, runtime follow-ups open (see [Follow-ups](#follow-ups)).
+
+## The bug that started this
+
+FuzeHub ships **four** independently-mountable Module-Federation remotes —
+`packages/fuzehub-{talent,recruiter,ventures,marketplace}/`, each exposing `./App`
+with its own scope — plus an admin/management surface that does not exist yet.
+
+When FuzeHub was onboarded to the app registry, it got **one** `registration/manifest.json`,
+because that is all the contract could express. The four surfaces collapsed into a
+single `iframe` entry pointing at the Next.js app.
+
+Nothing failed. No gate went red. The product simply lost four of its five portal
+entries, and the only reason it still worked in production is that a *legacy* Helm
+job (`register-apps-job.yaml`, predating the onboarding kit) was still POSTing those
+four to the older `/api/apps/register` endpoint. The modern, "correct" registration
+path was the lossy one.
+
+That is the shape of the defect worth naming: **the contract could not describe the
+product, so onboarding quietly described a smaller product instead.**
+
+## Why one row per surface, not one row with a list
+
+`roles`, `visibility`, `integration`, and `nav` are all **per-surface**. A recruiter
+surface and a talent surface want different roles and may want different sections. A
+single registry row cannot hold five `integration` blocks or five `roles` arrays.
+
+Two shapes were considered:
+
+- **`apps[]` nested inside one manifest** — the parent holds identity, children hold
+  the rest. But every field that differs per surface has to be repeated inside the
+  array, at which point it is one-row-per-surface with extra nesting, plus a new
+  fan-out rule for policy, activation, and status.
+- **One manifest per surface** (chosen) — each is a complete, independently valid
+  `AppManifest`. Zero new semantics for the registry: a surface is just an app.
+
+The only thing the second shape loses is the *grouping*: five flat siblings in the
+menu with nothing tying them together. That is what `nav.suite` restores, and it is
+purely presentational — it changes how the menu renders, never what is registered or
+authorized.
+
+A third option — `chrome.menu: "substitute"`, which already exists — was rejected. It
+lets an active app replace the portal menu with its own items, but the surfaces are
+then invisible until you have already entered the product, and individual surfaces
+cannot be role-gated. It solves in-app navigation, not portal presence.
+
+## `nav.suite`
+
+```jsonc
+"nav": {
+  "section": "plan",
+  "order": 10,                                  // rank WITHIN the suite
+  "suite": { "id": "fuzehub", "label": "FuzeHub", "order": 20 }  // rank OF the suite
+}
+```
+
+Sorting is **section → `suite.order` → `nav.order`**, ties broken on `slug` so the
+result is total and stable.
+
+Every sibling carries its own copy of the suite block rather than the platform holding
+a central suite table. This is the same principle that already governs `nav.section`:
+*onboarding a product must never require a FuzeFront edit.* A central table would mean
+every new suite is a PR against this repo.
+
+The cost is that siblings can disagree. Rather than pick arbitrarily, the host resolves
+deterministically — lowest `suite.order` wins, ties on the alphabetically-first `slug` —
+and `register.sh` logs each surface's suite id at registration so a typo that silently
+splits a group into two is visible in the pod log.
+
+## `modes[]` — surfaces are not mutually exclusive
+
+`mode` was a scalar, `portal | standalone`. That cannot say what is true of most
+products: **the same app is served in the portal on desktop/web, and standalone on its
+own host so that a mobile build has something to wrap.**
+
+It was also not even read. `backend/src/routes/appRegistry.ts` *derived* it:
+
+```ts
+const mode = row.integration_type === 'module-federation' ? 'portal' : 'standalone'
+```
+
+So a manifest's declared `mode` was decorative on that path — the integration type
+decided it.
+
+```jsonc
+"mode": "portal",                      // deprecated, still required, = modes[0]
+"modes": ["portal", "standalone"]      // authoritative; first entry is the default
+```
+
+`mode` stays required so every existing manifest keeps validating; `modes` wins when
+both are present.
+
+### `embed` — the third surface
+
+`embed` is an app rendered inside a **third-party** page via an SDK, with neither portal
+chrome nor FuzeFront navigation. FuzeBI is the existing example (registered as a
+non-registering embed SDK). An embed-only product is not a portal destination and may
+not register a menu entry at all.
+
+## Mobile requires standalone — as a member, not as an alternative
+
+To be precise, because the earlier phrasing was ambiguous: the rule is
+`"standalone" ∈ modes`, **not** `modes == ["standalone"]`.
+
+`["portal", "standalone"]` + mobile is the *normal* case, and the intended one: the app
+is mounted inside FuzeFront on desktop and web, and the very same app is separately
+reachable on its own host, which is what the APK wraps.
+
+The reason standalone must be present at all is mechanical, not philosophical. A TWA is
+a browser pointed at a URL with no portal chrome around it. An app that exists *only* as
+a federated remote inside the shell has no such URL — there is nothing for the store
+listing to open. So `standalone` in `modes` plus a `routing.host` is exactly the
+statement "there is a URL that stands on its own," which is the precondition for a
+mobile build and nothing more.
+
+## Hostnames
+
+| Surface | Host | Why |
+|---|---|---|
+| standalone (and mobile) | `fuzehub.fuzefront.com`, plus custom domains like `fuzehub.com` | User-facing, memorable, what an app-store listing points at |
+| portal `remoteEntry` | `fuzehub.prod.fuzefront.com` | Infra-convention host; `*.prod.fuzefront.com` is the Cloudflare-Tunnel wildcard |
+
+`routing.host` already existed for exactly this and needed no change.
+
+Note `remoteEntry` is fetched by the **browser**, not server-side — so the
+`*.prod.fuzefront.com` host is still public and CORS-reachable. It is a different
+convention, not a private network.
+
+## Where each capability is declared
+
+This is two manifests with two different audiences, and conflating them is easy:
+
+| File | Audience | Holds |
+|---|---|---|
+| `registration/manifest.json` (+ `apps/*.json`) | **FuzeFront at runtime** | Portal identity: `slug`, `menuLabel`, `icon`, `nav`, `modes`, `integration`, `routing`, `roles` |
+| `.fuze/manifest.json` | **Maintainer agents in CI** | Capability surface: `agents`, `mcp`, `a2a`, `hardening`, `dependsOn` |
+
+The maintainer agents (`mcp-maintain.yml`, `a2a-maintain.yml`) run on `pull_request` in
+each consuming repo, read `.fuze/manifest.json`, and reconcile the declared block
+against what is actually in the tree — building the surface the first time and
+correcting drift after.
+
+**`mobile` therefore belongs in `.fuze/manifest.json`**, alongside `mcp` and `a2a`, and
+`mobile-maintainer` becomes the third sibling of that pattern:
+
+```jsonc
+"mobile": {
+  "enabled": true,
+  "platforms": ["android"],
+  "applicationId": "com.fuzefront.fuzehub",
+  "standaloneSlug": "fuzehub-ventures"
+}
+```
+
+It is the one block that must **cross-reference the other manifest**: the URL to wrap
+lives in `registration/`, not `.fuze/`. So the gate is a pair check — `mobile.enabled`
+requires the referenced registration manifest to declare `standalone` in `modes` and a
+`routing.host`. That is deliberately the only coupling between the two files, and it is
+one-directional.
+
+## Worked example — FuzeHub
+
+```
+registration/
+  manifest.json          slug: fuzehub-ventures    (primary; owns policy + billing)
+  policy.json
+  apps/
+    talent.json          slug: fuzehub-talent
+    recruiter.json       slug: fuzehub-recruiter
+    marketplace.json     slug: fuzehub-marketplace
+    admin.json           slug: fuzehub-admin       (surface does not exist yet)
+```
+
+All five share `nav.suite.id = "fuzehub"`. Each portal surface points its
+`integration.remoteEntry` at its own built remote; `routing.host` is
+`fuzehub.fuzefront.com` for the standalone surface.
+
+`manifest.json` remains the **primary**: `policy.json` and `billing-profile.json` are
+per-*product*, not per-surface, so binding them to a fixed slug removes any ambiguity
+about which sibling owns them.
+
+### On federating the Next.js app
+
+FuzeHub's `frontend/` is Next 15 App Router on React 19. Federating it was considered
+and rejected for three concrete reasons:
+
+1. The host shares React `^18.3.1` as a singleton; the Next app is React `^19`. One
+   singleton cannot span both.
+2. The host uses `@originjs/vite-plugin-federation`; the remotes use
+   `@module-federation/vite`. Different runtimes, interop unverified.
+3. App Router + `@module-federation/nextjs-mf` is not a paved path (the RSC boundary).
+
+None of it is necessary, because the four Vite remotes are *already* React 18 MF
+remotes. The clean split is **portal → the remotes, standalone → the Next.js app,
+mobile → a TWA over the standalone URL**. The iframe integration goes away, which was
+the actual objection.
+
+The honest cost: `frontend/app/marketplace/` and `frontend/app/ventures/` are Next pages
+covering the same ground as the marketplace and ventures remotes. Measured, the literal
+duplication is small — the four remotes total ~577 lines and are static mock data with
+host-injected auth (`window.__FUZE_AUTH__`), while the Next pages total ~1348 lines with
+real auth wiring (`SimpleAuthProvider`) and no data fetching. They share no code and
+neither is finished. So this is duplicated *product surface*, not duplicated
+implementation — cheap to reconcile now, expensive once both are real.
+
+## Follow-ups
+
+Not in the contract PR, each independently shippable:
+
+1. **Backend reads `modes`** instead of deriving mode from `integration_type`
+   (`backend/src/routes/appRegistry.ts`). Needs a migration for the stored column.
+2. **Shell renders suite groups** in the side menu. This is feature UI, so it goes
+   through the design-frames flow first. Until it lands, siblings render as flat
+   entries — correct, just not grouped.
+3. **`mobile-maintainer`** in FuzeSDLC, plus the `mobile` block and its paired gate,
+   generalizing FuzeFront's existing `build-android-apk.yml`.
+4. **FuzeHub migration** to five manifests, and retiring `register-apps-job.yaml` — in
+   that order. The legacy job is the only thing registering those four surfaces today
+   and must not be removed before its replacement is live.
+5. **`modes` sweep** across the remaining product repos.

--- a/docs/planning/app-suites-and-modes.md
+++ b/docs/planning/app-suites-and-modes.md
@@ -272,6 +272,49 @@ and let Next import it, rather than federating Next itself.
 - Standalone URL renders with no portal chrome — that is what the APK wraps.
 - Both surfaces exercised in tests; a portal-only test suite hides standalone breakage.
 
+
+## `auth.oidc` — identity the product declares for itself
+
+Today an Authentik application + OIDC provider is created by hand-writing a blueprint
+under FuzeFront's `deploy/helm/fuzefront/authentik/blueprints/` (see
+`provider-oidc-mendys-platform.yaml`). So onboarding a product's *identity* requires an
+edit **inside FuzeFront** — exactly the coupling `nav` removed for the side menu and
+`policy` removed for authz. FuzeSocial had already written an `auth` block into its
+manifest by instinct; there was just no contract for it, and because `AppManifest` is
+`additionalProperties: false` that made its whole document invalid, so it was not
+registering at all.
+
+The block describes only what the **product** knows. Every secret stays platform-side:
+
+```jsonc
+"auth": {
+  "oidc": {
+    "applicationSlug": "fuzesocial",          // defaults to the app's slug
+    "clientType": "confidential",             // "public" = PKCE, for SPA/mobile
+    "redirectUris": ["https://social.fuzefront.com/api/auth/oidc/callback"],
+    "scopes": ["openid", "email", "profile"],
+    "claims": { "sub": "userId", "groups": "roles" },
+    "secretRef": { "name": "fuzesocial-oidc", "key": "clientSecret" }
+  }
+}
+```
+
+Three constraints are enforced by the schema rather than left to reviewers:
+
+1. **No literal secret.** There is no field to put one in — `additionalProperties: false`
+   rejects `clientSecret` outright, and `secretRef` points at a (Sealed)Secret instead.
+   A manifest is committed to a product repo *and* served back on read, so a secret here
+   would be published twice over.
+2. **No wildcard redirect URIs.** A redirect URI is where the authorization code is
+   delivered, so `https://*.example.com/cb` is a token-theft primitive, not a
+   convenience. HTTPS only, except loopback for local dev.
+3. **`applicationSlug` defaults to the app's own slug**, and the server MUST reject one
+   already claimed by a different app. A manifest is *self-declared* at registration —
+   without that check, a product could bind itself to another product's identity.
+
+The third is a server-side obligation the schema cannot express, and it is the one worth
+implementing carefully when the provisioning lands.
+
 ## Follow-ups
 
 Not in the contract PR, each independently shippable:
@@ -287,3 +330,8 @@ Not in the contract PR, each independently shippable:
    that order. The legacy job is the only thing registering those four surfaces today
    and must not be removed before its replacement is live.
 5. **`modes` sweep** across the remaining product repos.
+6. **Provision Authentik from `auth.oidc`** — generate the blueprint from the manifest
+   instead of hand-writing it, and enforce the `applicationSlug` ownership check plus
+   the redirect-host check (each host should be one the app already declares). Until
+   that lands the block is declarative only: it validates and is stored, but nothing
+   acts on it yet.

--- a/docs/planning/app-suites-and-modes.md
+++ b/docs/planning/app-suites-and-modes.md
@@ -142,23 +142,37 @@ each consuming repo, read `.fuze/manifest.json`, and reconcile the declared bloc
 against what is actually in the tree — building the surface the first time and
 correcting drift after.
 
-**`mobile` therefore belongs in `.fuze/manifest.json`**, alongside `mcp` and `a2a`, and
-`mobile-maintainer` becomes the third sibling of that pattern:
+**`mobile` therefore belongs in `.fuze/manifest.json`**, alongside `mcp` and `a2a` —
+and the contract for it **already exists**. FuzeSDLC ships
+`agent-templates/schema/mobile-requirements.schema.json`, which explicitly sanctions a
+`mobile` block in `.fuze/manifest.json`, plus the `mobile-app-engineer` agent and the
+`mobile-packaging` / `mobile-conformance` skills. An earlier draft of this document
+proposed a new block and a new `mobile-maintainer` agent; both were redundant, and
+inventing a parallel contract next to an unused one is how a standard stops being a
+standard. Use what is there:
 
 ```jsonc
 "mobile": {
-  "enabled": true,
-  "platforms": ["android"],
-  "applicationId": "com.fuzefront.fuzehub",
-  "standaloneSlug": "fuzehub-ventures"
+  "product": "FuzeHub",
+  "required": true,
+  "strategy": "pwa",                       // responsive-web | pwa | react-native | flutter
+  "targets": ["android", "mobile-web"],
+  "responsive": { "min_width": 375, "breakpoints": [375, 768, 1024], "min_tap_target_px": 44 },
+  "acceptance": [
+    "No horizontal scroll at min_width; the shell drawer replaces the desktop sidebar.",
+    { "check": "Lighthouse mobile performance", "min_score": 80, "at_width": 375 }
+  ]
 }
 ```
 
-It is the one block that must **cross-reference the other manifest**: the URL to wrap
-lives in `registration/`, not `.fuze/`. So the gate is a pair check — `mobile.enabled`
-requires the referenced registration manifest to declare `standalone` in `modes` and a
-`routing.host`. That is deliberately the only coupling between the two files, and it is
-one-directional.
+`strategy: pwa` is the family default because it is what FuzeFront actually ships — an
+installable PWA wrapped as a signed Android TWA (`build-android-apk.yml`).
+
+It is the one block that must **cross-reference the other manifest**: the URL a build
+wraps lives in `registration/`, not `.fuze/`. So the gate is a pair check —
+`required: true` demands that the product's registration manifest declare `standalone`
+in `modes` and a `routing.host`, because otherwise there is no URL to wrap. That is
+deliberately the only coupling between the two files, and it is one-directional.
 
 ## Worked example — FuzeHub
 
@@ -324,8 +338,11 @@ Not in the contract PR, each independently shippable:
 2. **Shell renders suite groups** in the side menu. This is feature UI, so it goes
    through the design-frames flow first. Until it lands, siblings render as flat
    entries — correct, just not grouped.
-3. **`mobile-maintainer`** in FuzeSDLC, plus the `mobile` block and its paired gate,
-   generalizing FuzeFront's existing `build-android-apk.yml`.
+3. **The `mobile` pair gate** — `required: true` must fail unless the product's
+   registration manifest declares `standalone` in `modes` and a `routing.host`. Plus
+   generalizing FuzeFront's `build-android-apk.yml` so `mobile-app-engineer` can build
+   a signed APK per product rather than only for the shell. No new agent is needed —
+   `mobile-app-engineer` already exists.
 4. **FuzeHub migration** to five manifests, and retiring `register-apps-job.yaml` — in
    that order. The legacy job is the only thing registering those four surfaces today
    and must not be removed before its replacement is live.

--- a/packages/onboarding-kit/bin/register.sh
+++ b/packages/onboarding-kit/bin/register.sh
@@ -47,18 +47,33 @@ jq empty "$MANIFEST" 2>/dev/null || die "$MANIFEST is not valid JSON"
 SLUG="$(jq -r '.slug // empty' "$MANIFEST")"
 [ -n "$SLUG" ] || die "manifest has no .slug"
 
-# nav placement is what orders the app in the portal's side menu. Not fatal if
-# absent (the platform defaults it to the 'platform' section, last) but it almost
-# always means someone forgot, so say so loudly rather than silently sorting last.
-NAV_SECTION="$(jq -r '.nav.section // empty' "$MANIFEST")"
-if [ -z "$NAV_SECTION" ]; then
-  log "WARNING: manifest declares no .nav.section — this app will sort LAST in the side menu."
+# ---- suite surfaces ----------------------------------------------------------
+# A repo may ship SEVERAL independently-mountable surfaces of one product — e.g.
+# FuzeHub's talent / recruiter / ventures / marketplace remotes. Each needs its own
+# registry row, because `roles`, `visibility`, `integration` and `nav` are per-surface
+# and one row cannot hold five of each. Before this, such a repo could only register
+# one of them and the rest silently vanished from the portal.
+#
+# manifest.json stays the PRIMARY surface and keeps owning the product-level
+# attachments (policy, billing) — those are per-product, not per-surface, so binding
+# them to a fixed slug removes any ambiguity about which sibling they belong to.
+# Additional surfaces go in apps/ and are registered identically. They group in the
+# menu by declaring the same nav.suite.id.
+APPS_DIR="${REGISTRATION_DIR}/apps"
+MANIFESTS="$MANIFEST"
+if [ -d "$APPS_DIR" ]; then
+  # Sorted so the registration order is deterministic across pods and replicas.
+  for _extra in $(find "$APPS_DIR" -maxdepth 1 -name '*.json' | sort); do
+    MANIFESTS="${MANIFESTS} ${_extra}"
+  done
 fi
 
 API="${FUZEFRONT_API_URL%/}/api/v1/app-registry"
 AUTH="Authorization: Bearer ${FUZEFRONT_REGISTRATION_TOKEN}"
 
-log "slug=${SLUG} section=${NAV_SECTION:-<unset>} api=${API}"
+_count=0
+for _m in $MANIFESTS; do _count=$((_count + 1)); done
+log "primary=${SLUG} surfaces=${_count} api=${API}"
 
 # ---- helpers -----------------------------------------------------------------
 # Emits the HTTP status on stdout and writes the body to $2. Retries transient
@@ -93,6 +108,31 @@ http() {
 BODY="$(mktemp)"
 # shellcheck disable=SC2064  # expand BODY now, on purpose
 trap "rm -f '$BODY'" EXIT
+
+# ---- 1+2. register + activate, once per surface ------------------------------
+# Run for the primary manifest and for every apps/*.json sibling. A failure on ANY
+# surface is fatal, exactly as before: a suite that comes up missing two of its five
+# entries is a broken product, not a degraded one, and the whole point of the init
+# container is that the pod must not serve in that state.
+register_surface() {
+  MANIFEST="$1"
+
+  jq empty "$MANIFEST" 2>/dev/null || die "$MANIFEST is not valid JSON"
+  SLUG="$(jq -r '.slug // empty' "$MANIFEST")"
+  [ -n "$SLUG" ] || die "$MANIFEST has no .slug"
+
+  # nav placement is what orders the app in the portal's side menu. Not fatal if
+  # absent (the platform defaults it to the 'platform' section, last) but it almost
+  # always means someone forgot, so say so loudly rather than silently sorting last.
+  NAV_SECTION="$(jq -r '.nav.section // empty' "$MANIFEST")"
+  if [ -z "$NAV_SECTION" ]; then
+    log "WARNING: ${SLUG} declares no .nav.section — it will sort LAST in the side menu."
+  fi
+
+  # Siblings group only if they agree on the suite key verbatim, so a typo silently
+  # splits the group in two. Cheap to surface here, invisible in the rendered menu.
+  NAV_SUITE="$(jq -r '.nav.suite.id // empty' "$MANIFEST")"
+  log "-- ${SLUG} section=${NAV_SECTION:-<unset>} suite=${NAV_SUITE:-<none>}"
 
 # ---- 1. register (idempotent) ------------------------------------------------
 CODE="$(http GET "${API}/apps/${SLUG}" "$BODY")"
@@ -146,6 +186,16 @@ else
     *) die "activate failed: HTTP ${CODE} $(cat "$BODY")" ;;
   esac
 fi
+}
+
+for _manifest in $MANIFESTS; do
+  register_surface "$_manifest"
+done
+
+# Product-level attachments below bind to the PRIMARY manifest, so restore its slug
+# after the loop left SLUG pointing at whichever sibling was registered last.
+MANIFEST="${REGISTRATION_DIR}/manifest.json"
+SLUG="$(jq -r '.slug // empty' "$MANIFEST")"
 
 # ---- 3. AuthZ policy (optional file) -----------------------------------------
 # The product declares its OWN Permit resources/roles with BARE keys; the platform

--- a/packages/onboarding-kit/manifest.schema.json
+++ b/packages/onboarding-kit/manifest.schema.json
@@ -40,7 +40,22 @@
       "$ref": "#/$defs/Icon"
     },
     "mode": {
-      "$ref": "#/$defs/AppMode"
+      "allOf": [
+        {
+          "$ref": "#/$defs/AppMode"
+        }
+      ],
+      "deprecated": true,
+      "description": "DEPRECATED — single-surface form, superseded by `modes`. A product can genuinely serve more than one surface (portal in the browser, standalone for its own host and for a mobile wrapper), which this scalar cannot say. Still REQUIRED so existing manifests keep validating; when both are present `modes` wins and `mode` MUST be its first entry."
+    },
+    "modes": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/AppMode"
+      },
+      "description": "Every surface this app supports, in preference order — the first entry is how the host serves it by default. `[\"portal\", \"standalone\"]` is the common case: mounted in the shell on desktop/web, and separately reachable on its own host so a mobile build has something to wrap. Omit to fall back to `[mode]`."
     },
     "builtin": {
       "type": "boolean",
@@ -113,7 +128,22 @@
           "$ref": "#/$defs/Icon"
         },
         "mode": {
-          "$ref": "#/$defs/AppMode"
+          "allOf": [
+            {
+              "$ref": "#/$defs/AppMode"
+            }
+          ],
+          "deprecated": true,
+          "description": "DEPRECATED — single-surface form, superseded by `modes`. A product can genuinely serve more than one surface (portal in the browser, standalone for its own host and for a mobile wrapper), which this scalar cannot say. Still REQUIRED so existing manifests keep validating; when both are present `modes` wins and `mode` MUST be its first entry."
+        },
+        "modes": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/AppMode"
+          },
+          "description": "Every surface this app supports, in preference order — the first entry is how the host serves it by default. `[\"portal\", \"standalone\"]` is the common case: mounted in the shell on desktop/web, and separately reachable on its own host so a mobile build has something to wrap. Omit to fall back to `[mode]`."
         },
         "builtin": {
           "type": "boolean",
@@ -158,10 +188,11 @@
     },
     "AppMode": {
       "type": "string",
-      "description": "`portal` — mounted inside the host shell at `/app/:slug` with chrome. `standalone` — rendered without portal chrome on its own host/path.",
+      "description": "A surface the app can be served on. NOT mutually exclusive — see `AppManifest.modes`, which is the multi-valued form. `portal` — mounted inside the host shell at `/app/:slug` with chrome. `standalone` — rendered without portal chrome on its own host/path (`routing.host`). This is the surface a mobile TWA/APK wraps, and the only one that can be, because an app store needs a URL that stands on its own. `embed` — rendered inside a THIRD-PARTY page via an SDK, with neither portal chrome nor FuzeFront navigation. An embed-only product is not a portal destination and may not register a menu entry at all.",
       "enum": [
         "portal",
-        "standalone"
+        "standalone",
+        "embed"
       ]
     },
     "IntegrationType": {
@@ -307,7 +338,10 @@
           "minimum": 0,
           "maximum": 9999,
           "default": 999,
-          "description": "Rank WITHIN the section, ascending. Ties break on `slug` so ordering is always total and stable. Leave unset (999) to sort after apps that care."
+          "description": "Rank WITHIN the section — or within the suite, when `suite` is declared. Ascending. Ties break on `slug` so ordering is always total and stable. Leave unset (999) to sort after apps that care."
+        },
+        "suite": {
+          "$ref": "#/$defs/Suite"
         }
       }
     },
@@ -324,6 +358,37 @@
         "platform"
       ],
       "default": "platform"
+    },
+    "Suite": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "label"
+      ],
+      "description": "Groups sibling apps that are surfaces of ONE product into a single named menu group. A repo that ships several independently-mountable surfaces — FuzeHub's talent / recruiter / ventures / marketplace / admin remotes — must register one app per surface, because `roles`, `visibility`, `integration` and `nav` are all per-surface and a single row cannot hold five of each. Without this key those five register as five unrelated top-level entries and the product disappears as a concept.\nEach sibling carries its own copy rather than the platform holding a central suite table, for the same reason `nav.section` is self-declared: onboarding a product must never require a FuzeFront edit. Siblings are expected to agree; the host resolves disagreement deterministically (lowest `order` wins, ties on the alphabetically-first `slug`) instead of picking arbitrarily.",
+      "properties": {
+        "id": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Slug"
+            }
+          ],
+          "description": "Stable group key, shared verbatim by every sibling. Apps with the same `id` in the same `section` render as one group."
+        },
+        "label": {
+          "type": "string",
+          "maxLength": 40,
+          "description": "Display name of the group (e.g. \"FuzeHub\")."
+        },
+        "order": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 9999,
+          "default": 999,
+          "description": "Rank of the GROUP within its section — distinct from `nav.order`, which ranks this app within the group. Sorting is section → suite.order → nav.order."
+        }
+      }
     },
     "Routing": {
       "type": "object",

--- a/packages/onboarding-kit/manifest.schema.json
+++ b/packages/onboarding-kit/manifest.schema.json
@@ -71,6 +71,9 @@
     "nav": {
       "$ref": "#/$defs/Nav"
     },
+    "auth": {
+      "$ref": "#/$defs/Auth"
+    },
     "routing": {
       "$ref": "#/$defs/Routing"
     },
@@ -158,6 +161,9 @@
         },
         "nav": {
           "$ref": "#/$defs/Nav"
+        },
+        "auth": {
+          "$ref": "#/$defs/Auth"
         },
         "routing": {
           "$ref": "#/$defs/Routing"
@@ -387,6 +393,106 @@
           "maximum": 9999,
           "default": 999,
           "description": "Rank of the GROUP within its section — distinct from `nav.order`, which ranks this app within the group. Sorting is section → suite.order → nav.order."
+        }
+      }
+    },
+    "Auth": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Identity the app needs the platform to provision for it. Today an Authentik application + OIDC provider is created by hand-writing a blueprint under FuzeFront's `deploy/helm/fuzefront/authentik/blueprints/`, which means onboarding a product's identity requires an edit INSIDE FuzeFront — the same coupling that `nav` removed for the side menu and `policy` removed for authz. Declaring it here lets the product own it.",
+      "properties": {
+        "oidc": {
+          "$ref": "#/$defs/AuthOidc"
+        }
+      }
+    },
+    "AuthOidc": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "redirectUris"
+      ],
+      "description": "An OIDC client for this app. Describes only what the PRODUCT knows; every secret stays on the platform side.",
+      "properties": {
+        "applicationSlug": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Slug"
+            }
+          ],
+          "description": "Authentik application slug. Defaults to the app's own `slug` when omitted. The server MUST reject a value claimed by a different app — a manifest is self-declared at registration, so an unchecked slug would let one product bind itself to another product's identity."
+        },
+        "clientType": {
+          "type": "string",
+          "enum": [
+            "confidential",
+            "public"
+          ],
+          "default": "confidential",
+          "description": "`public` (PKCE, no secret) is for clients that cannot hold one — a browser-only SPA or a mobile/TWA build. Anything with a server keeps `confidential`."
+        },
+        "redirectUris": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "format": "uri",
+            "pattern": "^(https://|http://localhost([:/]|$)|http://127\\.0\\.0\\.1([:/]|$))[^*\\s]*$",
+            "maxLength": 2048
+          },
+          "description": "Exact callback URIs. HTTPS only, except loopback for local dev. NO wildcards: a redirect URI is where the authorization code is delivered, so a permissive entry is a token-theft primitive, not a convenience. The server SHOULD additionally require each host to be one the app already declares (`routing.host`, or its integration URL)."
+        },
+        "postLogoutRedirectUris": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "format": "uri",
+            "pattern": "^(https://|http://localhost([:/]|$)|http://127\\.0\\.0\\.1([:/]|$))[^*\\s]*$",
+            "maxLength": 2048
+          }
+        },
+        "scopes": {
+          "type": "array",
+          "uniqueItems": true,
+          "default": [
+            "openid",
+            "email",
+            "profile"
+          ],
+          "items": {
+            "type": "string",
+            "maxLength": 64
+          },
+          "description": "Scopes the client requests. `openid` is implied and always granted."
+        },
+        "claims": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string",
+            "maxLength": 64
+          },
+          "description": "Maps an OIDC claim to the field the app expects, e.g. `{ \"sub\": \"userId\", \"groups\": \"roles\" }`."
+        },
+        "secretRef": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "name",
+            "key"
+          ],
+          "description": "Where the platform finds this client's secret — a (Sealed)Secret reference, NEVER the value. The manifest is committed to a product repo AND served back on read, so a literal secret here would be published twice over. There is deliberately no field to put one in.",
+          "properties": {
+            "name": {
+              "type": "string",
+              "maxLength": 253
+            },
+            "key": {
+              "type": "string",
+              "maxLength": 253
+            }
+          }
         }
       }
     },

--- a/packages/onboarding-kit/scripts/build-schema.mjs
+++ b/packages/onboarding-kit/scripts/build-schema.mjs
@@ -40,6 +40,7 @@ const NEEDED = [
   'Chrome',
   'Nav',
   'NavSection',
+  'Suite',
   'Routing',
   'Infra',
 ]
@@ -78,6 +79,34 @@ const schema = {
     'GENERATED from services/app-registry-service/openapi.yaml by scripts/build-schema.mjs. Do not edit by hand.',
   ...retarget(defs.AppManifest),
   $defs: retarget(defs),
+}
+
+// The NEEDED list above is explicit so that a new $ref is a LOUD failure rather
+// than a silent omission — but nothing was actually checking that, so adding
+// Nav.suite emitted a schema with a dangling `#/$defs/Suite` that every consumer
+// would fail to compile at *their* validate step, not ours. Close the loop: walk
+// what we emitted and assert every internal ref resolves.
+const collectRefs = (node, acc = new Set()) => {
+  if (Array.isArray(node)) node.forEach(n => collectRefs(n, acc))
+  else if (node && typeof node === 'object') {
+    for (const [k, v] of Object.entries(node)) {
+      if (k === '$ref' && typeof v === 'string' && v.startsWith('#/$defs/')) {
+        acc.add(v.slice('#/$defs/'.length))
+      } else collectRefs(v, acc)
+    }
+  }
+  return acc
+}
+
+const dangling = [...collectRefs(schema)].filter(name => !schema.$defs[name]).sort()
+if (dangling.length) {
+  console.error(
+    `build-schema: ${OPENAPI} references ${dangling.join(', ')}, which ${
+      dangling.length === 1 ? 'is' : 'are'
+    } not in NEEDED.\n` +
+      'Add it there so the generated schema is self-contained.'
+  )
+  process.exit(1)
 }
 
 const json = `${JSON.stringify(schema, null, 2)}\n`

--- a/packages/onboarding-kit/scripts/build-schema.mjs
+++ b/packages/onboarding-kit/scripts/build-schema.mjs
@@ -41,6 +41,8 @@ const NEEDED = [
   'Nav',
   'NavSection',
   'Suite',
+  'Auth',
+  'AuthOidc',
   'Routing',
   'Infra',
 ]

--- a/packages/onboarding-kit/tests/register.test.sh
+++ b/packages/onboarding-kit/tests/register.test.sh
@@ -116,6 +116,63 @@ set +e; run_register; RC=$?; set -e
 check "survives 2 transient 500s" "$RC" "0"
 cleanup; SERVER_PID=""
 
+# ---- 7. suite: apps/*.json siblings each register and activate ----------------
+# The failure this guards against is silent: before apps/ support, a repo shipping
+# several surfaces registered only the primary and the rest simply never appeared in
+# the portal — no error, no log line, just a product missing four of its five entries.
+mkdir -p "${REG}/apps"
+cat > "${REG}/apps/talent.json" <<'JSON'
+{
+  "manifestVersion": "1",
+  "slug": "testapp-talent",
+  "name": "TestApp Talent",
+  "menuLabel": "Talent",
+  "mode": "portal",
+  "modes": ["portal", "standalone"],
+  "integration": { "type": "module-federation", "remoteEntry": "https://testapp.example.com/talent/remoteEntry.js", "scope": "testappTalent", "module": "./App" },
+  "nav": { "section": "build", "order": 10, "suite": { "id": "testapp", "label": "TestApp", "order": 5 } },
+  "visibility": "organization"
+}
+JSON
+cat > "${REG}/apps/recruiter.json" <<'JSON'
+{
+  "manifestVersion": "1",
+  "slug": "testapp-recruiter",
+  "name": "TestApp Recruiter",
+  "menuLabel": "Recruiter",
+  "mode": "portal",
+  "integration": { "type": "module-federation", "remoteEntry": "https://testapp.example.com/recruiter/remoteEntry.js", "scope": "testappRecruiter", "module": "./App" },
+  "nav": { "section": "build", "order": 20, "suite": { "id": "testapp", "label": "TestApp", "order": 5 } },
+  "visibility": "organization"
+}
+JSON
+
+start_server
+: > "${WORK}/calls.txt"
+set +e; run_register; RC=$?; set -e
+check "suite run exits 0" "$RC" "0"
+SCALLS="$(cat "${WORK}/calls.txt")"
+echo "$SCALLS" | grep -q '^POST /api/v1/app-registry/apps/testapp-talent/activate$' \
+  && ok "registers+activates sibling 1" || notok "registers+activates sibling 1"
+echo "$SCALLS" | grep -q '^POST /api/v1/app-registry/apps/testapp-recruiter/activate$' \
+  && ok "registers+activates sibling 2" || notok "registers+activates sibling 2"
+# Product-level attachments must stay on the PRIMARY slug, not drift onto whichever
+# sibling happened to be registered last.
+echo "$SCALLS" | grep -q '^PUT /api/v1/app-registry/apps/testapp/policy$' \
+  && ok "policy still binds to the primary slug" || notok "policy still binds to the primary slug"
+SIBPOL="$(echo "$SCALLS" | grep -c '/apps/testapp-recruiter/policy' || true)"
+check "does NOT submit policy per sibling" "$SIBPOL" "0"
+cleanup; SERVER_PID=""
+
+# ---- 8. a broken sibling is FATAL (no half-registered suite) ------------------
+echo 'not json' > "${REG}/apps/broken.json"
+start_server
+set +e; run_register; RC=$?; set -e
+if [ "$RC" -ne 0 ]; then ok "invalid sibling manifest exits NON-ZERO"; else notok "invalid sibling manifest exits NON-ZERO (got 0)"; fi
+rm -f "${REG}/apps/broken.json"
+cleanup; SERVER_PID=""
+rm -rf "${REG}/apps"
+
 # ---- 6. missing required env is fatal ----------------------------------------
 set +e
 REGISTRATION_DIR="$REG" FUZEFRONT_API_URL="" FUZEFRONT_REGISTRATION_TOKEN="x" sh "$SCRIPT" >/dev/null 2>&1

--- a/services/app-registry-service/openapi.yaml
+++ b/services/app-registry-service/openapi.yaml
@@ -436,9 +436,17 @@ components:
     AppMode:
       type: string
       description: >-
+        A surface the app can be served on. NOT mutually exclusive — see
+        `AppManifest.modes`, which is the multi-valued form.
         `portal` — mounted inside the host shell at `/app/:slug` with chrome.
-        `standalone` — rendered without portal chrome on its own host/path.
-      enum: [portal, standalone]
+        `standalone` — rendered without portal chrome on its own host/path
+        (`routing.host`). This is the surface a mobile TWA/APK wraps, and the
+        only one that can be, because an app store needs a URL that stands on
+        its own.
+        `embed` — rendered inside a THIRD-PARTY page via an SDK, with neither
+        portal chrome nor FuzeFront navigation. An embed-only product is not a
+        portal destination and may not register a menu entry at all.
+      enum: [portal, standalone, embed]
 
     AppStatus:
       type: string
@@ -528,8 +536,49 @@ components:
           maximum: 9999
           default: 999
           description: >-
-            Rank WITHIN the section, ascending. Ties break on `slug` so ordering is
-            always total and stable. Leave unset (999) to sort after apps that care.
+            Rank WITHIN the section — or within the suite, when `suite` is declared.
+            Ascending. Ties break on `slug` so ordering is always total and stable.
+            Leave unset (999) to sort after apps that care.
+        suite: { $ref: '#/components/schemas/Suite' }
+
+    Suite:
+      type: object
+      additionalProperties: false
+      required: [id, label]
+      description: >-
+        Groups sibling apps that are surfaces of ONE product into a single named
+        menu group. A repo that ships several independently-mountable surfaces —
+        FuzeHub's talent / recruiter / ventures / marketplace / admin remotes — must
+        register one app per surface, because `roles`, `visibility`, `integration`
+        and `nav` are all per-surface and a single row cannot hold five of each.
+        Without this key those five register as five unrelated top-level entries and
+        the product disappears as a concept.
+
+        Each sibling carries its own copy rather than the platform holding a central
+        suite table, for the same reason `nav.section` is self-declared: onboarding a
+        product must never require a FuzeFront edit. Siblings are expected to agree;
+        the host resolves disagreement deterministically (lowest `order` wins, ties
+        on the alphabetically-first `slug`) instead of picking arbitrarily.
+      properties:
+        id:
+          allOf:
+            - $ref: '#/components/schemas/Slug'
+          description: >-
+            Stable group key, shared verbatim by every sibling. Apps with the same
+            `id` in the same `section` render as one group.
+        label:
+          type: string
+          maxLength: 40
+          description: Display name of the group (e.g. "FuzeHub").
+        order:
+          type: integer
+          minimum: 0
+          maximum: 9999
+          default: 999
+          description: >-
+            Rank of the GROUP within its section — distinct from `nav.order`, which
+            ranks this app within the group. Sorting is section → suite.order →
+            nav.order.
 
     Chrome:
       type: object
@@ -607,7 +656,27 @@ components:
           description: Label shown in the application menu / launcher (e.g. "Market").
         description: { type: string, maxLength: 1024 }
         icon: { $ref: '#/components/schemas/Icon' }
-        mode: { $ref: '#/components/schemas/AppMode' }
+        mode:
+          allOf:
+            - $ref: '#/components/schemas/AppMode'
+          deprecated: true
+          description: >-
+            DEPRECATED — single-surface form, superseded by `modes`. A product can
+            genuinely serve more than one surface (portal in the browser, standalone
+            for its own host and for a mobile wrapper), which this scalar cannot say.
+            Still REQUIRED so existing manifests keep validating; when both are
+            present `modes` wins and `mode` MUST be its first entry.
+        modes:
+          type: array
+          minItems: 1
+          uniqueItems: true
+          items: { $ref: '#/components/schemas/AppMode' }
+          description: >-
+            Every surface this app supports, in preference order — the first entry
+            is how the host serves it by default. `["portal", "standalone"]` is the
+            common case: mounted in the shell on desktop/web, and separately
+            reachable on its own host so a mobile build has something to wrap.
+            Omit to fall back to `[mode]`.
         builtin:
           type: boolean
           default: false

--- a/services/app-registry-service/openapi.yaml
+++ b/services/app-registry-service/openapi.yaml
@@ -622,6 +622,91 @@ components:
             Standalone-only: a dedicated host (e.g. `clock.fuzefront.com`). When
             omitted, standalone apps are path-based under the main app host.
 
+    Auth:
+      type: object
+      additionalProperties: false
+      description: >-
+        Identity the app needs the platform to provision for it. Today an Authentik
+        application + OIDC provider is created by hand-writing a blueprint under
+        FuzeFront's `deploy/helm/fuzefront/authentik/blueprints/`, which means
+        onboarding a product's identity requires an edit INSIDE FuzeFront — the same
+        coupling that `nav` removed for the side menu and `policy` removed for authz.
+        Declaring it here lets the product own it.
+      properties:
+        oidc: { $ref: '#/components/schemas/AuthOidc' }
+
+    AuthOidc:
+      type: object
+      additionalProperties: false
+      required: [redirectUris]
+      description: >-
+        An OIDC client for this app. Describes only what the PRODUCT knows; every
+        secret stays on the platform side.
+      properties:
+        applicationSlug:
+          allOf:
+            - $ref: '#/components/schemas/Slug'
+          description: >-
+            Authentik application slug. Defaults to the app's own `slug` when omitted.
+            The server MUST reject a value claimed by a different app — a manifest is
+            self-declared at registration, so an unchecked slug would let one product
+            bind itself to another product's identity.
+        clientType:
+          type: string
+          enum: [confidential, public]
+          default: confidential
+          description: >-
+            `public` (PKCE, no secret) is for clients that cannot hold one — a
+            browser-only SPA or a mobile/TWA build. Anything with a server keeps
+            `confidential`.
+        redirectUris:
+          type: array
+          minItems: 1
+          uniqueItems: true
+          items:
+            type: string
+            format: uri
+            pattern: '^(https://|http://localhost([:/]|$)|http://127\.0\.0\.1([:/]|$))[^*\s]*$'
+            maxLength: 2048
+          description: >-
+            Exact callback URIs. HTTPS only, except loopback for local dev. NO
+            wildcards: a redirect URI is where the authorization code is delivered, so
+            a permissive entry is a token-theft primitive, not a convenience. The
+            server SHOULD additionally require each host to be one the app already
+            declares (`routing.host`, or its integration URL).
+        postLogoutRedirectUris:
+          type: array
+          uniqueItems: true
+          items:
+            type: string
+            format: uri
+            pattern: '^(https://|http://localhost([:/]|$)|http://127\.0\.0\.1([:/]|$))[^*\s]*$'
+            maxLength: 2048
+        scopes:
+          type: array
+          uniqueItems: true
+          default: [openid, email, profile]
+          items: { type: string, maxLength: 64 }
+          description: Scopes the client requests. `openid` is implied and always granted.
+        claims:
+          type: object
+          additionalProperties: { type: string, maxLength: 64 }
+          description: >-
+            Maps an OIDC claim to the field the app expects, e.g.
+            `{ "sub": "userId", "groups": "roles" }`.
+        secretRef:
+          type: object
+          additionalProperties: false
+          required: [name, key]
+          description: >-
+            Where the platform finds this client's secret — a (Sealed)Secret reference,
+            NEVER the value. The manifest is committed to a product repo AND served back
+            on read, so a literal secret here would be published twice over. There is
+            deliberately no field to put one in.
+          properties:
+            name: { type: string, maxLength: 253 }
+            key: { type: string, maxLength: 253 }
+
     Infra:
       type: object
       additionalProperties: false
@@ -684,6 +769,7 @@ components:
         integration: { $ref: '#/components/schemas/Integration' }
         chrome: { $ref: '#/components/schemas/Chrome' }
         nav: { $ref: '#/components/schemas/Nav' }
+        auth: { $ref: '#/components/schemas/Auth' }
         routing: { $ref: '#/components/schemas/Routing' }
         infra:
           $ref: '#/components/schemas/Infra'


### PR DESCRIPTION
## 📋 Description

The manifest could not describe a product that ships **several independently-mountable surfaces**, so onboarding quietly described a smaller product instead.

FuzeHub ships four Module-Federation remotes — `packages/fuzehub-{talent,recruiter,ventures,marketplace}/`, each exposing `./App` with its own scope — plus an admin surface. It was onboarded with **one** manifest, because that is all the contract could express, and the four collapsed into a single `iframe` entry.

Nothing failed. No gate went red. The product simply lost four of its five portal entries, and it still works in production only because a *legacy* Helm job predating the onboarding kit is still registering those four against the older endpoint. **The modern, "correct" registration path was the lossy one.**

Design and rationale: `docs/planning/app-suites-and-modes.md`.

## 🔄 Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🧪 Test addition or improvement
- [x] 📝 Documentation update

## 🧪 Testing

- [x] Unit tests
- [x] Integration tests

**Test Configuration:** Node 22.22.2, Linux.

### Test Instructions

```bash
# 19 behavioural tests (13 pre-existing + 6 new)
sh packages/onboarding-kit/tests/register.test.sh

# generated schema is not stale
node packages/onboarding-kit/scripts/build-schema.mjs --check

# contract lint
cd apps-client && npm run lint:contract
```

## 🔧 Implementation Details

### Changes Made

**Contract** (`services/app-registry-service/openapi.yaml` — source of truth; JSON schema and typed client are generated from it):

- **`Nav.suite {id, label, order}`** — groups sibling apps that are surfaces of one product. One row *per surface*, because `roles`, `visibility`, `integration` and `nav` are all per-surface and a single row cannot hold five of each. `suite` restores only the grouping, which is purely presentational. Sorting is **section → `suite.order` → `nav.order`**, ties on `slug`.

  Each sibling carries its own copy rather than the platform holding a central suite table — the same principle that already governs `nav.section`: *onboarding a product must never require a FuzeFront edit.* Siblings can therefore disagree, so the host resolves deterministically (lowest `order`, ties on alphabetically-first `slug`) and `register.sh` logs each surface's suite id so a typo that silently splits a group is visible in the pod log.

- **`AppManifest.modes[]`** — surfaces are not mutually exclusive. Scalar `mode` could not say "portal in the browser **and** standalone on its own host", which is what most products need and what any mobile wrapper requires. It was also not even read on the `/api/apps` path: `appRegistry.ts` *derives* it from `integration_type`, so the declared value was decorative there. `mode` stays required so every existing manifest keeps validating; `modes` wins when both are present.

- **`AppMode` gains `embed`** — rendered inside a third-party page via an SDK, with neither portal chrome nor FuzeFront nav. FuzeBI is the existing instance.

**Onboarding kit:**

- `register.sh` registers `registration/apps/*.json` siblings alongside the primary manifest. `policy.json` and `billing-profile.json` stay bound to the **primary** slug — they are per-*product*, not per-surface, so a fixed binding removes any ambiguity about which sibling owns them. A broken sibling is fatal: a suite missing two of five entries is a broken product, not a degraded one.

- `build-schema.mjs` — its `NEEDED` list is explicit so that a new `$ref` is *"a loud failure, not a silent omission"*, but nothing actually enforced that. Adding `Nav.suite` emitted a schema with a dangling `#/$defs/Suite` that would have failed at every **consumer's** validate step rather than ours. Added the dangling-ref check the comment already claimed to provide.

### Code Quality

- [x] Self-review of code completed
- [x] Code is commented, particularly in hard-to-understand areas
- [x] No console.log or debugging statements left in code

### Documentation

- [x] Documentation has been updated (`docs/planning/app-suites-and-modes.md`)

## 🚨 Breaking Changes

None. `modes` and `nav.suite` are optional; `mode` remains required. Both on-disk product manifests (FuzeService, FuzeHub) were validated unchanged against the regenerated schema.

## 📋 Checklist

- [x] I have performed a self-review of my code
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes

## 📝 Additional Notes

### Verification

- **19/19** `register.sh` behavioural tests pass — 13 pre-existing unchanged, 6 new covering sibling registration/activation, primary-slug binding for policy, and fatal handling of a malformed sibling.
- Both on-disk product manifests still validate; empty / duplicate / unknown `modes`, a suite without a `label`, a non-slug `suite.id`, and an out-of-range `suite.order` are all rejected.
- Spectral reports no errors on the contract.
- The new `build-schema` guard was **proven to fire** by removing `Suite` from `NEEDED` and confirming a non-zero exit.

### Why not `apps[]` nested in one manifest

Every field that differs per surface would have to be repeated inside the array, at which point it is one-row-per-surface with extra nesting — plus new fan-out rules for policy, activation and status. `chrome.menu: "substitute"` was also rejected: it solves in-app navigation, not portal presence, and cannot role-gate individual surfaces.

### Not in this PR

Runtime follow-ups, each independently shippable and listed in the design doc:

1. Backend reading `modes` instead of deriving it (needs a column migration).
2. Shell rendering of suite groups — feature UI, so it goes through the frames flow first. Until then siblings render as flat entries: correct, just not grouped.
3. `mobile-maintainer` in FuzeSDLC, plus the `mobile` block and its paired gate.
4. FuzeHub migration to five manifests, then retiring `register-apps-job.yaml` — **in that order**, since the legacy job is the only thing registering those surfaces today.

### Not verified here

`tsc` on `apps-client` fails on a pre-existing `--ignoreDeprecations` value in `tsconfig.json:15` (a TS-version mismatch in a file this PR does not touch), present independently of this change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GaPa3JgrVNtWrGvqQEAEqv)_