### PR TITLE
ci: wire the billing-invoices Playwright suite into CI; fix release.yml missing chat-service trigger path

### DIFF
--- a/.github/workflows/billing-invoices-e2e.yml
+++ b/.github/workflows/billing-invoices-e2e.yml
@@ -1,0 +1,155 @@
+name: Billing invoices E2E (frames + built component)
+
+# INDEPENDENT front-end verification for the Billing "Invoice history" UI
+# (@fuzefront/billing-ui -> InvoiceHistoryPanel, flag
+# fuzefront.billing.invoice-history), owned by frontend-test-engineer per
+# tests/e2e/billing-invoices/README.md.
+#
+# This suite existed with three verification phases documented as "active —
+# GREEN" but was never wired into any workflow — the specs only ever ran on
+# whoever's machine happened to invoke them by hand. This file closes that gap
+# for the two phases that need no running stack:
+#
+#   - frames.spec.ts           frozen `design/frames/billing-invoices/*.html`
+#                               over file://, no stack.
+#   - built-component.spec.ts  the REAL React InvoiceHistoryPanel (esbuild
+#                               bundle + mocked listInvoices) over file://,
+#                               no stack. Skips cleanly (never hard-fails) if
+#                               its harness deps are absent — see the spec.
+#
+# The package is self-contained by design (its own package.json, does not
+# depend on a root `npm install` — see the README), so this workflow installs
+# only inside tests/e2e/billing-invoices/.
+#
+# postprod.smoke.spec.ts (phase 3, live BASE_URL) is intentionally NOT run
+# here: it targets the live app the same way frontend/e2e/post-prod/*.spec.ts
+# does, so it is wired as its own job below, dispatch-only, mirroring
+# post-prod-e2e.yml's pattern rather than running on every PR.
+
+on:
+  pull_request:
+    branches: [master]
+    paths:
+      - 'tests/e2e/billing-invoices/**'
+      - 'design/frames/billing-invoices/**'
+      - 'packages/billing-ui/**'
+      - 'packages/billing-client/**'
+  push:
+    branches: [master]
+    paths:
+      - 'tests/e2e/billing-invoices/**'
+      - 'design/frames/billing-invoices/**'
+      - 'packages/billing-ui/**'
+      - 'packages/billing-client/**'
+  workflow_dispatch:
+    inputs:
+      run_postprod_smoke:
+        description: 'Also run postprod.smoke.spec.ts against a live app'
+        type: boolean
+        required: false
+        default: false
+      base_url:
+        description: 'Target base URL for the postprod smoke (ignored unless run_postprod_smoke is true)'
+        required: false
+        default: 'https://app.fuzefront.com'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: billing-invoices-e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  frames-and-built-component:
+    name: Frames + built component (pre-production)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: tests/e2e/billing-invoices
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '24.x'
+          # No `cache: npm` here: tests/e2e/billing-invoices/.gitignore excludes
+          # package-lock.json (deliberately, matching this package's "no root
+          # install needed" self-containment) — actions/setup-node's cache step
+          # requires a committed lockfile to hash and fails outright without one.
+          # Only 8 deps; `npm install` finishes in seconds uncached.
+
+      # Self-contained package (README): does NOT depend on a root install.
+      # PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD — the browser is fetched explicitly
+      # below via `playwright install`, matching this repo's other e2e jobs.
+      - name: Install
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
+        run: npm install
+
+      - name: Install Playwright chromium
+        run: npx playwright install --with-deps chromium
+
+      # Both specs are file:// only — no dev server, no backend, no DB.
+      # built-component.spec.ts self-skips (never hard-fails) if esbuild/react
+      # somehow failed to resolve from the install above.
+      - name: Run frames + built-component specs
+        run: npx playwright test -c playwright.config.ts frames.spec.ts built-component.spec.ts --reporter=list,html
+
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: billing-invoices-playwright-report
+          path: |
+            tests/e2e/billing-invoices/playwright-report/
+            tests/e2e/billing-invoices/test-results/
+          retention-days: 14
+
+  postprod-smoke:
+    name: Postprod smoke (live app)
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.run_postprod_smoke }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: tests/e2e/billing-invoices
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '24.x'
+          # See the frames-and-built-component job above: no committed lockfile
+          # to cache against, by this package's own design.
+
+      - name: Install
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
+        run: npm install
+
+      - name: Install Playwright chromium
+        run: npx playwright install --with-deps chromium
+
+      # The spec self-skips cleanly (never hard-fails) unless BASE_URL AND both
+      # credentials are set (`haveCreds` in postprod.smoke.spec.ts) — same
+      # synthetic account post-prod-e2e.yml uses, remapped to the var names
+      # this spec reads (BASE_URL / E2E_USER_EMAIL / E2E_USER_PASSWORD), not
+      # post-prod-e2e.yml's POST_PROD_* names.
+      - name: Run postprod smoke
+        env:
+          BASE_URL: ${{ inputs.base_url || 'https://app.fuzefront.com' }}
+          E2E_USER_EMAIL: ${{ secrets.POST_PROD_EMAIL }}
+          E2E_USER_PASSWORD: ${{ secrets.POST_PROD_PASSWORD }}
+        run: npx playwright test -c playwright.config.ts postprod.smoke.spec.ts -g @postprod --reporter=list,html
+
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: billing-invoices-postprod-report
+          path: |
+            tests/e2e/billing-invoices/playwright-report/
+            tests/e2e/billing-invoices/test-results/
+          retention-days: 14

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,14 @@ on:
       - 'services/sms-service/**'
       - 'services/provisioning-service/**'
       - 'services/billing-service/**'
+      # Added in the same change that discovered the gap: #432 added the
+      # "Build & push chat-service" step below, but never added chat-service's
+      # own path here, so a change confined to services/chat-service/** (not
+      # touching packages/**, deploy/helm/fuzefront/**, or this file) would
+      # merge green and NEVER trigger a release — the exact same silent-ship
+      # failure mode the packages/** comment above describes, just for a
+      # different path. This was live for every commit between #432 and now.
+      - 'services/chat-service/**'
       - 'clock-app/**'
       - 'deploy/helm/fuzefront/**'
       - '.github/workflows/release.yml'


### PR DESCRIPTION
## 📋 Description

Two unrelated CI gaps, found together while auditing e2e coverage.

### 1. `tests/e2e/billing-invoices/` was never wired into any workflow

`frames.spec.ts`, `built-component.spec.ts`, `postprod.smoke.spec.ts` — owned by `frontend-test-engineer`, the INDEPENDENT verification for `@fuzefront/billing-ui → InvoiceHistoryPanel`. It has its own self-contained `playwright.config.ts` + `package.json`, and its README documents all three phases as **"active — GREEN"** — but I grepped every workflow file for the path and got zero hits. It only ever ran on whoever's machine happened to invoke it by hand.

New **`.github/workflows/billing-invoices-e2e.yml`**:

- **`frames-and-built-component`** — both `file://`-only specs (no stack, no server) on PRs/pushes touching `tests/e2e/billing-invoices/**`, `design/frames/billing-invoices/**`, `packages/billing-ui/**`, or `packages/billing-client/**`. Verified locally first, not just wired blind: **12/12 tests pass**.
- **`postprod-smoke`** — `postprod.smoke.spec.ts` against a live app, **dispatch-only** (mirrors `post-prod-e2e.yml`'s pattern rather than running on every PR), reusing the existing `POST_PROD_EMAIL`/`POST_PROD_PASSWORD` secrets remapped to the var names this spec actually reads (`E2E_USER_EMAIL`/`E2E_USER_PASSWORD` — different naming convention from `post-prod-e2e.yml`, easy to get wrong). The spec self-skips cleanly without `BASE_URL` + both creds, so it's safe even if the secrets are absent.
- **No `cache: npm`** on either job: `tests/e2e/billing-invoices/.gitignore` deliberately excludes `package-lock.json` (the package is designed to need no root install), and `actions/setup-node`'s cache step hard-fails without a committed lockfile to hash. Only 8 deps; install finishes in seconds uncached.
- Pinned action SHAs (checkout v4.2.2, setup-node v4.4.0, upload-artifact v4.6.2), matching `post-prod-e2e.yml`'s convention rather than the mutable `@v4` tags older e2e workflows in this repo still use.

### 2. `release.yml` never triggers on chat-service-only changes

`push.paths` never included `services/chat-service/**`, even though **#432** added a "Build & push chat-service" step to this same file. That means any change confined to `services/chat-service/**` — not touching `packages/**`, `deploy/helm/fuzefront/**`, or the workflow file itself — merges green and **silently never triggers a release**: the chat-service image doesn't rebuild. This is exactly the failure mode the `packages/**` comment in the same file already warns about, for a path I added and forgot to wire in.

**This was live for every commit between #432 (2026-07-27) and now** — my own oversight, caught while touching this file for reason (1).

## 🔄 Type of Change

- [x] 🐛 Bug fix (release.yml trigger gap)
- [x] 🔧 Build system or dependency update (new e2e workflow)

## 🧪 Testing

| Check | Result |
|---|---|
| `frames.spec.ts` + `built-component.spec.ts`, run locally against the real harness | **12/12 passed** |
| `billing-invoices-e2e.yml` parses as YAML | ✅ |
| `release.yml` parses as YAML; `services/chat-service/**` present in `push.paths` | ✅ |
| Lockfile handling | Confirmed `tests/e2e/billing-invoices/.gitignore` excludes `package-lock.json`; workflow does not reference one |

## 🔧 Implementation Details

Nothing here touches application code — CI-only. No runtime behavior changes for users; the chat-service path fix only affects whether *future* chat-service-only commits trigger a release.

## 📝 Additional Notes

Not fixed here, out of scope: the `*.red.spec.ts` files (`portal-admin-consoles`, `white-label-portal`, `account-security-hub`) — the design-first gate's TDD-red specs — are similarly unwired into any workflow. Flagging for a follow-up rather than folding into this PR, since they're a different feature area with their own trigger-scoping questions.

---
_Generated by [Claude Code](https://claude.ai/code/session_018GwoakPmfmvL4ot86LfFeX)_