### PR TITLE
FQ-173: cover unauthenticated app update endpoint

### DIFF
--- a/backend/applications/tests/app-registry.authentication.contract.test.ts
+++ b/backend/applications/tests/app-registry.authentication.contract.test.ts
@@ -31,4 +31,9 @@ describe('app registry authentication contract', () => {
     const response = await request(buildApp()).get('/api/v1/app-registry/apps/clock')
     expectUnauthenticated(response)
   })
+
+  it('rejects an unauthenticated PUT /api/v1/app-registry/apps/:slug request', async () => {
+    const response = await request(buildApp()).put('/api/v1/app-registry/apps/clock')
+    expectUnauthenticated(response)
+  })
 })


### PR DESCRIPTION
## Summary
- add missing-auth contract coverage for PUT /api/v1/app-registry/apps/{slug}
- preserve the controlled JSON 401 contract used by the existing app-registry endpoint tests

## Verification
- git diff --check
- clean PR CI (local worktree has no installed Jest dependencies)

Jira: FQ-173