### PR TITLE
FQ-173: close final FuzeFront API gaps

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -15,6 +15,7 @@ import appRegistryRoutes from './routes/appRegistry'
 import appRegistryProxyRoutes from './routes/app-registry'
 import flagsRoutes from './routes/flags'
 import portalRoutes from './routes/portal'
+import adminPortalRoutes from './routes/adminPortals'
 import { resolvePortalContext } from './middleware/portalContext'
 import { ensureRootPortal } from './repositories/portalRepository'
 import { syncPermitSchemaFromRegistry } from './permit/sync-permit-schema'
@@ -299,6 +300,7 @@ app.use('/api/flags', flagsRoutes)
 // Portal context boot + the caller's own portal (FF-EPIC-10-S2). Both routes
 // are individually flag-gated (404 when off) — see routes/portal.ts.
 app.use('/api/v1/portal', portalRoutes)
+app.use('/api/v1/admin/portals', adminPortalRoutes)
 // Billing proxy: browser -> backend -> fuzefront-billing-service:3006 (adds the
 // internal token). Webhook subroute is mounted separately above (raw body).
 app.use('/api/v1/billing', billingRoutes)

--- a/backend/src/routes/adminPortals.ts
+++ b/backend/src/routes/adminPortals.ts
@@ -32,6 +32,13 @@ export interface AdminPortalStore {
     identityPolicy?: PortalIdentityPolicy
   }): Promise<ReturnType<typeof rowToPortal>>
   get(portalId: string): Promise<ReturnType<typeof rowToPortal> | null>
+  update(portalId: string, patch: {
+    name?: string
+    status?: PortalStatus
+    billingMode?: BillingMode
+    branding?: PortalBranding
+    identityPolicy?: PortalIdentityPolicy
+  }): Promise<ReturnType<typeof rowToPortal> | null>
 }
 
 function encodeCursor(id: string): string {
@@ -132,6 +139,26 @@ export function createAdminPortalStore(database: Knex = db): AdminPortalStore {
       if (!row) return null
       return rowToPortal(row, await getPortalDomains(portalId, database))
     },
+    async update(portalId, patch) {
+      const existing = await database('portals').where({ id: portalId }).first()
+      if (!existing) return null
+      if (existing.is_root && patch.status === 'suspended') {
+        const error = new Error('ROOT_PORTAL_PROTECTED') as Error & { code: string }
+        error.code = 'ROOT_PORTAL_PROTECTED'
+        throw error
+      }
+      const changes: Record<string, unknown> = { updated_at: new Date() }
+      if (patch.name !== undefined) changes.name = patch.name
+      if (patch.status !== undefined) changes.status = patch.status
+      if (patch.billingMode !== undefined) changes.billing_mode = patch.billingMode
+      if (patch.branding !== undefined) changes.branding = JSON.stringify(patch.branding)
+      if (patch.identityPolicy !== undefined) {
+        changes.identity_policy = JSON.stringify(patch.identityPolicy)
+      }
+      await database('portals').where({ id: portalId }).update(changes)
+      const row = await database('portals').where({ id: portalId }).first()
+      return rowToPortal(row, await getPortalDomains(portalId, database))
+    },
   }
 }
 
@@ -202,6 +229,40 @@ export function createAdminPortalRouter(deps: {
       return response.status(404).json({ error: 'NOT_FOUND' })
     }
     return response.status(200).json(portal)
+  })
+
+  router.patch('/:portalId', authenticate, authorize, async (request, response) => {
+    const body = request.body ?? {}
+    const allowed = ['name', 'status', 'billingMode', 'branding', 'identityPolicy']
+    const supplied = Object.keys(body)
+    if (!supplied.length || supplied.some(key => !allowed.includes(key))) {
+      return response.status(400).json({
+        error: 'validation_error',
+        fields: [{ path: '', message: 'provide at least one supported mutable field' }],
+      })
+    }
+    if (body.name !== undefined && (typeof body.name !== 'string' || !body.name.trim() || body.name.length > 120)) {
+      return response.status(400).json({
+        error: 'validation_error',
+        fields: [{ path: 'name', message: 'name must contain 1 to 120 characters' }],
+      })
+    }
+    try {
+      const updated = await store.update(request.params.portalId, {
+        name: body.name?.trim(),
+        status: body.status,
+        billingMode: body.billingMode,
+        branding: body.branding,
+        identityPolicy: body.identityPolicy,
+      })
+      if (!updated) return response.status(404).json({ error: 'NOT_FOUND' })
+      return response.status(200).json(updated)
+    } catch (error: any) {
+      if (error?.code === 'ROOT_PORTAL_PROTECTED') {
+        return response.status(409).json({ error: 'ROOT_PORTAL_PROTECTED' })
+      }
+      throw error
+    }
   })
 
   return router

--- a/backend/src/routes/adminPortals.ts
+++ b/backend/src/routes/adminPortals.ts
@@ -265,6 +265,19 @@ export function createAdminPortalRouter(deps: {
     }
   })
 
+  router.post('/:portalId/suspend', authenticate, authorize, async (request, response) => {
+    try {
+      const updated = await store.update(request.params.portalId, { status: 'suspended' })
+      if (!updated) return response.status(404).json({ error: 'NOT_FOUND' })
+      return response.status(200).json(updated)
+    } catch (error: any) {
+      if (error?.code === 'ROOT_PORTAL_PROTECTED') {
+        return response.status(409).json({ error: 'ROOT_PORTAL_PROTECTED' })
+      }
+      throw error
+    }
+  })
+
   return router
 }
 

--- a/backend/src/routes/adminPortals.ts
+++ b/backend/src/routes/adminPortals.ts
@@ -31,6 +31,7 @@ export interface AdminPortalStore {
     branding?: PortalBranding
     identityPolicy?: PortalIdentityPolicy
   }): Promise<ReturnType<typeof rowToPortal>>
+  get(portalId: string): Promise<ReturnType<typeof rowToPortal> | null>
 }
 
 function encodeCursor(id: string): string {
@@ -126,6 +127,11 @@ export function createAdminPortalStore(database: Knex = db): AdminPortalStore {
       const row = await database('portals').where({ id: portalId }).first()
       return rowToPortal(row, await getPortalDomains(portalId, database))
     },
+    async get(portalId) {
+      const row = await database('portals').where({ id: portalId }).first()
+      if (!row) return null
+      return rowToPortal(row, await getPortalDomains(portalId, database))
+    },
   }
 }
 
@@ -188,6 +194,14 @@ export function createAdminPortalRouter(deps: {
       }
       throw error
     }
+  })
+
+  router.get('/:portalId', authenticate, authorize, async (request, response) => {
+    const portal = await store.get(request.params.portalId)
+    if (!portal) {
+      return response.status(404).json({ error: 'NOT_FOUND' })
+    }
+    return response.status(200).json(portal)
   })
 
   return router

--- a/backend/src/routes/adminPortals.ts
+++ b/backend/src/routes/adminPortals.ts
@@ -1,4 +1,5 @@
 import express, { NextFunction, Request, Response } from 'express'
+import rateLimit from 'express-rate-limit'
 import type { Knex } from 'knex'
 import { v4 as uuidv4 } from 'uuid'
 import { db } from '../config/database'
@@ -51,6 +52,14 @@ function decodeCursor(cursor: string): string | null {
   } catch {
     return null
   }
+}
+
+function validEmail(value: unknown): value is string {
+  if (typeof value !== 'string' || value.length < 3 || value.length > 320 || /\s/.test(value)) {
+    return false
+  }
+  const at = value.indexOf('@')
+  return at > 0 && at === value.lastIndexOf('@') && value.indexOf('.', at + 2) > at + 1
 }
 
 export function createAdminPortalStore(database: Knex = db): AdminPortalStore {
@@ -171,8 +180,15 @@ export function createAdminPortalRouter(deps: {
   const store = deps.store ?? createAdminPortalStore()
   const authenticate = deps.authenticate ?? authenticateToken
   const authorize = deps.authorize ?? requireRole(['admin'])
+  const adminRateLimiter = rateLimit({
+    windowMs: 60_000,
+    limit: 120,
+    standardHeaders: true,
+    legacyHeaders: false,
+    message: { error: 'Too many requests. Try again shortly.' },
+  })
 
-  router.get('/', authenticate, authorize, async (request, response) => {
+  router.get('/', adminRateLimiter, authenticate, authorize, async (request, response) => {
     const limit = Math.min(100, Math.max(1, Number.parseInt(String(request.query.limit ?? '25'), 10) || 25))
     const status = typeof request.query.status === 'string'
       ? request.query.status as PortalStatus
@@ -188,7 +204,7 @@ export function createAdminPortalRouter(deps: {
     })
   })
 
-  router.post('/', authenticate, authorize, async (request: any, response) => {
+  router.post('/', adminRateLimiter, authenticate, authorize, async (request: any, response) => {
     const body = request.body ?? {}
     const fields: Array<{ path: string; message: string }> = []
     if (typeof body.name !== 'string' || body.name.trim().length < 1 || body.name.length > 120) {
@@ -197,7 +213,7 @@ export function createAdminPortalRouter(deps: {
     if (typeof body.slug !== 'string' || !/^[a-z0-9][a-z0-9-]{1,38}[a-z0-9]$/.test(body.slug)) {
       fields.push({ path: 'slug', message: 'slug must be a lowercase URL-safe identifier' })
     }
-    if (typeof body.ownerEmail !== 'string' || !/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(body.ownerEmail)) {
+    if (!validEmail(body.ownerEmail)) {
       fields.push({ path: 'ownerEmail', message: 'ownerEmail must be a valid email address' })
     }
     if (fields.length) {
@@ -223,7 +239,7 @@ export function createAdminPortalRouter(deps: {
     }
   })
 
-  router.get('/:portalId', authenticate, authorize, async (request, response) => {
+  router.get('/:portalId', adminRateLimiter, authenticate, authorize, async (request, response) => {
     const portal = await store.get(request.params.portalId)
     if (!portal) {
       return response.status(404).json({ error: 'NOT_FOUND' })
@@ -231,7 +247,7 @@ export function createAdminPortalRouter(deps: {
     return response.status(200).json(portal)
   })
 
-  router.patch('/:portalId', authenticate, authorize, async (request, response) => {
+  router.patch('/:portalId', adminRateLimiter, authenticate, authorize, async (request, response) => {
     const body = request.body ?? {}
     const allowed = ['name', 'status', 'billingMode', 'branding', 'identityPolicy']
     const supplied = Object.keys(body)
@@ -265,7 +281,7 @@ export function createAdminPortalRouter(deps: {
     }
   })
 
-  router.post('/:portalId/suspend', authenticate, authorize, async (request, response) => {
+  router.post('/:portalId/suspend', adminRateLimiter, authenticate, authorize, async (request, response) => {
     try {
       const updated = await store.update(request.params.portalId, { status: 'suspended' })
       if (!updated) return response.status(404).json({ error: 'NOT_FOUND' })
@@ -278,7 +294,7 @@ export function createAdminPortalRouter(deps: {
     }
   })
 
-  router.post('/:portalId/resume', authenticate, authorize, async (request, response) => {
+  router.post('/:portalId/resume', adminRateLimiter, authenticate, authorize, async (request, response) => {
     const updated = await store.update(request.params.portalId, { status: 'active' })
     if (!updated) return response.status(404).json({ error: 'NOT_FOUND' })
     return response.status(200).json(updated)

--- a/backend/src/routes/adminPortals.ts
+++ b/backend/src/routes/adminPortals.ts
@@ -1,0 +1,89 @@
+import express, { NextFunction, Request, Response } from 'express'
+import type { Knex } from 'knex'
+import { db } from '../config/database'
+import { authenticateToken, requireRole } from '../middleware/auth'
+import { getPortalDomains, rowToPortal, type PortalStatus } from '../repositories/portalRepository'
+
+type Middleware = (request: Request, response: Response, next: NextFunction) => unknown
+
+export interface AdminPortalStore {
+  list(input: {
+    status?: PortalStatus
+    query?: string
+    limit: number
+    cursor?: string
+  }): Promise<{ items: ReturnType<typeof rowToPortal>[]; nextCursor: string | null }>
+}
+
+function encodeCursor(id: string): string {
+  return Buffer.from(id, 'utf8').toString('base64url')
+}
+
+function decodeCursor(cursor: string): string | null {
+  try {
+    return Buffer.from(cursor, 'base64url').toString('utf8') || null
+  } catch {
+    return null
+  }
+}
+
+export function createAdminPortalStore(database: Knex = db): AdminPortalStore {
+  return {
+    async list(input) {
+      const query = database('portals').orderBy('id', 'asc').limit(input.limit + 1)
+      if (input.status) query.where('status', input.status)
+      if (input.query) {
+        const pattern = `%${input.query.replace(/[%_\\]/g, '\\$&')}%`
+        query.andWhere(builder =>
+          builder.whereILike('name', pattern).orWhereILike('slug', pattern)
+        )
+      }
+      if (input.cursor) {
+        const id = decodeCursor(input.cursor)
+        if (id) query.andWhere('id', '>', id)
+      }
+
+      const rows = await query
+      const hasMore = rows.length > input.limit
+      const pageRows = rows.slice(0, input.limit)
+      const items = await Promise.all(
+        pageRows.map(async row => rowToPortal(row, await getPortalDomains(row.id, database)))
+      )
+      return {
+        items,
+        nextCursor: hasMore ? encodeCursor(pageRows[pageRows.length - 1].id) : null,
+      }
+    },
+  }
+}
+
+export function createAdminPortalRouter(deps: {
+  store?: AdminPortalStore
+  authenticate?: Middleware
+  authorize?: Middleware
+} = {}) {
+  const router = express.Router()
+  const store = deps.store ?? createAdminPortalStore()
+  const authenticate = deps.authenticate ?? authenticateToken
+  const authorize = deps.authorize ?? requireRole(['admin'])
+
+  router.get('/', authenticate, authorize, async (request, response) => {
+    const limit = Math.min(100, Math.max(1, Number.parseInt(String(request.query.limit ?? '25'), 10) || 25))
+    const status = typeof request.query.status === 'string'
+      ? request.query.status as PortalStatus
+      : undefined
+    const query = typeof request.query.q === 'string'
+      ? request.query.q.slice(0, 200)
+      : undefined
+    const cursor = typeof request.query.cursor === 'string' ? request.query.cursor : undefined
+    const result = await store.list({ status, query, limit, cursor })
+    response.status(200).json({
+      items: result.items,
+      page: { nextCursor: result.nextCursor },
+    })
+  })
+
+  return router
+}
+
+export default createAdminPortalRouter()

--- a/backend/src/routes/adminPortals.ts
+++ b/backend/src/routes/adminPortals.ts
@@ -278,6 +278,12 @@ export function createAdminPortalRouter(deps: {
     }
   })
 
+  router.post('/:portalId/resume', authenticate, authorize, async (request, response) => {
+    const updated = await store.update(request.params.portalId, { status: 'active' })
+    if (!updated) return response.status(404).json({ error: 'NOT_FOUND' })
+    return response.status(200).json(updated)
+  })
+
   return router
 }
 

--- a/backend/src/routes/adminPortals.ts
+++ b/backend/src/routes/adminPortals.ts
@@ -1,8 +1,17 @@
 import express, { NextFunction, Request, Response } from 'express'
 import type { Knex } from 'knex'
+import { v4 as uuidv4 } from 'uuid'
 import { db } from '../config/database'
 import { authenticateToken, requireRole } from '../middleware/auth'
-import { getPortalDomains, rowToPortal, type PortalStatus } from '../repositories/portalRepository'
+import {
+  generatePortalId,
+  getPortalDomains,
+  rowToPortal,
+  type BillingMode,
+  type PortalBranding,
+  type PortalIdentityPolicy,
+  type PortalStatus,
+} from '../repositories/portalRepository'
 
 type Middleware = (request: Request, response: Response, next: NextFunction) => unknown
 
@@ -13,6 +22,15 @@ export interface AdminPortalStore {
     limit: number
     cursor?: string
   }): Promise<{ items: ReturnType<typeof rowToPortal>[]; nextCursor: string | null }>
+  create(input: {
+    actorUserId: string
+    name: string
+    slug: string
+    ownerEmail: string
+    billingMode: BillingMode
+    branding?: PortalBranding
+    identityPolicy?: PortalIdentityPolicy
+  }): Promise<ReturnType<typeof rowToPortal>>
 }
 
 function encodeCursor(id: string): string {
@@ -54,6 +72,60 @@ export function createAdminPortalStore(database: Knex = db): AdminPortalStore {
         nextCursor: hasMore ? encodeCursor(pageRows[pageRows.length - 1].id) : null,
       }
     },
+    async create(input) {
+      const organizationId = uuidv4()
+      const portalId = generatePortalId()
+      await database.transaction(async transaction => {
+        await transaction('organizations').insert({
+          id: organizationId,
+          name: input.name,
+          slug: input.slug,
+          parent_id: null,
+          owner_id: input.actorUserId,
+          type: 'organization',
+          settings: JSON.stringify({}),
+          metadata: JSON.stringify({ portalId }),
+          is_active: true,
+          provisioning_state: 'pending',
+        })
+        await transaction('organization_memberships').insert({
+          id: uuidv4(),
+          user_id: input.actorUserId,
+          organization_id: organizationId,
+          role: 'owner',
+          status: 'active',
+          joined_at: new Date(),
+          permissions: JSON.stringify({}),
+          metadata: JSON.stringify({ invitedOwnerEmail: input.ownerEmail }),
+        })
+        await transaction('portals').insert({
+          id: portalId,
+          organization_id: organizationId,
+          slug: input.slug,
+          name: input.name,
+          status: 'provisioned-pending-invite',
+          billing_mode: input.billingMode,
+          branding: JSON.stringify(input.branding ?? { name: input.name }),
+          identity_policy: JSON.stringify(input.identityPolicy ?? {
+            allowPasswordLogin: true,
+            allowSelfSignup: false,
+          }),
+          owner_email: input.ownerEmail,
+          is_root: false,
+        })
+        await transaction('portal_domains').insert({
+          id: uuidv4(),
+          portal_id: portalId,
+          domain: `${input.slug}.fuzefront.com`,
+          kind: 'subdomain',
+          is_primary: true,
+          verification_status: 'verified',
+          tls_status: 'pending',
+        })
+      })
+      const row = await database('portals').where({ id: portalId }).first()
+      return rowToPortal(row, await getPortalDomains(portalId, database))
+    },
   }
 }
 
@@ -81,6 +153,41 @@ export function createAdminPortalRouter(deps: {
       items: result.items,
       page: { nextCursor: result.nextCursor },
     })
+  })
+
+  router.post('/', authenticate, authorize, async (request: any, response) => {
+    const body = request.body ?? {}
+    const fields: Array<{ path: string; message: string }> = []
+    if (typeof body.name !== 'string' || body.name.trim().length < 1 || body.name.length > 120) {
+      fields.push({ path: 'name', message: 'name must contain 1 to 120 characters' })
+    }
+    if (typeof body.slug !== 'string' || !/^[a-z0-9][a-z0-9-]{1,38}[a-z0-9]$/.test(body.slug)) {
+      fields.push({ path: 'slug', message: 'slug must be a lowercase URL-safe identifier' })
+    }
+    if (typeof body.ownerEmail !== 'string' || !/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(body.ownerEmail)) {
+      fields.push({ path: 'ownerEmail', message: 'ownerEmail must be a valid email address' })
+    }
+    if (fields.length) {
+      return response.status(400).json({ error: 'validation_error', fields })
+    }
+
+    try {
+      const portal = await store.create({
+        actorUserId: request.user.id,
+        name: body.name.trim(),
+        slug: body.slug,
+        ownerEmail: body.ownerEmail,
+        billingMode: body.billingMode ?? 'free',
+        branding: body.branding,
+        identityPolicy: body.identityPolicy,
+      })
+      return response.status(201).json(portal)
+    } catch (error: any) {
+      if (error?.code === '23505') {
+        return response.status(409).json({ error: 'SLUG_TAKEN' })
+      }
+      throw error
+    }
   })
 
   return router

--- a/backend/tests/admin-portals-routes.test.ts
+++ b/backend/tests/admin-portals-routes.test.ts
@@ -207,3 +207,46 @@ describe('PATCH /api/v1/admin/portals/:portalId', () => {
     expect(store.update).not.toHaveBeenCalled()
   })
 })
+
+describe('POST /api/v1/admin/portals/:portalId/suspend', () => {
+  it('200 suspends the portal and returns the declared response', async () => {
+    // @fuzequality api suspendPortal
+    const suspended = { ...portal, status: 'suspended' as const }
+    const store: AdminPortalStore = {
+      list: jest.fn(), create: jest.fn(), get: jest.fn(),
+      update: jest.fn().mockResolvedValue(suspended),
+    }
+    const response = await request(appWith(store))
+      .post('/api/v1/admin/portals/prt_acme/suspend')
+      .set('Authorization', 'Bearer test')
+
+    expect(response.status).toBe(200)
+    expect(response.body.status).toBe('suspended')
+    expect(store.update).toHaveBeenCalledWith('prt_acme', { status: 'suspended' })
+  })
+
+  it('401 when authentication is missing', async () => {
+    // @fuzequality api suspendPortal
+    const store: AdminPortalStore = {
+      list: jest.fn(), create: jest.fn(), get: jest.fn(), update: jest.fn(),
+    }
+    const response = await request(appWith(store))
+      .post('/api/v1/admin/portals/prt_acme/suspend')
+
+    expect(response.status).toBe(401)
+    expect(store.update).not.toHaveBeenCalled()
+  })
+
+  it('does not suspend a portal when the required portalId path parameter is missing', async () => {
+    // @fuzequality api suspendPortal
+    const store: AdminPortalStore = {
+      list: jest.fn(), create: jest.fn(), get: jest.fn(), update: jest.fn(),
+    }
+    const response = await request(appWith(store))
+      .post('/api/v1/admin/portals//suspend')
+      .set('Authorization', 'Bearer test')
+
+    expect(response.status).toBe(404)
+    expect(store.update).not.toHaveBeenCalled()
+  })
+})

--- a/backend/tests/admin-portals-routes.test.ts
+++ b/backend/tests/admin-portals-routes.test.ts
@@ -41,6 +41,7 @@ describe('GET /api/v1/admin/portals', () => {
     const store: AdminPortalStore = {
       list: jest.fn().mockResolvedValue({ items: [portal], nextCursor: 'next-page' }),
       create: jest.fn(),
+      get: jest.fn(),
     }
     const response = await request(appWith(store))
       .get('/api/v1/admin/portals?status=active&limit=10')
@@ -64,6 +65,7 @@ describe('GET /api/v1/admin/portals', () => {
     const store: AdminPortalStore = {
       list: jest.fn().mockResolvedValue({ items: [], nextCursor: null }),
       create: jest.fn(),
+      get: jest.fn(),
     }
     const response = await request(appWith(store)).get('/api/v1/admin/portals')
 
@@ -79,6 +81,7 @@ describe('POST /api/v1/admin/portals', () => {
     const store: AdminPortalStore = {
       list: jest.fn(),
       create: jest.fn().mockResolvedValue(created),
+      get: jest.fn(),
     }
     const response = await request(appWith(store))
       .post('/api/v1/admin/portals')
@@ -98,12 +101,54 @@ describe('POST /api/v1/admin/portals', () => {
 
   it('401 when authentication is missing', async () => {
     // @fuzequality api createPortal
-    const store: AdminPortalStore = { list: jest.fn(), create: jest.fn() }
+    const store: AdminPortalStore = { list: jest.fn(), create: jest.fn(), get: jest.fn() }
     const response = await request(appWith(store))
       .post('/api/v1/admin/portals')
       .send({ name: 'Acme', slug: 'acme', ownerEmail: 'owner@example.com' })
 
     expect(response.status).toBe(401)
     expect(store.create).not.toHaveBeenCalled()
+  })
+})
+
+describe('GET /api/v1/admin/portals/:portalId', () => {
+  it('200 returns the declared portal detail response', async () => {
+    // @fuzequality api getPortal
+    const store: AdminPortalStore = {
+      list: jest.fn(),
+      create: jest.fn(),
+      get: jest.fn().mockResolvedValue(portal),
+    }
+    const response = await request(appWith(store))
+      .get('/api/v1/admin/portals/prt_acme')
+      .set('Authorization', 'Bearer test')
+
+    expect(response.status).toBe(200)
+    expect(response.body.id).toBe('prt_acme')
+    expect(store.get).toHaveBeenCalledWith('prt_acme')
+  })
+
+  it('401 when authentication is missing', async () => {
+    // @fuzequality api getPortal
+    const store: AdminPortalStore = { list: jest.fn(), create: jest.fn(), get: jest.fn() }
+    const response = await request(appWith(store)).get('/api/v1/admin/portals/prt_acme')
+
+    expect(response.status).toBe(401)
+    expect(store.get).not.toHaveBeenCalled()
+  })
+
+  it('does not perform a portal lookup when the required portalId path parameter is missing', async () => {
+    // @fuzequality api getPortal
+    const store: AdminPortalStore = {
+      list: jest.fn().mockResolvedValue({ items: [], nextCursor: null }),
+      create: jest.fn(),
+      get: jest.fn(),
+    }
+    const response = await request(appWith(store))
+      .get('/api/v1/admin/portals/')
+      .set('Authorization', 'Bearer test')
+
+    expect(response.status).toBe(200)
+    expect(store.get).not.toHaveBeenCalled()
   })
 })

--- a/backend/tests/admin-portals-routes.test.ts
+++ b/backend/tests/admin-portals-routes.test.ts
@@ -1,0 +1,70 @@
+import express, { Request, Response, NextFunction } from 'express'
+import request from 'supertest'
+import { createAdminPortalRouter, type AdminPortalStore } from '../src/routes/adminPortals'
+
+const portal = {
+  id: 'prt_acme',
+  slug: 'acme',
+  name: 'Acme',
+  status: 'active' as const,
+  isRoot: false,
+  organizationId: 'org-acme',
+  ownerEmail: 'owner@example.com',
+  billingMode: 'platform' as const,
+  branding: { name: 'Acme' },
+  identityPolicy: { allowPasswordLogin: true, allowSelfSignup: false },
+  domains: [],
+  primaryDomain: null,
+  createdAt: '2026-07-31T00:00:00.000Z',
+  updatedAt: '2026-07-31T00:00:00.000Z',
+}
+
+function appWith(store: AdminPortalStore) {
+  const authenticate = (req: Request, res: Response, next: NextFunction) => {
+    if (!req.header('authorization')) return res.status(401).json({ error: 'missing authentication' })
+    next()
+  }
+  const app = express()
+  app.use(express.json())
+  app.use('/api/v1/admin/portals', createAdminPortalRouter({
+    store,
+    authenticate,
+    authorize: (_req, _res, next) => next(),
+  }))
+  return app
+}
+
+describe('GET /api/v1/admin/portals', () => {
+  it('200 returns the declared cursor-paginated portal fleet response', async () => {
+    // @fuzequality api listPortals
+    const store: AdminPortalStore = {
+      list: jest.fn().mockResolvedValue({ items: [portal], nextCursor: 'next-page' }),
+    }
+    const response = await request(appWith(store))
+      .get('/api/v1/admin/portals?status=active&limit=10')
+      .set('Authorization', 'Bearer test')
+
+    expect(response.status).toBe(200)
+    expect(response.body).toEqual({
+      items: [portal],
+      page: { nextCursor: 'next-page' },
+    })
+    expect(store.list).toHaveBeenCalledWith({
+      status: 'active',
+      query: undefined,
+      limit: 10,
+      cursor: undefined,
+    })
+  })
+
+  it('401 when authentication is missing', async () => {
+    // @fuzequality api listPortals
+    const store: AdminPortalStore = {
+      list: jest.fn().mockResolvedValue({ items: [], nextCursor: null }),
+    }
+    const response = await request(appWith(store)).get('/api/v1/admin/portals')
+
+    expect(response.status).toBe(401)
+    expect(store.list).not.toHaveBeenCalled()
+  })
+})

--- a/backend/tests/admin-portals-routes.test.ts
+++ b/backend/tests/admin-portals-routes.test.ts
@@ -250,3 +250,46 @@ describe('POST /api/v1/admin/portals/:portalId/suspend', () => {
     expect(store.update).not.toHaveBeenCalled()
   })
 })
+
+describe('POST /api/v1/admin/portals/:portalId/resume', () => {
+  it('200 resumes the portal and returns the declared response', async () => {
+    // @fuzequality api resumePortal
+    const active = { ...portal, status: 'active' as const }
+    const store: AdminPortalStore = {
+      list: jest.fn(), create: jest.fn(), get: jest.fn(),
+      update: jest.fn().mockResolvedValue(active),
+    }
+    const response = await request(appWith(store))
+      .post('/api/v1/admin/portals/prt_acme/resume')
+      .set('Authorization', 'Bearer test')
+
+    expect(response.status).toBe(200)
+    expect(response.body.status).toBe('active')
+    expect(store.update).toHaveBeenCalledWith('prt_acme', { status: 'active' })
+  })
+
+  it('401 when authentication is missing', async () => {
+    // @fuzequality api resumePortal
+    const store: AdminPortalStore = {
+      list: jest.fn(), create: jest.fn(), get: jest.fn(), update: jest.fn(),
+    }
+    const response = await request(appWith(store))
+      .post('/api/v1/admin/portals/prt_acme/resume')
+
+    expect(response.status).toBe(401)
+    expect(store.update).not.toHaveBeenCalled()
+  })
+
+  it('does not resume a portal when the required portalId path parameter is missing', async () => {
+    // @fuzequality api resumePortal
+    const store: AdminPortalStore = {
+      list: jest.fn(), create: jest.fn(), get: jest.fn(), update: jest.fn(),
+    }
+    const response = await request(appWith(store))
+      .post('/api/v1/admin/portals//resume')
+      .set('Authorization', 'Bearer test')
+
+    expect(response.status).toBe(404)
+    expect(store.update).not.toHaveBeenCalled()
+  })
+})

--- a/backend/tests/admin-portals-routes.test.ts
+++ b/backend/tests/admin-portals-routes.test.ts
@@ -22,6 +22,7 @@ const portal = {
 function appWith(store: AdminPortalStore) {
   const authenticate = (req: Request, res: Response, next: NextFunction) => {
     if (!req.header('authorization')) return res.status(401).json({ error: 'missing authentication' })
+    ;(req as any).user = { id: 'user-admin', roles: ['admin'] }
     next()
   }
   const app = express()
@@ -39,6 +40,7 @@ describe('GET /api/v1/admin/portals', () => {
     // @fuzequality api listPortals
     const store: AdminPortalStore = {
       list: jest.fn().mockResolvedValue({ items: [portal], nextCursor: 'next-page' }),
+      create: jest.fn(),
     }
     const response = await request(appWith(store))
       .get('/api/v1/admin/portals?status=active&limit=10')
@@ -61,10 +63,47 @@ describe('GET /api/v1/admin/portals', () => {
     // @fuzequality api listPortals
     const store: AdminPortalStore = {
       list: jest.fn().mockResolvedValue({ items: [], nextCursor: null }),
+      create: jest.fn(),
     }
     const response = await request(appWith(store)).get('/api/v1/admin/portals')
 
     expect(response.status).toBe(401)
     expect(store.list).not.toHaveBeenCalled()
+  })
+})
+
+describe('POST /api/v1/admin/portals', () => {
+  it('201 creates a provisioned-pending-invite portal with the declared response', async () => {
+    // @fuzequality api createPortal
+    const created = { ...portal, status: 'provisioned-pending-invite' as const }
+    const store: AdminPortalStore = {
+      list: jest.fn(),
+      create: jest.fn().mockResolvedValue(created),
+    }
+    const response = await request(appWith(store))
+      .post('/api/v1/admin/portals')
+      .set('Authorization', 'Bearer test')
+      .send({ name: 'Acme', slug: 'acme', ownerEmail: 'owner@example.com' })
+
+    expect(response.status).toBe(201)
+    expect(response.body.status).toBe('provisioned-pending-invite')
+    expect(store.create).toHaveBeenCalledWith(expect.objectContaining({
+      actorUserId: 'user-admin',
+      name: 'Acme',
+      slug: 'acme',
+      ownerEmail: 'owner@example.com',
+      billingMode: 'free',
+    }))
+  })
+
+  it('401 when authentication is missing', async () => {
+    // @fuzequality api createPortal
+    const store: AdminPortalStore = { list: jest.fn(), create: jest.fn() }
+    const response = await request(appWith(store))
+      .post('/api/v1/admin/portals')
+      .send({ name: 'Acme', slug: 'acme', ownerEmail: 'owner@example.com' })
+
+    expect(response.status).toBe(401)
+    expect(store.create).not.toHaveBeenCalled()
   })
 })

--- a/backend/tests/admin-portals-routes.test.ts
+++ b/backend/tests/admin-portals-routes.test.ts
@@ -42,6 +42,7 @@ describe('GET /api/v1/admin/portals', () => {
       list: jest.fn().mockResolvedValue({ items: [portal], nextCursor: 'next-page' }),
       create: jest.fn(),
       get: jest.fn(),
+      update: jest.fn(),
     }
     const response = await request(appWith(store))
       .get('/api/v1/admin/portals?status=active&limit=10')
@@ -66,6 +67,7 @@ describe('GET /api/v1/admin/portals', () => {
       list: jest.fn().mockResolvedValue({ items: [], nextCursor: null }),
       create: jest.fn(),
       get: jest.fn(),
+      update: jest.fn(),
     }
     const response = await request(appWith(store)).get('/api/v1/admin/portals')
 
@@ -82,6 +84,7 @@ describe('POST /api/v1/admin/portals', () => {
       list: jest.fn(),
       create: jest.fn().mockResolvedValue(created),
       get: jest.fn(),
+      update: jest.fn(),
     }
     const response = await request(appWith(store))
       .post('/api/v1/admin/portals')
@@ -101,7 +104,7 @@ describe('POST /api/v1/admin/portals', () => {
 
   it('401 when authentication is missing', async () => {
     // @fuzequality api createPortal
-    const store: AdminPortalStore = { list: jest.fn(), create: jest.fn(), get: jest.fn() }
+    const store: AdminPortalStore = { list: jest.fn(), create: jest.fn(), get: jest.fn(), update: jest.fn() }
     const response = await request(appWith(store))
       .post('/api/v1/admin/portals')
       .send({ name: 'Acme', slug: 'acme', ownerEmail: 'owner@example.com' })
@@ -118,6 +121,7 @@ describe('GET /api/v1/admin/portals/:portalId', () => {
       list: jest.fn(),
       create: jest.fn(),
       get: jest.fn().mockResolvedValue(portal),
+      update: jest.fn(),
     }
     const response = await request(appWith(store))
       .get('/api/v1/admin/portals/prt_acme')
@@ -130,7 +134,7 @@ describe('GET /api/v1/admin/portals/:portalId', () => {
 
   it('401 when authentication is missing', async () => {
     // @fuzequality api getPortal
-    const store: AdminPortalStore = { list: jest.fn(), create: jest.fn(), get: jest.fn() }
+    const store: AdminPortalStore = { list: jest.fn(), create: jest.fn(), get: jest.fn(), update: jest.fn() }
     const response = await request(appWith(store)).get('/api/v1/admin/portals/prt_acme')
 
     expect(response.status).toBe(401)
@@ -143,6 +147,7 @@ describe('GET /api/v1/admin/portals/:portalId', () => {
       list: jest.fn().mockResolvedValue({ items: [], nextCursor: null }),
       create: jest.fn(),
       get: jest.fn(),
+      update: jest.fn(),
     }
     const response = await request(appWith(store))
       .get('/api/v1/admin/portals/')
@@ -150,5 +155,55 @@ describe('GET /api/v1/admin/portals/:portalId', () => {
 
     expect(response.status).toBe(200)
     expect(store.get).not.toHaveBeenCalled()
+  })
+})
+
+describe('PATCH /api/v1/admin/portals/:portalId', () => {
+  it('200 returns the declared updated portal response', async () => {
+    // @fuzequality api updatePortal
+    const updated = { ...portal, name: 'Acme Updated' }
+    const store: AdminPortalStore = {
+      list: jest.fn(),
+      create: jest.fn(),
+      get: jest.fn(),
+      update: jest.fn().mockResolvedValue(updated),
+    }
+    const response = await request(appWith(store))
+      .patch('/api/v1/admin/portals/prt_acme')
+      .set('Authorization', 'Bearer test')
+      .send({ name: 'Acme Updated' })
+
+    expect(response.status).toBe(200)
+    expect(response.body.name).toBe('Acme Updated')
+    expect(store.update).toHaveBeenCalledWith('prt_acme', expect.objectContaining({
+      name: 'Acme Updated',
+    }))
+  })
+
+  it('401 when authentication is missing', async () => {
+    // @fuzequality api updatePortal
+    const store: AdminPortalStore = {
+      list: jest.fn(), create: jest.fn(), get: jest.fn(), update: jest.fn(),
+    }
+    const response = await request(appWith(store))
+      .patch('/api/v1/admin/portals/prt_acme')
+      .send({ name: 'Acme Updated' })
+
+    expect(response.status).toBe(401)
+    expect(store.update).not.toHaveBeenCalled()
+  })
+
+  it('does not update a portal when the required portalId path parameter is missing', async () => {
+    // @fuzequality api updatePortal
+    const store: AdminPortalStore = {
+      list: jest.fn(), create: jest.fn(), get: jest.fn(), update: jest.fn(),
+    }
+    const response = await request(appWith(store))
+      .patch('/api/v1/admin/portals/')
+      .set('Authorization', 'Bearer test')
+      .send({ name: 'Acme Updated' })
+
+    expect(response.status).toBe(404)
+    expect(store.update).not.toHaveBeenCalled()
   })
 })

--- a/backend/tests/portal-routes.test.ts
+++ b/backend/tests/portal-routes.test.ts
@@ -202,7 +202,7 @@ describe('GET /api/v1/portal/current — flag OFF', () => {
 })
 
 describe('GET /api/v1/portal/current — flag ON (FF-EPIC-10-S3 JWT/session binding)', () => {
-  it('returns the caller\'s own portal resolved from the token portal_id claim', async () => {
+  it('200 returns the caller\'s own portal resolved from the token portal_id claim', async () => {
     // @fuzequality api getCurrentPortal
     flagEnabled = true
     await createPortal({ slug: ROOT_PORTAL_SLUG, isRoot: true })


### PR DESCRIPTION
## Summary
- expose current-portal response evidence
- implement authenticated platform-admin portal list/create/get/update routes
- implement protected suspend and idempotent resume lifecycle actions
- map every remaining FuzeFront OpenAPI operation to assertion-bearing tests

## Verification
- admin portal isolated route suite: 16 passed
- backend TypeScript type-check: passed
- batch 14 production rescan leaves only these seven portal operations