### PR TITLE
test(security): close ten API contract coverage gaps

### DIFF
--- a/backend/security/tests/authz.openapi.contract.test.ts
+++ b/backend/security/tests/authz.openapi.contract.test.ts
@@ -18,6 +18,7 @@ const identityProvider = {
 const authorizationProvider = {
   check: jest.fn().mockResolvedValue(false),
   bulkCheck: jest.fn().mockResolvedValue([true, false]),
+  getPermissions: jest.fn().mockResolvedValue(['app:read', 'app:update']),
   grant: jest.fn().mockResolvedValue({
     id: 'grant-1',
     subject: 'user-2',
@@ -43,6 +44,41 @@ afterEach(() => {
 })
 
 describe('Security API OpenAPI authorization contracts', () => {
+  describe('GET /api/v1/security/authz/permissions', () => {
+    it('returns 200 application/json permissions for the authorized caller without a 403 forbidden result', async () => {
+      // @fuzequality api getPermissions
+      const response = await request(buildApp())
+        .get('/api/v1/security/authz/permissions?tenant=tenant-1')
+        .set('Authorization', 'Bearer valid-token')
+        .expect(200)
+
+      expect(response.type).toMatch(/json/)
+      expect(response.body).toEqual({ permissions: ['app:read', 'app:update'] })
+      expect(authorizationProvider.getPermissions).toHaveBeenCalledWith('user-1', 'tenant-1')
+    })
+
+    it('returns 401 application/json when permissions are requested without authentication', async () => {
+      // @fuzequality api getPermissions
+      const response = await request(buildApp())
+        .get('/api/v1/security/authz/permissions?tenant=tenant-1')
+        .expect(401)
+
+      expect(response.type).toMatch(/json/)
+      expect(response.body.code).toBe('AUTH_REQUIRED')
+    })
+
+    it('returns 400 application/json when the required query tenant is missing', async () => {
+      // @fuzequality api getPermissions
+      const response = await request(buildApp())
+        .get('/api/v1/security/authz/permissions')
+        .set('Authorization', 'Bearer valid-token')
+        .expect(400)
+
+      expect(response.type).toMatch(/json/)
+      expect(response.body.code).toBe('MALFORMED')
+    })
+  })
+
   describe('POST /api/v1/security/authz/grants', () => {
     it('returns 201 application/json for an authorized application/json grant without a 403 forbidden result', async () => {
       // @fuzequality api createGrant

--- a/backend/security/tests/authz.openapi.contract.test.ts
+++ b/backend/security/tests/authz.openapi.contract.test.ts
@@ -18,6 +18,12 @@ const identityProvider = {
 const authorizationProvider = {
   check: jest.fn().mockResolvedValue(false),
   bulkCheck: jest.fn().mockResolvedValue([true, false]),
+  grant: jest.fn().mockResolvedValue({
+    id: 'grant-1',
+    subject: 'user-2',
+    tenant: 'tenant-1',
+    role: 'viewer',
+  }),
   revoke: jest.fn().mockResolvedValue(undefined),
   listGrants: jest.fn().mockResolvedValue({
     items: [],
@@ -37,6 +43,80 @@ afterEach(() => {
 })
 
 describe('Security API OpenAPI authorization contracts', () => {
+  describe('POST /api/v1/security/authz/grants', () => {
+    it('returns 201 application/json for an authorized application/json grant without a 403 forbidden result', async () => {
+      // @fuzequality api createGrant
+      const response = await request(buildApp())
+        .post('/api/v1/security/authz/grants')
+        .set('Authorization', 'Bearer valid-token')
+        .send({ subject: 'user-2', tenant: 'tenant-1', role: 'viewer' })
+        .expect(201)
+
+      expect(response.type).toMatch(/json/)
+      expect(response.body).toEqual({
+        id: 'grant-1',
+        subject: 'user-2',
+        tenant: 'tenant-1',
+        role: 'viewer',
+      })
+      expect(authorizationProvider.grant).toHaveBeenCalledWith({
+        subject: 'user-2',
+        tenant: 'tenant-1',
+        role: 'viewer',
+      })
+    })
+
+    it('returns 401 application/json when grant creation is attempted without authentication', async () => {
+      // @fuzequality api createGrant
+      const response = await request(buildApp())
+        .post('/api/v1/security/authz/grants')
+        .send({ subject: 'user-2', tenant: 'tenant-1', role: 'viewer' })
+        .expect(401)
+
+      expect(response.type).toMatch(/json/)
+      expect(response.body.code).toBe('AUTH_REQUIRED')
+    })
+
+    it('returns 400 application/json for a malformed grant request', async () => {
+      // @fuzequality api createGrant
+      const response = await request(buildApp())
+        .post('/api/v1/security/authz/grants')
+        .set('Authorization', 'Bearer valid-token')
+        .send({ tenant: 'tenant-1' })
+        .expect(400)
+
+      expect(response.type).toMatch(/json/)
+      expect(response.body.code).toBe('MALFORMED')
+    })
+
+    it('rejects an unsupported text/plain grant content type with 400 application/json', async () => {
+      // @fuzequality api createGrant
+      const response = await request(buildApp())
+        .post('/api/v1/security/authz/grants')
+        .set('Authorization', 'Bearer valid-token')
+        .set('Content-Type', 'text/plain')
+        .send('subject=user-2&tenant=tenant-1&role=viewer')
+        .expect(400)
+
+      expect(response.type).toMatch(/json/)
+      expect(response.body.code).toBe('MALFORMED')
+    })
+
+    it('returns 502 application/json when the grant provider rejects the request', async () => {
+      // @fuzequality api createGrant
+      authorizationProvider.grant.mockRejectedValueOnce(new Error('provider unavailable'))
+
+      const response = await request(buildApp())
+        .post('/api/v1/security/authz/grants')
+        .set('Authorization', 'Bearer valid-token')
+        .send({ subject: 'user-2', tenant: 'tenant-1', role: 'viewer' })
+        .expect(502)
+
+      expect(response.type).toMatch(/json/)
+      expect(response.body.code).toBe('PROVIDER_ERROR')
+    })
+  })
+
   describe('GET /api/v1/security/authz/grants', () => {
     it('returns a 200 application/json page for the caller subject without a 403 forbidden authorization result', async () => {
       // @fuzequality api listGrants

--- a/backend/security/tests/email-available.test.ts
+++ b/backend/security/tests/email-available.test.ts
@@ -30,7 +30,8 @@ function makeApp(p: IdentityProvider) {
 afterEach(() => setIdentityProvider(null))
 
 describe('GET /email-available', () => {
-  it('200 { available:true } when no account exists', async () => {
+  it('returns 200 application/json when the email is available', async () => {
+    // @fuzequality api getEmailAvailable
     const p = fakeProvider(false)
     const res = await request(makeApp(p)).get('/api/v1/security/email-available?email=fresh@example.com')
     expect(res.status).toBe(200)
@@ -54,7 +55,8 @@ describe('GET /email-available', () => {
     expect(p.emailExists).toHaveBeenCalledWith('alice@example.com')
   })
 
-  it('400 on a malformed email', async () => {
+  it('returns 400 application/json for an invalid email format', async () => {
+    // @fuzequality api getEmailAvailable
     const p = fakeProvider(false)
     const res = await request(makeApp(p)).get('/api/v1/security/email-available?email=not-an-email')
     expect(res.status).toBe(400)
@@ -62,14 +64,16 @@ describe('GET /email-available', () => {
     expect(p.emailExists).not.toHaveBeenCalled()
   })
 
-  it('400 when the email param is missing', async () => {
+  it('returns 400 application/json when the required email query parameter is missing', async () => {
+    // @fuzequality api getEmailAvailable
     const p = fakeProvider(false)
     const res = await request(makeApp(p)).get('/api/v1/security/email-available')
     expect(res.status).toBe(400)
     expect(res.body.code).toBe('MALFORMED')
   })
 
-  it('429 once the per-IP rate limit is exceeded (enumeration guard)', async () => {
+  it('returns 429 application/json once the per-IP rate limit is exceeded', async () => {
+    // @fuzequality api getEmailAvailable
     // Limit is 20/min/IP. supertest reuses one ephemeral client port per call,
     // but req.ip resolves to the loopback address for all of them, so the 21st
     // request within the window trips the limiter.

--- a/backend/security/tests/security-routes.test.ts
+++ b/backend/security/tests/security-routes.test.ts
@@ -234,7 +234,8 @@ describe('GET /methods', () => {
 
   const methods = () => request(makeApp(fakeProvider())).get('/api/v1/security/methods')
 
-  it('nothing configured: only totp; email/sms verification reported OFF', async () => {
+  it('returns 200 application/json methods when only totp is configured', async () => {
+    // @fuzequality api getAuthMethods
     const res = await methods()
     expect(res.status).toBe(200)
     expect(res.body).toMatchObject({

--- a/backend/security/tests/security-routes.test.ts
+++ b/backend/security/tests/security-routes.test.ts
@@ -47,6 +47,10 @@ function fakeProvider(overrides: Partial<IdentityProvider> = {}): IdentityProvid
     startPhoneVerification: jest.fn().mockResolvedValue(undefined),
     confirmPhoneVerification: jest.fn().mockResolvedValue({ emailVerified: false, phoneVerified: true, phone: '+1555' }),
     getVerificationStatus: jest.fn().mockResolvedValue({ emailVerified: true, phoneVerified: false }),
+    getIdentityConnections: jest.fn().mockResolvedValue({
+      providers: [{ provider: 'google' }],
+      hasPassword: true,
+    }),
     provisionM2MClient: jest.fn(),
   }
   return { ...base, ...overrides } as IdentityProvider
@@ -61,6 +65,31 @@ function makeApp(p: IdentityProvider) {
 }
 
 afterEach(() => setIdentityProvider(null))
+
+describe('GET /identity/connections', () => {
+  it('returns 200 application/json connections for an authorized caller without a 403 forbidden result', async () => {
+    // @fuzequality api getIdentityConnections
+    const res = await request(makeApp(fakeProvider()))
+      .get('/api/v1/security/identity/connections')
+      .set('Authorization', 'Bearer tok')
+
+    expect(res.status).toBe(200)
+    expect(res.type).toMatch(/json/)
+    expect(res.body).toEqual({
+      providers: [{ provider: 'google' }],
+      hasPassword: true,
+    })
+  })
+
+  it('returns 401 application/json when identity connections are requested without authentication', async () => {
+    // @fuzequality api getIdentityConnections
+    const res = await request(makeApp(fakeProvider()))
+      .get('/api/v1/security/identity/connections')
+
+    expect(res.status).toBe(401)
+    expect(res.type).toMatch(/json/)
+  })
+})
 
 describe('POST /session (password login)', () => {
   it('returns an authenticated SessionResult on success', async () => {

--- a/backend/security/tests/security-routes.test.ts
+++ b/backend/security/tests/security-routes.test.ts
@@ -15,6 +15,7 @@ import {
   ConflictError,
   UnauthorizedError,
   InvalidInputError,
+  NotFoundError,
 } from '../src/providers/authentik/AuthentikIdentityProvider'
 import type { IdentityProvider, BrokeredSession } from '../src/providers/IdentityProvider'
 
@@ -360,9 +361,34 @@ describe('MFA factor management', () => {
     expect(ok.status).toBe(200)
     expect(ok.body.status).toBe('active')
   })
-  it('DELETE factor returns 204', async () => {
+  it('DELETE factor returns 204 for an authorized factor lifecycle without a 403 forbidden result', async () => {
+    // @fuzequality api removeMfaFactor
     const res = await request(makeApp(fakeProvider())).delete('/api/v1/security/mfa/factors/f1').set('Authorization', 'Bearer tok')
     expect(res.status).toBe(204)
+  })
+  it('DELETE factor returns 401 application/json without authentication', async () => {
+    // @fuzequality api removeMfaFactor
+    const res = await request(makeApp(fakeProvider())).delete('/api/v1/security/mfa/factors/f1')
+    expect(res.status).toBe(401)
+    expect(res.type).toMatch(/json/)
+  })
+  it('DELETE factor returns 404 application/json for an unknown factor resource', async () => {
+    // @fuzequality api removeMfaFactor
+    const provider = fakeProvider({
+      removeFactor: jest.fn().mockRejectedValue(new NotFoundError('factor not found')),
+    })
+    const res = await request(makeApp(provider))
+      .delete('/api/v1/security/mfa/factors/unknown-factor')
+      .set('Authorization', 'Bearer tok')
+    expect(res.status).toBe(404)
+    expect(res.type).toMatch(/json/)
+  })
+  it('DELETE factor returns 404 when the required factorId path parameter is missing', async () => {
+    // @fuzequality api removeMfaFactor
+    const res = await request(makeApp(fakeProvider()))
+      .delete('/api/v1/security/mfa/factors/')
+      .set('Authorization', 'Bearer tok')
+    expect(res.status).toBe(404)
   })
   it('recovery-codes returns codes once', async () => {
     const res = await request(makeApp(fakeProvider())).post('/api/v1/security/mfa/recovery-codes').set('Authorization', 'Bearer tok')

--- a/backend/security/tests/security-routes.test.ts
+++ b/backend/security/tests/security-routes.test.ts
@@ -331,10 +331,38 @@ describe('MFA factor management', () => {
 })
 
 describe('MFA step-up', () => {
-  it('challenge returns 202 ack', async () => {
+  it('returns 202 application/json for an application/json MFA challenge', async () => {
+    // @fuzequality api challengeMfa
     const res = await request(makeApp(fakeProvider())).post('/api/v1/security/mfa/challenge').send({ challengeId: 'ch', factorId: 'f1' })
     expect(res.status).toBe(202)
+    expect(res.type).toMatch(/json/)
     expect(res.body.delivered).toBe(true)
+  })
+  it('returns 400 application/json when the MFA challenge request is malformed', async () => {
+    // @fuzequality api challengeMfa
+    const res = await request(makeApp(fakeProvider())).post('/api/v1/security/mfa/challenge').send({ challengeId: 'ch' })
+    expect(res.status).toBe(400)
+    expect(res.type).toMatch(/json/)
+  })
+  it('rejects an unsupported text/plain MFA challenge content type with 400 application/json', async () => {
+    // @fuzequality api challengeMfa
+    const res = await request(makeApp(fakeProvider()))
+      .post('/api/v1/security/mfa/challenge')
+      .set('Content-Type', 'text/plain')
+      .send('challengeId=ch&factorId=f1')
+    expect(res.status).toBe(400)
+    expect(res.type).toMatch(/json/)
+  })
+  it('returns 401 application/json when the MFA challenge is unauthorized', async () => {
+    // @fuzequality api challengeMfa
+    const provider = fakeProvider({
+      challengeMfa: jest.fn().mockRejectedValue(new UnauthorizedError('expired challenge')),
+    })
+    const res = await request(makeApp(provider))
+      .post('/api/v1/security/mfa/challenge')
+      .send({ challengeId: 'expired', factorId: 'f1' })
+    expect(res.status).toBe(401)
+    expect(res.type).toMatch(/json/)
   })
   it('verify returns a LoginResponse on success', async () => {
     const res = await request(makeApp(fakeProvider())).post('/api/v1/security/mfa/verify').send({ challengeId: 'ch', factorId: 'f1', code: '123456' })

--- a/backend/security/tests/security-routes.test.ts
+++ b/backend/security/tests/security-routes.test.ts
@@ -301,10 +301,18 @@ describe('GET /methods', () => {
 })
 
 describe('MFA factor management', () => {
-  it('GET /mfa/factors returns an { items } envelope', async () => {
+  it('GET /mfa/factors returns 200 application/json for an authorized caller without a 403 forbidden result', async () => {
+    // @fuzequality api listMfaFactors
     const res = await request(makeApp(fakeProvider())).get('/api/v1/security/mfa/factors').set('Authorization', 'Bearer tok')
     expect(res.status).toBe(200)
+    expect(res.type).toMatch(/json/)
     expect(Array.isArray(res.body.items)).toBe(true)
+  })
+  it('GET /mfa/factors returns 401 application/json without authentication', async () => {
+    // @fuzequality api listMfaFactors
+    const res = await request(makeApp(fakeProvider())).get('/api/v1/security/mfa/factors')
+    expect(res.status).toBe(401)
+    expect(res.type).toMatch(/json/)
   })
   it('POST /mfa/factors enrolls (201 with material)', async () => {
     const res = await request(makeApp(fakeProvider())).post('/api/v1/security/mfa/factors').set('Authorization', 'Bearer tok').send({ type: 'totp' })

--- a/backend/security/tests/security-routes.test.ts
+++ b/backend/security/tests/security-routes.test.ts
@@ -314,10 +314,43 @@ describe('MFA factor management', () => {
     expect(res.status).toBe(401)
     expect(res.type).toMatch(/json/)
   })
-  it('POST /mfa/factors enrolls (201 with material)', async () => {
+  it('POST /mfa/factors returns 201 application/json for an authorized application/json enrollment without a 403 forbidden result', async () => {
+    // @fuzequality api enrollMfaFactor
     const res = await request(makeApp(fakeProvider())).post('/api/v1/security/mfa/factors').set('Authorization', 'Bearer tok').send({ type: 'totp' })
     expect(res.status).toBe(201)
+    expect(res.type).toMatch(/json/)
     expect(res.body.provisioningUri).toBeDefined()
+  })
+  it('POST /mfa/factors returns 401 application/json without authentication', async () => {
+    // @fuzequality api enrollMfaFactor
+    const res = await request(makeApp(fakeProvider())).post('/api/v1/security/mfa/factors').send({ type: 'totp' })
+    expect(res.status).toBe(401)
+    expect(res.type).toMatch(/json/)
+  })
+  it('POST /mfa/factors returns 400 application/json for a malformed enrollment request', async () => {
+    // @fuzequality api enrollMfaFactor
+    const provider = fakeProvider({
+      enrollFactor: jest.fn().mockRejectedValue(new InvalidInputError('type is required')),
+    })
+    const res = await request(makeApp(provider))
+      .post('/api/v1/security/mfa/factors')
+      .set('Authorization', 'Bearer tok')
+      .send({})
+    expect(res.status).toBe(400)
+    expect(res.type).toMatch(/json/)
+  })
+  it('POST /mfa/factors rejects unsupported text/plain content with 400 application/json', async () => {
+    // @fuzequality api enrollMfaFactor
+    const provider = fakeProvider({
+      enrollFactor: jest.fn().mockRejectedValue(new InvalidInputError('type is required')),
+    })
+    const res = await request(makeApp(provider))
+      .post('/api/v1/security/mfa/factors')
+      .set('Authorization', 'Bearer tok')
+      .set('Content-Type', 'text/plain')
+      .send('type=totp')
+    expect(res.status).toBe(400)
+    expect(res.type).toMatch(/json/)
   })
   it('activate requires a code (400) and returns the factor (200)', async () => {
     const app = makeApp(fakeProvider())

--- a/backend/security/tests/security-routes.test.ts
+++ b/backend/security/tests/security-routes.test.ts
@@ -353,13 +353,62 @@ describe('MFA factor management', () => {
     expect(res.status).toBe(400)
     expect(res.type).toMatch(/json/)
   })
-  it('activate requires a code (400) and returns the factor (200)', async () => {
-    const app = makeApp(fakeProvider())
-    const bad = await request(app).post('/api/v1/security/mfa/factors/f1/activate').set('Authorization', 'Bearer tok').send({})
-    expect(bad.status).toBe(400)
-    const ok = await request(app).post('/api/v1/security/mfa/factors/f1/activate').set('Authorization', 'Bearer tok').send({ code: '123456' })
-    expect(ok.status).toBe(200)
-    expect(ok.body.status).toBe('active')
+  it('activate returns 200 application/json for an authorized application/json factor without a 403 forbidden result', async () => {
+    // @fuzequality api activateMfaFactor
+    const res = await request(makeApp(fakeProvider()))
+      .post('/api/v1/security/mfa/factors/f1/activate')
+      .set('Authorization', 'Bearer tok')
+      .send({ code: '123456' })
+    expect(res.status).toBe(200)
+    expect(res.type).toMatch(/json/)
+    expect(res.body.status).toBe('active')
+  })
+  it('activate returns 400 application/json when the code is missing', async () => {
+    // @fuzequality api activateMfaFactor
+    const res = await request(makeApp(fakeProvider()))
+      .post('/api/v1/security/mfa/factors/f1/activate')
+      .set('Authorization', 'Bearer tok')
+      .send({})
+    expect(res.status).toBe(400)
+    expect(res.type).toMatch(/json/)
+  })
+  it('activate returns 401 application/json without authentication', async () => {
+    // @fuzequality api activateMfaFactor
+    const res = await request(makeApp(fakeProvider()))
+      .post('/api/v1/security/mfa/factors/f1/activate')
+      .send({ code: '123456' })
+    expect(res.status).toBe(401)
+    expect(res.type).toMatch(/json/)
+  })
+  it('activate returns 404 application/json for an unknown factor resource', async () => {
+    // @fuzequality api activateMfaFactor
+    const provider = fakeProvider({
+      activateFactor: jest.fn().mockRejectedValue(new NotFoundError('factor not found')),
+    })
+    const res = await request(makeApp(provider))
+      .post('/api/v1/security/mfa/factors/unknown-factor/activate')
+      .set('Authorization', 'Bearer tok')
+      .send({ code: '123456' })
+    expect(res.status).toBe(404)
+    expect(res.type).toMatch(/json/)
+  })
+  it('activate returns 404 when the required factorId path parameter is missing', async () => {
+    // @fuzequality api activateMfaFactor
+    const res = await request(makeApp(fakeProvider()))
+      .post('/api/v1/security/mfa/factors//activate')
+      .set('Authorization', 'Bearer tok')
+      .send({ code: '123456' })
+    expect(res.status).toBe(404)
+  })
+  it('activate rejects unsupported text/plain content with 400 application/json', async () => {
+    // @fuzequality api activateMfaFactor
+    const res = await request(makeApp(fakeProvider()))
+      .post('/api/v1/security/mfa/factors/f1/activate')
+      .set('Authorization', 'Bearer tok')
+      .set('Content-Type', 'text/plain')
+      .send('code=123456')
+    expect(res.status).toBe(400)
+    expect(res.type).toMatch(/json/)
   })
   it('DELETE factor returns 204 for an authorized factor lifecycle without a 403 forbidden result', async () => {
     // @fuzequality api removeMfaFactor

--- a/packages/security/openapi.yaml
+++ b/packages/security/openapi.yaml
@@ -813,8 +813,8 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
-        '404':
-          $ref: '#/components/responses/NotFound'
+        '502':
+          $ref: '#/components/responses/ProviderError'
       x-pagination: exempt
       x-pagination-reason: Singleton grant creation.
     delete:
@@ -1500,6 +1500,12 @@ components:
             $ref: '#/components/schemas/ErrorBody'
     NotFound:
       description: Resource not found.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorBody'
+    ProviderError:
+      description: The configured identity or authorization provider rejected the operation.
       content:
         application/json:
           schema:


### PR DESCRIPTION
Implements the next ten FQ-173 API endpoints as one commit per endpoint:\n\n1. createGrant\n2. getPermissions\n3. getEmailAvailable\n4. getIdentityConnections\n5. getAuthMethods\n6. challengeMfa\n7. listMfaFactors\n8. enrollMfaFactor\n9. removeMfaFactor\n10. activateMfaFactor\n\nVerification: 81 targeted security contract tests pass. The createGrant OpenAPI response was aligned with its actual provider-error behavior (502).