### PR TITLE
fix(login): Google button disappearing + drop redundant userinfo round-trip

### DIFF
--- a/backend/security/src/services/oidc.ts
+++ b/backend/security/src/services/oidc.ts
@@ -295,13 +295,59 @@ class OIDCService {
         'oidc: token exchange completed'
       );
 
-      // Get user info
-      const userinfoStart = Date.now();
-      const userinfo = await this.client.userinfo(tokenSet.access_token!);
-      logger.info(
-        { elapsedMs: Math.round(Date.now() - userinfoStart), email: userinfo.email },
-        'oidc: userinfo retrieved'
-      );
+      // Claims come from the ID TOKEN, not a second HTTP call.
+      //
+      // A sign-in is a chain of SEQUENTIAL round-trips to the identity provider
+      // (flow-executor stages, then authorize -> code, then this token
+      // exchange), and Authentik averages ~1.3s per request with multi-second
+      // spikes — so the round-trip COUNT is the dominant cost, and a redundant
+      // one is pure added latency on every single login.
+      //
+      // `userinfo` was exactly that. The provider blueprint sets
+      // `include_claims_in_id_token: true` and grants the `openid email
+      // profile` scope mappings we request, so the ID token already carries
+      // every field syncUserToDatabase reads: email, email_verified, name,
+      // given_name (see deploy/helm/.../blueprints/provider-oidc.yaml). The
+      // extra endpoint call re-fetched data we were already holding.
+      //
+      // Trust: `client.callback()` has already verified the ID token's
+      // signature, issuer, audience and expiry, so these claims are no less
+      // authoritative than the userinfo response — same provider, same
+      // mappings, one fewer hop.
+      //
+      // FALL BACK, don't assume. If `include_claims_in_id_token` is ever turned
+      // off, or a provider is configured without the profile/email mappings,
+      // `email` will be missing — and email is the natural key user sync
+      // matches on, so guessing would create duplicate accounts. Absent email
+      // means we still make the userinfo call rather than proceed on partial
+      // data.
+      const claimsStart = Date.now();
+      let userinfo: Record<string, unknown> = {};
+      try {
+        userinfo = tokenSet.claims() as Record<string, unknown>;
+      } catch (err) {
+        // A malformed/absent id_token should not be fatal — the fallback below
+        // covers it.
+        logger.warn(
+          { err: (err as Error).message },
+          'oidc: could not read id_token claims; falling back to userinfo'
+        );
+      }
+      if (!userinfo.email) {
+        const userinfoStart = Date.now();
+        userinfo = (await this.client.userinfo(
+          tokenSet.access_token!
+        )) as Record<string, unknown>;
+        logger.info(
+          { elapsedMs: Math.round(Date.now() - userinfoStart) },
+          'oidc: userinfo retrieved (id_token carried no email)'
+        );
+      } else {
+        logger.info(
+          { elapsedMs: Math.round(Date.now() - claimsStart) },
+          'oidc: claims read from id_token (userinfo round-trip skipped)'
+        );
+      }
 
       // Sync user to local database
       const syncStart = Date.now();

--- a/backend/security/tests/oidc-google-signin.test.ts
+++ b/backend/security/tests/oidc-google-signin.test.ts
@@ -240,6 +240,49 @@ describe('OIDCService.handleCallback()', () => {
     expect(mockClient.userinfo).toHaveBeenCalledWith('at-specific')
   })
 
+  // Sign-in is a chain of SEQUENTIAL provider round-trips and Authentik averages
+  // ~1.3s each, so the round-trip COUNT is the dominant cost. The provider sets
+  // `include_claims_in_id_token: true` and grants the scopes we ask for, so the
+  // token exchange already returns every claim user-sync reads — the separate
+  // userinfo call was re-fetching data we were already holding.
+  it('skips the userinfo round-trip when the id_token already carries the claims', async () => {
+    mockClient.callback.mockResolvedValue({
+      access_token: 'at-with-claims',
+      claims: () => ({
+        sub: 'idtoken-sub-001',
+        email: 'fromidtoken@oidctest.example.com',
+        given_name: 'Id',
+        family_name: 'Token',
+        email_verified: true,
+      }),
+    })
+
+    const user = await oidcService.handleCallback('c', 's', 'v')
+
+    // The whole point: one fewer sequential hop per login.
+    expect(mockClient.userinfo).not.toHaveBeenCalled()
+    // And the identity is taken from the (already signature-verified) claims.
+    expect(user).toMatchObject({
+      email: 'fromidtoken@oidctest.example.com',
+      firstName: 'Id',
+      lastName: 'Token',
+    })
+  })
+
+  it('falls back to userinfo when the id_token carries no email', async () => {
+    // email is the natural key user-sync matches on, so proceeding without it
+    // would risk creating duplicate accounts — worth the extra hop.
+    mockClient.callback.mockResolvedValue({
+      access_token: 'at-no-email',
+      claims: () => ({ sub: 'no-email-sub', given_name: 'Partial' }),
+    })
+
+    const user = await oidcService.handleCallback('c', 's', 'v')
+
+    expect(mockClient.userinfo).toHaveBeenCalledWith('at-no-email')
+    expect(user.email).toBe(mockUserInfo.email)
+  })
+
   it('returns a User with the correct shape from the userinfo claims', async () => {
     const user = await oidcService.handleCallback('auth-code-xyz', 'state-abc', 'verifier-123')
     expect(user).toMatchObject({

--- a/frontend/src/__tests__/LoginPage.google-signin.test.tsx
+++ b/frontend/src/__tests__/LoginPage.google-signin.test.tsx
@@ -160,6 +160,31 @@ describe('LoginPage — social / Google Sign-In UI', () => {
     expect(screen.queryByRole('button', { name: /sign in with google/i })).not.toBeInTheDocument()
   })
 
+  // ── 1c: Regression — the fallback must match the server's real default ────
+  //
+  // "The Google button doesn't show in some cases" was reported in prod. The
+  // fallback rendered while GET /methods is in flight — and used again if that
+  // call ever fails — declared `social: []`. The security service's actual
+  // default (routes/security.ts) is Google ENABLED unless SECURITY_SOCIAL_GOOGLE
+  // is explicitly set to 'false', which no deploy env does. So any time that
+  // fetch was slow, raced an unmount, or errored outright, a legitimately
+  // available Google button silently vanished — intermittently, with nothing
+  // resembling an error to explain it. This test pins the fix: the button must
+  // survive a failed capability fetch, not just a slow-then-successful one.
+  it('still shows the Google button when GET /methods fails outright (fallback matches the real default)', async () => {
+    vi.mocked(authAPI.getAuthMethods).mockRejectedValue(new Error('network error'))
+
+    render(<LoginPage />)
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/email/i)).toBeInTheDocument()
+    })
+
+    expect(
+      screen.getByRole('button', { name: /sign in with google/i })
+    ).toBeInTheDocument()
+  })
+
   // ── 1b: Regression — auth methods fetched ONCE, not in a render loop ─────
 
   it('fetches auth methods exactly once (no re-render loop)', async () => {

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -24,12 +24,23 @@ const GOOGLE_BRAND = {
   green: '#34A853', // ds-conformance-allow: third-party brand mark (Google identity guidelines)
 }
 
-// Neutral fallback capability descriptor — password-only. Used when the Security
-// API can't be reached so the form is still usable. No provider is named: the
-// browser only ever knows FuzeFront's own /api/v1/security surface.
+// Fallback capability descriptor, used when GET /methods hasn't resolved yet
+// or fails outright — the form must still be usable without it. `social:
+// ['google']` mirrors the SERVER'S OWN default (routes/security.ts: enabled
+// unless SECURITY_SOCIAL_GOOGLE=false, which is not set in any deploy env).
+//
+// This was `social: []` — plausible-looking ("if we don't know, assume
+// nothing's configured"), but wrong: it doesn't describe an unknown provider,
+// it describes the SPECIFIC, known default this app actually deploys with. A
+// fallback that disagrees with the real default only ever LOOKS right on the
+// happy path (methods resolves before anyone notices), and is silently wrong
+// every time that fetch is slow, races an unmount, or errors — which reads to
+// users as "the Google button disappeared," intermittently, for no visible
+// reason. If the real default ever changes, update this to match — it must
+// describe reality, not the safest-sounding guess.
 const FALLBACK_METHODS: AuthMethods = {
   password: true,
-  social: [],
+  social: ['google'],
   mfa: { enabled: false, types: [] },
   verification: { email: false, sms: false },
 }

--- a/packages/auth-ui/src/components/AuthPanel.test.tsx
+++ b/packages/auth-ui/src/components/AuthPanel.test.tsx
@@ -146,6 +146,25 @@ describe('AuthPanel', () => {
     expect(screen.queryByRole('button', { name: /sign in with google/i })).not.toBeInTheDocument()
   })
 
+  // Regression — "the Google button doesn't show in some cases," reported in
+  // prod. The fallback used while getAuthMethods() is in flight — and again if
+  // it fails outright — declared `social: []`. The security service's actual
+  // default (backend/security/src/routes/security.ts) is Google ENABLED unless
+  // SECURITY_SOCIAL_GOOGLE is explicitly 'false', which no deploy env sets. So
+  // a slow, unmount-raced, or failed fetch silently hid a button that WAS
+  // available. Pins that a failed fetch is no longer indistinguishable from a
+  // server that genuinely disabled Google.
+  it('still shows the Google button when getAuthMethods() fails outright (fallback matches the real default)', async () => {
+    const transport = makeTransport({
+      startSocial: vi.fn().mockResolvedValue(undefined),
+      getAuthMethods: vi.fn().mockRejectedValue(new Error('network error')),
+    })
+    render(<AuthPanel variant="compact" transport={transport} onAuthenticated={vi.fn()} />)
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /sign in with google/i })).toBeInTheDocument(),
+    )
+  })
+
   it('toggles between sign-in and sign-up labels and clears the name fields context', async () => {
     render(<AuthPanel variant="compact" transport={makeTransport()} onAuthenticated={vi.fn()} />)
     expect(screen.getByRole('button', { name: 'Sign In' })).toBeInTheDocument()

--- a/packages/auth-ui/src/components/AuthPanel.tsx
+++ b/packages/auth-ui/src/components/AuthPanel.tsx
@@ -9,13 +9,25 @@ import type {
 import { DEFAULT_AUTH_LABELS } from '../types'
 import { GoogleGlyph } from './GoogleGlyph'
 
-/** Password-only, no-social fallback — rendered immediately so the form is never
- * gated on the `getAuthMethods()` round trip. Mirrors LoginPage's fail-open
- * posture: a slow/failed capability fetch degrades to the password form,
- * never to a blank screen. */
+/**
+ * Fallback capability descriptor — rendered immediately so the form is never
+ * gated on the `getAuthMethods()` round trip; a slow/failed capability fetch
+ * degrades to this, never to a blank screen.
+ *
+ * `social: ['google']` mirrors the SECURITY SERVICE'S OWN default
+ * (backend/security/src/routes/security.ts: enabled unless
+ * SECURITY_SOCIAL_GOOGLE=false, which no deploy env sets) — this panel's
+ * `transport` is that service's contract, not a generic unknown backend, so
+ * the fallback should describe what that specific backend actually does by
+ * default, not the safest-sounding guess. `social: []` looked plausible but
+ * was wrong: every time the fetch was slow, raced an unmount, or errored, a
+ * legitimately-enabled Google button silently vanished — "it doesn't show in
+ * some cases," reported against LoginPage, which carried the same bug and is
+ * fixed the same way. If the security-service default ever changes, update
+ * this to match. */
 const FALLBACK_METHODS: AuthMethods = {
   password: true,
-  social: [],
+  social: ['google'],
   mfa: { enabled: false, types: [] },
   verification: { email: false, sms: false },
 }

--- a/packages/auth-ui/src/vanilla/mount.test.ts
+++ b/packages/auth-ui/src/vanilla/mount.test.ts
@@ -87,6 +87,22 @@ describe('vanilla mount()', () => {
     expect(socialWrap.style.display).toBe('block')
   })
 
+  // Regression — the fallback used while getAuthMethods() is in flight (and
+  // again if it fails) must match the security service's real default (Google
+  // enabled), not silently disagree with it — see the FALLBACK_METHODS
+  // doc-comment in ./mount.ts. Opting into `social: true` here is what a host
+  // that WANTS the button would set; a failed fetch must not then hide it.
+  it('still shows the Google button when getAuthMethods() fails outright and social is opted in', async () => {
+    const transport = makeTransport({
+      startSocial: vi.fn().mockResolvedValue(undefined),
+      getAuthMethods: vi.fn().mockRejectedValue(new Error('network error')),
+    })
+    mount(container, { transport, onAuthenticated: vi.fn(), social: true })
+    await new Promise((r) => setTimeout(r, 0))
+    const socialWrap = container.querySelector('.fzf-auth-panel__social') as HTMLElement
+    expect(socialWrap.style.display).toBe('block')
+  })
+
   it('unmount() removes the rendered markup', () => {
     const handle = mount(container, { transport: makeTransport(), onAuthenticated: vi.fn() })
     expect(container.querySelector('.fzf-auth-panel')).toBeTruthy()

--- a/packages/auth-ui/src/vanilla/mount.ts
+++ b/packages/auth-ui/src/vanilla/mount.ts
@@ -17,9 +17,16 @@ import type {
 } from '../types'
 import { DEFAULT_AUTH_LABELS } from '../types'
 
+// `social: ['google']` mirrors the security service's own default (enabled
+// unless SECURITY_SOCIAL_GOOGLE=false server-side) — see the matching
+// FALLBACK_METHODS doc-comment in ../components/AuthPanel.tsx for why a
+// fallback of `[]` here silently hid an available Google button on every
+// slow/failed getAuthMethods() call, independent of the `social` opt-in
+// below (which gates whether this host wants social shown AT ALL, not
+// whether the SERVER offers it).
 const FALLBACK_METHODS: AuthMethods = {
   password: true,
-  social: [],
+  social: ['google'],
   mfa: { enabled: false, types: [] },
   verification: { email: false, sms: false },
 }


### PR DESCRIPTION
## 📋 Description

Two fixes, both on the sign-in path, added to this PR as they were found:

### 1. "Sign-in with Google seems to disappear. It doesn't show in some cases." (added in this update)

**Root cause: three places render the Google button gated on a local fallback that disagreed with the server's real default.**

`frontend/src/pages/LoginPage.tsx`, `packages/auth-ui/src/components/AuthPanel.tsx` (the new reusable panel from #458), and `packages/auth-ui/src/vanilla/mount.ts` all render the Google button based on `authMethods.social.includes('google')`, and all three use a **local fallback value** for `authMethods` while `GET /v1/security/methods` is in flight, or if it fails outright. That fallback declared `social: []`.

The server's actual default (`backend/security/src/routes/security.ts`) is the **opposite**: Google is enabled unless `SECURITY_SOCIAL_GOOGLE` is explicitly set to `'false'` — and no deploy environment sets it. So the fallback didn't represent "we don't know yet"; it confidently asserted a **different, wrong** state. Every time that fetch was slow, raced a fast unmount, or errored outright, a legitimately available Google button silently vanished, with nothing resembling an error to explain it. That is exactly "it doesn't show in some cases" — it depends on network timing, not on any deliberate config.

**Fix:** all three fallbacks now declare `social: ['google']`, matching the security service's real default. The vanilla mount's separate `social` **opt-in** default (OFF, intentional, documented — whether a non-React host wants social shown *at all*) is untouched; only the "what does the server actually do" guess changed.

> If the server's real default is ever flipped, these fallbacks must be updated to match — they describe reality, not a guess, and a stale one fails the same way in the opposite direction.

### 2. Sign-in is still slow after #455 (original PR content)

That PR stopped sign-in *failing*; it did not make it *fast*. **The cost is round-trip count.** A login is a chain of *sequential* calls to the identity provider, and Authentik averages ~1.3s per request with multi-second spikes (per this repo's own recorded measurements), so every hop is ~1.3s+ of wall clock the user sits through:

| # | Hop | Removable? |
|---|---|---|
| 1 | `GET` flow executor → identification challenge | flow config |
| 2 | `POST` identification → password challenge | flow config |
| 3 | `POST` password → `xak-flow-redirect` | needed |
| 4 | `GET` authorize → 302 with code | architectural |
| 5 | `POST` token endpoint | needed |
| 6 | `GET` **userinfo** | **✅ this PR — it was doing nothing** |

`userinfo` was a second HTTP call to re-fetch data we were **already holding**. The provider blueprint sets `include_claims_in_id_token: true` and grants the `openid email profile` scope mappings we request, so the ID token returned by the token exchange already carries every field `syncUserToDatabase` reads — `email`, `email_verified`, `name`, `given_name` (`deploy/helm/fuzefront/authentik/blueprints/provider-oidc.yaml`).

**Trust is unchanged.** `client.callback()` has already verified the ID token's signature, issuer, audience and expiry, so these claims are exactly as authoritative as the userinfo response.

**Falls back rather than assuming.** If `include_claims_in_id_token` is ever turned off, or a provider lacks the email/profile mappings, `email` will be missing — and email is the natural key user-sync matches on, so proceeding on partial data would risk duplicate accounts. No email → still call userinfo.

Removes one of six sequential hops from **both** password login and the social/redirect callback, which share this code.

## 🔄 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ⚡ Performance improvement
- [x] 🧪 Test addition or improvement

## 🧪 Testing

- [x] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [ ] Manual testing — not possible from this environment (network policy blocks `app.fuzefront.com`)

**Test Configuration:**

- Node.js version: 22.22.2 (repo `engines` targets ≥24; CI covers 24.x)
- npm version: 10.9.7
- OS: Linux

### Test Instructions

```bash
npm install
npm run type-check -w backend/security
PERMIT_API_KEY=test-key npm test -w backend/security -- tests/oidc-google-signin.test.ts
cd frontend && npx vitest run src/__tests__/LoginPage.google-signin.test.tsx
cd packages/auth-ui && npx vitest run
```

Results, all measured by diffing full-suite output **with and without** this branch via a clean `git worktree` of `origin/master` (not stash — avoids any risk of comparing against a dirty tree):

- `backend/security` full suite: **31 suites, identical pass/fail set before and after** (11 pre-existing failures, unrelated `referenceApp.ts`/contract-fixture issues — neither grew nor shrank)
- `frontend` full suite: **12 suites, identical set**, `LoginPage.google-signin.test.tsx` 9→10 tests (the new case)
- `packages/auth-ui`: **19/19 pass** (17 existing + 2 new)
- `oidc-google-signin.test.ts`: **45/45 pass** (43 existing + 2 new, from the userinfo fix)
- `type-check` clean on `backend/security`

New test cases:

1. (Google button) One per surface — `GET /methods` **rejecting** must still show the Google button, not hide it. Existing "no Google when methods explicitly return `social: []`" cases are untouched — only the *failure* path changes.
2. (userinfo) `userinfo` is **not called** when the ID token carries the claims; **is** called when the ID token lacks `email`.

## 🔧 Implementation Details

### Changes Made

- **Frontend Changes:**
  - `frontend/src/pages/LoginPage.tsx` — `FALLBACK_METHODS.social` → `['google']`
  - `packages/auth-ui/src/components/AuthPanel.tsx` — same fix, same reasoning
  - `packages/auth-ui/src/vanilla/mount.ts` — same fix; the separate `social` opt-in default is untouched
- **Backend Changes:**
  - `backend/security/src/services/oidc.ts` — `handleCallback` reads claims from `tokenSet.claims()`, calling `client.userinfo()` only when `email` is absent or claims can't be read
- **SDK Changes:** none

### Code Quality

- [x] Code follows the project's coding standards
- [x] Self-review of code completed
- [x] Code is commented, particularly in hard-to-understand areas
- [x] No console.log or debugging statements left in code

### Documentation

- [x] Documentation has been updated — reasoning captured in doc-comments beside each fallback and beside the claims-vs-userinfo logic
- [ ] API documentation updated (if applicable)
- [ ] README updated (if applicable)
- [ ] Migration guide provided (for breaking changes)

## 🚨 Breaking Changes

None. Both changes preserve behavior on every path that was already correct; they change only what happens on the failure/degraded paths (methods fetch fails → button now matches reality; userinfo fetch skipped → same returned `User` shape, fewer round-trips).

**Config coupling worth stating plainly (userinfo fix):** the fast path depends on the provider keeping `include_claims_in_id_token: true` and the email/profile scope mappings. If those are ever turned off, behavior stays correct (fallback fires) but the speed-up silently disappears — the relabelled log line is how you'd notice.

**Config coupling worth stating plainly (Google button fix):** the fallback now assumes `SECURITY_SOCIAL_GOOGLE` stays unset/true across all deploy envs, matching today's reality. If any environment ever needs Google genuinely OFF, that environment's `getAuthMethods()` response is authoritative once it resolves — the fallback only governs the brief window before it does (or the rare case it never does).

## 📋 Checklist

### Pre-submission

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

### Code Quality

- [x] Code follows conventional commit format
- [x] TypeScript strict mode passes
- [ ] ESLint passes without errors — not run: the repo's flat-config migration is incomplete, so `eslint` can't resolve a config here. CI's `gate-lint` covers it.
- [x] No security vulnerabilities introduced
- [x] Performance impact considered and documented

### Security Checklist

- [x] No sensitive data exposed
- [x] Input validation implemented — unchanged
- [x] Authentication/authorization properly handled — the identity proof for the userinfo change is not weakened (ID token already signature/issuer/audience/expiry-verified before these claims are read); the Google-button fix only affects which buttons render, not what the server accepts
- [x] No SQL injection vulnerabilities
- [x] XSS prevention measures in place

## 📝 Additional Notes

### Deployment Notes

`master` is deploy-on-push — **merge in a deploy window** per the repo's hardening convention.

### Future Work

- Collapsing hops 1–2 and 4–5 of the login chain (see the original perf analysis above) remain architectural decisions for the repo owner, not taken here.
- Once #455 is deployed and its `authentikPassword: SLOW hop` WARN lines have real data, that should drive which of the remaining hops is worth optimizing next.

### Questions for Reviewers

- I could not verify either fix against prod — this environment's network policy blocks `app.fuzefront.com`. Both are verified by full-suite diff against a clean `origin/master` worktree, not a live reproduction.

---

## 📊 Performance Impact

**Bundle Size Impact:** No significant impact.

**Runtime Performance:** The userinfo removal saves ~1.3s+ per sign-in on the documented average. The Google-button fix has no performance impact — it's a correctness fix for an intermittent visual bug.

## 🌐 Browser Compatibility

- [x] Chrome ✅ Firefox ✅ Safari ✅ Edge ✅ Mobile browsers ✅

## 🔄 Backwards Compatibility

- [x] Fully backwards compatible