### PR TITLE
FQ-182: tenant access, ownership, and integration administration

### DIFF
--- a/FuzeQuality/apps/api/src/authentication.test.ts
+++ b/FuzeQuality/apps/api/src/authentication.test.ts
@@ -25,6 +25,11 @@ describe('FuzeQuality platform-authenticated request allowlist', () => {
     expect(isPlatformAuthenticatedRequest('GET', '/api/v1/admin/organizations')).toBe(true)
     expect(isPlatformAuthenticatedRequest('POST', '/api/v1/admin/organizations/tenant-a/context')).toBe(true)
     expect(isPlatformAuthenticatedRequest('POST', '/api/v1/suggestions/id/decision')).toBe(true)
+    expect(isPlatformAuthenticatedRequest('GET', '/api/v1/organization/members')).toBe(true)
+    expect(isPlatformAuthenticatedRequest('POST', '/api/v1/organization/invitations')).toBe(true)
+    expect(isPlatformAuthenticatedRequest('PUT', '/api/v1/organization/members/member-1')).toBe(true)
+    expect(isPlatformAuthenticatedRequest('DELETE', '/api/v1/organization/members/member-1')).toBe(true)
+    expect(isPlatformAuthenticatedRequest('PATCH', '/api/v1/repositories/repo-1/administration')).toBe(true)
   })
 
   it('does not admit internal worker or unrelated unguarded routes', () => {

--- a/FuzeQuality/apps/api/src/authentication.ts
+++ b/FuzeQuality/apps/api/src/authentication.ts
@@ -13,7 +13,7 @@ export function isPublicRequest(method: string, path: string) {
  * the worker service token.
  */
 export function isPlatformAuthenticatedRequest(method: string, path: string) {
-  if (!['GET', 'POST'].includes(method)) return false
+  if (!['GET', 'POST', 'PUT', 'PATCH', 'DELETE'].includes(method)) return false
   const exact = [
     '/api/v1/portfolio',
     '/api/v1/repositories',
@@ -25,6 +25,7 @@ export function isPlatformAuthenticatedRequest(method: string, path: string) {
     '/api/v1/jira/sync',
   ]
   const prefixes = [
+    '/api/v1/organization/',
     '/api/v1/repositories/',
     '/api/v1/catalog/',
     '/api/v1/coverage/',

--- a/FuzeQuality/apps/api/src/index.ts
+++ b/FuzeQuality/apps/api/src/index.ts
@@ -38,17 +38,64 @@ const store = createCatalogStore()
 const events = createEventBus()
 const port = Number(process.env.PORT ?? 4180)
 const repositoryAccess = createGitHubAccessVerifier(githubInstallationToken)
-const mayReadRepositories = requirePlatformPermission('fuzequality.repository', 'read')
-const mayManageRepositories = requirePlatformPermission('fuzequality.repository', 'create')
-const mayScanRepositories = requirePlatformPermission('fuzequality.repository', 'scan')
-const mayReadCatalog = requirePlatformPermission('fuzequality.catalog', 'read')
-const mayReadRequirements = requirePlatformPermission('fuzequality.requirement', 'read')
-const mayReviewSuggestions = requirePlatformPermission('fuzequality.suggestion', 'review')
-const maySyncRequirements = requirePlatformPermission('fuzequality.requirement', 'sync')
-const mayCreateTestImplementation = requirePlatformPermission('fuzequality.test-implementation', 'create')
-const mayReadTestImplementation = requirePlatformPermission('fuzequality.test-implementation', 'read')
-const mayAdministerPlatform = requirePlatformAdminPermission('fuzequality.platform-administration', 'read')
+const mayReadRepositories = requirePlatformPermission('fuzequality.Repository', 'read')
+const mayManageRepositories = requirePlatformPermission('fuzequality.Repository', 'onboard')
+const mayScanRepositories = requirePlatformPermission('fuzequality.Repository', 'scan')
+const mayReadCatalog = requirePlatformPermission('fuzequality.Evidence', 'read')
+const mayReadRequirements = requirePlatformPermission('fuzequality.Evidence', 'read')
+const mayReviewSuggestions = requirePlatformPermission('fuzequality.Evidence', 'export')
+const maySyncRequirements = requirePlatformPermission('fuzequality.Evidence', 'export')
+const mayCreateTestImplementation = requirePlatformPermission('fuzequality.TestImplementation', 'create')
+const mayReadTestImplementation = requirePlatformPermission('fuzequality.TestImplementation', 'read')
+const mayReadOrganizationAccess = requirePlatformPermission('fuzequality.OrganizationAccess', 'read')
+const mayManageOrganizationAccess = requirePlatformPermission('fuzequality.OrganizationAccess', 'manage')
+const mayManageRepositoryAdministration = requirePlatformPermission('fuzequality.RepositoryAdministration', 'manage')
+const mayAdministerPlatform = requirePlatformAdminPermission('fuzequality.PlatformAdministration', 'read')
 const adminContextSchema = z.object({ reason: z.string().trim().min(3).max(500) }).strict()
+const organizationRoleSchema = z.enum(['owner', 'admin', 'member', 'viewer'])
+const invitationSchema = z.object({
+  email: z.string().trim().email(),
+  role: organizationRoleSchema,
+}).strict()
+const memberRoleSchema = z.object({ role: organizationRoleSchema }).strict()
+const repositoryAdministrationSchema = z.object({
+  ownership: z.object({
+    team: z.string().trim().min(1).max(100),
+    contact: z.string().trim().email().optional(),
+  }).optional(),
+  jiraBindings: z.array(z.object({
+    project: z.string().trim().regex(/^[A-Z][A-Z0-9_]{1,19}$/),
+    component: z.string().trim().min(1).max(255).optional(),
+  })).max(100),
+  storybookBaseUrl: z.string().trim().url().refine(value => new URL(value).protocol === 'https:').optional(),
+}).strict()
+
+async function proxyOrganizationSecurity(
+  request: express.Request,
+  response: express.Response,
+  path: string,
+  init?: RequestInit
+) {
+  const baseUrl = process.env.FUZEFRONT_SECURITY_URL?.replace(/\/$/, '')
+  const authorization = request.header('authorization')
+  if (!baseUrl || !authorization) {
+    return response.status(503).json({ error: 'Platform security is unavailable', code: 'SECURITY_UNAVAILABLE' })
+  }
+  try {
+    const upstream = await fetch(`${baseUrl}${path}`, {
+      ...init,
+      headers: {
+        authorization,
+        accept: 'application/json',
+        ...(init?.body ? { 'content-type': 'application/json' } : {}),
+      },
+    })
+    const body = await upstream.json().catch(() => ({ error: 'Platform security returned an invalid response' }))
+    response.status(upstream.status).json(body)
+  } catch {
+    response.status(503).json({ error: 'Platform security is unavailable', code: 'SECURITY_UNAVAILABLE' })
+  }
+}
 
 function organizationSummaries(portfolio: Portfolio): OrganizationQualitySummary[] {
   const staleAfter = Number(process.env.FUZEQUALITY_STALE_AFTER_MS ?? 86_400_000)
@@ -155,6 +202,52 @@ app.post('/api/v1/admin/organizations/:tenantId/context', mayAdministerPlatform,
     enteredAt: audit.createdAt,
     portfolio,
   })
+})
+app.get('/api/v1/organization/members', mayReadOrganizationAccess, async (request, response) => {
+  const identity = requestIdentity(request)!
+  const query = new URLSearchParams()
+  for (const key of ['page', 'pageSize', 'search']) {
+    if (typeof request.query[key] === 'string') query.set(key, request.query[key])
+  }
+  const suffix = query.size ? `?${query.toString()}` : ''
+  await proxyOrganizationSecurity(request, response, `/api/organizations/${encodeURIComponent(identity.tenantId)}/members${suffix}`)
+})
+app.get('/api/v1/organization/roles', mayReadOrganizationAccess, async (request, response) => {
+  const identity = requestIdentity(request)!
+  await proxyOrganizationSecurity(request, response, `/api/organizations/${encodeURIComponent(identity.tenantId)}/roles`)
+})
+app.post('/api/v1/organization/invitations', mayManageOrganizationAccess, async (request, response) => {
+  const parsed = invitationSchema.safeParse(request.body)
+  if (!parsed.success) return response.status(400).json({ error: parsed.error.flatten() })
+  const identity = requestIdentity(request)!
+  await proxyOrganizationSecurity(
+    request,
+    response,
+    `/api/organizations/${encodeURIComponent(identity.tenantId)}/invitations`,
+    { method: 'POST', body: JSON.stringify(parsed.data) }
+  )
+})
+app.put('/api/v1/organization/members/:memberId', mayManageOrganizationAccess, async (request, response) => {
+  const parsed = memberRoleSchema.safeParse(request.body)
+  if (!parsed.success) return response.status(400).json({ error: parsed.error.flatten() })
+  const identity = requestIdentity(request)!
+  const memberId = Array.isArray(request.params.memberId) ? request.params.memberId[0] : request.params.memberId
+  await proxyOrganizationSecurity(
+    request,
+    response,
+    `/api/organizations/${encodeURIComponent(identity.tenantId)}/members/${encodeURIComponent(memberId)}`,
+    { method: 'PUT', body: JSON.stringify(parsed.data) }
+  )
+})
+app.delete('/api/v1/organization/members/:memberId', mayManageOrganizationAccess, async (request, response) => {
+  const identity = requestIdentity(request)!
+  const memberId = Array.isArray(request.params.memberId) ? request.params.memberId[0] : request.params.memberId
+  await proxyOrganizationSecurity(
+    request,
+    response,
+    `/api/organizations/${encodeURIComponent(identity.tenantId)}/members/${encodeURIComponent(memberId)}`,
+    { method: 'DELETE' }
+  )
 })
 app.get('/api/v1/internal/repositories/:id', async (request, response) => {
   const repositoryId = Array.isArray(request.params.id) ? request.params.id[0] : request.params.id
@@ -265,6 +358,15 @@ app.post('/api/v1/repositories/:id/scans', mayScanRepositories, async (request, 
     const result = publicAccessError(error)
     response.status(result.status).json(result.body)
   }
+})
+app.patch('/api/v1/repositories/:id/administration', mayManageRepositoryAdministration, async (request, response) => {
+  const parsed = repositoryAdministrationSchema.safeParse(request.body)
+  if (!parsed.success) return response.status(400).json({ error: parsed.error.flatten() })
+  const identity = requestIdentity(request)!
+  const repositoryId = Array.isArray(request.params.id) ? request.params.id[0] : request.params.id
+  const repository = await store.updateRepositoryAdministration(repositoryId, identity.tenantId, parsed.data)
+  if (!repository) return response.status(404).json({ error: 'Repository not found', code: 'REPOSITORY_NOT_FOUND' })
+  response.json(repository)
 })
 
 app.get('/api/v1/catalog/apis', mayReadCatalog, async (request, response) =>

--- a/FuzeQuality/apps/api/src/platform-authorization.test.ts
+++ b/FuzeQuality/apps/api/src/platform-authorization.test.ts
@@ -27,12 +27,12 @@ describe('FQ-18 platform authorization', () => {
     const response = responseDouble()
     const next = vi.fn() as NextFunction
 
-    await requirePlatformPermission('fuzequality.repository', 'create')(request, response, next)
+    await requirePlatformPermission('fuzequality.Repository', 'onboard')(request, response, next)
 
     expect(next).toHaveBeenCalledOnce()
     expect(requestIdentity(request)?.tenantId).toBe('tenant-1')
     expect(JSON.parse(fetchMock.mock.calls[1][1].body)).toMatchObject({
-      subject: 'user-1', tenant: 'tenant-1', resource: { type: 'fuzequality.repository' }, action: 'create',
+      subject: 'user-1', tenant: 'tenant-1', resource: { type: 'fuzequality.Repository' }, action: 'onboard',
     })
   })
 
@@ -43,7 +43,7 @@ describe('FQ-18 platform authorization', () => {
     const response = responseDouble()
     const next = vi.fn() as NextFunction
 
-    await requirePlatformPermission('fuzequality.repository', 'create')(request, response, next)
+    await requirePlatformPermission('fuzequality.Repository', 'onboard')(request, response, next)
 
     expect(next).not.toHaveBeenCalled()
     expect(response.status).toHaveBeenCalledWith(503)
@@ -59,7 +59,7 @@ describe('FQ-18 platform authorization', () => {
     const response = responseDouble()
     const next = vi.fn() as NextFunction
 
-    await requirePlatformAdminPermission('fuzequality.platform-administration', 'read')(request, response, next)
+    await requirePlatformAdminPermission('fuzequality.PlatformAdministration', 'read')(request, response, next)
 
     expect(next).toHaveBeenCalledOnce()
     expect(requestIdentity(request)?.roles).toContain('admin')
@@ -74,7 +74,7 @@ describe('FQ-18 platform authorization', () => {
     const response = responseDouble()
     const next = vi.fn() as NextFunction
 
-    await requirePlatformAdminPermission('fuzequality.platform-administration', 'read')(request, response, next)
+    await requirePlatformAdminPermission('fuzequality.PlatformAdministration', 'read')(request, response, next)
 
     expect(next).not.toHaveBeenCalled()
     expect(response.status).toHaveBeenCalledWith(403)

--- a/FuzeQuality/apps/web/src/App.tsx
+++ b/FuzeQuality/apps/web/src/App.tsx
@@ -22,9 +22,13 @@ import {
   Plus,
   RefreshCw,
   Search,
+  Save,
   ShieldCheck,
   Sparkles,
   TestTube2,
+  Trash2,
+  UserPlus,
+  Users,
   X,
 } from 'lucide-react'
 import type {
@@ -39,11 +43,11 @@ import type {
   TestExpectation,
   TestImplementationRequest,
 } from '@fuzequality/contracts'
-import { api } from './api'
+import { api, type OrganizationMember, type OrganizationRole } from './api'
 import { planGap } from './testPlan'
 import { storybookPreviewUrl } from './storybook'
 
-type View = 'overview' | 'repositories' | 'api' | 'frontend' | 'requirements' | 'review' | 'administration'
+type View = 'overview' | 'repositories' | 'api' | 'frontend' | 'requirements' | 'review' | 'organization' | 'administration'
 
 const navigation: Array<{ id: View; label: string; icon: typeof Activity }> = [
   { id: 'overview', label: 'Portfolio', icon: Activity },
@@ -52,6 +56,7 @@ const navigation: Array<{ id: View; label: string; icon: typeof Activity }> = [
   { id: 'frontend', label: 'Frontend inventory', icon: Layers3 },
   { id: 'requirements', label: 'Requirements & flows', icon: Network },
   { id: 'review', label: 'AI review queue', icon: Sparkles },
+  { id: 'organization', label: 'Organization', icon: Users },
   { id: 'administration', label: 'Organizations', icon: Building2 },
 ]
 
@@ -432,6 +437,93 @@ function ReviewQueue({ data, reload }: { data: Portfolio; reload: () => Promise<
   return <><PageHeading eyebrow="Human-in-the-loop" title="AI review queue" detail="Evidence-backed proposals never affect authoritative coverage until you decide." /><div className="review-list">{proposals.map(item => { const requirement = data.requirements.find(req => req.id === item.requirementId); return <article className="review-card" key={item.id}><div className="confidence"><Sparkles /><strong>{Math.round(item.confidence * 100)}%</strong><span>confidence</span></div><div className="review-body"><div className="review-context"><span>{requirement?.jiraKey ?? 'Unknown story'}</span><ChevronRight size={14} /><span>{item.type}</span></div><h3>{item.title}</h3><div className="evidence-list">{item.evidence.map(evidence => <blockquote key={evidence}>“{evidence}”</blockquote>)}</div></div><div className="review-actions"><button className="reject-button" onClick={() => decide(item.id, 'reject')}><X size={16} /> Reject</button><button className="confirm-button" onClick={() => decide(item.id, 'confirm')}><Check size={16} /> Confirm</button></div></article>})}{!proposals.length && <div className="empty-state roomy"><ShieldCheck /><strong>Review queue cleared</strong><span>New semantic proposals will appear after Jira analysis.</span></div>}</div></>
 }
 
+function RepositoryAdministrationCard({ repository, reload }: { repository: Repository; reload: () => Promise<void> }) {
+  const [team, setTeam] = useState(repository.ownership?.team ?? '')
+  const [contact, setContact] = useState(repository.ownership?.contact ?? '')
+  const [jiraProject, setJiraProject] = useState(repository.jiraBindings[0]?.project ?? '')
+  const [jiraComponent, setJiraComponent] = useState(repository.jiraBindings[0]?.component ?? '')
+  const [storybookBaseUrl, setStorybookBaseUrl] = useState(repository.storybookBaseUrl ?? '')
+  const [busy, setBusy] = useState(false)
+  const [saved, setSaved] = useState(false)
+  async function save() {
+    setBusy(true); setSaved(false)
+    try {
+      await api.updateRepositoryAdministration(repository.id, {
+        ownership: team ? { team, contact: contact || undefined } : undefined,
+        jiraBindings: jiraProject ? [{ project: jiraProject.toUpperCase(), component: jiraComponent || undefined }] : [],
+        storybookBaseUrl: storybookBaseUrl || undefined,
+      })
+      setSaved(true)
+      await reload()
+    } finally { setBusy(false) }
+  }
+  return <article className="repository-admin-card">
+    <div className="repository-admin-title"><div className="repo-mark">{repository.name.slice(0, 2).toUpperCase()}</div><div><strong>{repository.name}</strong><small>{repository.owner}</small></div>{saved && <span>Saved</span>}</div>
+    <div className="repository-admin-fields">
+      <label>Owning team<input value={team} onChange={event => setTeam(event.target.value)} placeholder="Platform" /></label>
+      <label>Owner contact<input value={contact} onChange={event => setContact(event.target.value)} type="email" placeholder="team@example.com" /></label>
+      <label>Jira project<input value={jiraProject} onChange={event => setJiraProject(event.target.value)} placeholder="FQ" /></label>
+      <label>Jira component<input value={jiraComponent} onChange={event => setJiraComponent(event.target.value)} placeholder="Catalog" /></label>
+      <label className="wide-field">Storybook URL<input value={storybookBaseUrl} onChange={event => setStorybookBaseUrl(event.target.value)} type="url" placeholder="https://storybook.example.com" /></label>
+    </div>
+    <button className="secondary-button" disabled={busy} onClick={save}><Save size={14} /> {busy ? 'Saving…' : 'Save bindings'}</button>
+  </article>
+}
+
+function OrganizationSettings({ data, reload }: { data: Portfolio; reload: () => Promise<void> }) {
+  const roles: OrganizationRole[] = ['owner', 'admin', 'member', 'viewer']
+  const [members, setMembers] = useState<OrganizationMember[]>([])
+  const [email, setEmail] = useState('')
+  const [role, setRole] = useState<OrganizationRole>('member')
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+  async function loadMembers() {
+    setLoading(true)
+    try {
+      const result = await api.organizationMembers()
+      setMembers(Array.isArray(result) ? result : result.items ?? result.members ?? [])
+      setError('')
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause))
+    } finally { setLoading(false) }
+  }
+  useEffect(() => { void loadMembers() }, [])
+  async function invite(event: FormEvent) {
+    event.preventDefault()
+    await api.inviteOrganizationMember(email, role)
+    setEmail('')
+    await loadMembers()
+  }
+  async function updateRole(member: OrganizationMember, nextRole: OrganizationRole) {
+    await api.updateOrganizationMember(member.id, nextRole)
+    await loadMembers()
+  }
+  async function remove(member: OrganizationMember) {
+    if (!window.confirm(`Remove ${member.email ?? member.name ?? member.id} from this organization?`)) return
+    await api.removeOrganizationMember(member.id)
+    await loadMembers()
+  }
+  return <>
+    <PageHeading eyebrow="Tenant administration" title="Organization access & integrations" detail="Membership delegates to FuzeFront security. FuzeQuality owns only QA repository ownership and integration bindings." />
+    <section className="organization-settings-grid">
+      <article className="panel">
+        <div className="panel-heading"><div><p className="eyebrow">FuzeFront security</p><h2>Members & roles</h2></div><span className="header-badge"><Users /> {members.length}</span></div>
+        <form className="member-invite" onSubmit={invite}><input type="email" value={email} onChange={event => setEmail(event.target.value)} placeholder="teammate@example.com" required /><select value={role} onChange={event => setRole(event.target.value as OrganizationRole)}>{roles.map(item => <option key={item}>{item}</option>)}</select><button className="primary-button"><UserPlus size={15} /> Invite</button></form>
+        {error && <p className="form-error" role="alert">{error}</p>}
+        <div className="member-list">
+          {members.map(member => <div className="member-row" key={member.id}><div><strong>{member.displayName ?? member.name ?? member.email ?? member.userId ?? member.user_id ?? member.id}</strong><small>{member.email ?? member.status ?? 'Active member'}</small></div><select value={member.role} onChange={event => updateRole(member, event.target.value as OrganizationRole)}>{roles.map(item => <option key={item}>{item}</option>)}</select><button className="icon-button danger-button" onClick={() => remove(member)} aria-label="Remove member"><Trash2 size={14} /></button></div>)}
+          {!loading && !members.length && <div className="empty-state"><Users /><strong>No members returned</strong><span>Membership remains authoritative in FuzeFront security.</span></div>}
+          {loading && <div className="loading-row"><RefreshCw className="spin" size={15} /> Loading members…</div>}
+        </div>
+      </article>
+      <article className="panel">
+        <div className="panel-heading"><div><p className="eyebrow">QA source ownership</p><h2>Repositories & bindings</h2></div><span className="header-badge"><GitBranch /> {data.repositories.length}</span></div>
+        <div className="repository-admin-list">{data.repositories.map(repository => <RepositoryAdministrationCard key={repository.id} repository={repository} reload={reload} />)}</div>
+      </article>
+    </section>
+  </>
+}
+
 function OrganizationAdministration({ organizations }: { organizations: OrganizationQualitySummary[] }) {
   const [query, setQuery] = useState('')
   const [context, setContext] = useState<AdminTenantContext>()
@@ -506,5 +598,5 @@ export function App() {
   useEffect(() => { void reload() }, [])
   const visibleNavigation = useMemo(() => navigation.filter(item => item.id !== 'administration' || organizations), [organizations])
   const active = useMemo(() => visibleNavigation.find(item => item.id === view), [view, visibleNavigation])
-  return <div className="app-shell"><aside className="sidebar"><div className="brand"><div className="brand-symbol"><span /><span /><span /></div><div><strong>FuzeQuality</strong><small>Evidence control</small></div></div><nav>{visibleNavigation.map(item => { const Icon = item.icon; const count = item.id === 'review' ? data?.suggestions.filter(s => s.state === 'proposed').length : undefined; return <button key={item.id} className={view === item.id ? 'active' : ''} onClick={() => setView(item.id)}><Icon size={18} /><span>{item.label}</span>{count ? <b>{count}</b> : null}</button> })}</nav><div className="sidebar-footer"><Database size={16} /><div><span>Catalog revision</span><strong>{data ? 'live / v1' : 'connecting'}</strong></div></div></aside><main><div className="topbar"><span>{active?.label}</span><div><span className="live-dot" /> default branches <button className="icon-button" onClick={() => reload()} aria-label="Reload"><RefreshCw size={15} className={loading ? 'spin' : ''} /></button></div></div><div className="content">{error && <div className="error-banner"><AlertTriangle /> <div><strong>Catalog API unavailable</strong><span>{error}</span></div></div>}{!data ? <div className="loading-screen"><RefreshCw className="spin" /><span>Loading evidence graph…</span></div> : <>{view === 'overview' && <Overview data={data} onNavigate={setView} />}{view === 'repositories' && <Repositories data={data} reload={reload} />}{view === 'api' && <ApiCatalogPage data={data} />}{view === 'frontend' && <CatalogPage type="frontend" data={data} />}{view === 'requirements' && <Requirements data={data} />}{view === 'review' && <ReviewQueue data={data} reload={reload} />}{view === 'administration' && organizations && <OrganizationAdministration organizations={organizations} />}</>}</div></main></div>
+  return <div className="app-shell"><aside className="sidebar"><div className="brand"><div className="brand-symbol"><span /><span /><span /></div><div><strong>FuzeQuality</strong><small>Evidence control</small></div></div><nav>{visibleNavigation.map(item => { const Icon = item.icon; const count = item.id === 'review' ? data?.suggestions.filter(s => s.state === 'proposed').length : undefined; return <button key={item.id} className={view === item.id ? 'active' : ''} onClick={() => setView(item.id)}><Icon size={18} /><span>{item.label}</span>{count ? <b>{count}</b> : null}</button> })}</nav><div className="sidebar-footer"><Database size={16} /><div><span>Catalog revision</span><strong>{data ? 'live / v1' : 'connecting'}</strong></div></div></aside><main><div className="topbar"><span>{active?.label}</span><div><span className="live-dot" /> default branches <button className="icon-button" onClick={() => reload()} aria-label="Reload"><RefreshCw size={15} className={loading ? 'spin' : ''} /></button></div></div><div className="content">{error && <div className="error-banner"><AlertTriangle /> <div><strong>Catalog API unavailable</strong><span>{error}</span></div></div>}{!data ? <div className="loading-screen"><RefreshCw className="spin" /><span>Loading evidence graph…</span></div> : <>{view === 'overview' && <Overview data={data} onNavigate={setView} />}{view === 'repositories' && <Repositories data={data} reload={reload} />}{view === 'api' && <ApiCatalogPage data={data} />}{view === 'frontend' && <CatalogPage type="frontend" data={data} />}{view === 'requirements' && <Requirements data={data} />}{view === 'review' && <ReviewQueue data={data} reload={reload} />}{view === 'organization' && <OrganizationSettings data={data} reload={reload} />}{view === 'administration' && organizations && <OrganizationAdministration organizations={organizations} />}</>}</div></main></div>
 }

--- a/FuzeQuality/apps/web/src/api.ts
+++ b/FuzeQuality/apps/web/src/api.ts
@@ -57,4 +57,39 @@ export const api = {
       method: 'POST',
       body: JSON.stringify({ reason }),
     }),
+  organizationMembers: () =>
+    request<{ items?: OrganizationMember[]; members?: OrganizationMember[] } | OrganizationMember[]>('/api/v1/organization/members'),
+  organizationRoles: () =>
+    request<unknown>('/api/v1/organization/roles'),
+  inviteOrganizationMember: (email: string, role: OrganizationRole) =>
+    request('/api/v1/organization/invitations', {
+      method: 'POST',
+      body: JSON.stringify({ email, role }),
+    }),
+  updateOrganizationMember: (memberId: string, role: OrganizationRole) =>
+    request(`/api/v1/organization/members/${encodeURIComponent(memberId)}`, {
+      method: 'PUT',
+      body: JSON.stringify({ role }),
+    }),
+  removeOrganizationMember: (memberId: string) =>
+    request(`/api/v1/organization/members/${encodeURIComponent(memberId)}`, { method: 'DELETE' }),
+  updateRepositoryAdministration: (
+    repositoryId: string,
+    value: Pick<Portfolio['repositories'][number], 'ownership' | 'jiraBindings' | 'storybookBaseUrl'>
+  ) => request<Portfolio['repositories'][number]>(`/api/v1/repositories/${repositoryId}/administration`, {
+    method: 'PATCH',
+    body: JSON.stringify(value),
+  }),
+}
+
+export type OrganizationRole = 'owner' | 'admin' | 'member' | 'viewer'
+export type OrganizationMember = {
+  id: string
+  userId?: string
+  user_id?: string
+  email?: string
+  name?: string
+  displayName?: string
+  role: OrganizationRole
+  status?: string
 }

--- a/FuzeQuality/apps/web/src/lucide-react.d.ts
+++ b/FuzeQuality/apps/web/src/lucide-react.d.ts
@@ -23,8 +23,12 @@ declare module 'lucide-react' {
   export const Plus: LucideIcon
   export const RefreshCw: LucideIcon
   export const Search: LucideIcon
+  export const Save: LucideIcon
   export const ShieldCheck: LucideIcon
   export const Sparkles: LucideIcon
   export const TestTube2: LucideIcon
+  export const Trash2: LucideIcon
+  export const UserPlus: LucideIcon
+  export const Users: LucideIcon
   export const X: LucideIcon
 }

--- a/FuzeQuality/apps/web/src/styles.css
+++ b/FuzeQuality/apps/web/src/styles.css
@@ -180,6 +180,11 @@ button:disabled { cursor: wait; opacity: .55; }
 .organization-table article:first-of-type { border-top: 0; }
 .organization-table strong, .organization-table b, .organization-table small { display: block; }.organization-table strong { color: var(--cyan); }.organization-table b { font: 600 17px 'Space Grotesk'; }.organization-table small { margin-top: 3px; color: var(--muted); font-size: 10px; }
 .organization-risk b { color: var(--coral); }
+.organization-settings-grid { display: grid; grid-template-columns: minmax(360px, .8fr) minmax(540px, 1.2fr); gap: 20px; }
+.member-invite { display: grid; grid-template-columns: 1fr 120px auto; gap: 8px; margin-bottom: 16px; }.member-invite input, .member-invite select, .member-row select, .repository-admin-fields input { min-width: 0; padding: 9px 10px; border: 1px solid #294359; background: #07131e; color: var(--text); }
+.member-list { display: grid; }.member-row { display: grid; grid-template-columns: 1fr 110px auto; align-items: center; gap: 9px; padding: 11px 0; border-top: 1px solid #172b3d; }.member-row strong, .member-row small { display: block; }.member-row small { margin-top: 2px; color: var(--muted); font-size: 10px; }.danger-button { color: var(--coral); }.loading-row { display: flex; align-items: center; justify-content: center; gap: 8px; padding: 24px; color: var(--muted); }
+.repository-admin-list { display: grid; gap: 12px; max-height: 680px; overflow: auto; }.repository-admin-card { padding: 15px; border: 1px solid var(--line); background: #091724; }.repository-admin-title { display: grid; grid-template-columns: auto 1fr auto; align-items: center; gap: 10px; margin-bottom: 13px; }.repository-admin-title strong, .repository-admin-title small { display: block; }.repository-admin-title small { color: var(--muted); }.repository-admin-title > span { color: var(--cyan); font: 9px 'IBM Plex Mono'; text-transform: uppercase; }
+.repository-admin-fields { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; margin-bottom: 12px; }.repository-admin-fields label { display: grid; gap: 5px; color: var(--muted); font-size: 10px; }.repository-admin-fields .wide-field { grid-column: 1 / -1; }
 
 @media (max-width: 720px) {
   .preview-drawer { padding: 21px 16px; }
@@ -188,4 +193,5 @@ button:disabled { cursor: wait; opacity: .55; }
   .storybook-frame { height: 60vh; }
   .tenant-context-banner { top: 0; grid-template-columns: auto 1fr; }.tenant-context-banner button { grid-column: 1 / -1; }
   .organization-table { overflow-x: auto; }.organization-table-head, .organization-table article { min-width: 920px; }
+  .organization-settings-grid { grid-template-columns: 1fr; }.member-invite { grid-template-columns: 1fr; }.repository-admin-fields { grid-template-columns: 1fr; }.repository-admin-fields .wide-field { grid-column: auto; }
 }

--- a/FuzeQuality/packages/core/src/store.tenant-isolation.test.ts
+++ b/FuzeQuality/packages/core/src/store.tenant-isolation.test.ts
@@ -45,4 +45,20 @@ describe('MemoryCatalogStore tenant isolation', () => {
     expect(audit.id).toBeTruthy()
     expect(new Date(audit.createdAt).toString()).not.toBe('Invalid Date')
   })
+
+  it('updates repository administration only inside the caller tenant', async () => {
+    const repository = { id: 'repo-a', tenantId: 'tenant-a', owner: 'fuze', name: 'A', canonicalUrl: 'https://github.com/fuze/A', defaultBranch: 'main', kind: 'service' as const, enabled: true, includeGlobs: [], excludeGlobs: [], jiraProjects: [], jiraBindings: [], lastScanStatus: 'complete' as const }
+    const store = new MemoryCatalogStore({ repositories: [repository] })
+    const value = {
+      ownership: { team: 'Payments' },
+      jiraBindings: [{ project: 'PAY', component: 'Checkout' }],
+      storybookBaseUrl: 'https://storybook.example.com',
+    }
+
+    expect(await store.updateRepositoryAdministration('repo-a', 'tenant-b', value)).toBeUndefined()
+    expect((await store.repository('repo-a', 'tenant-a'))?.ownership).toBeUndefined()
+
+    const updated = await store.updateRepositoryAdministration('repo-a', 'tenant-a', value)
+    expect(updated).toMatchObject(value)
+  })
 })

--- a/FuzeQuality/packages/core/src/store.ts
+++ b/FuzeQuality/packages/core/src/store.ts
@@ -17,6 +17,11 @@ export interface CatalogStore {
   portfolio(tenantId?: string): Promise<Portfolio>
   repository(id: string, tenantId?: string): Promise<Repository | undefined>
   addRepository(input: RepositoryInput, tenantId?: string): Promise<Repository>
+  updateRepositoryAdministration(
+    id: string,
+    tenantId: string,
+    value: Pick<RepositoryInput, 'ownership' | 'jiraBindings' | 'storybookBaseUrl'>
+  ): Promise<Repository | undefined>
   setRepositoryStatus(id: string, status: Repository['lastScanStatus']): Promise<void>
   saveScan(result: ScanResult): Promise<void>
   saveIntelligence(results: Array<{ requirement: Requirement; suggestions: Suggestion[] }>): Promise<void>
@@ -95,6 +100,17 @@ export class MemoryCatalogStore implements CatalogStore {
       lastScanStatus: 'never',
     }
     this.data.repositories.push(repository)
+    return repository
+  }
+
+  async updateRepositoryAdministration(
+    id: string,
+    tenantId: string,
+    value: Pick<RepositoryInput, 'ownership' | 'jiraBindings' | 'storybookBaseUrl'>
+  ) {
+    const repository = await this.repository(id, tenantId)
+    if (!repository) return undefined
+    Object.assign(repository, value)
     return repository
   }
 
@@ -267,6 +283,22 @@ export class PostgresCatalogStore implements CatalogStore {
       [tenantId, input.owner, input.name, canonicalUrl, input.defaultBranch, input.kind, input.installationId, input]
     )
     return (await this.repository(result.rows[0].id, tenantId))!
+  }
+
+  async updateRepositoryAdministration(
+    id: string,
+    tenantId: string,
+    value: Pick<RepositoryInput, 'ownership' | 'jiraBindings' | 'storybookBaseUrl'>
+  ) {
+    const result = await this.pool.query(
+      `UPDATE fuzequality.repositories
+       SET config = config || $3::jsonb, updated_at = now()
+       WHERE id = $1 AND tenant_id = $2 AND enabled = true
+       RETURNING id`,
+      [id, tenantId, JSON.stringify(value)]
+    )
+    if (!result.rowCount) return undefined
+    return this.repository(id, tenantId)
   }
 
   async setRepositoryStatus(id: string, status: Repository['lastScanStatus']) {

--- a/FuzeQuality/registration/policy.json
+++ b/FuzeQuality/registration/policy.json
@@ -25,11 +25,33 @@
         "create": { "name": "Create" },
         "read": { "name": "Read" }
       }
+    },
+    {
+      "key": "OrganizationAccess",
+      "name": "Organization access",
+      "actions": {
+        "read": { "name": "Read" },
+        "manage": { "name": "Manage" }
+      }
+    },
+    {
+      "key": "RepositoryAdministration",
+      "name": "Repository administration",
+      "actions": {
+        "manage": { "name": "Manage" }
+      }
+    },
+    {
+      "key": "PlatformAdministration",
+      "name": "Platform administration",
+      "actions": {
+        "read": { "name": "Read" }
+      }
     }
   ],
   "roles": [
-    { "key": "viewer", "name": "Viewer", "permissions": ["Repository:read", "Evidence:read"] },
-    { "key": "analyst", "name": "Analyst", "permissions": ["Repository:read", "Repository:scan", "Evidence:read", "Evidence:export", "TestImplementation:read", "TestImplementation:create"] },
-    { "key": "admin", "name": "Admin", "permissions": ["Repository:read", "Repository:onboard", "Repository:scan", "Evidence:read", "Evidence:export", "TestImplementation:read", "TestImplementation:create"] }
+    { "key": "viewer", "name": "Viewer", "permissions": ["Repository:read", "Evidence:read", "OrganizationAccess:read"] },
+    { "key": "analyst", "name": "Analyst", "permissions": ["Repository:read", "Repository:scan", "Evidence:read", "Evidence:export", "TestImplementation:read", "TestImplementation:create", "OrganizationAccess:read"] },
+    { "key": "admin", "name": "Admin", "permissions": ["Repository:read", "Repository:onboard", "Repository:scan", "Evidence:read", "Evidence:export", "TestImplementation:read", "TestImplementation:create", "OrganizationAccess:read", "OrganizationAccess:manage", "RepositoryAdministration:manage", "PlatformAdministration:read"] }
   ]
 }


### PR DESCRIPTION
## Outcome

Adds organization-level administration without creating a parallel identity system.

- delegates member listing, invitations, role changes, and removal to FuzeFront security services
- derives organization identity exclusively from the validated FuzeFront session
- adds tenant-isolated repository ownership, Jira binding, and Storybook binding updates
- aligns runtime authorization keys/actions with the namespaced registered FuzeQuality product policy
- adds Organization UI for members, roles, owners, and integration settings
- expands registered product permissions for read/manage boundaries
- fails closed for cross-tenant repository identifiers and unavailable security services

## Verification

- npm run type-check
- npm test (64 passed, 1 intentional Chroma integration skip)
- npm run build:web

## Jira

- FQ-182
- FQ-191
- FQ-192
- FQ-193
- FQ-194