### PR TITLE
docs(governance): mandate Node 24 LTS / React 19 as the toolchain floor

### DIFF
--- a/.fuze/manifest.json
+++ b/.fuze/manifest.json
@@ -23,6 +23,18 @@
     "fuzeinfra-expert",
     "a2a-maintainer"
   ],
+  "toolchain": {
+    "node": ">=24.0.0",
+    "npm": ">=10.0.0",
+    "typesNode": "^24.13.3",
+    "react": "^19.2.0",
+    "reactPeerRange": "^19.0.0",
+    "typesReact": "^19.2.0",
+    "moduleFederationRequiredVersion": "^19.0.0",
+    "dockerBaseImage": "node:24-alpine",
+    "ciNodeVersion": "24.x",
+    "note": "Mandated MINIMUMS for this repo and every consuming remote — see the 'Toolchain baseline' section of CLAUDE.md. FuzeFront is the Module-Federation host, so moduleFederationRequiredVersion must be identical here and in every remote or the remote loads its own React copy and fails with 'Invalid hook call'. Raising the floor is fine; lowering it is a breaking change to the family. Declarative only — no CI gate reads this today."
+  },
   "designSystem": {
     "base": "@fuzefront/design-system",
     "extendsAs": "@fuzefront/design-system",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,27 @@ Read the baseline for the full governance model (3 layers, repo tiers, single-re
 - **Backend:** Express + Postgres, with **Authentik** (identity/SSO) and **Permit** (authorization) for auth. The frontend talks to the API on a **same-origin API base** (no cross-origin base URL) so it works identically under local TLS and prod ingress — never hard-code an absolute API host.
 - **Runs on FuzeInfra.** Deploys to Kubernetes (kind-fuzeinfra locally / Contabo k3s prod) via Helm. Infra changes are **delegated to FuzeInfra via `@claude`** — never edit FuzeInfra or operate the cluster from here.
 
+## Toolchain baseline — Node 24 LTS / React 19 are a floor, not a suggestion
+
+These are **minimums every manifest, image, workflow and remote must meet.** FuzeFront is the Module-Federation host, so its React major *is* the shared-singleton contract for the whole family — drift here does not surface as a version warning, it surfaces as a white screen in somebody else's app.
+
+| Thing | Mandated minimum | Declared in |
+|---|---|---|
+| Node | `>=24.0.0` (Krypton, Active LTS) | `engines.node` in every manifest; `.nvmrc` = `24` |
+| npm | `>=10.0.0` | `engines.npm` |
+| `@types/node` | `^24.13.3` | every manifest |
+| `react` / `react-dom` | `^19.2.0` | app dependencies |
+| React peer range | `^19.0.0` | `peerDependencies` of every published `@fuzefront/*` package + the SDK |
+| `@types/react` / `@types/react-dom` | `^19.2.0` | root **and** `design-system` (it ships `.d.ts` that import React types) |
+| MF shared `requiredVersion` | `^19.0.0` | host `frontend/vite.config.ts` **and** every remote |
+| Docker base image | `node:24-alpine` / `node:24-bookworm-slim` | every Dockerfile |
+| CI runner | `node-version: '24.x'` | every workflow |
+
+- **Raising the floor is fine; lowering it is a breaking change to the family.** Node 18/20/22 and React 18 no longer satisfy these manifests. Bumping the React major means bumping the host, both in-repo remotes, every published peer range and every out-of-repo consumer together — it is never a single-package decision.
+- **Host and remote `requiredVersion` must be identical.** If they differ, the remote silently loads its own React copy and dies on "Invalid hook call" at runtime, in the browser, with nothing in CI to catch it.
+- **Out-of-repo remotes are bound by this too.** React 18 consumers fail peer resolution against the published packages; see `docs/guides/BUILDING_ON_FUZEFRONT.md`.
+- **Nothing enforces this yet.** No CI job reads `engines`, `.nvmrc`, the peer ranges or the MF `requiredVersion` — `gate-version` only checks SemVer bump discipline. Until a `gate-toolchain` exists, this table is the source of truth and the rule survives on review alone. Frozen point-in-time records under `docs/superpowers/plans/`, `sdd/` and `docs/chats/` deliberately still quote the versions current when they were written; they are history, not governance.
+
 ## Design system — FuzeFront IS the base
 
 - FuzeFront publishes the **"fuse seam" design system** as the base package **`@fuzefront/design-system`** — the single source of truth for color/spacing/type/primitives for the whole Fuze family.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,8 +23,8 @@ This project and everyone participating in it is governed by our [Code of Conduc
 
 ### Prerequisites
 
-- **Node.js 20+** (required for latest dependencies)
-- **npm 10+**
+- **Node.js 24+** (Krypton, Active LTS — enforced by `engines.node >=24.0.0`; `.nvmrc` pins the major)
+- **npm 10+** (enforced by `engines.npm >=10.0.0`)
 - **Git**
 - **Code Editor** (VS Code recommended with TypeScript extensions)
 

--- a/backend/docs/developer-guide.md
+++ b/backend/docs/developer-guide.md
@@ -262,11 +262,11 @@ export default defineConfig({
       shared: {
         react: {
           singleton: true,
-          requiredVersion: '^18.0.0',
+          requiredVersion: '^19.0.0',
         },
         'react-dom': {
           singleton: true,
-          requiredVersion: '^18.0.0',
+          requiredVersion: '^19.0.0',
         },
         '@frontfuse/sdk': {
           singleton: true,

--- a/docs/BACKEND_TESTING_SUMMARY.md
+++ b/docs/BACKEND_TESTING_SUMMARY.md
@@ -274,7 +274,7 @@ USE_POSTGRES=true bash scripts/run-backend-tests.sh
 ### **CI/CD Benefits**
 
 - ✅ **Automated Testing**: Every push/PR triggers tests
-- ✅ **Multi-Environment**: Node.js 18.x and 20.x testing
+- ✅ **Runtime**: Node.js 24.x (Active LTS — matches `engines.node >=24.0.0`)
 - ✅ **Coverage Reporting**: Codecov integration
 - ✅ **Artifact Collection**: Test results preserved
 

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -262,11 +262,11 @@ export default defineConfig({
       shared: {
         react: {
           singleton: true,
-          requiredVersion: '^18.0.0',
+          requiredVersion: '^19.0.0',
         },
         'react-dom': {
           singleton: true,
-          requiredVersion: '^18.0.0',
+          requiredVersion: '^19.0.0',
         },
         '@frontfuse/sdk': {
           singleton: true,

--- a/docs/guides/BUILDING_ON_FUZEFRONT.md
+++ b/docs/guides/BUILDING_ON_FUZEFRONT.md
@@ -70,6 +70,16 @@ loads the remote on demand using `@originjs/vite-plugin-federation`. React /
 React-DOM are shared singletons for performance, so keep your React major in step
 with the host.
 
+**The host is on React 19 and Node 24 (Active LTS). These are minimums, not targets:**
+
+- Your federation `shared` block must declare `requiredVersion: '^19.0.0'` for both
+  `react` and `react-dom` — **identical to the host**. If it differs, your remote
+  quietly loads its own React copy and fails at runtime with "Invalid hook call";
+  nothing in your build or the host's CI will warn you first.
+- Your app needs `react`/`react-dom` `^19.2.0` and `@types/react(-dom)` `^19.2.0`.
+- Build on Node `>=24.0.0` / npm `>=10.0.0`. The published `@fuzefront/*` packages
+  peer-depend on `react@^19.0.0`, so a React 18 consumer fails peer resolution outright.
+
 ---
 
 ## 2. Consume the `@fuzefront/*` packages

--- a/docs/guides/MODULE_FEDERATION_GUIDE.md
+++ b/docs/guides/MODULE_FEDERATION_GUIDE.md
@@ -71,11 +71,11 @@ export default defineConfig({
       shared: {
         react: {
           singleton: true,
-          requiredVersion: '^18.0.0',
+          requiredVersion: '^19.0.0',
         } as any,
         'react-dom': {
           singleton: true,
-          requiredVersion: '^18.0.0',
+          requiredVersion: '^19.0.0',
         } as any,
       },
     }),
@@ -187,7 +187,7 @@ npm run preview
 
 ```dockerfile
 # Multi-stage build for production
-FROM node:18-alpine AS builder
+FROM node:24-alpine AS builder
 
 WORKDIR /app
 COPY package*.json ./

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -421,7 +421,7 @@ npm run build
 ### Docker Deployment
 
 ```dockerfile
-FROM node:18-alpine as builder
+FROM node:24-alpine as builder
 WORKDIR /app
 COPY package*.json ./
 RUN npm ci


### PR DESCRIPTION
## 📋 Description

#450 moved every manifest, image and workflow onto **Node 24 LTS** and **React 19.2** — but it never wrote down that those versions are now *required*, and several live guides still taught the old ones. This adds the mandate and makes the docs agree with it.

The gap mattered most for **out-of-repo remotes**: `docs/guides/MODULE_FEDERATION_GUIDE.md` was still handing remote authors `requiredVersion: '^18.0.0'` — a value that, copied today, makes their remote load its own React copy and die on "Invalid hook call" at runtime, with nothing in their build or the host's CI to warn them.

## 🔄 Type of Change

- [x] 📝 Documentation update

## 🧪 Testing

- [x] Manual testing (verified the mandate matches the code)

### Test Instructions

The mandate is only worth anything if it describes reality. Both checks pass:

```bash
# no Dockerfile is off node:24
grep -rn "^FROM node:" --include="Dockerfile*" . | grep -v node_modules | grep -v "node:24"

# no declared engines.node targets anything but 24
python3 -c "
import json,glob
for f in glob.glob('**/package.json',recursive=True):
    if 'node_modules' in f: continue
    try: p=json.load(open(f))
    except Exception: continue
    e=(p.get('engines') or {}).get('node')
    if e and '24' not in e: print(f,e)
"

# manifest still parses
python3 -c "import json; json.load(open('.fuze/manifest.json'))"
```

Both greps return empty; the manifest parses.

## 🔧 Implementation Details

### Changes Made

**The mandate**

- **`CLAUDE.md`** — new `## Toolchain baseline` section, placed right after "What FuzeFront is". This is the agent-binding source of truth: the one file every agent reads. Contains the table of mandated minimums, plus the two rules that are easy to get wrong:
  - raising the floor is fine; **lowering it is a family-wide breaking change**, never a single-package decision
  - **host and remote `requiredVersion` must be identical** — the "Invalid hook call" failure mode above
- **`.fuze/manifest.json`** — matching machine-readable `toolchain` block. Purely additive: `governance-sync.yml` only reads `baselineRef` and `agents[]`, so nothing reconciles against it today.

| Thing | Mandated minimum |
|---|---|
| Node | `>=24.0.0` (Krypton, Active LTS) |
| npm | `>=10.0.0` |
| `@types/node` | `^24.13.3` |
| `react` / `react-dom` | `^19.2.0` |
| React peer range | `^19.0.0` |
| `@types/react(-dom)` | `^19.2.0` |
| MF `requiredVersion` | `^19.0.0` |
| Docker base | `node:24-alpine` / `node:24-bookworm-slim` |
| CI runner | `24.x` |

**Docs that contradicted it**

- `docs/guides/BUILDING_ON_FUZEFRONT.md` — the remote-author contract said *"keep your React major in step with the host"* without ever naming the major. Now names it and spells out the failure mode.
- `CONTRIBUTING.md` — prerequisites said **Node.js 20+**, directly contradicting `engines.node >=24.0.0`.
- `docs/guides/MODULE_FEDERATION_GUIDE.md`, `docs/developer-guide.md`, `backend/docs/developer-guide.md` — 6 × `requiredVersion: '^18.0.0'` → `'^19.0.0'`.
- `docs/guides/MODULE_FEDERATION_GUIDE.md`, `sdk/README.md` — `node:18-alpine` → `node:24-alpine`.
- `docs/BACKEND_TESTING_SUMMARY.md` — claimed a "Node.js 18.x and 20.x" matrix that no longer exists.

### Deliberately left alone

Frozen point-in-time records under `docs/superpowers/plans/`, `sdd/`, `docs/chats/` and `docs/planning/` keep their original versions. They are history, not governance — rewriting them would falsify the record. `CLAUDE.md` says so explicitly so the next person doesn't "fix" them.

### Code Quality

- [x] Code follows the project's coding standards
- [x] Self-review of code completed
- [x] No console.log or debugging statements left in code

### Documentation

- [x] Documentation has been updated
- [x] README updated (n/a — `README.md:620` already said Node 24+)

## 🚨 Breaking Changes

None — documentation and one additive manifest field. It documents a breaking change that already shipped in #450.

## 📋 Checklist

### Pre-submission

- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective — n/a, docs; the two greps above are the verification

### Code Quality

- [x] Code follows conventional commit format
- [x] No security vulnerabilities introduced

## 📝 Additional Notes

### Deployment Notes

- [ ] Requires database migration
- [ ] Requires environment variable changes
- [ ] Requires dependency updates

No image or chart changes, so the deploy-on-push release is a no-op rebuild.

### Known gap — this mandate is not enforced

**No CI job reads `engines`, `.nvmrc`, the React peer ranges, or the MF `requiredVersion`.** `gate-version` only checks SemVer bump discipline on changed manifests, and `scripts/check-workspace-deps.mjs` checks workspace resolution, never version ranges. Every workflow pins `node-version: '24.x'` by duplication rather than by asserting a single source of truth.

That leaves this section surviving on review alone — which is the exact failure mode `CLAUDE.md` warns about elsewhere ("Governance nobody can skip beats a step someone is supposed to remember"). `CLAUDE.md` states the gap plainly rather than implying enforcement that does not exist.

**Recommended follow-up:** a `gate-toolchain` job asserting the table against the tree. `scripts/check-workspace-deps.mjs` is the natural sibling to extend — it already walks every tracked `package.json`. Out of scope here, which is docs.

### Future Work

- The durable home for a *family-wide* mandate is the FuzeSDLC L0 baseline with a vendored copy here (the `governance/pagination-standard.md` pattern). This lands it as an L1 overlay rule first; promoting it to L0 is `platform-governance`'s call and a cross-repo change.

---
_Generated by [Claude Code](https://claude.ai/code/session_019S8focNVqanpWGCqhmvRMQ)_