### PR TITLE
feat(design-system): password Input show/hide (eye) toggle

### DIFF
--- a/design-system/components/forms/Input.d.ts
+++ b/design-system/components/forms/Input.d.ts
@@ -10,6 +10,11 @@ export interface InputProps
   label?: string;
   /** Validation message; when present, borders the input red and renders below it. */
   error?: string;
+  /**
+   * For `type="password"` fields, render an in-field show/hide (eye) toggle.
+   * Defaults to `true`; set `false` to opt out. No effect on non-password inputs.
+   */
+  revealToggle?: boolean;
 }
 
 export function Input(props: InputProps): React.JSX.Element;

--- a/design-system/components/forms/Input.jsx
+++ b/design-system/components/forms/Input.jsx
@@ -134,7 +134,11 @@ export function Input({
             // Keep focus on the field: a mousedown on the button would otherwise
             // blur the input (losing the focus ring) before the click fires.
             onMouseDown={(e) => e.preventDefault()}
-            aria-label={revealed ? "Hide password" : "Show password"}
+            // Accessible name comes from the visually-hidden <span> below, NOT an
+            // aria-label: an aria-label of "Show password" is also matched by
+            // Testing Library's getByLabelText(/password/i), so it collided with
+            // the password field itself in consumer tests. Text content gives the
+            // same accessible name (getByRole name) without that false match.
             aria-pressed={revealed}
             aria-controls={fieldId}
             title={revealed ? "Hide password" : "Show password"}
@@ -166,6 +170,21 @@ export function Input({
               e.currentTarget.style.boxShadow = "none";
             }}
           >
+            <span
+              style={{
+                position: "absolute",
+                width: "1px",
+                height: "1px",
+                padding: 0,
+                margin: "-1px",
+                overflow: "hidden",
+                clip: "rect(0 0 0 0)",
+                whiteSpace: "nowrap",
+                border: 0,
+              }}
+            >
+              {revealed ? "Hide password" : "Show password"}
+            </span>
             {revealed ? <EyeOffIcon /> : <EyeIcon />}
           </button>
         )}

--- a/design-system/components/forms/Input.jsx
+++ b/design-system/components/forms/Input.jsx
@@ -9,15 +9,42 @@ const WarningIcon = ({ size = 14 }) => (
   </svg>
 );
 
+const EyeIcon = ({ size = 18 }) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill="none"
+    stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"
+    style={{ flex: "none" }} aria-hidden="true">
+    <path d="M2 12s3.5-7 10-7 10 7 10 7-3.5 7-10 7-10-7-10-7Z" />
+    <circle cx="12" cy="12" r="3" />
+  </svg>
+);
+
+const EyeOffIcon = ({ size = 18 }) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill="none"
+    stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"
+    style={{ flex: "none" }} aria-hidden="true">
+    <path d="M9.9 4.24A9.12 9.12 0 0 1 12 4c6.5 0 10 7 10 7a13.2 13.2 0 0 1-1.67 2.68" />
+    <path d="M6.61 6.61A13.5 13.5 0 0 0 2 12s3.5 7 10 7a9.7 9.7 0 0 0 5.39-1.61" />
+    <path d="M14.12 14.12a3 3 0 1 1-4.24-4.24" />
+    <line x1="2" y1="2" x2="22" y2="22" />
+  </svg>
+);
+
 /**
  * Labeled text field for the shell's forms and config dialogs. Focus lights the
  * "fuse seam" accent; the error state borders red and surfaces the message.
+ *
+ * Password fields (`type="password"`) automatically get a show/hide reveal
+ * toggle (an eye button) inside the field. Pass `revealToggle={false}` to opt
+ * out. The toggle only swaps the input's `type` locally — the bound `value`
+ * (React state) is never touched, so a controlled password field keeps working.
  */
 export function Input({
   label,
   error = "",
   id,
+  type,
   disabled = false,
+  revealToggle = true,
   style,
   ...rest
 }) {
@@ -28,6 +55,13 @@ export function Input({
   // (accessibility + testing-library getByLabelText).
   const reactId = React.useId();
   const fieldId = id ?? reactId;
+
+  const [revealed, setRevealed] = React.useState(false);
+  const isPassword = type === "password";
+  const showToggle = isPassword && revealToggle && !disabled;
+  // When revealed, render as a text input so the value is visible; the bound
+  // `value`/`onChange` are unchanged, so this is purely a display swap.
+  const effectiveType = isPassword && revealed ? "text" : type;
 
   return (
     <div
@@ -52,43 +86,90 @@ export function Input({
           {label}
         </label>
       )}
-      <input
-        id={fieldId}
-        disabled={disabled}
-        aria-invalid={hasError || undefined}
-        style={{
-          width: "100%",
-          boxSizing: "border-box",
-          padding: "var(--space-3) var(--space-3)",
-          fontFamily: "var(--font-sans)",
-          fontSize: "var(--text-sm)",
-          fontWeight: "var(--weight-regular)",
-          lineHeight: 1.4,
-          color: "var(--text-primary)",
-          background: "var(--bg-secondary)",
-          border: `1px solid ${baseBorder}`,
-          borderRadius: "var(--radius-md)",
-          outline: "none",
-          opacity: disabled ? 0.5 : 1,
-          cursor: disabled ? "not-allowed" : "text",
-          transition:
-            "border-color var(--duration-base) var(--ease-standard), box-shadow var(--duration-base) var(--ease-standard), background var(--duration-base) var(--ease-standard)",
-          ...style,
-        }}
-        onFocus={(e) => {
-          e.currentTarget.style.borderColor = hasError
-            ? "var(--error-color)"
-            : "var(--accent-color)";
-          e.currentTarget.style.boxShadow = "0 0 0 3px var(--accent-soft)";
-          if (rest.onFocus) rest.onFocus(e);
-        }}
-        onBlur={(e) => {
-          e.currentTarget.style.borderColor = baseBorder;
-          e.currentTarget.style.boxShadow = "none";
-          if (rest.onBlur) rest.onBlur(e);
-        }}
-        {...rest}
-      />
+      <div style={{ position: "relative", display: "flex", width: "100%" }}>
+        <input
+          id={fieldId}
+          type={effectiveType}
+          disabled={disabled}
+          aria-invalid={hasError || undefined}
+          style={{
+            width: "100%",
+            boxSizing: "border-box",
+            padding: "var(--space-3) var(--space-3)",
+            // Clear room for the reveal button so text never runs under it.
+            paddingInlineEnd: showToggle ? "var(--space-10)" : undefined,
+            fontFamily: "var(--font-sans)",
+            fontSize: "var(--text-sm)",
+            fontWeight: "var(--weight-regular)",
+            lineHeight: 1.4,
+            color: "var(--text-primary)",
+            background: "var(--bg-secondary)",
+            border: `1px solid ${baseBorder}`,
+            borderRadius: "var(--radius-md)",
+            outline: "none",
+            opacity: disabled ? 0.5 : 1,
+            cursor: disabled ? "not-allowed" : "text",
+            transition:
+              "border-color var(--duration-base) var(--ease-standard), box-shadow var(--duration-base) var(--ease-standard), background var(--duration-base) var(--ease-standard)",
+            ...style,
+          }}
+          onFocus={(e) => {
+            e.currentTarget.style.borderColor = hasError
+              ? "var(--error-color)"
+              : "var(--accent-color)";
+            e.currentTarget.style.boxShadow = "0 0 0 3px var(--accent-soft)";
+            if (rest.onFocus) rest.onFocus(e);
+          }}
+          onBlur={(e) => {
+            e.currentTarget.style.borderColor = baseBorder;
+            e.currentTarget.style.boxShadow = "none";
+            if (rest.onBlur) rest.onBlur(e);
+          }}
+          {...rest}
+        />
+        {showToggle && (
+          <button
+            type="button"
+            onClick={() => setRevealed((v) => !v)}
+            // Keep focus on the field: a mousedown on the button would otherwise
+            // blur the input (losing the focus ring) before the click fires.
+            onMouseDown={(e) => e.preventDefault()}
+            aria-label={revealed ? "Hide password" : "Show password"}
+            aria-pressed={revealed}
+            aria-controls={fieldId}
+            title={revealed ? "Hide password" : "Show password"}
+            style={{
+              position: "absolute",
+              insetBlockStart: "50%",
+              insetInlineEnd: "var(--space-3)",
+              transform: "translateY(-50%)",
+              display: "inline-flex",
+              alignItems: "center",
+              justifyContent: "center",
+              padding: 0,
+              border: "none",
+              background: "transparent",
+              color: "var(--text-secondary)",
+              cursor: "pointer",
+              lineHeight: 0,
+              borderRadius: "var(--radius-sm)",
+              transition: "color var(--duration-base) var(--ease-standard)",
+            }}
+            onMouseEnter={(e) => { e.currentTarget.style.color = "var(--text-primary)"; }}
+            onMouseLeave={(e) => { e.currentTarget.style.color = "var(--text-secondary)"; }}
+            onFocus={(e) => {
+              e.currentTarget.style.color = "var(--accent-color)";
+              e.currentTarget.style.boxShadow = "0 0 0 3px var(--accent-soft)";
+            }}
+            onBlur={(e) => {
+              e.currentTarget.style.color = "var(--text-secondary)";
+              e.currentTarget.style.boxShadow = "none";
+            }}
+          >
+            {revealed ? <EyeOffIcon /> : <EyeIcon />}
+          </button>
+        )}
+      </div>
       {hasError && (
         <span
           role="alert"

--- a/design-system/components/forms/Input.test.jsx
+++ b/design-system/components/forms/Input.test.jsx
@@ -1,0 +1,55 @@
+import React from "react";
+import { describe, it, expect } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { Input } from "./Input.jsx";
+
+describe("<Input> password reveal toggle", () => {
+  it("renders a 'Show password' toggle for password fields, hidden by default", () => {
+    render(<Input label="Password" type="password" defaultValue="hunter2" />);
+    const field = screen.getByLabelText("Password");
+    expect(field).toHaveAttribute("type", "password");
+    expect(screen.getByRole("button", { name: "Show password" })).toBeInTheDocument();
+  });
+
+  it("toggles the field between password and text (value untouched)", () => {
+    render(<Input label="Password" type="password" defaultValue="hunter2" />);
+    const field = screen.getByLabelText("Password");
+
+    fireEvent.click(screen.getByRole("button", { name: "Show password" }));
+    expect(field).toHaveAttribute("type", "text");
+    expect(field).toHaveValue("hunter2");
+    expect(screen.getByRole("button", { name: "Hide password" })).toHaveAttribute("aria-pressed", "true");
+
+    fireEvent.click(screen.getByRole("button", { name: "Hide password" }));
+    expect(field).toHaveAttribute("type", "password");
+  });
+
+  it("does NOT render the toggle for non-password inputs", () => {
+    render(<Input label="Email" type="email" />);
+    expect(screen.queryByRole("button", { name: /password/i })).not.toBeInTheDocument();
+  });
+
+  it("respects revealToggle={false} on a password field", () => {
+    render(<Input label="Password" type="password" revealToggle={false} />);
+    expect(screen.queryByRole("button", { name: /password/i })).not.toBeInTheDocument();
+  });
+
+  it("hides the toggle when disabled", () => {
+    render(<Input label="Password" type="password" disabled />);
+    expect(screen.queryByRole("button", { name: /password/i })).not.toBeInTheDocument();
+  });
+
+  it("keeps a controlled password field working through a reveal", () => {
+    function Controlled() {
+      const [v, setV] = React.useState("");
+      return <Input label="Password" type="password" value={v} onChange={(e) => setV(e.target.value)} />;
+    }
+    render(<Controlled />);
+    const field = screen.getByLabelText("Password");
+    fireEvent.change(field, { target: { value: "abc" } });
+    expect(field).toHaveValue("abc");
+    fireEvent.click(screen.getByRole("button", { name: "Show password" }));
+    expect(field).toHaveAttribute("type", "text");
+    expect(field).toHaveValue("abc");
+  });
+});


### PR DESCRIPTION
## What
Adds an in-field **show/hide (eye) toggle** to design-system `Input` for `type="password"` fields.

- Tokens-only, RTL-safe (`insetInlineEnd`/`paddingInlineEnd`), accessible (`aria-label` Show/Hide password, `aria-pressed`, `aria-controls`, `type="button"` so it never submits the form).
- **Value-preserving:** only swaps the input's `type` locally — controlled password fields keep working.
- Opt out via `revealToggle={false}`; non-password and disabled fields render no toggle.

## Where it shows
`AuthPanel` (and thus `LoginPage`) render their password field via this `Input`, so they inherit the toggle with **no feature-UI change** (no `frontend/src` or `packages/*-ui` edit).

## Verification
- Rendered the real component in headed Chrome: eye ↔ eye-off states, value preserved through toggle, email/opted-out fields show no icon, **0 console errors**.
- 6 new RTL unit tests (`Input.test.jsx`): renders/toggles/opt-out/disabled/non-password/controlled.

## Note
Live `app.fuzefront.com` currently serves the pre-AuthPanel build, so the toggle appears on prod once the AuthPanel build deploys. Live everywhere the DS `Input` is used in current source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)