### PR TITLE
FQ-173: cover unauthenticated app policy endpoint

### DIFF
--- a/backend/applications/tests/app-registry.authentication.contract.test.ts
+++ b/backend/applications/tests/app-registry.authentication.contract.test.ts
@@ -36,4 +36,9 @@ describe('app registry authentication contract', () => {
     const response = await request(buildApp()).put('/api/v1/app-registry/apps/clock')
     expectUnauthenticated(response)
   })
+
+  it('rejects an unauthenticated PUT /api/v1/app-registry/apps/:slug/policy request', async () => {
+    const response = await request(buildApp()).put('/api/v1/app-registry/apps/clock/policy')
+    expectUnauthenticated(response)
+  })
 })


### PR DESCRIPTION
## Summary
- add missing-auth contract coverage for PUT /api/v1/app-registry/apps/{slug}/policy
- preserve the controlled JSON 401 contract used by app-registry endpoints

## Verification
- git diff --check
- clean PR CI

Jira: FQ-173