### PR TITLE
ci: gate-sealed-keys — block PRs that drop a previously-sealed key (prevents #500)

### DIFF
--- a/.github/workflows/gate-sealed-keys.yml
+++ b/.github/workflows/gate-sealed-keys.yml
@@ -1,0 +1,39 @@
+name: gate-sealed-keys
+
+# Fails a PR that DROPS a previously-sealed key from any deploy/contabo/sealed/*.yaml
+# SealedSecret. This is the guard that was missing when a from-scratch re-seal
+# (50b01ab) silently dropped SMTP_USER/SMTP_PASS and wedged prod email (#500).
+#
+# Runs on every PR (no path filter) so it is safe to add to the branch ruleset's
+# required checks: when a PR touches no sealed files, it passes in seconds.
+
+on:
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  gate-sealed-keys:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (full history for base comparison)
+        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608  # v5
+        with:
+          fetch-depth: 0
+
+      - name: Check for SealedSecret key regressions
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
+        run: |
+          set -euo pipefail
+          git fetch origin "$BASE_REF" --quiet
+          ALLOW=0
+          if echo "$LABELS" | grep -q '"allow-secret-key-removal"'; then
+            ALLOW=1
+            echo "Label 'allow-secret-key-removal' present — intentional removals permitted."
+          fi
+          ALLOW_SEALED_KEY_REMOVAL=$ALLOW \
+            bash deploy/scripts/check-sealed-key-regression.sh "origin/$BASE_REF"

--- a/deploy/scripts/check-sealed-key-regression.sh
+++ b/deploy/scripts/check-sealed-key-regression.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+#
+# check-sealed-key-regression.sh — fail if any committed SealedSecret DROPS an
+# encryptedData key that exists on the base ref.
+#
+# WHY THIS EXISTS (issue #500): on 2026-07-28 commit 50b01ab re-sealed
+# fuzefront-secrets FROM SCRATCH (`kubeseal -o json` on a fresh `kubectl create
+# secret`) instead of `seal-secret.sh --merge-into`, silently dropping 5 keys —
+# SMTP_USER/SMTP_PASS (→ email-service wedged in CreateContainerConfigError, #500),
+# plus TURNSTILE_SECRET_KEY, TURNSTILE_SITE_KEY, MENDYS_DATASETS_CLIENT_SECRET.
+# The chart's helm guards check `smtp.host`, never the SealedSecret's key SET, so
+# nothing caught it until the pod wedged in prod. This gate is that missing check.
+#
+# It compares the encryptedData key SET (names only — never values) of each
+# deploy/contabo/sealed/*.yaml against the base ref, and fails on any key that
+# disappeared. Intentional removals: set ALLOW_SEALED_KEY_REMOVAL=1 (CI wires this
+# to the `allow-secret-key-removal` PR label).
+#
+# Usage: check-sealed-key-regression.sh [BASE_REF]   (default: origin/master)
+set -euo pipefail
+
+BASE="${1:-origin/master}"
+DIR="deploy/contabo/sealed"
+
+# Extract the UPPER_SNAKE encryptedData key names from a SealedSecret on stdin.
+# Works for BOTH the YAML form (`    SMTP_USER: Ag...`) and the JSON form that a
+# from-scratch `kubeseal -o json` produces (`"SMTP_USER": "Ag..."`). SealedSecret
+# scaffolding (apiVersion/kind/metadata/template/annotations/type) is all
+# lowercase, and base64 ciphertext contains no `:` or `"`, so an all-caps
+# key-before-colon match isolates exactly the secret keys.
+extract_keys() {
+  grep -oE '(^[[:space:]]+[A-Z0-9_]+[[:space:]]*:|"[A-Z0-9_]+"[[:space:]]*:)' \
+    | grep -oE '[A-Z0-9_]+' | sort -u
+}
+
+fail=0
+shopt -s nullglob
+for f in "$DIR"/*.yaml; do
+  if ! git cat-file -e "$BASE:$f" 2>/dev/null; then
+    echo "· $f: new on this branch (no base version) — skipping"
+    continue
+  fi
+  base_keys=$(git show "$BASE:$f" | extract_keys || true)
+  head_keys=$(extract_keys < "$f" || true)
+  dropped=$(comm -23 <(printf '%s\n' "$base_keys") <(printf '%s\n' "$head_keys") | grep -v '^$' || true)
+  if [ -n "$dropped" ]; then
+    echo "::error file=$f::SealedSecret key regression — $f drops key(s) present on $BASE: $(echo $dropped | tr '\n' ' ')"
+    fail=1
+  else
+    echo "· $f: OK ($(printf '%s\n' "$head_keys" | grep -c . ) keys, none dropped)"
+  fi
+done
+
+if [ "$fail" = 1 ]; then
+  if [ "${ALLOW_SEALED_KEY_REMOVAL:-0}" = 1 ]; then
+    echo "::warning::Key regression detected, but ALLOW_SEALED_KEY_REMOVAL=1 (the 'allow-secret-key-removal' label is set) — passing."
+    exit 0
+  fi
+  echo ""
+  echo "A previously-sealed key disappeared from a SealedSecret."
+  echo "  • If UNINTENTIONAL (the usual case): you re-sealed from scratch and dropped keys."
+  echo "    Re-add each with:  deploy/scripts/seal-secret.sh <KEY> --scope <ns>/<name> \\"
+  echo "                         --manifest <file>   (ALWAYS --merge-into; NEVER 'kubeseal -o json' from scratch)."
+  echo "  • If INTENTIONAL (rotating a key out): add the 'allow-secret-key-removal' label to this PR."
+  exit 1
+fi
+
+echo "All SealedSecrets retain their base-ref keys. No regression."


### PR DESCRIPTION
## Why
Root-cause of #500, found via git pickaxe: commit `50b01ab` (2026-07-28, "seal MENDYS_PLATFORM_CLIENT_SECRET") re-sealed `fuzefront-secrets` **from scratch** (`kubeseal -o json` on a fresh `kubectl create secret`) instead of `seal-secret.sh --merge-into`, silently dropping **5 keys**: `SMTP_USER`/`SMTP_PASS` (→ email-service wedged in `CreateContainerConfigError`, #500) plus `TURNSTILE_SECRET_KEY`, `TURNSTILE_SITE_KEY`, `MENDYS_DATASETS_CLIENT_SECRET`. The chart's helm guards check `smtp.host` but never the SealedSecret's **key set**, so nothing caught it until the pod wedged in prod. This gate is that missing check.

## What
- **`deploy/scripts/check-sealed-key-regression.sh`** — for each `deploy/contabo/sealed/*.yaml`, compares its `encryptedData` **key set (names only, never values)** against the base ref and fails on any dropped key. Handles both the YAML form and the from-scratch-JSON form a bad re-seal produces. Intentional removals: `ALLOW_SEALED_KEY_REMOVAL=1`, wired to an `allow-secret-key-removal` PR label.
- **`.github/workflows/gate-sealed-keys.yml`** — runs on every PR to `master` (no path filter, so it's safe to add to the required-checks ruleset; no-ops in seconds when no sealed files changed).

## Verified locally
- Passes clean against `origin/master` (billing 4, fuzefront 22, unleash 3, payment 0-empty keys).
- Fails (exit 1) on a simulated `SMTP_PASS` drop, with an actionable message pointing at `seal-secret.sh --merge-into`.
- `allow-secret-key-removal` override flips it back to pass.

## Follow-up (not in this PR)
Add `gate-sealed-keys` to the `master` ruleset's required checks so it *blocks* (not just reports). Deferred to a separate governance step so the check name exists first.

Co-Authored-By: Claude claude-opus-4-8 <noreply@anthropic.com>