### PR TITLE
fix(chart): give chat-service its own DB to stop the migrate-hook crash-loop (#499)

### DIFF
--- a/deploy/helm/fuzefront/templates/chat-db-migrate-job.yaml
+++ b/deploy/helm/fuzefront/templates/chat-db-migrate-job.yaml
@@ -13,9 +13,19 @@ metadata:
     # turn fails on the first INSERT — nothing else in the chart ran these
     # migrations, and index.ts does not self-migrate.
     #
-    # Weight -3 puts it after the shared db-bootstrap (which ensures the database
-    # and role exist) and before the workload. Idempotent: knex tracks applied
-    # migrations in knex_migrations, so re-running on upgrade is a no-op.
+    # Weight -3 puts it after the shared db-bootstrap (which ensures the
+    # dedicated `fuzefront_chat` database — see chatService.dbName — and the
+    # runtime role exist) and before the workload. Idempotent: knex tracks
+    # applied migrations in knex_migrations, so re-running on upgrade is a
+    # no-op.
+    #
+    # #499: this Job used to run against the SHARED backend database
+    # (database.name = fuzefront_platform). Its knex ledger then collided with
+    # the backend's ~18-migration `knex_migrations` row set in the same DB —
+    # validateMigrationList found the backend's files "missing" from this
+    # image and aborted, crash-looping the Job and leaving the whole
+    # `fuzefront` Argo Application stuck Degraded/OutOfSync. Pointing this Job
+    # at its own database (chatService.dbName) removes the collision entirely.
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-3"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
@@ -49,8 +59,10 @@ spec:
               value: {{ .Values.fuzeinfra.postgres.host | quote }}
             - name: DB_PORT
               value: {{ .Values.fuzeinfra.postgres.port | quote }}
+            # Dedicated DB (#499) — NOT database.name (the shared backend
+            # fuzefront_platform). Must match chat-service.yaml's DB_NAME.
             - name: DB_NAME
-              value: {{ .Values.database.name | quote }}
+              value: {{ .Values.chatService.dbName | quote }}
             - name: DB_USER
               value: {{ .Values.database.user | quote }}
             - name: DB_PASSWORD

--- a/deploy/helm/fuzefront/templates/chat-service.yaml
+++ b/deploy/helm/fuzefront/templates/chat-service.yaml
@@ -42,8 +42,11 @@ spec:
               value: {{ .Values.fuzeinfra.postgres.host | quote }}
             - name: DB_PORT
               value: {{ .Values.fuzeinfra.postgres.port | quote }}
+            # Dedicated DB (#499) — NOT database.name (the shared backend
+            # fuzefront_platform). Provisioned by db-bootstrap-job.yaml via
+            # EXTRA_DATABASES, owned by the same runtime role below.
             - name: DB_NAME
-              value: {{ .Values.database.name | quote }}
+              value: {{ .Values.chatService.dbName | quote }}
             - name: DB_USER
               value: {{ .Values.database.user | quote }}
             - name: DB_PASSWORD

--- a/deploy/helm/fuzefront/templates/db-bootstrap-job.yaml
+++ b/deploy/helm/fuzefront/templates/db-bootstrap-job.yaml
@@ -43,11 +43,25 @@ spec:
               value: {{ .Values.fuzeinfra.postgres.port | quote }}
             - name: DB_NAME
               value: {{ .Values.database.name | quote }}
+            {{- /*
+            Additional databases co-located on this Postgres that other
+            components own but which the bootstrap Job still creates + grants to
+            the shared `database.user` role (see db-bootstrap.ts EXTRA_DATABASES
+            handling): Authentik's own DB, and — since #499 — chat-service's own
+            `fuzefront_chat` DB, so its knex migration ledger can never collide
+            with the backend's (see chatService.dbName in values.yaml). Comma-
+            separated, only the enabled ones are listed.
+            */}}
+            {{- $extraDbs := list }}
             {{- if .Values.authentik.enabled }}
-            # Authentik needs its own DB (chart: authentik.dbName "must pre-exist").
-            # The bootstrap creates + grants it here so Authentik can connect + migrate.
+            {{- $extraDbs = append $extraDbs .Values.authentik.dbName }}
+            {{- end }}
+            {{- if .Values.chatService.enabled }}
+            {{- $extraDbs = append $extraDbs .Values.chatService.dbName }}
+            {{- end }}
+            {{- if $extraDbs }}
             - name: EXTRA_DATABASES
-              value: {{ .Values.authentik.dbName | quote }}
+              value: {{ join "," $extraDbs | quote }}
             {{- end }}
             # The least-privilege runtime role this Job creates. Must match the
             # DB_USER the backend Deployment connects with.

--- a/deploy/helm/fuzefront/values-prod.yaml
+++ b/deploy/helm/fuzefront/values-prod.yaml
@@ -478,6 +478,13 @@ chatService:
   image:
     repository: ghcr.io/izzywdev/fuzefront-chat-service
     tag: 6568010a0e1c
+  # #499: dedicated database so chat's knex migration ledger never collides
+  # with the backend's `fuzefront_platform` knex_migrations rows (this is the
+  # fix for the fuzefront-chat-db-migrate crash-loop that stuck the umbrella
+  # Argo app Degraded/OutOfSync). Same value as the values.yaml default —
+  # listed explicitly here since this is the values file prod actually syncs
+  # from. See values.yaml chatService.dbName for the full rationale.
+  dbName: fuzefront_chat
   affinity:
     nodeAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:

--- a/deploy/helm/fuzefront/values.yaml
+++ b/deploy/helm/fuzefront/values.yaml
@@ -462,6 +462,22 @@ chatService:
   litellmUrl: "http://litellm.fuzeinfra.svc.cluster.local:4000"
   # ChromaDB vector store in fuzeinfra namespace (enabled via fuzeinfra Argo values).
   chromaUrl: "http://fuzeinfra-chromadb.fuzeinfra.svc.cluster.local:8000"
+  # Dedicated database for chat-service's OWN knex migration ledger (#499).
+  # chat-service used to share `database.name` (the backend's fuzefront_platform)
+  # and self-migrate via knex on the same Postgres instance/DB. That put its
+  # small migration dir and the backend's ~18-file dir in the SAME
+  # `knex_migrations` table: whichever service's migrate Job ran last saw the
+  # OTHER service's files as "missing" and knex's validateMigrationList aborted
+  # — the crash-loop that stuck the whole `fuzefront` Argo Application
+  # Degraded/OutOfSync. Isolating chat onto its own database gives it its own
+  # `knex_migrations` row set with zero collision risk.
+  #
+  # Provisioned by the shared db-bootstrap Job (templates/db-bootstrap-job.yaml)
+  # via the same EXTRA_DATABASES mechanism already used for `authentik.dbName` —
+  # owned by the existing least-privilege `database.user` role (fuzefront_user),
+  # not a new role, since this DB has no other tenant to isolate FROM at the
+  # role level (only the migration ledger needed isolating).
+  dbName: fuzefront_chat
   # FuzeFront backend for user/org lookups.
   backendUrl: "http://fuzefront-backend:3001"
   # Permit PDP for authorization checks. When permit.enabled=true the in-cluster PDP runs


### PR DESCRIPTION
## Summary
`fuzefront-chat-db-migrate` was crash-looping in prod because it ran chat-service's Knex migrations against the **shared backend database `fuzefront_platform`** (same `DB_NAME`/`DB_USER` as the backend). Knex's `validateMigrationList` compares the migration directory on disk against the `knex_migrations` ledger row-set in that DB — since the backend's ~18 migrations (`001_create_users_table.js` ... `014_seed_platform_registrar_user.js`) live in the same table as chat's own (small) set, whichever service's migrate Job ran later saw the other's files as "missing" and aborted. That crash-loop kept the umbrella `fuzefront` Argo Application stuck **Degraded/OutOfSync**.

## Fix (data-tier isolation — preferred option from the issue)
Give chat-service a **dedicated `fuzefront_chat` database**, so its knex ledger can never collide with the backend's:

- `deploy/helm/fuzefront/values.yaml` / `values-prod.yaml`: new `chatService.dbName: fuzefront_chat` value (same override structure as the existing `billingService.dbUser` / `authentik.dbName`).
- `deploy/helm/fuzefront/templates/db-bootstrap-job.yaml`: extended the existing `EXTRA_DATABASES` mechanism (already used to provision Authentik's own DB) to also list `chatService.dbName` when chat is enabled. This reuses the established, idempotent `db-bootstrap.ts` codepath verbatim (`CREATE DATABASE` + `ALTER DATABASE OWNER TO fuzefront_user` if absent) — no new role, since only the migration ledger needed isolating, not a new tenant boundary.
- `deploy/helm/fuzefront/templates/chat-service.yaml` (Deployment) and `templates/chat-db-migrate-job.yaml` (the pre-install/pre-upgrade hook): `DB_NAME` now reads `chatService.dbName` instead of `database.name`. `DB_USER`/`DB_PASSWORD` unchanged (still `fuzefront_user` / the existing secret key) since the runtime role itself didn't need to change.
- Hook ordering unchanged and still correct: `db-bootstrap` (`hook-weight: -5`, creates `fuzefront_chat` via `EXTRA_DATABASES`) → `chat-db-migrate` (`hook-weight: -3`, migrates against `fuzefront_chat`) → chat-service Deployment. The backend stays on `fuzefront_platform`, untouched.

## Verification
```
$ helm lint deploy/helm/fuzefront -f deploy/helm/fuzefront/values-prod.yaml
==> Linting deploy/helm/fuzefront
[INFO] Chart.yaml: icon is recommended
1 chart(s) linted, 0 chart(s) failed

$ helm template fuzefront deploy/helm/fuzefront -f deploy/helm/fuzefront/values-prod.yaml   # exit 0, no errors
```

Rendered `fuzefront-db-bootstrap` Job (superuser bootstrap) now provisions both DBs:
```yaml
            - name: DB_NAME
              value: "fuzefront_platform"
            - name: EXTRA_DATABASES
              value: "authentik,fuzefront_chat"
```

Rendered `fuzefront-chat-db-migrate` Job (the hook that was crash-looping) now targets the isolated DB:
```yaml
            - name: DB_NAME
              value: "fuzefront_chat"
            - name: DB_USER
              value: "fuzefront_user"
```

Rendered `fuzefront-chat-service` Deployment matches it:
```yaml
            - name: DB_NAME
              value: "fuzefront_chat"
            - name: DB_USER
              value: "fuzefront_user"
```

Also re-rendered with default `values.yaml` (where `chatService.enabled: false`) to confirm `EXTRA_DATABASES` correctly omits `fuzefront_chat` when chat is disabled (`value: "authentik"` only) — no regression for the disabled/local-default path.

The backend's own db-bootstrap Job env (`DB_NAME: fuzefront_platform`) and the backend Deployment are unchanged.

## Out of scope (not done here)
- Merge/deploy — this must land via Git→Argo in a deploy window; I have NOT merged this or touched the live cluster (no `kubectl patch/exec`).
- Verifying the actual prod `fuzefront-chat-db-migrate` Job completes and the Argo `fuzefront` app returns to Healthy — that's a post-merge, post-sync verification step for the orchestrator, not provable from a chart render.
- Noted but NOT fixed here (separate, pre-existing latent issue, same shape, different service): `notification-service`'s `fuzefront-notification-db-migrate` Job has the identical shared-DB pattern (`database.name`/`database.user`) with its own small Knex migration dir. It is currently `enabled: false` in prod so it isn't live-crash-looping today, but the same collision would reproduce if/when it's turned on. Flagging for a follow-up issue rather than bundling an unrelated service's fix into this PR.

Closes #499