### PR TITLE
FQ-181: platform-owner organization QA portfolio

### DIFF
--- a/FuzeQuality/apps/api/src/authentication.test.ts
+++ b/FuzeQuality/apps/api/src/authentication.test.ts
@@ -22,10 +22,13 @@ describe('FuzeQuality platform-authenticated request allowlist', () => {
     expect(isPlatformAuthenticatedRequest('POST', '/api/v1/repositories/id/scans')).toBe(true)
     expect(isPlatformAuthenticatedRequest('POST', '/api/v1/test-implementations')).toBe(true)
     expect(isPlatformAuthenticatedRequest('GET', '/api/v1/requirements')).toBe(true)
+    expect(isPlatformAuthenticatedRequest('GET', '/api/v1/admin/organizations')).toBe(true)
+    expect(isPlatformAuthenticatedRequest('POST', '/api/v1/admin/organizations/tenant-a/context')).toBe(true)
+    expect(isPlatformAuthenticatedRequest('POST', '/api/v1/suggestions/id/decision')).toBe(true)
   })
 
   it('does not admit internal worker or unrelated unguarded routes', () => {
     expect(isPlatformAuthenticatedRequest('POST', '/api/v1/internal/scans/results')).toBe(false)
-    expect(isPlatformAuthenticatedRequest('POST', '/api/v1/suggestions/id/decision')).toBe(false)
+    expect(isPlatformAuthenticatedRequest('POST', '/api/v1/unscoped-operation')).toBe(false)
   })
 })

--- a/FuzeQuality/apps/api/src/authentication.ts
+++ b/FuzeQuality/apps/api/src/authentication.ts
@@ -30,6 +30,7 @@ export function isPlatformAuthenticatedRequest(method: string, path: string) {
     '/api/v1/coverage/',
     '/api/v1/test-implementations/',
     '/api/v1/suggestions/',
+    '/api/v1/admin/',
   ]
   return exact.includes(path) || prefixes.some(prefix => path.startsWith(prefix))
 }

--- a/FuzeQuality/apps/api/src/index.ts
+++ b/FuzeQuality/apps/api/src/index.ts
@@ -1,10 +1,13 @@
 import express from 'express'
 import { randomUUID } from 'node:crypto'
+import { z } from 'zod'
 import {
   TOPICS,
   repositoryInputSchema,
   reviewDecisionSchema,
   testImplementationRequestSchema,
+  type OrganizationQualitySummary,
+  type Portfolio,
 } from '@fuzequality/contracts'
 import {
   apiCoverageCatalog,
@@ -21,7 +24,7 @@ import {
 } from '@fuzequality/github-app'
 import { githubInstallationToken } from '../../workers/src/github'
 import { createGitHubAccessVerifier, publicAccessError } from './repository-onboarding'
-import { requestIdentity, requirePlatformPermission } from './platform-authorization'
+import { requestIdentity, requirePlatformAdminPermission, requirePlatformPermission } from './platform-authorization'
 import { isPlatformAuthenticatedRequest, isPublicRequest } from './authentication'
 import {
   buildImplementationManifest,
@@ -44,6 +47,40 @@ const mayReviewSuggestions = requirePlatformPermission('fuzequality.suggestion',
 const maySyncRequirements = requirePlatformPermission('fuzequality.requirement', 'sync')
 const mayCreateTestImplementation = requirePlatformPermission('fuzequality.test-implementation', 'create')
 const mayReadTestImplementation = requirePlatformPermission('fuzequality.test-implementation', 'read')
+const mayAdministerPlatform = requirePlatformAdminPermission('fuzequality.platform-administration', 'read')
+const adminContextSchema = z.object({ reason: z.string().trim().min(3).max(500) }).strict()
+
+function organizationSummaries(portfolio: Portfolio): OrganizationQualitySummary[] {
+  const staleAfter = Number(process.env.FUZEQUALITY_STALE_AFTER_MS ?? 86_400_000)
+  const now = Date.now()
+  const tenantIds = [...new Set(portfolio.repositories.map(repository => repository.tenantId).filter(Boolean))] as string[]
+  return tenantIds.map(organizationId => {
+    const repositories = portfolio.repositories.filter(repository => repository.tenantId === organizationId)
+    const repositoryIds = new Set(repositories.map(repository => repository.id))
+    const operations = portfolio.operations.filter(item => repositoryIds.has(item.repositoryId))
+    const surfaces = portfolio.surfaces.filter(item => repositoryIds.has(item.repositoryId))
+    const tests = portfolio.tests.filter(item => repositoryIds.has(item.repositoryId))
+    const subjectIds = new Set([...operations.map(item => item.id), ...surfaces.map(item => item.id)])
+    const expectations = portfolio.expectations.filter(item => subjectIds.has(item.subjectId) && item.priority !== 'not-applicable')
+    const covered = expectations.filter(item => item.coverage.startsWith('covered')).length
+    const scans = repositories.flatMap(repository => repository.lastScanAt ? [Date.parse(repository.lastScanAt)] : [])
+    return {
+      organizationId,
+      repositories: repositories.length,
+      apiOperations: operations.length,
+      frontendSurfaces: surfaces.length,
+      tests: tests.length,
+      expectations: expectations.length,
+      coveredExpectations: covered,
+      gaps: expectations.filter(item => item.coverage === 'gap').length,
+      openFindings: portfolio.findings.filter(item => item.status === 'open' && (!item.repositoryId || repositoryIds.has(item.repositoryId))).length,
+      failedScans: repositories.filter(item => item.lastScanStatus === 'failed').length,
+      staleScans: repositories.filter(item => !item.lastScanAt || now - Date.parse(item.lastScanAt) > staleAfter).length,
+      coveragePercent: expectations.length ? Math.round((covered / expectations.length) * 100) : 0,
+      latestScanAt: scans.length ? new Date(Math.max(...scans)).toISOString() : undefined,
+    }
+  }).sort((left, right) => right.gaps - left.gaps || left.organizationId.localeCompare(right.organizationId))
+}
 
 app.use(express.json({
   limit: '2mb',
@@ -94,6 +131,31 @@ app.get('/metrics', async (_request, response) => {
 app.get('/api/v1/portfolio', mayReadCatalog, async (request, response) =>
   response.json(await store.portfolio(requestIdentity(request)!.tenantId))
 )
+app.get('/api/v1/admin/organizations', mayAdministerPlatform, async (_request, response) =>
+  response.json(organizationSummaries(await store.portfolio()))
+)
+app.post('/api/v1/admin/organizations/:tenantId/context', mayAdministerPlatform, async (request, response) => {
+  const parsed = adminContextSchema.safeParse(request.body)
+  if (!parsed.success) return response.status(400).json({ error: parsed.error.flatten(), code: 'CONTEXT_REASON_REQUIRED' })
+  const targetTenantId = Array.isArray(request.params.tenantId) ? request.params.tenantId[0] : request.params.tenantId
+  const identity = requestIdentity(request)!
+  const portfolio = await store.portfolio(targetTenantId)
+  if (!portfolio.repositories.length) return response.status(404).json({ error: 'Organization catalog not found', code: 'ORGANIZATION_NOT_FOUND' })
+  const audit = await store.recordAdminContext({
+    actorId: identity.userId,
+    sourceTenantId: identity.tenantId,
+    targetTenantId,
+    reason: parsed.data.reason,
+    correlationId: request.header('x-correlation-id') ?? undefined,
+  })
+  response.json({
+    organizationId: targetTenantId,
+    mode: 'read-only',
+    auditId: audit.id,
+    enteredAt: audit.createdAt,
+    portfolio,
+  })
+})
 app.get('/api/v1/internal/repositories/:id', async (request, response) => {
   const repositoryId = Array.isArray(request.params.id) ? request.params.id[0] : request.params.id
   const repository = await store.repository(repositoryId)

--- a/FuzeQuality/apps/api/src/platform-authorization.test.ts
+++ b/FuzeQuality/apps/api/src/platform-authorization.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { NextFunction, Request, Response } from 'express'
-import { requestIdentity, requirePlatformPermission } from './platform-authorization'
+import { requestIdentity, requirePlatformAdminPermission, requirePlatformPermission } from './platform-authorization'
 
 function responseDouble() {
   const response = {
@@ -48,5 +48,39 @@ describe('FQ-18 platform authorization', () => {
     expect(next).not.toHaveBeenCalled()
     expect(response.status).toHaveBeenCalledWith(503)
     expect(response.json).toHaveBeenCalledWith({ error: 'Platform security is unavailable', code: 'SECURITY_UNAVAILABLE' })
+  })
+
+  it('allows an authorized FuzeFront platform administrator', async () => {
+    process.env.FUZEFRONT_SECURITY_URL = 'https://security.example'
+    vi.stubGlobal('fetch', vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ identity: { userId: 'admin-1', tenantId: 'tenant-1', roles: ['admin'] } }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ allow: true }), { status: 200 })))
+    const request = { header: vi.fn().mockReturnValue('Bearer caller-token') } as unknown as Request
+    const response = responseDouble()
+    const next = vi.fn() as NextFunction
+
+    await requirePlatformAdminPermission('fuzequality.platform-administration', 'read')(request, response, next)
+
+    expect(next).toHaveBeenCalledOnce()
+    expect(requestIdentity(request)?.roles).toContain('admin')
+  })
+
+  it('denies a tenant administrator without the platform admin role', async () => {
+    process.env.FUZEFRONT_SECURITY_URL = 'https://security.example'
+    vi.stubGlobal('fetch', vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ identity: { userId: 'tenant-admin', tenantId: 'tenant-1', roles: ['owner'] } }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ allow: true }), { status: 200 })))
+    const request = { header: vi.fn().mockReturnValue('Bearer caller-token') } as unknown as Request
+    const response = responseDouble()
+    const next = vi.fn() as NextFunction
+
+    await requirePlatformAdminPermission('fuzequality.platform-administration', 'read')(request, response, next)
+
+    expect(next).not.toHaveBeenCalled()
+    expect(response.status).toHaveBeenCalledWith(403)
+    expect(response.json).toHaveBeenCalledWith({
+      error: 'Platform administrator access required',
+      code: 'PLATFORM_ADMIN_REQUIRED',
+    })
   })
 })

--- a/FuzeQuality/apps/api/src/platform-authorization.ts
+++ b/FuzeQuality/apps/api/src/platform-authorization.ts
@@ -10,7 +10,7 @@ export function requirePlatformPermission(resource: string, action: string) {
     const authorization = request.header('authorization')
     const baseUrl = process.env.FUZEFRONT_SECURITY_URL?.replace(/\/$/, '')
     if (process.env.FUZEQUALITY_DEV_AUTH_BYPASS === 'true' && process.env.NODE_ENV !== 'production') {
-      identities.set(request, { userId: 'local-developer', tenantId: 'local' })
+      identities.set(request, { userId: 'local-developer', tenantId: 'local', roles: ['admin'] })
       return next()
     }
     if (!authorization?.startsWith('Bearer ')) return response.status(401).json({ error: 'Authentication required', code: 'IDENTITY_MISSING' })
@@ -35,4 +35,16 @@ export function requirePlatformPermission(resource: string, action: string) {
       response.status(503).json({ error: 'Platform security is unavailable', code: 'SECURITY_UNAVAILABLE' })
     }
   }
+}
+
+export function requirePlatformAdminPermission(resource: string, action: string) {
+  const requirePermission = requirePlatformPermission(resource, action)
+  return (request: Request, response: Response, next: NextFunction) =>
+    requirePermission(request, response, () => {
+      const identity = requestIdentity(request)
+      if (!identity?.roles?.includes('admin')) {
+        return response.status(403).json({ error: 'Platform administrator access required', code: 'PLATFORM_ADMIN_REQUIRED' })
+      }
+      next()
+    })
 }

--- a/FuzeQuality/apps/web/src/App.tsx
+++ b/FuzeQuality/apps/web/src/App.tsx
@@ -5,6 +5,7 @@ import {
   ArrowRight,
   BookOpen,
   Braces,
+  Building2,
   Check,
   ChevronRight,
   CircleDot,
@@ -15,6 +16,8 @@ import {
   Eye,
   ExternalLink,
   Layers3,
+  LockKeyhole,
+  LogOut,
   Network,
   Plus,
   RefreshCw,
@@ -26,9 +29,11 @@ import {
 } from 'lucide-react'
 import type {
   ApiOperation,
+  AdminTenantContext,
   CoverageState,
   FrontendSurface,
   Portfolio,
+  OrganizationQualitySummary,
   Repository,
   StorybookStory,
   TestExpectation,
@@ -38,7 +43,7 @@ import { api } from './api'
 import { planGap } from './testPlan'
 import { storybookPreviewUrl } from './storybook'
 
-type View = 'overview' | 'repositories' | 'api' | 'frontend' | 'requirements' | 'review'
+type View = 'overview' | 'repositories' | 'api' | 'frontend' | 'requirements' | 'review' | 'administration'
 
 const navigation: Array<{ id: View; label: string; icon: typeof Activity }> = [
   { id: 'overview', label: 'Portfolio', icon: Activity },
@@ -47,6 +52,7 @@ const navigation: Array<{ id: View; label: string; icon: typeof Activity }> = [
   { id: 'frontend', label: 'Frontend inventory', icon: Layers3 },
   { id: 'requirements', label: 'Requirements & flows', icon: Network },
   { id: 'review', label: 'AI review queue', icon: Sparkles },
+  { id: 'administration', label: 'Organizations', icon: Building2 },
 ]
 
 const coverageLabel: Record<CoverageState, string> = {
@@ -426,15 +432,79 @@ function ReviewQueue({ data, reload }: { data: Portfolio; reload: () => Promise<
   return <><PageHeading eyebrow="Human-in-the-loop" title="AI review queue" detail="Evidence-backed proposals never affect authoritative coverage until you decide." /><div className="review-list">{proposals.map(item => { const requirement = data.requirements.find(req => req.id === item.requirementId); return <article className="review-card" key={item.id}><div className="confidence"><Sparkles /><strong>{Math.round(item.confidence * 100)}%</strong><span>confidence</span></div><div className="review-body"><div className="review-context"><span>{requirement?.jiraKey ?? 'Unknown story'}</span><ChevronRight size={14} /><span>{item.type}</span></div><h3>{item.title}</h3><div className="evidence-list">{item.evidence.map(evidence => <blockquote key={evidence}>“{evidence}”</blockquote>)}</div></div><div className="review-actions"><button className="reject-button" onClick={() => decide(item.id, 'reject')}><X size={16} /> Reject</button><button className="confirm-button" onClick={() => decide(item.id, 'confirm')}><Check size={16} /> Confirm</button></div></article>})}{!proposals.length && <div className="empty-state roomy"><ShieldCheck /><strong>Review queue cleared</strong><span>New semantic proposals will appear after Jira analysis.</span></div>}</div></>
 }
 
+function OrganizationAdministration({ organizations }: { organizations: OrganizationQualitySummary[] }) {
+  const [query, setQuery] = useState('')
+  const [context, setContext] = useState<AdminTenantContext>()
+  const [busy, setBusy] = useState('')
+  const [error, setError] = useState('')
+  const visible = organizations.filter(item => item.organizationId.toLowerCase().includes(query.toLowerCase()))
+  async function enter(organizationId: string) {
+    setBusy(organizationId)
+    setError('')
+    try {
+      setContext(await api.enterOrganizationContext(organizationId, 'Platform QA portfolio review'))
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause))
+    } finally {
+      setBusy('')
+    }
+  }
+  const contextSummary = context ? coverageSummary(context.portfolio.expectations) : undefined
+  return <>
+    {context && <div className="tenant-context-banner" role="status">
+      <LockKeyhole size={17} />
+      <div><strong>Read-only organization context</strong><span>{context.organizationId} · audited as {context.auditId.slice(0, 8)}</span></div>
+      <button className="secondary-button" onClick={() => setContext(undefined)}><LogOut size={15} /> Exit context</button>
+    </div>}
+    <PageHeading
+      eyebrow="Platform administration"
+      title={context ? `Organization ${context.organizationId}` : 'Organization QA portfolio'}
+      detail={context ? 'This audited context exposes QA evidence only. Repository, integration, and review mutations remain unavailable.' : 'Compare inventory freshness, coverage, gaps, and scan health across organizations.'}
+      action={<div className="header-badge"><Building2 /> {organizations.length} organizations</div>}
+    />
+    {error && <div className="error-banner"><AlertTriangle /><div><strong>Organization context unavailable</strong><span>{error}</span></div></div>}
+    {context && contextSummary ? <section className="stats-grid" aria-label="Selected organization totals">
+      <Stat label="Repositories" value={context.portfolio.repositories.length} detail="read-only sources" />
+      <Stat label="API operations" value={context.portfolio.operations.length} detail="cataloged contracts" />
+      <Stat label="Frontend surfaces" value={context.portfolio.surfaces.length} detail="routes and components" />
+      <Stat label="Coverage" value={`${contextSummary.percent}%`} detail={`${contextSummary.gaps} gaps`} tone={contextSummary.gaps ? 'danger' : 'neutral'} />
+    </section> : <>
+      <div className="filter-bar"><Search size={16} /><input value={query} onChange={event => setQuery(event.target.value)} placeholder="Filter organizations…" /><span>{visible.length} shown</span></div>
+      <div className="organization-table">
+        <div className="organization-table-head"><span>Organization</span><span>Inventory</span><span>Coverage</span><span>Risk</span><span /></div>
+        {visible.map(item => <article key={item.organizationId}>
+          <div><strong>{item.organizationId}</strong><small>{item.latestScanAt ? `Latest scan ${new Date(item.latestScanAt).toLocaleString()}` : 'No completed scan'}</small></div>
+          <div><b>{item.repositories}</b><small>{item.apiOperations} APIs · {item.frontendSurfaces} UI · {item.tests} tests</small></div>
+          <div><b>{item.coveragePercent}%</b><small>{item.coveredExpectations} / {item.expectations} expectations</small></div>
+          <div className={item.gaps || item.failedScans ? 'organization-risk' : ''}><b>{item.gaps} gaps</b><small>{item.openFindings} findings · {item.failedScans} failed · {item.staleScans} stale</small></div>
+          <button className="secondary-button" disabled={busy === item.organizationId} onClick={() => enter(item.organizationId)}><LockKeyhole size={14} /> Review</button>
+        </article>)}
+        {!visible.length && <div className="empty-state"><Building2 /><strong>No organizations match</strong><span>Adjust the filter or onboard a tenant repository.</span></div>}
+      </div>
+    </>}
+  </>
+}
+
 function PageHeading({ eyebrow, title, detail, action }: { eyebrow: string; title: string; detail: string; action?: React.ReactNode }) { return <header className="page-header compact"><div><p className="eyebrow">{eyebrow}</p><h1>{title}</h1><p className="lede">{detail}</p></div>{action}</header> }
 
 export function App() {
   const [view, setView] = useState<View>('overview')
   const [data, setData] = useState<Portfolio | null>(null)
   const [error, setError] = useState<string>()
+  const [organizations, setOrganizations] = useState<OrganizationQualitySummary[]>()
   const [loading, setLoading] = useState(true)
-  async function reload() { setLoading(true); try { setData(await api.portfolio()); setError(undefined) } catch (value) { setError(value instanceof Error ? value.message : String(value)) } finally { setLoading(false) } }
+  async function reload() {
+    setLoading(true)
+    try {
+      setData(await api.portfolio())
+      setError(undefined)
+      try { setOrganizations(await api.platformOrganizations()) } catch { setOrganizations(undefined) }
+    } catch (value) {
+      setError(value instanceof Error ? value.message : String(value))
+    } finally { setLoading(false) }
+  }
   useEffect(() => { void reload() }, [])
-  const active = useMemo(() => navigation.find(item => item.id === view), [view])
-  return <div className="app-shell"><aside className="sidebar"><div className="brand"><div className="brand-symbol"><span /><span /><span /></div><div><strong>FuzeQuality</strong><small>Evidence control</small></div></div><nav>{navigation.map(item => { const Icon = item.icon; const count = item.id === 'review' ? data?.suggestions.filter(s => s.state === 'proposed').length : undefined; return <button key={item.id} className={view === item.id ? 'active' : ''} onClick={() => setView(item.id)}><Icon size={18} /><span>{item.label}</span>{count ? <b>{count}</b> : null}</button> })}</nav><div className="sidebar-footer"><Database size={16} /><div><span>Catalog revision</span><strong>{data ? 'live / v1' : 'connecting'}</strong></div></div></aside><main><div className="topbar"><span>{active?.label}</span><div><span className="live-dot" /> default branches <button className="icon-button" onClick={() => reload()} aria-label="Reload"><RefreshCw size={15} className={loading ? 'spin' : ''} /></button></div></div><div className="content">{error && <div className="error-banner"><AlertTriangle /> <div><strong>Catalog API unavailable</strong><span>{error}</span></div></div>}{!data ? <div className="loading-screen"><RefreshCw className="spin" /><span>Loading evidence graph…</span></div> : <>{view === 'overview' && <Overview data={data} onNavigate={setView} />}{view === 'repositories' && <Repositories data={data} reload={reload} />}{view === 'api' && <ApiCatalogPage data={data} />}{view === 'frontend' && <CatalogPage type="frontend" data={data} />}{view === 'requirements' && <Requirements data={data} />}{view === 'review' && <ReviewQueue data={data} reload={reload} />}</>}</div></main></div>
+  const visibleNavigation = useMemo(() => navigation.filter(item => item.id !== 'administration' || organizations), [organizations])
+  const active = useMemo(() => visibleNavigation.find(item => item.id === view), [view, visibleNavigation])
+  return <div className="app-shell"><aside className="sidebar"><div className="brand"><div className="brand-symbol"><span /><span /><span /></div><div><strong>FuzeQuality</strong><small>Evidence control</small></div></div><nav>{visibleNavigation.map(item => { const Icon = item.icon; const count = item.id === 'review' ? data?.suggestions.filter(s => s.state === 'proposed').length : undefined; return <button key={item.id} className={view === item.id ? 'active' : ''} onClick={() => setView(item.id)}><Icon size={18} /><span>{item.label}</span>{count ? <b>{count}</b> : null}</button> })}</nav><div className="sidebar-footer"><Database size={16} /><div><span>Catalog revision</span><strong>{data ? 'live / v1' : 'connecting'}</strong></div></div></aside><main><div className="topbar"><span>{active?.label}</span><div><span className="live-dot" /> default branches <button className="icon-button" onClick={() => reload()} aria-label="Reload"><RefreshCw size={15} className={loading ? 'spin' : ''} /></button></div></div><div className="content">{error && <div className="error-banner"><AlertTriangle /> <div><strong>Catalog API unavailable</strong><span>{error}</span></div></div>}{!data ? <div className="loading-screen"><RefreshCw className="spin" /><span>Loading evidence graph…</span></div> : <>{view === 'overview' && <Overview data={data} onNavigate={setView} />}{view === 'repositories' && <Repositories data={data} reload={reload} />}{view === 'api' && <ApiCatalogPage data={data} />}{view === 'frontend' && <CatalogPage type="frontend" data={data} />}{view === 'requirements' && <Requirements data={data} />}{view === 'review' && <ReviewQueue data={data} reload={reload} />}{view === 'administration' && organizations && <OrganizationAdministration organizations={organizations} />}</>}</div></main></div>
 }

--- a/FuzeQuality/apps/web/src/api.ts
+++ b/FuzeQuality/apps/web/src/api.ts
@@ -1,4 +1,9 @@
-import type { Portfolio, TestImplementationRequest } from '@fuzequality/contracts'
+import type {
+  AdminTenantContext,
+  OrganizationQualitySummary,
+  Portfolio,
+  TestImplementationRequest,
+} from '@fuzequality/contracts'
 
 async function request<T>(path: string, init?: RequestInit): Promise<T> {
   const token = localStorage.getItem('authToken')
@@ -45,4 +50,11 @@ export const api = {
     }),
   testImplementation: (id: string) =>
     request<TestImplementationRequest>(`/api/v1/test-implementations/${id}`),
+  platformOrganizations: () =>
+    request<OrganizationQualitySummary[]>('/api/v1/admin/organizations'),
+  enterOrganizationContext: (organizationId: string, reason: string) =>
+    request<AdminTenantContext>(`/api/v1/admin/organizations/${encodeURIComponent(organizationId)}/context`, {
+      method: 'POST',
+      body: JSON.stringify({ reason }),
+    }),
 }

--- a/FuzeQuality/apps/web/src/lucide-react.d.ts
+++ b/FuzeQuality/apps/web/src/lucide-react.d.ts
@@ -6,6 +6,7 @@ declare module 'lucide-react' {
   export const ArrowRight: LucideIcon
   export const BookOpen: LucideIcon
   export const Braces: LucideIcon
+  export const Building2: LucideIcon
   export const Check: LucideIcon
   export const ChevronRight: LucideIcon
   export const CircleDot: LucideIcon
@@ -16,6 +17,8 @@ declare module 'lucide-react' {
   export const Eye: LucideIcon
   export const ExternalLink: LucideIcon
   export const Layers3: LucideIcon
+  export const LockKeyhole: LucideIcon
+  export const LogOut: LucideIcon
   export const Network: LucideIcon
   export const Plus: LucideIcon
   export const RefreshCw: LucideIcon

--- a/FuzeQuality/apps/web/src/styles.css
+++ b/FuzeQuality/apps/web/src/styles.css
@@ -171,9 +171,21 @@ button:disabled { cursor: wait; opacity: .55; }
 .preview-empty code { color: #8cb4cc; font-size: 10px; }
 .preview-provenance { display: flex; align-items: center; gap: 7px; margin-top: 13px; color: #657f93; font: 9px 'IBM Plex Mono'; }
 
+.tenant-context-banner { position: sticky; z-index: 8; top: 58px; display: grid; grid-template-columns: auto 1fr auto; align-items: center; gap: 12px; margin: -8px 0 22px; padding: 12px 14px; border: 1px solid #6b5632; background: #2a2112; color: var(--amber); box-shadow: 0 8px 30px rgba(0,0,0,.3); }
+.tenant-context-banner strong, .tenant-context-banner span { display: block; }.tenant-context-banner strong { color: #ffe0a8; }.tenant-context-banner span { margin-top: 2px; color: #bfa778; font: 10px 'IBM Plex Mono'; }
+.organization-table { border: 1px solid var(--line); border-top: 0; }
+.organization-table-head, .organization-table article { display: grid; grid-template-columns: minmax(180px, 1.3fr) minmax(190px, 1fr) minmax(170px, .8fr) minmax(220px, 1fr) auto; align-items: center; gap: 18px; padding: 14px 16px; }
+.organization-table-head { background: #102333; color: var(--muted); font: 10px 'IBM Plex Mono'; text-transform: uppercase; letter-spacing: .08em; }
+.organization-table article { border-top: 1px solid var(--line); background: rgba(10, 23, 35, .76); }
+.organization-table article:first-of-type { border-top: 0; }
+.organization-table strong, .organization-table b, .organization-table small { display: block; }.organization-table strong { color: var(--cyan); }.organization-table b { font: 600 17px 'Space Grotesk'; }.organization-table small { margin-top: 3px; color: var(--muted); font-size: 10px; }
+.organization-risk b { color: var(--coral); }
+
 @media (max-width: 720px) {
   .preview-drawer { padding: 21px 16px; }
   .preview-toolbar { align-items: stretch; flex-direction: column; }
   .preview-toolbar select { width: 100%; }
   .storybook-frame { height: 60vh; }
+  .tenant-context-banner { top: 0; grid-template-columns: auto 1fr; }.tenant-context-banner button { grid-column: 1 / -1; }
+  .organization-table { overflow-x: auto; }.organization-table-head, .organization-table article { min-width: 920px; }
 }

--- a/FuzeQuality/db/migrations/009_admin_context_audits.sql
+++ b/FuzeQuality/db/migrations/009_admin_context_audits.sql
@@ -1,0 +1,15 @@
+CREATE TABLE IF NOT EXISTS fuzequality.admin_context_audits (
+  id uuid PRIMARY KEY,
+  actor_id text NOT NULL,
+  source_tenant_id text NOT NULL,
+  target_tenant_id text NOT NULL,
+  reason text NOT NULL CHECK (length(reason) BETWEEN 3 AND 500),
+  correlation_id text,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS admin_context_audits_actor_idx
+  ON fuzequality.admin_context_audits (actor_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS admin_context_audits_target_idx
+  ON fuzequality.admin_context_audits (target_tenant_id, created_at DESC);

--- a/FuzeQuality/packages/contracts/src/index.ts
+++ b/FuzeQuality/packages/contracts/src/index.ts
@@ -302,6 +302,40 @@ export type Portfolio = {
   suggestions: Suggestion[]
 }
 
+export type OrganizationQualitySummary = {
+  organizationId: string
+  repositories: number
+  apiOperations: number
+  frontendSurfaces: number
+  tests: number
+  expectations: number
+  coveredExpectations: number
+  gaps: number
+  openFindings: number
+  failedScans: number
+  staleScans: number
+  coveragePercent: number
+  latestScanAt?: string
+}
+
+export type AdminTenantContext = {
+  organizationId: string
+  mode: 'read-only'
+  auditId: string
+  enteredAt: string
+  portfolio: Portfolio
+}
+
+export type AdminContextAudit = {
+  id: string
+  actorId: string
+  sourceTenantId: string
+  targetTenantId: string
+  reason: string
+  correlationId?: string
+  createdAt: string
+}
+
 export const testImplementationRequestSchema = z.object({
   repositoryId: z.string().uuid(),
   sourceRevision: z.string().regex(/^[0-9a-f]{40}$/i),

--- a/FuzeQuality/packages/core/src/store.tenant-isolation.test.ts
+++ b/FuzeQuality/packages/core/src/store.tenant-isolation.test.ts
@@ -24,4 +24,25 @@ describe('MemoryCatalogStore tenant isolation', () => {
     expect(portfolio.flows).toEqual([])
     expect(portfolio.suggestions).toEqual([])
   })
+
+  it('creates an immutable audit record when a platform administrator enters tenant context', async () => {
+    const store = new MemoryCatalogStore()
+    const audit = await store.recordAdminContext({
+      actorId: 'platform-admin',
+      sourceTenantId: 'platform',
+      targetTenantId: 'tenant-a',
+      reason: 'Review QA gaps',
+      correlationId: 'correlation-1',
+    })
+
+    expect(audit).toMatchObject({
+      actorId: 'platform-admin',
+      sourceTenantId: 'platform',
+      targetTenantId: 'tenant-a',
+      reason: 'Review QA gaps',
+      correlationId: 'correlation-1',
+    })
+    expect(audit.id).toBeTruthy()
+    expect(new Date(audit.createdAt).toString()).not.toBe('Invalid Date')
+  })
 })

--- a/FuzeQuality/packages/core/src/store.ts
+++ b/FuzeQuality/packages/core/src/store.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'node:crypto'
 import pg from 'pg'
 import type {
   Flow,
+  AdminContextAudit,
   Portfolio,
   Repository,
   RepositoryInput,
@@ -23,6 +24,7 @@ export interface CatalogStore {
   createTestImplementation(request: TestImplementationRequest, idempotencyKey: string): Promise<TestImplementationRequest>
   testImplementation(id: string, tenantId: string): Promise<TestImplementationRequest | undefined>
   updateTestImplementation(id: string, value: Partial<Pick<TestImplementationRequest, 'status' | 'workflowUrl' | 'pullRequestUrl' | 'error'>>): Promise<void>
+  recordAdminContext(input: Omit<AdminContextAudit, 'id' | 'createdAt'>): Promise<AdminContextAudit>
 }
 
 const emptyPortfolio = (): Portfolio => ({
@@ -41,6 +43,7 @@ const emptyPortfolio = (): Portfolio => ({
 export class MemoryCatalogStore implements CatalogStore {
   private data = emptyPortfolio()
   private implementations: Array<TestImplementationRequest & { idempotencyKey: string }> = []
+  private adminContextAudits: AdminContextAudit[] = []
 
   constructor(seed?: Partial<Portfolio>) {
     this.data = { ...this.data, ...seed }
@@ -170,6 +173,12 @@ export class MemoryCatalogStore implements CatalogStore {
   async updateTestImplementation(id: string, value: Partial<Pick<TestImplementationRequest, 'status' | 'workflowUrl' | 'pullRequestUrl' | 'error'>>) {
     const item = this.implementations.find(candidate => candidate.id === id)
     if (item) Object.assign(item, value, { updatedAt: new Date().toISOString() })
+  }
+
+  async recordAdminContext(input: Omit<AdminContextAudit, 'id' | 'createdAt'>) {
+    const audit = { ...input, id: randomUUID(), createdAt: new Date().toISOString() }
+    this.adminContextAudits.push(audit)
+    return audit
   }
 }
 
@@ -329,6 +338,18 @@ export class PostgresCatalogStore implements CatalogStore {
        WHERE id=$1`,
       [id, value.status, value.workflowUrl, value.pullRequestUrl, value.error],
     )
+  }
+
+  async recordAdminContext(input: Omit<AdminContextAudit, 'id' | 'createdAt'>): Promise<AdminContextAudit> {
+    const id = randomUUID()
+    const result = await this.pool.query(
+      `INSERT INTO fuzequality.admin_context_audits
+       (id, actor_id, source_tenant_id, target_tenant_id, reason, correlation_id)
+       VALUES ($1,$2,$3,$4,$5,$6)
+       RETURNING created_at`,
+      [id, input.actorId, input.sourceTenantId, input.targetTenantId, input.reason, input.correlationId]
+    )
+    return { ...input, id, createdAt: result.rows[0].created_at.toISOString() }
   }
 
   private mapTestImplementation(row: Record<string, any>): TestImplementationRequest {


### PR DESCRIPTION
## Outcome

Adds the first multi-tenant platform-owner administration slice for FuzeQuality.

- platform-admin-only organization QA aggregates using FuzeFront security and authorization services
- audited, explicitly read-only tenant context entry
- durable PostgreSQL audit trail with actor, source tenant, target tenant, reason, correlation, and timestamp
- organization portfolio UX with coverage, inventory, gaps, findings, scan health, persistent context banner, and safe exit
- platform administration navigation is hidden when the FuzeFront platform-admin check is denied
- ordinary tenant users cannot select or override tenant identity

## Verification

- npm run type-check
- npm test (63 passed, 1 intentional Chroma integration skip)
- npm run build:web

## Jira

- FQ-181
- FQ-187
- FQ-188
- FQ-189
- FQ-190