### PR TITLE
docs(secrets): fix the unrunnable SMTP seal recipe blocking #500

### DIFF
--- a/deploy/contabo/SEAL_PROD_SECRETS.md
+++ b/deploy/contabo/SEAL_PROD_SECRETS.md
@@ -23,8 +23,10 @@ Argo app-of-apps registration, FuzeInfra prod) is already live.
 
 ```bash
 # 0. Fetch the cluster's sealed-secrets public cert (once)
+#    (the old sealed-secrets.fuzeinfra.fuzefront.com host no longer resolves —
+#     prod is canonical, and seal-secret.sh fetches this same URL automatically)
 CERT=/tmp/ff-sealed.pem
-curl -fsSL https://sealed-secrets.fuzeinfra.fuzefront.com/v1/cert.pem -o "$CERT"
+curl -fsSL https://sealed-secrets.prod.fuzefront.com/v1/cert.pem -o "$CERT"
 
 # 1. fuzefront-secrets (Opaque) — fill every value with the REAL secret
 #    DB_SUPERUSER_PASSWORD : the FuzeInfra Postgres superuser password (must be real)
@@ -101,15 +103,20 @@ shipped.
 The chart now wires SMTP from `emailService.email.smtp` (host/port/secure — NOT
 secret, they live in values) plus these two keys from the SealedSecret:
 
+Prod uses **ZeptoMail** (`emailService.email.smtp.host: smtp.zeptomail.com`,
+port 587, STARTTLS — already set in `values-prod.yaml`, which is the source of
+truth; the "Zoho" wording that used to be here was stale):
+
 | Key | Where to get it | Used by |
 |-----|-----------------|---------|
-| `SMTP_USER` | Zoho mailbox / app-specific user for the sending domain (e.g. `noreply@fuzefront.com`) | email-service → SMTP relay |
-| `SMTP_PASS` | Zoho **app-specific password** (not the account password; generate one per app) | email-service → SMTP relay |
+| `SMTP_USER` | ZeptoMail → Mail Agent → SMTP credentials: the SMTP **username** for the `fuzefront.com` sending domain | email-service → SMTP relay |
+| `SMTP_PASS` | ZeptoMail → Mail Agent → SMTP credentials: the generated **send-mail token** (NOT your ZeptoMail account password) | email-service → SMTP relay |
 
 Both are mounted with **hard** `secretKeyRef`s (no `optional: true`) on the SMTP
-provider path — deliberately. An authenticated relay like Zoho rejects anonymous
-mail, so a missing credential must stop the pod at start rather than degrade back
-into silently dropping mail. Sealing these keys and setting the host go together.
+provider path — deliberately. An authenticated relay like ZeptoMail rejects
+anonymous mail, so a missing credential must stop the pod at start rather than
+degrade back into silently dropping mail. Sealing these keys and setting the host
+go together.
 
 **The chart will not let you enable verification without a sender.** Setting
 `securityService.requireEmailVerification: true` while
@@ -119,21 +126,35 @@ turning verification on with no deliverable sender locks out *every* new signup
 renders, on+no-host fails, on+host renders with SMTP env.
 
 ```bash
-# Seal the two SMTP credentials in place (does not disturb other keys).
+# Seal the two SMTP credentials in place (does not disturb the other keys).
+# NOTE the flags: --in / --scope / --manifest are the ONLY flags seal-secret.sh
+# accepts (there is no --from-file or --into). --scope is REQUIRED here: the
+# script defaults to name=billing-secrets, so without it the value seals into the
+# wrong secret and the controller can never decrypt it into fuzefront-secrets.
 for KEY in SMTP_USER SMTP_PASS; do
   read -rsp "value for ${KEY}: " V; echo
   printf '%s' "$V" | tr -d '[:space:]' > /tmp/smtp-val.txt
   deploy/scripts/seal-secret.sh "$KEY" \
-    --from-file /tmp/smtp-val.txt \
-    --into deploy/contabo/sealed/fuzefront-secrets.yaml
+    --in /tmp/smtp-val.txt \
+    --scope fuzefront/fuzefront-secrets \
+    --manifest deploy/contabo/sealed/fuzefront-secrets.yaml
+  rm -f /tmp/smtp-val.txt
 done
-rm -f /tmp/smtp-val.txt
+
+git add deploy/contabo/sealed/fuzefront-secrets.yaml
+git commit -m "secrets(prod): seal SMTP_USER + SMTP_PASS for email-service"
+git push
 ```
 
 **Go-live for email verification + password reset — in this order:**
 1. **Owner** seals `SMTP_USER` + `SMTP_PASS` (above).
-2. Set `emailService.email.smtp.host` (e.g. `smtp.zoho.com`), `port: 587`,
-   `secure: false` in `values-prod.yaml` via GitOps.
+2. Set `emailService.email.smtp.host` (`smtp.zeptomail.com`), `port: 587`,
+   `secure: false` in `values-prod.yaml` via GitOps. **This is already set** — so
+   once step 1 lands, the wedged rollout self-heals on the next sync; restart it
+   with `kubectl -n fuzefront rollout restart deployment/fuzefront-email-service`
+   if you don't want to wait. (Because the host is set but the two keys were never
+   sealed, the new ReplicaSet currently sits in `CreateContainerConfigError` — the
+   hard `secretKeyRef`s cannot resolve. That is issue #500.)
 3. **Prove the sender end-to-end** — a real message delivered to a real inbox.
    Password reset starts working at this step (it needs no flag; it only needs
    `EMAIL_SERVICE_URL`, which is already wired).

--- a/deploy/helm/fuzefront/templates/email-service.yaml
+++ b/deploy/helm/fuzefront/templates/email-service.yaml
@@ -59,7 +59,7 @@ spec:
             - name: SMTP_SECURE
               value: {{ $smtp.secure | default false | quote }}
             # Credentials come from the SealedSecret and are NEVER in values.
-            # Hard refs (no `optional`) — an authenticated relay like Zoho rejects
+            # Hard refs (no `optional`) — an authenticated relay like ZeptoMail rejects
             # anonymous mail, so a missing credential must CrashLoop the pod at
             # start, loudly, rather than degrade into dropping mail at runtime.
             - name: SMTP_USER

--- a/deploy/helm/fuzefront/values-prod.yaml
+++ b/deploy/helm/fuzefront/values-prod.yaml
@@ -141,11 +141,12 @@ emailService:
       # password reset have both been live-dead in prod: pod healthy, /health
       # green, zero delivery.
       #
-      # Set this to the real relay (Zoho: smtp.zoho.com) ONLY once the owner has
-      # sealed SMTP_USER + SMTP_PASS — the chart mounts them as HARD secretKeyRefs
-      # on this path, so setting a host without sealing them CrashLoops the pod at
-      # start (loud) instead of dropping mail at runtime (silent). That trade is
-      # deliberate. See deploy/contabo/SEAL_PROD_SECRETS.md.
+      # Real relay = ZeptoMail. This host is SET, which mounts SMTP_USER/SMTP_PASS
+      # as HARD secretKeyRefs on this path — so those two keys MUST be sealed into
+      # fuzefront-secrets or the pod wedges in CreateContainerConfigError (loud)
+      # instead of dropping mail at runtime (silent). That trade is deliberate.
+      # (Setting this host before the keys were sealed is exactly what wedged the
+      # rollout in issue #500.) See deploy/contabo/SEAL_PROD_SECRETS.md.
       host: "smtp.zeptomail.com"
       port: 587
       secure: false   # STARTTLS on 587; true for implicit TLS on 465

--- a/deploy/helm/fuzefront/values.yaml
+++ b/deploy/helm/fuzefront/values.yaml
@@ -410,7 +410,7 @@ emailService:
     # every message is dropped. That is exactly how signup email-verification and
     # password-reset sat live-dead in prod.
     smtp:
-      host: ""          # e.g. smtp.zoho.com — empty = dev mailhog fallback
+      host: ""          # e.g. smtp.zeptomail.com — empty = dev mailhog fallback
       port: 587
       secure: false     # true for implicit TLS (465); false for STARTTLS (587)
   resources:


### PR DESCRIPTION
## What & why
Issue #500: the prod `fuzefront-email-service` rollout is wedged in `CreateContainerConfigError` because `SMTP_USER`/`SMTP_PASS` were never sealed into the `fuzefront-secrets` SealedSecret. Root cause of *why they were never sealed*: **the owner-only go-live recipe in `deploy/contabo/SEAL_PROD_SECRETS.md` was unrunnable.**

The SMTP section used `--from-file` and `--into` — **neither flag exists** in `deploy/scripts/seal-secret.sh` (it accepts `--in` / `--scope` / `--manifest`). Worse, it omitted `--scope fuzefront/fuzefront-secrets`, and the script **defaults to `name=billing-secrets`** — so even if the flags were valid, the value would have sealed into the wrong secret and never decrypted into `fuzefront-secrets`. The Twilio recipe immediately below it in the same doc is correct; this aligns SMTP to it.

## Changes (doc only — no chart/template change)
- **Fix the seal flags:** `--from-file`/`--into` → `--in`/`--manifest`, and add the **required** `--scope fuzefront/fuzefront-secrets`.
- **Provider naming:** `Zoho` → `ZeptoMail` (`values-prod.yaml` already sets `host: smtp.zeptomail.com`; the prose was stale) + accurate "where to get the credentials".
- **Stale cert URL:** `sealed-secrets.fuzeinfra.fuzefront.com` → `sealed-secrets.prod.fuzefront.com` (the script's own comment notes the old host no longer resolves).
- **Go-live step 2:** note the host is *already set*, so sealing the two keys is the only remaining owner action; the wedged ReplicaSet self-heals on next Argo sync (or `rollout restart` to force it).

## What this does NOT do
It does **not** resolve #500's acceptance criteria. The actual fix — sealing the real **ZeptoMail** `SMTP_USER`/`SMTP_PASS` into `deploy/contabo/sealed/fuzefront-secrets.yaml` — is **owner-only**: it needs the real credentials + the sealing cert, and per repo policy (and safety) those values are never handled by an agent, pasted into a PR, or committed in plaintext. This PR makes the owner's one-command path actually work. #500 stays open until the keys are sealed and the pod reaches `Running`.

Verified: no app code / Helm template changes; the Deployment (`email-service.yaml`) and `values-prod.yaml` are already wired correctly.

Refs #500.

Co-Authored-By: Claude claude-opus-4-8 <noreply@anthropic.com>