### PR TITLE
FQ-173: complete app-registry authentication coverage

### DIFF
--- a/backend/applications/tests/app-registry.authentication.contract.test.ts
+++ b/backend/applications/tests/app-registry.authentication.contract.test.ts
@@ -51,4 +51,9 @@ describe('app registry authentication contract', () => {
     const response = await request(buildApp()).delete('/api/v1/app-registry/apps/clock')
     expectUnauthenticated(response)
   })
+
+  it('rejects an unauthenticated POST /api/v1/app-registry/apps/:slug/activate request', async () => {
+    const response = await request(buildApp()).post('/api/v1/app-registry/apps/clock/activate')
+    expectUnauthenticated(response)
+  })
 })

--- a/backend/applications/tests/app-registry.authentication.contract.test.ts
+++ b/backend/applications/tests/app-registry.authentication.contract.test.ts
@@ -2,8 +2,20 @@ import express from 'express'
 import request from 'supertest'
 import appRegistryRouter from '../src/routes/app-registry'
 
+jest.mock('../src/app-registry/service', () => ({
+  appRegistryService: {
+    getHeartbeatToken: jest.fn().mockResolvedValue('expected-heartbeat-token'),
+    findBySlug: jest.fn().mockResolvedValue({
+      slug: 'clock',
+      organizationId: 'org-test',
+      manifest: { name: 'Clock' },
+    }),
+  },
+}))
+
 function buildApp() {
   const app = express()
+  app.use(express.json())
   app.use('/api/v1/app-registry', appRegistryRouter)
   return app
 }
@@ -60,5 +72,17 @@ describe('app registry authentication contract', () => {
   it('rejects an unauthenticated POST /api/v1/app-registry/apps/:slug/suspend request', async () => {
     const response = await request(buildApp()).post('/api/v1/app-registry/apps/clock/suspend')
     expectUnauthenticated(response)
+  })
+
+  it('rejects an unauthenticated POST /api/v1/app-registry/apps/:slug/heartbeat request', async () => {
+    const response = await request(buildApp())
+      .post('/api/v1/app-registry/apps/clock/heartbeat')
+      .send({ status: 'online' })
+    expect(response.status).toBe(401)
+    expect(response.type).toMatch(/json/)
+    expect(response.body).toEqual({
+      error: 'unauthorized',
+      message: 'Invalid app heartbeat token',
+    })
   })
 })

--- a/backend/applications/tests/app-registry.authentication.contract.test.ts
+++ b/backend/applications/tests/app-registry.authentication.contract.test.ts
@@ -46,4 +46,9 @@ describe('app registry authentication contract', () => {
     const response = await request(buildApp()).put('/api/v1/app-registry/apps/clock/billing-profile')
     expectUnauthenticated(response)
   })
+
+  it('rejects an unauthenticated DELETE /api/v1/app-registry/apps/:slug request', async () => {
+    const response = await request(buildApp()).delete('/api/v1/app-registry/apps/clock')
+    expectUnauthenticated(response)
+  })
 })

--- a/backend/applications/tests/app-registry.authentication.contract.test.ts
+++ b/backend/applications/tests/app-registry.authentication.contract.test.ts
@@ -41,4 +41,9 @@ describe('app registry authentication contract', () => {
     const response = await request(buildApp()).put('/api/v1/app-registry/apps/clock/policy')
     expectUnauthenticated(response)
   })
+
+  it('rejects an unauthenticated PUT /api/v1/app-registry/apps/:slug/billing-profile request', async () => {
+    const response = await request(buildApp()).put('/api/v1/app-registry/apps/clock/billing-profile')
+    expectUnauthenticated(response)
+  })
 })

--- a/backend/applications/tests/app-registry.authentication.contract.test.ts
+++ b/backend/applications/tests/app-registry.authentication.contract.test.ts
@@ -56,4 +56,9 @@ describe('app registry authentication contract', () => {
     const response = await request(buildApp()).post('/api/v1/app-registry/apps/clock/activate')
     expectUnauthenticated(response)
   })
+
+  it('rejects an unauthenticated POST /api/v1/app-registry/apps/:slug/suspend request', async () => {
+    const response = await request(buildApp()).post('/api/v1/app-registry/apps/clock/suspend')
+    expectUnauthenticated(response)
+  })
 })


### PR DESCRIPTION
## Summary
- cover missing authentication for billing-profile updates
- cover missing authentication for delete, activate, and suspend operations
- cover missing per-app token rejection for heartbeat
- complete all ten non-health OpenAPI operations in the app-registry authentication contract

## Commit discipline
- one endpoint per commit
- five endpoint commits in this branch; the preceding five operations are already on master

## Verification
- git diff --check
- PR backend and contract CI

Jira: FQ-173