### PR TITLE
feat(authentik): Gmail login + OIDC providers for the FuzeInfra admin plane

### DIFF
--- a/deploy/helm/fuzefront/authentik/blueprints/groups-fuzeinfra-admins.yaml
+++ b/deploy/helm/fuzefront/authentik/blueprints/groups-fuzeinfra-admins.yaml
@@ -1,0 +1,51 @@
+# Authentik Blueprint — fuzeinfra-admins group + the infra admin identity
+#
+# WHY A PRE-CREATED USER
+# source-google.yaml sets user_matching_mode: link_by_email. A Google sign-in
+# whose email matches an existing Authentik user LINKS into that account and
+# inherits its privileges; an unmatched email runs the enrollment flow and lands
+# as an ordinary, non-privileged account. Since the infra admin's Google address
+# (a gmail.com address) is not the akadmin bootstrap address
+# (admin@fuzefront.com), signing in with Google would otherwise produce a
+# powerless second account.
+#
+# Pre-creating the user here means the FIRST Google sign-in links straight into
+# an account that is already a superuser. No post-login clickops, and a rebuild
+# from scratch reproduces it.
+#
+# No password is set on this user, so the account is Google-only. The akadmin
+# bootstrap account (AUTHENTIK_BOOTSTRAP_PASSWORD) remains the break-glass login
+# if Google federation breaks.
+#
+# THIS GROUP NAME IS A CONTRACT. It is consumed by:
+#   - Grafana  — grafana.oidc.roleAttributePath  (izzywdev/FuzeInfra values.yaml)
+#   - ArgoCD   — policy.csv in argocd-rbac-cm    (izzywdev/FuzeInfra)
+# Renaming it silently demotes every admin to the lowest role rather than
+# failing loudly. Rename in lockstep across all three repos' worth of config.
+version: 1
+metadata:
+  name: FuzeInfra Admins Group
+  labels:
+    blueprints.goauthentik.io/instantiate: "true"
+entries:
+  - model: authentik_core.group
+    state: present
+    identifiers:
+      name: fuzeinfra-admins
+    attrs:
+      name: fuzeinfra-admins
+      # Grants the Authentik admin interface itself (/if/admin/), which is what
+      # makes this account able to administer the IdP, not just consume it.
+      is_superuser: true
+
+  - model: authentik_core.user
+    state: present
+    identifiers:
+      username: izzy
+    attrs:
+      username: izzy
+      name: Izzy Weinberg
+      email: izzy.weinberg@gmail.com
+      is_active: true
+      groups:
+        - !Find [authentik_core.group, [name, fuzeinfra-admins]]

--- a/deploy/helm/fuzefront/authentik/blueprints/provider-oidc-fuzeinfra-admin.yaml
+++ b/deploy/helm/fuzefront/authentik/blueprints/provider-oidc-fuzeinfra-admin.yaml
@@ -1,0 +1,256 @@
+# Authentik Blueprint — FuzeInfra admin-plane OIDC providers
+#
+# Creates the OIDC providers + Applications that let the FuzeInfra admin plane
+# (izzywdev/FuzeInfra) authenticate against Authentik instead of each service
+# carrying its own local password:
+#
+#   cloudflare-access  the Cloudflare Access wall on *.prod.fuzefront.com.
+#                      Covers EVERY admin tile, including ones with no SSO
+#                      support of their own (Prometheus, Alertmanager,
+#                      Mongo Express, ChromaDB).
+#   grafana            replaces the local `admin` account as the primary login.
+#   argocd             replaces the local `admin` account as the primary login.
+#   kafka-ui           kafka-ui has NO auth at all without this.
+#
+# client_secret is injected at blueprint-apply time via Authentik's !Env YAML
+# tag, read from the worker pod's environment (sourced from the chart Secret via
+# an OPTIONAL secretKeyRef). No secret value is stored in this file or in the
+# ConfigMap.
+#
+# NOTE: attrs.client_id / attrs.client_secret are respected at *creation time*
+# by the Authentik 2024.x blueprint runner. If the provider already exists,
+# these fields are not updated. Rotation requires deleting the provider entry
+# and re-applying. Rotating a secret here must be done in lockstep with the
+# consuming side (a SealedSecret in FuzeInfra, or a GitHub secret for Terraform).
+#
+# DESIGN: everything is defined inline in ONE blueprint — no !Find to objects
+# owned by a different blueprint. Authentik's Celery runner applies blueprints
+# concurrently, so a cross-blueprint !Find silently aborts the entry when the
+# target isn't in the DB yet. Entries WITHIN a blueprint are applied in order,
+# so the shared flow and scope mappings below are safe to reference. Same
+# rationale as provider-oidc-mendys-platform.yaml.
+version: 1
+metadata:
+  name: FuzeInfra Admin OIDC Providers
+  labels:
+    blueprints.goauthentik.io/instantiate: "true"
+entries:
+  # ── Shared authorization flow (implicit consent) ─────────────────────────────
+  # Implicit, not explicit: these are first-party admin tools reached many times
+  # a day. An explicit-consent screen on every login would be pure friction.
+  - model: authentik_flows.flow
+    state: present
+    identifiers:
+      slug: fuzeinfra-admin-authorization-implicit-consent
+    attrs:
+      name: FuzeInfra Admin Authorization (Implicit Consent)
+      slug: fuzeinfra-admin-authorization-implicit-consent
+      designation: authorization
+      title: FuzeInfra Admin Sign In
+      authentication: require_authenticated
+      policy_engine_mode: all
+
+  # ── Shared scope mappings ────────────────────────────────────────────────────
+  - model: authentik_providers_oauth2.scopemapping
+    state: present
+    identifiers:
+      name: "FuzeInfra Admin OIDC scope - openid"
+    attrs:
+      name: "FuzeInfra Admin OIDC scope - openid"
+      scope_name: openid
+      expression: "return {}"
+
+  - model: authentik_providers_oauth2.scopemapping
+    state: present
+    identifiers:
+      name: "FuzeInfra Admin OIDC scope - email"
+    attrs:
+      name: "FuzeInfra Admin OIDC scope - email"
+      scope_name: email
+      expression: |
+        return {
+            "email": request.user.email,
+            "email_verified": True,
+        }
+
+  - model: authentik_providers_oauth2.scopemapping
+    state: present
+    identifiers:
+      name: "FuzeInfra Admin OIDC scope - profile"
+    attrs:
+      name: "FuzeInfra Admin OIDC scope - profile"
+      scope_name: profile
+      expression: |
+        return {
+            "name": request.user.name,
+            "given_name": request.user.name,
+            "preferred_username": request.user.username,
+            "nickname": request.user.username,
+        }
+
+  # A DEDICATED `groups` scope, not just groups-inside-profile. Grafana's
+  # role_attribute_path and ArgoCD's policy.csv both key off this claim, and both
+  # request `groups` as an explicit scope — it has to exist as a scope of that
+  # name or the claim never reaches them and every user silently lands with the
+  # lowest role.
+  - model: authentik_providers_oauth2.scopemapping
+    state: present
+    identifiers:
+      name: "FuzeInfra Admin OIDC scope - groups"
+    attrs:
+      name: "FuzeInfra Admin OIDC scope - groups"
+      scope_name: groups
+      expression: |
+        return {
+            "groups": [g.name for g in request.user.ak_groups.all()],
+        }
+
+  # ── Provider: Cloudflare Access ──────────────────────────────────────────────
+  # Consumed by cloudflare_zero_trust_access_identity_provider.authentik in
+  # izzywdev/FuzeInfra (terraform/contabo/cloudflare.tf). The redirect URI is
+  # fixed by Cloudflare and derives from the Zero Trust team domain
+  # (fuzefront.cloudflareaccess.com) — it is NOT free-form.
+  - model: authentik_providers_oauth2.oauth2provider
+    state: present
+    identifiers:
+      name: FuzeInfra Cloudflare Access
+    attrs:
+      name: FuzeInfra Cloudflare Access
+      client_type: confidential
+      client_id: "cloudflare-access"
+      client_secret: !Env [AUTHENTIK_CF_ACCESS_CLIENT_SECRET, ""]
+      redirect_uris:
+        - matching_mode: strict
+          url: "https://fuzefront.cloudflareaccess.com/cdn-cgi/access/callback"
+      property_mappings:
+        - !Find [authentik_providers_oauth2.scopemapping, [name, "FuzeInfra Admin OIDC scope - openid"]]
+        - !Find [authentik_providers_oauth2.scopemapping, [name, "FuzeInfra Admin OIDC scope - email"]]
+        - !Find [authentik_providers_oauth2.scopemapping, [name, "FuzeInfra Admin OIDC scope - profile"]]
+        - !Find [authentik_providers_oauth2.scopemapping, [name, "FuzeInfra Admin OIDC scope - groups"]]
+      sub_mode: user_email
+      include_claims_in_id_token: true
+      authorization_flow: !Find [authentik_flows.flow, [slug, fuzeinfra-admin-authorization-implicit-consent]]
+
+  - model: authentik_core.application
+    state: present
+    identifiers:
+      slug: cloudflare-access
+    attrs:
+      name: FuzeInfra Cloudflare Access
+      slug: cloudflare-access
+      provider: !Find [authentik_providers_oauth2.oauth2provider, [name, FuzeInfra Cloudflare Access]]
+      meta_description: "Zero Trust wall in front of every *.prod.fuzefront.com admin UI"
+      policy_engine_mode: all
+      open_in_new_tab: false
+
+  # ── Provider: Grafana ────────────────────────────────────────────────────────
+  - model: authentik_providers_oauth2.oauth2provider
+    state: present
+    identifiers:
+      name: FuzeInfra Grafana
+    attrs:
+      name: FuzeInfra Grafana
+      client_type: confidential
+      client_id: "grafana"
+      client_secret: !Env [AUTHENTIK_GRAFANA_CLIENT_SECRET, ""]
+      redirect_uris:
+        - matching_mode: strict
+          url: "https://grafana.prod.fuzefront.com/login/generic_oauth"
+      property_mappings:
+        - !Find [authentik_providers_oauth2.scopemapping, [name, "FuzeInfra Admin OIDC scope - openid"]]
+        - !Find [authentik_providers_oauth2.scopemapping, [name, "FuzeInfra Admin OIDC scope - email"]]
+        - !Find [authentik_providers_oauth2.scopemapping, [name, "FuzeInfra Admin OIDC scope - profile"]]
+        - !Find [authentik_providers_oauth2.scopemapping, [name, "FuzeInfra Admin OIDC scope - groups"]]
+      sub_mode: user_email
+      include_claims_in_id_token: true
+      authorization_flow: !Find [authentik_flows.flow, [slug, fuzeinfra-admin-authorization-implicit-consent]]
+
+  # Application slug is load-bearing: it forms the issuer URL
+  # https://auth.fuzefront.com/application/o/grafana/ that FuzeInfra's
+  # values.yaml (grafana.oidc.issuer) points at.
+  - model: authentik_core.application
+    state: present
+    identifiers:
+      slug: grafana
+    attrs:
+      name: Grafana
+      slug: grafana
+      provider: !Find [authentik_providers_oauth2.oauth2provider, [name, FuzeInfra Grafana]]
+      meta_launch_url: "https://grafana.prod.fuzefront.com/"
+      meta_description: "FuzeInfra metrics, logs and alerting"
+      policy_engine_mode: all
+      open_in_new_tab: false
+
+  # ── Provider: ArgoCD ─────────────────────────────────────────────────────────
+  - model: authentik_providers_oauth2.oauth2provider
+    state: present
+    identifiers:
+      name: FuzeInfra ArgoCD
+    attrs:
+      name: FuzeInfra ArgoCD
+      client_type: confidential
+      client_id: "argocd"
+      client_secret: !Env [AUTHENTIK_ARGOCD_CLIENT_SECRET, ""]
+      redirect_uris:
+        - matching_mode: strict
+          url: "https://argocd.prod.fuzefront.com/auth/callback"
+        # The ArgoCD CLI's `argocd login --sso` uses a loopback listener.
+        - matching_mode: strict
+          url: "http://localhost:8085/auth/callback"
+      property_mappings:
+        - !Find [authentik_providers_oauth2.scopemapping, [name, "FuzeInfra Admin OIDC scope - openid"]]
+        - !Find [authentik_providers_oauth2.scopemapping, [name, "FuzeInfra Admin OIDC scope - email"]]
+        - !Find [authentik_providers_oauth2.scopemapping, [name, "FuzeInfra Admin OIDC scope - profile"]]
+        - !Find [authentik_providers_oauth2.scopemapping, [name, "FuzeInfra Admin OIDC scope - groups"]]
+      sub_mode: user_email
+      include_claims_in_id_token: true
+      authorization_flow: !Find [authentik_flows.flow, [slug, fuzeinfra-admin-authorization-implicit-consent]]
+
+  - model: authentik_core.application
+    state: present
+    identifiers:
+      slug: argocd
+    attrs:
+      name: ArgoCD
+      slug: argocd
+      provider: !Find [authentik_providers_oauth2.oauth2provider, [name, FuzeInfra ArgoCD]]
+      meta_launch_url: "https://argocd.prod.fuzefront.com/"
+      meta_description: "GitOps continuous delivery for the cluster"
+      policy_engine_mode: all
+      open_in_new_tab: false
+
+  # ── Provider: Kafka UI ───────────────────────────────────────────────────────
+  - model: authentik_providers_oauth2.oauth2provider
+    state: present
+    identifiers:
+      name: FuzeInfra Kafka UI
+    attrs:
+      name: FuzeInfra Kafka UI
+      client_type: confidential
+      client_id: "kafka-ui"
+      client_secret: !Env [AUTHENTIK_KAFKA_UI_CLIENT_SECRET, ""]
+      redirect_uris:
+        # The trailing path segment is Spring's registration id, which kafka-ui
+        # derives from the AUTH_OAUTH2_CLIENT_<ID>_ env prefix (here: AUTHENTIK).
+        - matching_mode: strict
+          url: "https://kafka-ui.prod.fuzefront.com/login/oauth2/code/authentik"
+      property_mappings:
+        - !Find [authentik_providers_oauth2.scopemapping, [name, "FuzeInfra Admin OIDC scope - openid"]]
+        - !Find [authentik_providers_oauth2.scopemapping, [name, "FuzeInfra Admin OIDC scope - email"]]
+        - !Find [authentik_providers_oauth2.scopemapping, [name, "FuzeInfra Admin OIDC scope - profile"]]
+      sub_mode: user_email
+      include_claims_in_id_token: true
+      authorization_flow: !Find [authentik_flows.flow, [slug, fuzeinfra-admin-authorization-implicit-consent]]
+
+  - model: authentik_core.application
+    state: present
+    identifiers:
+      slug: kafka-ui
+    attrs:
+      name: Kafka UI
+      slug: kafka-ui
+      provider: !Find [authentik_providers_oauth2.oauth2provider, [name, FuzeInfra Kafka UI]]
+      meta_launch_url: "https://kafka-ui.prod.fuzefront.com/"
+      meta_description: "Kafka topics, consumers and cluster config"
+      policy_engine_mode: all
+      open_in_new_tab: false

--- a/deploy/helm/fuzefront/authentik/blueprints/source-google-binding.yaml
+++ b/deploy/helm/fuzefront/authentik/blueprints/source-google-binding.yaml
@@ -1,0 +1,37 @@
+# Authentik Blueprint — show "Sign in with Google" on the login page
+#
+# WHY THIS EXISTS
+# source-google.yaml creates the Google OAuth source and sets its
+# authentication_flow/enrollment_flow. That is NOT enough to put a Google button
+# on the login screen: the button is rendered from the `sources` M2M on the
+# IDENTIFICATION STAGE, and creating a source does not add it there. Without
+# this blueprint the Google source exists, is enabled, and is unreachable — the
+# exact state prod was in.
+#
+# WHAT IT DOES
+# Rewrites the `sources` list on Authentik's built-in
+# `default-authentication-identification` stage.
+#
+# THE BUILT-IN SOURCE MUST STAY IN THE LIST. This field is a replace, not an
+# append. Dropping `authentik-built-in` removes username/password login
+# entirely, which would strand the akadmin bootstrap account — the break-glass
+# path if Google federation ever breaks.
+#
+# FAIL-SAFE: if either !Find fails to resolve, Authentik aborts THIS ENTRY and
+# leaves the stage untouched, so a bad slug costs a missing button, not a
+# lockout. Verify after applying (see docs) rather than assuming it landed.
+version: 1
+metadata:
+  name: FuzeFront Google Login Binding
+  labels:
+    blueprints.goauthentik.io/instantiate: "true"
+entries:
+  - model: authentik_stages_identification.identificationstage
+    state: present
+    identifiers:
+      name: default-authentication-identification
+    attrs:
+      sources:
+        - !Find [authentik_core.source, [slug, authentik-built-in]]
+        - !Find [authentik_core.source, [slug, google]]
+      show_source_labels: true

--- a/deploy/helm/fuzefront/templates/authentik.yaml
+++ b/deploy/helm/fuzefront/templates/authentik.yaml
@@ -91,6 +91,40 @@
       name: {{ include "fuzefront.secretName" . }}
       key: MENDYS_PLATFORM_CLIENT_SECRET
       optional: true
+# FuzeInfra admin-plane OIDC client secrets — read by
+# provider-oidc-fuzeinfra-admin.yaml via !Env at apply time. These let the
+# FuzeInfra admin UIs (Cloudflare Access, Grafana, ArgoCD, Kafka UI) authenticate
+# against Authentik instead of each carrying a local password.
+#
+# Optional, matching the Mendys convention: a missing key stamps an empty client
+# secret, which is inert until the value is sealed. But note the blueprint runner
+# only honours client_secret at CREATION time — if a provider is created while
+# the key is absent, setting the key later does NOT update it. Seal the values
+# BEFORE the first apply, or delete the provider entry and re-apply.
+- name: AUTHENTIK_CF_ACCESS_CLIENT_SECRET
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "fuzefront.secretName" . }}
+      key: CF_ACCESS_CLIENT_SECRET
+      optional: true
+- name: AUTHENTIK_GRAFANA_CLIENT_SECRET
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "fuzefront.secretName" . }}
+      key: GRAFANA_CLIENT_SECRET
+      optional: true
+- name: AUTHENTIK_ARGOCD_CLIENT_SECRET
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "fuzefront.secretName" . }}
+      key: ARGOCD_CLIENT_SECRET
+      optional: true
+- name: AUTHENTIK_KAFKA_UI_CLIENT_SECRET
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "fuzefront.secretName" . }}
+      key: KAFKA_UI_CLIENT_SECRET
+      optional: true
 {{- if .Values.smsService.enabled }}
 # SMS MFA — the stages-sms blueprint reads these env vars at apply time.
 # AUTHENTIK_SMS_SEND_URL / AUTHENTIK_SMS_VERIFY_URL point at the in-cluster
@@ -157,6 +191,16 @@ spec:
       app: authentik-server
   template:
     metadata:
+      annotations:
+        # Roll the pod when a blueprint changes.
+        #
+        # Blueprints are mounted from the authentik-blueprints ConfigMap and are
+        # discovered by Authentik at STARTUP. Updating the ConfigMap alone does
+        # not restart anything, so without this annotation an edited blueprint
+        # sits unapplied indefinitely — which is why blueprint changes appeared
+        # to "fail silently" in prod and had to be pushed through the
+        # prod-authentik-ops workflow by hand.
+        checksum/blueprints: {{ include (print $.Template.BasePath "/authentik-blueprints.yaml") . | sha256sum }}
       labels:
         {{- include "fuzefront.labels" . | nindent 8 }}
         app: authentik-server
@@ -212,6 +256,10 @@ spec:
       app: authentik-worker
   template:
     metadata:
+      annotations:
+        # The worker is the process that actually applies blueprints, so this
+        # annotation matters most here. See the note on authentik-server above.
+        checksum/blueprints: {{ include (print $.Template.BasePath "/authentik-blueprints.yaml") . | sha256sum }}
       labels:
         {{- include "fuzefront.labels" . | nindent 8 }}
         app: authentik-worker


### PR DESCRIPTION
Makes Authentik usable as the single sign-on for FuzeInfra's admin UIs, and fixes the two reasons Google sign-in has never actually worked.

**This is the IdP half and must merge first.** Consumer half: izzywdev/FuzeInfra#470.

## Google sign-in was wired but unreachable

`source-google.yaml` creates the Google OAuth source, sets `enabled: true`, and configures its flows. But the login button is rendered from the **`sources` M2M on the identification stage**, and creating a source does not add it there. So the source existed, was enabled, and no user could ever reach it — the comment in that file (`# Show a "Sign in with Google" button on the login page`) describes an outcome the config does not produce.

`source-google-binding.yaml` adds it to `default-authentication-identification`. **`authentik-built-in` is kept in the list** — the field is a replace, not an append, and dropping it would remove username/password login entirely and strand the `akadmin` bootstrap account.

## Google users had nowhere to land

With `user_matching_mode: link_by_email`, an email matching an existing user links into that account; an unmatched email enrolls a fresh, unprivileged one. The infra admin's Google address is not the `akadmin` bootstrap address (`admin@fuzefront.com`), so signing in with Google would have produced a powerless second account.

`groups-fuzeinfra-admins.yaml` pre-creates the user in a superuser group, so the **first** Google sign-in links straight into it. No post-login clickops, and a rebuild from scratch reproduces it. The user has no password, so the account is Google-only.

## Four OIDC providers for the FuzeInfra admin plane

`provider-oidc-fuzeinfra-admin.yaml` adds **Cloudflare Access** (which fronts every `*.prod` admin tile, including services with no SSO of their own), **Grafana**, **ArgoCD** and **Kafka UI**.

All entries live in **one** blueprint so nothing depends on a cross-blueprint `!Find` — per the concurrent-apply race documented in `provider-oidc-mendys-platform.yaml`. Entries *within* a blueprint apply in order, so the shared flow and scope mappings are safe to reference.

A **dedicated `groups` scope** is defined, not just groups-inside-`profile`: Grafana's `role_attribute_path` and ArgoCD's `policy.csv` both request `groups` by name, and without a scope of that name the claim never arrives and every user silently lands on the lowest role.

## Blueprint changes never rolled the pods

Neither Deployment had a `checksum/blueprints` annotation, even though `authentik/ops.py:8` states the deployments "roll on blueprint changes via a checksum annotation". Blueprints are discovered at **startup**, so editing the ConfigMap changed nothing and edits sat unapplied — which is why `prod-authentik-ops.yml` describes the file-based runner as failing "silently" and exists as a manual `workflow_dispatch` escape hatch.

Both Deployments now carry the annotation. This is a precondition for everything else in this PR actually applying.

## Client secrets

Four optional `secretKeyRef`s (`CF_ACCESS_CLIENT_SECRET`, `GRAFANA_CLIENT_SECRET`, `ARGOCD_CLIENT_SECRET`, `KAFKA_UI_CLIENT_SECRET`) on `fuzefront-secrets`. **Not minted in this PR** — see `deploy/sealed-secrets/authentik-oidc-secrets.yaml.template` in FuzeInfra for the sealing runbook.

⚠️ **Seal the values before these providers are first created.** The 2024.x blueprint runner honours `client_secret` only at **creation time**; if a provider is created while the key is absent it is stamped with an empty secret, and sealing the value later does *not* update it. Recovery is deleting the provider entry and re-applying.

## Verified

`helm template` with `values-prod.yaml`: all three blueprints land in the ConfigMap, all four env vars appear on **both** server and worker, and the `checksum/blueprints` annotation matches across both pod templates.

**Not verified:** nothing applied to the cluster; no live Authentik API call made.

## Noticed in passing, not fixed here

- `MENDYS_DATASETS_CLIENT_SECRET` is absent from the prod SealedSecret, so that provider was created with an **empty** client secret (silent — the `secretKeyRef` is `optional`).
- Prod Authentik has **no SMTP** (`authentik.smtp.host` unset in `values-prod.yaml`), so the blueprinted enrollment-verification and recovery email stages cannot deliver.
- `docs/AUTHENTICATION_SETUP.md` and `README.md:95` still describe Authentik as docker-compose + clickops, which has been wrong since the blueprints landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
