### PR TITLE
fix(identity-ui): bind global fetch so Members tabs load

### DIFF
--- a/packages/identity-ui/src/api/http.test.ts
+++ b/packages/identity-ui/src/api/http.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { HttpClient, HttpError } from './http'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('HttpClient — fetch binding', () => {
+  it('invokes the global fetch with the correct receiver (no "Illegal invocation")', async () => {
+    // Reproduce the browser contract: the native `fetch` throws a TypeError
+    // when called with a receiver other than the global object. The bug was
+    // storing the bare `globalThis.fetch` on the instance and calling it as
+    // `this.fetchImpl(...)`, which re-bound `this` to the HttpClient.
+    const nativeLike = function (this: unknown, _input: string, _init?: RequestInit) {
+      if (this !== globalThis && this !== undefined) {
+        throw new TypeError(
+          "Failed to execute 'fetch' on 'Window': Illegal invocation"
+        )
+      }
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        text: async () => JSON.stringify({ ok: true }),
+      } as Response)
+    }
+    vi.stubGlobal('fetch', nativeLike)
+
+    // No injected fetchImpl → falls back to the (bound) global fetch.
+    const client = new HttpClient({ baseUrl: '' })
+    await expect(client.get('/api/organizations/org-1/members')).resolves.toEqual({
+      ok: true,
+    })
+  })
+
+  it('surfaces a non-OK response as an HttpError carrying the backend error', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 403,
+      statusText: 'Forbidden',
+      text: async () => JSON.stringify({ error: 'Insufficient permissions' }),
+    } as Response)
+    const client = new HttpClient({ fetchImpl })
+    const err = await client.get('/api/organizations/org-1/members').catch((e) => e)
+    expect(err).toBeInstanceOf(HttpError)
+    expect(err).toMatchObject({ status: 403, message: 'Insufficient permissions' })
+  })
+
+  it('attaches the bearer token and JSON body on writes', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      text: async () => '',
+    } as Response)
+    const client = new HttpClient({ fetchImpl, getToken: () => 'tok-123' })
+    await client.post('/api/organizations/org-1/invitations', { email: 'a@b.c', role: 'member' })
+    expect(fetchImpl).toHaveBeenCalledWith(
+      '/api/organizations/org-1/invitations',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ email: 'a@b.c', role: 'member' }),
+        headers: expect.objectContaining({
+          Authorization: 'Bearer tok-123',
+          'Content-Type': 'application/json',
+        }),
+      })
+    )
+  })
+})

--- a/packages/identity-ui/src/api/http.ts
+++ b/packages/identity-ui/src/api/http.ts
@@ -33,7 +33,13 @@ export class HttpClient {
   constructor(opts: HttpClientOptions = {}) {
     this.baseUrl = opts.baseUrl ?? ''
     this.getToken = opts.getToken
-    this.fetchImpl = opts.fetchImpl ?? globalThis.fetch
+    // The global `fetch` is a native method that MUST be invoked with `this`
+    // bound to the global object. Storing the bare reference on an instance and
+    // later calling `this.fetchImpl(...)` re-binds `this` to the HttpClient,
+    // which the browser rejects with "Failed to execute 'fetch' on 'Window':
+    // Illegal invocation" — breaking every request this client makes. Bind the
+    // fallback to `globalThis`; an injected `fetchImpl` (tests) is left as-is.
+    this.fetchImpl = opts.fetchImpl ?? globalThis.fetch.bind(globalThis)
   }
 
   async request<T>(method: string, path: string, body?: unknown): Promise<T> {


### PR DESCRIPTION
## 📋 Description

All tabs under **Members** at `https://app.fuzefront.com/organizations` (Members, Permissions, Pending Invitations, API Tokens) failed to load, surfacing the raw exception string **"Failed to execute 'fetch' on 'Window': Illegal invocation"** directly to the user instead of a real error state.

**Root cause:** `HttpClient` (`packages/identity-ui/src/api/http.ts`) stored the bare global `fetch` reference on the instance (`this.fetchImpl = globalThis.fetch`) and later invoked it as `this.fetchImpl(...)`. Calling `fetch` as a method of the `HttpClient` re-binds its receiver away from the global object, and the browser rejects that with the "Illegal invocation" `TypeError`. Every request the identity client makes went through this path, so all four Members tabs broke. The raw `err.message` then leaked into the tab error panels.

**Fix:** bind the fallback to `globalThis` — `opts.fetchImpl ?? globalThis.fetch.bind(globalThis)`. An injected `fetchImpl` (used by tests) is left untouched.

## 🔄 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🧪 Test addition or improvement

## 🧪 Testing

- [x] Unit tests

Added `packages/identity-ui/src/api/http.test.ts` with a regression test that reproduces the receiver contract (a native-like `fetch` that throws "Illegal invocation" when called with the wrong receiver), plus coverage for the `HttpError` non-OK path and the bearer-token / JSON-body write path.

**Test Configuration:**
- Node.js version: 24.x
- OS: Linux
- Browser (if applicable): Chromium

### Test Instructions

```bash
npm install
cd packages/identity-ui
npx vitest run      # 82 passed
npx tsc --noEmit    # clean
```

## 🔧 Implementation Details

### Changes Made

- **Frontend Changes:**
  - `packages/identity-ui/src/api/http.ts` — bind the fallback global `fetch` to `globalThis` in the `HttpClient` constructor so `this.fetchImpl(...)` keeps a valid receiver.
  - `packages/identity-ui/src/api/http.test.ts` — new regression + behaviour tests for the client.

### Code Quality

- [x] Code follows the project's coding standards
- [x] Self-review of code completed
- [x] Code is commented, particularly in hard-to-understand areas
- [x] No console.log or debugging statements left in code

## 📋 Checklist

### Pre-submission

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes (82 passed)

### Code Quality

- [x] Code follows conventional commit format
- [x] TypeScript strict mode passes
- [x] No security vulnerabilities introduced

## 🔄 Backwards Compatibility

- [x] Fully backwards compatible

---
_Generated by [Claude Code](https://claude.ai/code/session_017zdYnxKQVVhFyRubDa1BmK)_