### PR TITLE
fix(authentik-mendys): force re-apply of mendys-platform OIDC provider (#514)

### DIFF
--- a/deploy/helm/fuzefront/authentik/blueprints-mendys/provider-oidc-mendys-platform.yaml
+++ b/deploy/helm/fuzefront/authentik/blueprints-mendys/provider-oidc-mendys-platform.yaml
@@ -35,6 +35,16 @@ metadata:
   name: MendysRobotics Platform OIDC Provider
   labels:
     blueprints.goauthentik.io/instantiate: "true"
+    # RE-APPLY MARKER (#514 / FuzeInfra#495): this label's value is a parsed part
+    # of the blueprint, so bumping it changes the blueprint content hash and forces
+    # Authentik's runner to RE-APPLY (upsert) the entries below. Needed because the
+    # LIVE mendys-platform provider was created from an OLDER blueprint (before
+    # authorization_flow + grant_types were added) and the ConfigMap had not changed
+    # since — so authorize returned `invalid_request`. The provider entry below
+    # already carries the correct authorization_flow, grant_types, invalidation_flow
+    # and strict redirect_uris; re-applying upserts them onto the stale provider.
+    # To force another re-apply in future, bump the date suffix.
+    fuzefront.io/blueprint-reapply: "2026-08-03-invalid-request-514"
 entries:
   # ── Authorization flow (implicit consent) ────────────────────────────────────
   # An empty authorization flow = implicit consent in Authentik. The blueprint


### PR DESCRIPTION
Closes #514. Delegated from FuzeInfra#495 (URGENT — `live.mendysrobotics.com` login redirect loop).

## Root cause
The live `authentik-mendys` `mendys-platform` OIDC provider returns `invalid_request` on authorize because it was created from an **older blueprint** (before `authorization_flow` + `grant_types` existed) and the blueprint ConfigMap hasn't changed since — so Authentik's runner never re-applied it (NULL `authorization_flow` / empty `grant_types`).

## Fix
The blueprint file already has the correct `authorization_flow`, `grant_types: [authorization_code, refresh_token]`, `invalidation_flow`, and both strict redirect URIs. This adds a parsed `fuzefront.io/blueprint-reapply` metadata label whose value changes the blueprint **content hash**, forcing the runner to **re-apply (upsert)** the provider with those fields. Bump the date suffix to force future re-applies.

## Verified (`helm template … --set authentikMendys.enabled=true`)
- Re-apply marker present in the rendered ConfigMap.
- Provider renders with `grant_types`, `authorization_flow`, and **both** strict redirect URIs:
  - `https://live.mendysrobotics.com/api/auth/oidc/callback`
  - `https://marketplace.mendysrobotics.com/api/auth/oidc/callback`
- Application slug `mendys-platform` bound to the provider (no drift).
- No secret stored — `client_secret` stays an `!Env` tag.

Lands via Git→Argo (ConfigMap change → worker re-applies); no `kubectl patch`.

Refs FuzeInfra#495.

Co-Authored-By: Claude claude-opus-4-8 <noreply@anthropic.com>