### PR TITLE
test: close ten readiness and billing API gaps

### DIFF
--- a/custom-hostname-client/tests/stub.integration.test.ts
+++ b/custom-hostname-client/tests/stub.integration.test.ts
@@ -84,6 +84,14 @@ describe('custom hostname API — against FuzeInfra stub', () => {
     expect(res.ok).toBe(true);
   });
 
+  it('returns the declared 200 response from GET /readyz', async () => {
+    // @fuzequality api readyz
+    if (!reachable) return;
+    const res = await fetch(`${BASE_URL}/readyz`);
+    expect(res.status).toBe(200);
+    expect(res.ok).toBe(true);
+  });
+
   it('rejects a domain inside fuzefront.com with 422 validation_error', async () => {
     if (!reachable) return;
     // These are already served by the static wildcard Ingress rule. Sending

--- a/services/billing-service/tests/contract/api.contract.test.ts
+++ b/services/billing-service/tests/contract/api.contract.test.ts
@@ -310,6 +310,7 @@ describe('billing-service contract :: cancelSubscription (DELETE /subscriptions/
 
 describe('billing-service contract :: createSetupIntent (POST /setup-intent)', () => {
   it('200 {clientSecret} on success', async () => {
+    // @fuzequality api createSetupIntent
     const { app, stubs } = buildApp({ internalToken: INTERNAL_TOKEN });
     stubs.stripe.setupIntents.create.mockResolvedValue({ client_secret: 'seti_secret_xyz' });
     const res = await request(app)
@@ -343,6 +344,7 @@ describe('billing-service contract :: createSetupIntent (POST /setup-intent)', (
   });
 
   it('401 Unauthorized without token', async () => {
+    // @fuzequality api createSetupIntent
     const { app } = buildApp({ internalToken: INTERNAL_TOKEN });
     const res = await request(app).post(`${BASE}/setup-intent`).send({ entityType: 'user', entityId: USER_ID });
     expect(res.status).toBe(401);

--- a/services/billing-service/tests/contract/api.contract.test.ts
+++ b/services/billing-service/tests/contract/api.contract.test.ts
@@ -122,6 +122,7 @@ describe('billing-service contract :: createSubscription (POST /subscriptions)',
   });
 
   it('401 Unauthorized when the internal token is missing', async () => {
+    // @fuzequality api createSubscription
     const { app } = buildApp({ internalToken: INTERNAL_TOKEN });
     const res = await request(app)
       .post(`${BASE}/subscriptions`)

--- a/services/billing-service/tests/contract/api.contract.test.ts
+++ b/services/billing-service/tests/contract/api.contract.test.ts
@@ -154,6 +154,7 @@ describe('billing-service contract :: createSubscription (POST /subscriptions)',
 
 describe('billing-service contract :: getSubscription (GET /subscriptions/{id})', () => {
   it('200 {subscription} when the mirror exists', async () => {
+    // @fuzequality api getSubscription
     const { app, stubs } = buildApp({ internalToken: INTERNAL_TOKEN });
     stubs.subscriptionRepo.findByStripeId.mockResolvedValue(makeSubscription());
     const res = await request(app)
@@ -174,9 +175,19 @@ describe('billing-service contract :: getSubscription (GET /subscriptions/{id})'
   });
 
   it('401 Unauthorized without token', async () => {
+    // @fuzequality api getSubscription
     const { app } = buildApp({ internalToken: INTERNAL_TOKEN });
     const res = await request(app).get(`${BASE}/subscriptions/sub_test123`);
     expect(res.status).toBe(401);
+  });
+
+  it('does not get a subscription when the required subscriptionId path parameter is missing', async () => {
+    // @fuzequality api getSubscription
+    const { app } = buildApp({ internalToken: INTERNAL_TOKEN });
+    await request(app)
+      .get(`${BASE}/subscriptions/`)
+      .set(...authHeader())
+      .expect(401);
   });
 });
 

--- a/services/billing-service/tests/contract/api.contract.test.ts
+++ b/services/billing-service/tests/contract/api.contract.test.ts
@@ -193,6 +193,7 @@ describe('billing-service contract :: getSubscription (GET /subscriptions/{id})'
 
 describe('billing-service contract :: updateSubscription (PATCH /subscriptions/{id})', () => {
   it('200 {subscription} on a valid plan change', async () => {
+    // @fuzequality api updateSubscription
     const { app, stubs } = buildApp({ internalToken: INTERNAL_TOKEN });
     stubs.subscriptionService.update.mockResolvedValue(makeSubscription({ priceId: 'price_pro' }));
     const res = await request(app)
@@ -250,9 +251,20 @@ describe('billing-service contract :: updateSubscription (PATCH /subscriptions/{
   });
 
   it('401 Unauthorized without token', async () => {
+    // @fuzequality api updateSubscription
     const { app } = buildApp({ internalToken: INTERNAL_TOKEN });
     const res = await request(app).patch(`${BASE}/subscriptions/sub_test123`).send({ priceId: 'price_pro' });
     expect(res.status).toBe(401);
+  });
+
+  it('does not update a subscription when the required subscriptionId path parameter is missing', async () => {
+    // @fuzequality api updateSubscription
+    const { app } = buildApp({ internalToken: INTERNAL_TOKEN });
+    await request(app)
+      .patch(`${BASE}/subscriptions/`)
+      .set(...authHeader())
+      .send({ priceId: 'price_pro' })
+      .expect(404);
   });
 });
 

--- a/services/billing-service/tests/contract/api.contract.test.ts
+++ b/services/billing-service/tests/contract/api.contract.test.ts
@@ -353,6 +353,7 @@ describe('billing-service contract :: createSetupIntent (POST /setup-intent)', (
 
 describe('billing-service contract :: addCredits (POST /credits)', () => {
   it('201 {id, endingBalance} on success', async () => {
+    // @fuzequality api addCredits
     const { app, stubs } = buildApp({ internalToken: INTERNAL_TOKEN });
     stubs.stripe.customers.createBalanceTransaction.mockResolvedValue({
       id: 'cbtxn_1',
@@ -407,12 +408,14 @@ describe('billing-service contract :: addCredits (POST /credits)', () => {
   });
 
   it('401 Unauthorized without token', async () => {
+    // @fuzequality api addCredits
     const { app } = buildApp({ internalToken: INTERNAL_TOKEN });
     const res = await request(app).post(`${BASE}/credits`).send({ entityType: 'organization', entityId: ORG_ID, amount: 500 });
     expect(res.status).toBe(401);
   });
 
-  it('403 Forbidden with a valid token but WITHOUT admin context (HIGH-1)', async () => {
+  it('403 Forbidden when the X-Billing-Actor-Is-Admin header is missing (HIGH-1)', async () => {
+    // @fuzequality api addCredits
     const { app, stubs } = buildApp({ internalToken: INTERNAL_TOKEN });
     const res = await request(app)
       .post(`${BASE}/credits`)

--- a/services/billing-service/tests/contract/api.contract.test.ts
+++ b/services/billing-service/tests/contract/api.contract.test.ts
@@ -270,6 +270,7 @@ describe('billing-service contract :: updateSubscription (PATCH /subscriptions/{
 
 describe('billing-service contract :: cancelSubscription (DELETE /subscriptions/{id})', () => {
   it('200 {subscription} with cancellation scheduled', async () => {
+    // @fuzequality api cancelSubscription
     const { app, stubs } = buildApp({ internalToken: INTERNAL_TOKEN });
     stubs.subscriptionService.cancel.mockResolvedValue(makeSubscription({ cancelAtPeriodEnd: true }));
     const res = await request(app)
@@ -291,9 +292,19 @@ describe('billing-service contract :: cancelSubscription (DELETE /subscriptions/
   });
 
   it('401 Unauthorized without token', async () => {
+    // @fuzequality api cancelSubscription
     const { app } = buildApp({ internalToken: INTERNAL_TOKEN });
     const res = await request(app).delete(`${BASE}/subscriptions/sub_test123`);
     expect(res.status).toBe(401);
+  });
+
+  it('does not cancel a subscription when the required subscriptionId path parameter is missing', async () => {
+    // @fuzequality api cancelSubscription
+    const { app } = buildApp({ internalToken: INTERNAL_TOKEN });
+    await request(app)
+      .delete(`${BASE}/subscriptions/`)
+      .set(...authHeader())
+      .expect(404);
   });
 });
 

--- a/services/billing-service/tests/contract/api.contract.test.ts
+++ b/services/billing-service/tests/contract/api.contract.test.ts
@@ -45,6 +45,7 @@ describe('billing-service contract :: getHealth (GET /health)', () => {
 
 describe('billing-service contract :: getPlans (GET /plans)', () => {
   it('200 {plans: Plan[]} — public, no auth required', async () => {
+    // @fuzequality api getPlans
     const { app } = buildApp({ internalToken: INTERNAL_TOKEN });
     const res = await request(app).get(`${BASE}/plans`); // no Authorization header
     expect(res.status).toBe(200);

--- a/services/billing-service/tests/routes/checkout.test.ts
+++ b/services/billing-service/tests/routes/checkout.test.ts
@@ -35,6 +35,7 @@ function orgCustomerStub() {
 
 describe('POST /checkout — hosted Stripe Checkout Session', () => {
   it('200 {url, sessionId}; creates a subscription-mode session for the resolved price + customer', async () => {
+    // @fuzequality api createCheckoutSession
     const { app, stubs } = buildApp({
       internalToken: INTERNAL_TOKEN,
       stubs: { ...orgCustomerStub() },
@@ -123,7 +124,8 @@ describe('POST /checkout — hosted Stripe Checkout Session', () => {
     expect(res.status).toBe(401);
   });
 
-  it('401 when the proxy actor-context headers are absent (CRITICAL-2)', async () => {
+  it('401 when X-Billing-Actor-User-Id, X-Billing-Entity-Type, and X-Billing-Entity-Id headers are missing (CRITICAL-2)', async () => {
+    // @fuzequality api createCheckoutSession
     const { app, stubs } = buildApp({ internalToken: INTERNAL_TOKEN, stubs: { ...orgCustomerStub() } });
     const res = await request(app)
       .post(URL)

--- a/services/billing-service/tests/routes/portal.test.ts
+++ b/services/billing-service/tests/routes/portal.test.ts
@@ -63,6 +63,7 @@ const RETURN_URL = 'https://app.fuzefront.com/billing';
 
 describe('POST /portal — Stripe Customer Portal session', () => {
   it('200 {url} on the happy path; creates the session for the resolved customer', async () => {
+    // @fuzequality api createPortalSession
     const create = jest.fn().mockResolvedValue({
       id: 'bps_1',
       url: 'https://billing.stripe.com/p/session/bps_1',
@@ -130,7 +131,8 @@ describe('POST /portal — Stripe Customer Portal session', () => {
     expect(res.status).toBe(400);
   });
 
-  it('401 when the proxy actor-context headers are absent', async () => {
+  it('401 when X-Billing-Actor-User-Id, X-Billing-Entity-Type, and X-Billing-Entity-Id headers are missing', async () => {
+    // @fuzequality api createPortalSession
     const create = jest.fn();
     const { app } = buildApp({
       internalToken: INTERNAL_TOKEN,
@@ -145,6 +147,7 @@ describe('POST /portal — Stripe Customer Portal session', () => {
   });
 
   it('401 when the internal token is missing', async () => {
+    // @fuzequality api createPortalSession
     const { app } = buildApp({
       internalToken: INTERNAL_TOKEN,
       stubs: { ...stripeStub(), ...orgCustomerRepoStub() },


### PR DESCRIPTION
## Summary
- cover the final custom-hostname readiness endpoint
- cover billing plan listing, subscription create/read/update/cancel, setup intent, credits, hosted checkout, and customer portal contracts
- expose exact required-header, authentication, path-parameter, and response-status evidence

## Verification
- billing contract/checkout/portal suites: 54 passed
- custom-hostname client TypeScript check: passed
- readiness test executes against the required FuzeInfra stub in CI
- git diff --check passes

Jira: FQ-173