### PR TITLE
FQ-173: unblock production repository rescans

### DIFF
--- a/FuzeQuality/apps/api/src/index.ts
+++ b/FuzeQuality/apps/api/src/index.ts
@@ -130,7 +130,10 @@ function organizationSummaries(portfolio: Portfolio): OrganizationQualitySummary
 }
 
 app.use(express.json({
-  limit: '2mb',
+  // A normalized inventory for the current FuzeFront repository is ~2.4 MB.
+  // Keep this above the scanner's bounded payload while still rejecting
+  // unexpectedly large webhook and user-request bodies.
+  limit: '5mb',
   verify: (request, _response, buffer) => {
     ;(request as express.Request & { rawBody?: Buffer }).rawBody = Buffer.from(buffer)
   },


### PR DESCRIPTION
## Summary
- raise the FuzeQuality API JSON limit from 2 MB to 5 MB
- admit the measured 2.35 MB normalized FuzeFront inventory
- retain a bounded limit for webhook and user-request safety

## Production evidence
The exact-master rescan reached the API and failed with PayloadTooLargeError: expected 2,354,231 bytes, limit 2,097,152 bytes.

## Verification
- git diff --check
- PR FuzeQuality/API CI
- retry the queued exact-SHA scan after deployment

Jira: FQ-173