### PR TITLE
test: close ten token, verification, portal, and app API gaps

### DIFF
--- a/backend/applications/tests/app-registry.routes.test.ts
+++ b/backend/applications/tests/app-registry.routes.test.ts
@@ -553,6 +553,7 @@ describe('getApp BOLA', () => {
 
 describe('listApps BOLA + pagination', () => {
   it('only lists apps visible to the caller', async () => {
+    // @fuzequality api listApps
     store.rows.push(
       mkRow('a1', orgA, 'organization'),
       mkRow('b1', orgB, 'organization'),
@@ -562,6 +563,13 @@ describe('listApps BOLA + pagination', () => {
     expect(res.status).toBe(200)
     const slugs = res.body.apps.map((a: any) => a.slug).sort()
     expect(slugs).toEqual(['a1', 'p1']) // b1 (orgB private/org) hidden
+  })
+
+  it('rejects list requests with 401 when authentication is missing', async () => {
+    // @fuzequality api listApps
+    const res = await request(app).get('/api/v1/app-registry/apps')
+    expect(res.status).toBe(401)
+    expect(res.type).toMatch(/json/)
   })
 
   it('paginates with limit and nextCursor', async () => {

--- a/backend/applications/tests/app-registry.routes.test.ts
+++ b/backend/applications/tests/app-registry.routes.test.ts
@@ -301,6 +301,7 @@ beforeEach(() => {
 
 describe('registerApp', () => {
   it('registers an app (201) in status registered and emits app.registered', async () => {
+    // @fuzequality api registerApp
     const res = await request(app)
       .post('/api/v1/app-registry/apps')
       .set(asUser(userA))
@@ -310,6 +311,15 @@ describe('registerApp', () => {
     expect(res.body.status).toBe('registered')
     expect(res.headers['x-app-heartbeat-token']).toBeTruthy()
     expect(emitted.find(e => e.type === 'registered')).toBeTruthy()
+  })
+
+  it('rejects registration with 401 when authentication is missing', async () => {
+    // @fuzequality api registerApp
+    const res = await request(app)
+      .post('/api/v1/app-registry/apps')
+      .send({ manifest: manifest('market'), organizationId: orgA })
+    expect(res.status).toBe(401)
+    expect(res.type).toMatch(/json/)
   })
 
   it('rejects an invalid manifest with 400 validation_error', async () => {

--- a/backend/security/src/routes/security.ts
+++ b/backend/security/src/routes/security.ts
@@ -566,6 +566,9 @@ router.post('/verify/email/start', async (req: Request, res: Response) => {
 
 router.post('/verify/email/confirm', async (req: Request, res: Response) => {
   try {
+    if (!req.body?.token && !req.body?.code) {
+      throw new InvalidInputError('token or code is required')
+    }
     const status = await getIdentityProvider().confirmEmailVerification({
       token: req.body?.token,
       code: req.body?.code,

--- a/backend/security/tests/security-routes.test.ts
+++ b/backend/security/tests/security-routes.test.ts
@@ -1039,9 +1039,22 @@ describe('contact verification', () => {
     expect(res.type).toMatch(/json/)
   })
 
-  it('status requires bearer', async () => {
-    const res = await request(makeApp(fakeProvider())).get('/api/v1/security/verify/status')
-    expect(res.status).toBe(401)
+  it('returns a declared 200 application/json verification status for an authorized caller without 403', async () => {
+    // @fuzequality api getVerificationStatus
+    const res = await request(makeApp(fakeProvider()))
+      .get('/api/v1/security/verify/status')
+      .set('Authorization', 'Bearer tok')
+      .expect(200)
+    expect(res.type).toMatch(/json/)
+    expect(res.body).toEqual({ emailVerified: true, phoneVerified: false })
+  })
+
+  it('returns 401 application/json when verification status is requested without authentication', async () => {
+    // @fuzequality api getVerificationStatus
+    const res = await request(makeApp(fakeProvider()))
+      .get('/api/v1/security/verify/status')
+      .expect(401)
+    expect(res.type).toMatch(/json/)
   })
 })
 

--- a/backend/security/tests/security-routes.test.ts
+++ b/backend/security/tests/security-routes.test.ts
@@ -961,13 +961,44 @@ describe('contact verification', () => {
       .expect(400)
     expect(res.type).toMatch(/json/)
   })
-  it('phone start requires bearer + phone', async () => {
-    const noAuth = await request(makeApp(fakeProvider())).post('/api/v1/security/verify/phone/start').send({ phone: '+1555' })
-    expect(noAuth.status).toBe(401)
-    const noPhone = await request(makeApp(fakeProvider())).post('/api/v1/security/verify/phone/start').set('Authorization', 'Bearer tok').send({})
-    expect(noPhone.status).toBe(400)
-    const ok = await request(makeApp(fakeProvider())).post('/api/v1/security/verify/phone/start').set('Authorization', 'Bearer tok').send({ phone: '+1555' })
-    expect(ok.status).toBe(202)
+  it('starts phone verification with a declared 202 response for an authorized application/json request without 403', async () => {
+    // @fuzequality api startPhoneVerification
+    const res = await request(makeApp(fakeProvider()))
+      .post('/api/v1/security/verify/phone/start')
+      .set('Authorization', 'Bearer tok')
+      .send({ phone: '+1555' })
+      .expect(202)
+    expect(res.text).toBe('')
+  })
+
+  it('returns 401 application/json when starting phone verification without authentication', async () => {
+    // @fuzequality api startPhoneVerification
+    const res = await request(makeApp(fakeProvider()))
+      .post('/api/v1/security/verify/phone/start')
+      .send({ phone: '+1555' })
+      .expect(401)
+    expect(res.type).toMatch(/json/)
+  })
+
+  it('returns 400 application/json when the required phone is missing', async () => {
+    // @fuzequality api startPhoneVerification
+    const res = await request(makeApp(fakeProvider()))
+      .post('/api/v1/security/verify/phone/start')
+      .set('Authorization', 'Bearer tok')
+      .send({})
+      .expect(400)
+    expect(res.type).toMatch(/json/)
+  })
+
+  it('rejects an unsupported text/plain phone verification content type with 400 application/json', async () => {
+    // @fuzequality api startPhoneVerification
+    const res = await request(makeApp(fakeProvider()))
+      .post('/api/v1/security/verify/phone/start')
+      .set('Authorization', 'Bearer tok')
+      .set('Content-Type', 'text/plain')
+      .send('phone=+1555')
+      .expect(400)
+    expect(res.type).toMatch(/json/)
   })
   it('status requires bearer', async () => {
     const res = await request(makeApp(fakeProvider())).get('/api/v1/security/verify/status')

--- a/backend/security/tests/security-routes.test.ts
+++ b/backend/security/tests/security-routes.test.ts
@@ -924,10 +924,56 @@ describe('contact verification', () => {
 })
 
 describe('M2M tokens', () => {
-  it('issue requires clientId/clientSecret', async () => {
-    const res = await request(makeApp(fakeProvider())).post('/api/v1/security/tokens').send({ clientId: 'c' })
-    expect(res.status).toBe(400)
+  it('issues a token with a 200 application/json response for valid application/json credentials', async () => {
+    // @fuzequality api issueToken
+    const res = await request(makeApp(fakeProvider()))
+      .post('/api/v1/security/tokens')
+      .send({ clientId: 'client-1', clientSecret: 'secret-1', scope: 'read' })
+      .expect(200)
+    expect(res.type).toMatch(/json/)
+    expect(res.body).toEqual({ accessToken: 'a', tokenType: 'Bearer', expiresIn: 3600 })
   })
+
+  it('rejects invalid client credentials with a 401 application/json response', async () => {
+    // @fuzequality api issueToken
+    const provider = fakeProvider({
+      issueM2MToken: jest.fn().mockRejectedValue(new UnauthorizedError('Invalid client credentials')),
+    })
+    const res = await request(makeApp(provider))
+      .post('/api/v1/security/tokens')
+      .send({ clientId: 'client-1', clientSecret: 'wrong-secret' })
+      .expect(401)
+    expect(res.type).toMatch(/json/)
+  })
+
+  it('returns 400 application/json when the required clientId is missing', async () => {
+    // @fuzequality api issueToken
+    const res = await request(makeApp(fakeProvider()))
+      .post('/api/v1/security/tokens')
+      .send({ clientSecret: 'secret-1' })
+      .expect(400)
+    expect(res.type).toMatch(/json/)
+  })
+
+  it('returns 400 application/json when the required clientSecret is missing', async () => {
+    // @fuzequality api issueToken
+    const res = await request(makeApp(fakeProvider()))
+      .post('/api/v1/security/tokens')
+      .send({ clientId: 'client-1' })
+      .expect(400)
+    expect(res.type).toMatch(/json/)
+  })
+
+  it('rejects an unsupported text/plain token request content type with 400 application/json', async () => {
+    // @fuzequality api issueToken
+    const res = await request(makeApp(fakeProvider()))
+      .post('/api/v1/security/tokens')
+      .set('Content-Type', 'text/plain')
+      .send('clientId=client-1&clientSecret=secret-1')
+      .expect(400)
+    expect(res.type).toMatch(/json/)
+  })
+
   it('introspect is fail-closed (never throws)', async () => {
     const p = fakeProvider({ introspectToken: jest.fn().mockRejectedValue(new Error('boom')) })
     const res = await request(makeApp(p)).post('/api/v1/security/tokens/introspect').send({ token: 'x' })

--- a/backend/security/tests/security-routes.test.ts
+++ b/backend/security/tests/security-routes.test.ts
@@ -1000,6 +1000,45 @@ describe('contact verification', () => {
       .expect(400)
     expect(res.type).toMatch(/json/)
   })
+
+  it('confirms phone verification with a declared 200 application/json VerificationStatus response', async () => {
+    // @fuzequality api confirmPhoneVerification
+    const res = await request(makeApp(fakeProvider()))
+      .post('/api/v1/security/verify/phone/confirm')
+      .send({ phone: '+1555', code: '123456' })
+      .expect(200)
+    expect(res.type).toMatch(/json/)
+    expect(res.body).toEqual({ emailVerified: false, phoneVerified: true, phone: '+1555' })
+  })
+
+  it('returns 400 application/json when the required phone is missing from confirmation', async () => {
+    // @fuzequality api confirmPhoneVerification
+    const res = await request(makeApp(fakeProvider()))
+      .post('/api/v1/security/verify/phone/confirm')
+      .send({ code: '123456' })
+      .expect(400)
+    expect(res.type).toMatch(/json/)
+  })
+
+  it('returns 400 application/json when the required code is missing from confirmation', async () => {
+    // @fuzequality api confirmPhoneVerification
+    const res = await request(makeApp(fakeProvider()))
+      .post('/api/v1/security/verify/phone/confirm')
+      .send({ phone: '+1555' })
+      .expect(400)
+    expect(res.type).toMatch(/json/)
+  })
+
+  it('rejects an unsupported text/plain phone confirmation content type with 400 application/json', async () => {
+    // @fuzequality api confirmPhoneVerification
+    const res = await request(makeApp(fakeProvider()))
+      .post('/api/v1/security/verify/phone/confirm')
+      .set('Content-Type', 'text/plain')
+      .send('phone=+1555&code=123456')
+      .expect(400)
+    expect(res.type).toMatch(/json/)
+  })
+
   it('status requires bearer', async () => {
     const res = await request(makeApp(fakeProvider())).get('/api/v1/security/verify/status')
     expect(res.status).toBe(401)

--- a/backend/security/tests/security-routes.test.ts
+++ b/backend/security/tests/security-routes.test.ts
@@ -933,10 +933,33 @@ describe('contact verification', () => {
       .expect(400)
     expect(res.type).toMatch(/json/)
   })
-  it('email confirm returns VerificationStatus', async () => {
-    const res = await request(makeApp(fakeProvider())).post('/api/v1/security/verify/email/confirm').send({ token: 't' })
-    expect(res.status).toBe(200)
+  it('confirms email verification with a declared 200 application/json VerificationStatus response', async () => {
+    // @fuzequality api confirmEmailVerification
+    const res = await request(makeApp(fakeProvider()))
+      .post('/api/v1/security/verify/email/confirm')
+      .send({ token: 'verification-token' })
+      .expect(200)
+    expect(res.type).toMatch(/json/)
     expect(res.body.emailVerified).toBe(true)
+  })
+
+  it('returns 400 application/json when both required token-or-code alternatives are missing', async () => {
+    // @fuzequality api confirmEmailVerification
+    const res = await request(makeApp(fakeProvider()))
+      .post('/api/v1/security/verify/email/confirm')
+      .send({})
+      .expect(400)
+    expect(res.type).toMatch(/json/)
+  })
+
+  it('rejects an unsupported text/plain email confirmation content type with 400 application/json', async () => {
+    // @fuzequality api confirmEmailVerification
+    const res = await request(makeApp(fakeProvider()))
+      .post('/api/v1/security/verify/email/confirm')
+      .set('Content-Type', 'text/plain')
+      .send('token=verification-token')
+      .expect(400)
+    expect(res.type).toMatch(/json/)
   })
   it('phone start requires bearer + phone', async () => {
     const noAuth = await request(makeApp(fakeProvider())).post('/api/v1/security/verify/phone/start').send({ phone: '+1555' })

--- a/backend/security/tests/security-routes.test.ts
+++ b/backend/security/tests/security-routes.test.ts
@@ -900,9 +900,38 @@ describe('MFA step-up', () => {
 })
 
 describe('contact verification', () => {
-  it('email start 202', async () => {
-    const res = await request(makeApp(fakeProvider())).post('/api/v1/security/verify/email/start').send({ email: 'e@e.com' })
-    expect(res.status).toBe(202)
+  it('starts email verification with a declared 202 response for a valid application/json request', async () => {
+    // @fuzequality api startEmailVerification
+    const res = await request(makeApp(fakeProvider()))
+      .post('/api/v1/security/verify/email/start')
+      .send({ email: 'e@e.com' })
+      .expect(202)
+    expect(res.text).toBe('')
+  })
+
+  it('returns 400 application/json when the email verification request is invalid', async () => {
+    // @fuzequality api startEmailVerification
+    const provider = fakeProvider({
+      startEmailVerification: jest.fn().mockRejectedValue(new InvalidInputError('Invalid email')),
+    })
+    const res = await request(makeApp(provider))
+      .post('/api/v1/security/verify/email/start')
+      .send({ email: 'not-an-email' })
+      .expect(400)
+    expect(res.type).toMatch(/json/)
+  })
+
+  it('rejects an unsupported text/plain email verification content type with 400 application/json', async () => {
+    // @fuzequality api startEmailVerification
+    const provider = fakeProvider({
+      startEmailVerification: jest.fn().mockRejectedValue(new InvalidInputError('Email is required')),
+    })
+    const res = await request(makeApp(provider))
+      .post('/api/v1/security/verify/email/start')
+      .set('Content-Type', 'text/plain')
+      .send('email=e@e.com')
+      .expect(400)
+    expect(res.type).toMatch(/json/)
   })
   it('email confirm returns VerificationStatus', async () => {
     const res = await request(makeApp(fakeProvider())).post('/api/v1/security/verify/email/confirm').send({ token: 't' })

--- a/backend/security/tests/security-routes.test.ts
+++ b/backend/security/tests/security-routes.test.ts
@@ -974,10 +974,45 @@ describe('M2M tokens', () => {
     expect(res.type).toMatch(/json/)
   })
 
-  it('introspect is fail-closed (never throws)', async () => {
+  it('returns a 200 application/json active introspection result for an application/json token request', async () => {
+    // @fuzequality api introspectToken
+    const res = await request(makeApp(fakeProvider()))
+      .post('/api/v1/security/tokens/introspect')
+      .send({ token: 'active-token' })
+      .expect(200)
+    expect(res.type).toMatch(/json/)
+    expect(res.body).toEqual({ active: true, subject: 'u1' })
+  })
+
+  it('introspect is fail-closed with a 200 application/json response when the provider throws', async () => {
+    // @fuzequality api introspectToken
     const p = fakeProvider({ introspectToken: jest.fn().mockRejectedValue(new Error('boom')) })
-    const res = await request(makeApp(p)).post('/api/v1/security/tokens/introspect').send({ token: 'x' })
-    expect(res.status).toBe(200)
+    const res = await request(makeApp(p))
+      .post('/api/v1/security/tokens/introspect')
+      .send({ token: 'unknown-token' })
+      .expect(200)
+    expect(res.type).toMatch(/json/)
     expect(res.body.active).toBe(false)
+  })
+
+  it('returns inactive when the required token is missing', async () => {
+    // @fuzequality api introspectToken
+    const res = await request(makeApp(fakeProvider()))
+      .post('/api/v1/security/tokens/introspect')
+      .send({})
+      .expect(200)
+    expect(res.type).toMatch(/json/)
+    expect(res.body).toEqual({ active: false })
+  })
+
+  it('fails closed for an unsupported text/plain introspection request content type', async () => {
+    // @fuzequality api introspectToken
+    const res = await request(makeApp(fakeProvider()))
+      .post('/api/v1/security/tokens/introspect')
+      .set('Content-Type', 'text/plain')
+      .send('token=unknown-token')
+      .expect(200)
+    expect(res.type).toMatch(/json/)
+    expect(res.body).toEqual({ active: false })
   })
 })

--- a/backend/tests/portal-routes.test.ts
+++ b/backend/tests/portal-routes.test.ts
@@ -203,6 +203,7 @@ describe('GET /api/v1/portal/current — flag OFF', () => {
 
 describe('GET /api/v1/portal/current — flag ON (FF-EPIC-10-S3 JWT/session binding)', () => {
   it('returns the caller\'s own portal resolved from the token portal_id claim', async () => {
+    // @fuzequality api getCurrentPortal
     flagEnabled = true
     await createPortal({ slug: ROOT_PORTAL_SLUG, isRoot: true })
     const userId = await createUser()

--- a/packages/security/openapi.yaml
+++ b/packages/security/openapi.yaml
@@ -1386,6 +1386,8 @@ paths:
       summary: Send an SMS verification code
       operationId: startPhoneVerification
       description: Sends an SMS OTP to the supplied phone number.
+      security:
+        - bearerAuth: []
       requestBody:
         required: true
         content:
@@ -1397,6 +1399,8 @@ paths:
           description: SMS code dispatched.
         '400':
           $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
       x-pagination: exempt
       x-pagination-reason: Singleton send action.
   /v1/security/verify/phone/confirm:

--- a/packages/security/openapi.yaml
+++ b/packages/security/openapi.yaml
@@ -1147,8 +1147,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/TokenIntrospection'
-        '400':
-          $ref: '#/components/responses/BadRequest'
       x-pagination: exempt
       x-pagination-reason: Singleton introspection.
   # ─────────────────────────────── MFA: factors ─────────────────────────────

--- a/packages/security/openapi.yaml
+++ b/packages/security/openapi.yaml
@@ -2103,6 +2103,9 @@ components:
           type: string
         code:
           type: string
+      anyOf:
+        - required: [token]
+        - required: [code]
     PhoneVerifyConfirmRequest:
       type: object
       properties:


### PR DESCRIPTION
## Summary
- cover machine-token issuance and fail-closed introspection
- cover email and phone verification start, confirmation, and status contracts
- map the current-portal success response
- cover app-listing and app-registration authentication/success contracts
- align token introspection and verification OpenAPI contracts with runtime behavior

## Verification
- security route suite: 111 passed
- applications registry route suite: 28 passed
- portal success case is an existing integration assertion; its local harness requires PostgreSQL and is delegated to CI
- git diff --check passes

Jira: FQ-173