### PR TITLE
fix(chat-db): drop cross-service FKs in 001 so chat migrates in its isolated DB (#499)

### DIFF
--- a/services/chat-service/src/db/migrations/001_create_chat_tables.ts
+++ b/services/chat-service/src/db/migrations/001_create_chat_tables.ts
@@ -2,16 +2,23 @@ import { Knex } from 'knex';
 
 // Migration: create all four chat tables in a single file.
 // SQL is the exact schema from plan §6e.
-// FK references: users(id) and organizations(id) are owned by the backend in
-// the same fuzefront_platform database. This migration assumes those tables exist.
+// DECOUPLED IDENTITY: user_id/org_id are opaque identifiers OWNED BY OTHER
+// SERVICES (security/backend), whose tables live in a SEPARATE database. They are
+// therefore NOT foreign-keyed here — a cross-database FK is impossible in
+// Postgres, and creating `REFERENCES users(id)` inline made this migration abort
+// with "relation users does not exist" against chat's own isolated DB
+// (fuzefront_chat), wedging the pre-sync hook and the whole Argo sync (#499).
+// Referential integrity to users/orgs is an application/event-layer concern, not
+// a DB constraint. Migration 002 further widens these to TEXT for multi-app
+// subjects. Intra-chat FKs (messages→conversations, feedback→messages) remain.
 // down() drops tables in reverse FK dependency order.
 
 export async function up(knex: Knex): Promise<void> {
   await knex.raw(`
     CREATE TABLE IF NOT EXISTS chat_conversations (
       id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-      user_id     UUID NOT NULL REFERENCES users(id),
-      org_id      UUID REFERENCES organizations(id),
+      user_id     UUID NOT NULL,
+      org_id      UUID,
       title       TEXT,
       created_at  TIMESTAMPTZ DEFAULT NOW(),
       updated_at  TIMESTAMPTZ DEFAULT NOW()


### PR DESCRIPTION
## Why (prod is currently wedged on this)
PR #508 gave chat-service its own DB (`fuzefront_chat`), but migration `001` still created `chat_conversations` with inline **`REFERENCES users(id)` / `REFERENCES organizations(id)`** — backend-owned tables that live in a *separate* database. Postgres can't foreign-key across databases, so `001` aborts with *"relation users does not exist"* against `fuzefront_chat` → the `chat-db-migrate` PreSync hook hits its backoff limit → **the failing hook blocks the entire `fuzefront` Argo sync** (every Deployment `OutOfSync`).

**Verified live:** `fuzefront_chat` exists (owned by `fuzefront_user`), `knex_migrations` empty, lock free — `001` attempted and rolled back, never recorded.

## Fix
`user_id`/`org_id` become plain `UUID` columns (no DB-level FK). This matches the intent already in `002.up()`, which drops those constraints and widens the columns to `TEXT` for multi-app subjects. Referential integrity to users/orgs is an application/event-layer concern in the decoupled model. Intra-chat FKs (`messages→conversations`, `feedback→messages`) are unchanged.

No test change needed: `migration.test.ts`'s CI path only checks the module exports; its live round-trip is `describe.skip` in CI and now works against any empty DB instead of requiring `users`/`organizations` to pre-exist.

## Deploy path
Merging rebuilds the chat-service image (migration is baked into it) + bumps the prod tag → Argo syncs → fixed `001` runs against `fuzefront_chat` → hook passes → sync converges. I'm watching prod for convergence.

Refs #499. Follow-up (#2, in progress): per-service bootstrap ownership so services don't know each other's DBs, and fix `002.down()` which still re-adds the cross-DB FKs on rollback.

Co-Authored-By: Claude claude-opus-4-8 <noreply@anthropic.com>