### PR TITLE
fix(identity): surface caller's org role and show a non-member state on the Members tab

### DIFF
--- a/.claude/agents/backend-engineer.md
+++ b/.claude/agents/backend-engineer.md
@@ -4,7 +4,7 @@ model: sonnet
 description: Implements ONLY the backend slice of a feature — HTTP API/services, business logic, DB schema/migrations, events, and the backend's own unit tests — against a frozen API contract. Does NOT build UI, the independent test suite, deploy wiring, or docs. Use for backend implementation in a contract-first fan-out.
 # Figma is reserved for frontend-engineer; pure-code agent gets core tools only (no MCP).
 tools: Task, Bash, Glob, Grep, LS, Read, Edit, MultiEdit, Write, NotebookEdit, WebFetch, WebSearch, TodoWrite
-skills: [api-contract-first, feature-flags, verification-protocol, model-cascade]
+skills: [api-contract-first, feature-flags, logging, verification-protocol, model-cascade]
 ---
 
 You are a **backend engineer** for FuzeFront. You implement the **backend slice only**.

--- a/.claude/agents/frontend-engineer.md
+++ b/.claude/agents/frontend-engineer.md
@@ -5,7 +5,7 @@ description: Implements ONLY the UI slice of a feature — a design-system-first
 # SOLE owner of the Figma MCP plugin (design-to-code). All other domain agents have
 # Figma removed from their tool grant — it is reserved here for the UI/design-system slice.
 tools: "*"
-skills: [fuzefront-ui-package, design-system-inheritance, design-system-conformance, ui-frame-contract, frontend-design, feature-flags, ui-runtime-validation, verification-protocol, model-cascade]
+skills: [fuzefront-ui-package, design-system-inheritance, design-system-conformance, ui-frame-contract, frontend-design, feature-flags, logging, ui-runtime-validation, verification-protocol, model-cascade]
 ---
 
 You are a **frontend engineer**. You implement the **UI slice only**.

--- a/agent-templates/schema/role-manifest.schema.json
+++ b/agent-templates/schema/role-manifest.schema.json
@@ -80,6 +80,40 @@
     "metadata": {
       "type": "object",
       "description": "Passed through as agent `metadata` (free-form tracking)."
+    },
+    "a2a": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "OPTIONAL A2A discoverability/publication block. Mirrors the frozen contract FuzeAgent/agent-templates/contracts/a2a/v1/schema/role-a2a-extension.schema.json. Every field has a derived default, so no existing role.json needs it. The card projection reads role/name/description/services/metadata/coordinator regardless; this block only lets a role improve discoverability (examples/tags) or opt out of publication.",
+      "properties": {
+        "publish": {
+          "type": "boolean",
+          "default": true,
+          "description": "false hides this role from the public card. Still reachable on the EXTENDED card if the caller is allowlisted (authz.md §5)."
+        },
+        "extendedOnly": {
+          "type": "boolean",
+          "default": false,
+          "description": "true publishes this skill ONLY on the authenticated extended card, never on the anonymous /.well-known/agent-card.json. Use for skills whose mere existence is sensitive."
+        },
+        "tags": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Extra tags merged with the derived tags. Derived tags are never removed."
+        },
+        "examples": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Example prompts a caller can send to this skill — the primary signal a calling agent uses to decide fit. Absent examples make a skill effectively undiscoverable."
+        },
+        "inputModes": { "type": "array", "items": { "type": "string" } },
+        "outputModes": { "type": "array", "items": { "type": "string" } },
+        "scopes": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "OAuth scopes required for THIS skill, projected into the skill's securityRequirements."
+        }
+      }
     }
   }
 }

--- a/backend/security/src/routes/organizations.ts
+++ b/backend/security/src/routes/organizations.ts
@@ -359,7 +359,8 @@ router.get('/', authenticateToken, async (req: any, res) => {
     // Transform results. `user_role` is the caller's own role in each org, or
     // `null` when they are NOT a member (they can still see `platform`-type orgs
     // without belonging to them). An owner always resolves to 'owner' even if a
-    // membership row is somehow missing.
+    // membership row is somehow missing — the owner is authoritative over any
+    // stale/absent membership row.
     type OrgRole = OrganizationMembership['role']
     const transformedOrganizations: Array<
       Organization & { user_role: OrgRole | null }

--- a/backend/security/src/routes/organizations.ts
+++ b/backend/security/src/routes/organizations.ts
@@ -282,9 +282,11 @@ router.get('/', authenticateToken, async (req: any, res) => {
     const sortField = validSortFields.includes(sort) ? sort : 'name'
     const sortOrder = ['asc', 'desc'].includes(order) ? order : 'asc'
 
-    // Build query
+    // Build query. Also project the caller's own membership role (via the
+    // left-join below) as `user_role` so the UI can show "your role" and
+    // distinguish a real member from someone merely seeing a platform org.
     let query = db('organizations')
-      .select('organizations.*')
+      .select('organizations.*', 'organization_memberships.role as user_role')
       .leftJoin('organization_memberships', function () {
         this.on(
           'organizations.id',
@@ -354,8 +356,14 @@ router.get('/', authenticateToken, async (req: any, res) => {
       .limit(limitNum)
       .offset(offset)
 
-    // Transform results
-    const transformedOrganizations: Organization[] = organizations.map(org => ({
+    // Transform results. `user_role` is the caller's own role in each org, or
+    // `null` when they are NOT a member (they can still see `platform`-type orgs
+    // without belonging to them). An owner always resolves to 'owner' even if a
+    // membership row is somehow missing.
+    type OrgRole = OrganizationMembership['role']
+    const transformedOrganizations: Array<
+      Organization & { user_role: OrgRole | null }
+    > = organizations.map(org => ({
       id: org.id,
       name: org.name,
       slug: org.slug,
@@ -367,6 +375,9 @@ router.get('/', authenticateToken, async (req: any, res) => {
       is_active: org.is_active,
       created_at: org.created_at,
       updated_at: org.updated_at,
+      user_role:
+        (org.user_role as OrgRole | null) ??
+        (org.owner_id === req.user.id ? 'owner' : null),
     }))
 
     res.json({
@@ -395,9 +406,11 @@ router.get(
     try {
       const { id } = req.params
 
-      // Check if user has access to this organization
+      // Check if user has access to this organization. Project the caller's own
+      // membership role (via the left-join) as `user_role`, mirroring the list
+      // endpoint so the UI can show the role and detect non-membership.
       const organization = await db('organizations')
-        .select('organizations.*')
+        .select('organizations.*', 'organization_memberships.role as user_role')
         .leftJoin('organization_memberships', function () {
           this.on(
             'organizations.id',
@@ -431,7 +444,8 @@ router.get(
           .json({ error: 'Organization not found or access denied' })
       }
 
-      const result: Organization = {
+      type OrgRole = OrganizationMembership['role']
+      const result: Organization & { user_role: OrgRole | null } = {
         id: organization.id,
         name: organization.name,
         slug: organization.slug,
@@ -443,6 +457,9 @@ router.get(
         is_active: organization.is_active,
         created_at: organization.created_at,
         updated_at: organization.updated_at,
+        user_role:
+          (organization.user_role as OrgRole | null) ??
+          (organization.owner_id === req.user.id ? 'owner' : null),
       }
 
       res.json(result)

--- a/backend/security/tests/organizations.members.test.ts
+++ b/backend/security/tests/organizations.members.test.ts
@@ -600,3 +600,76 @@ describe('Organization Members', () => {
     })
   })
 })
+
+// GET /api/organizations/:id must project the caller's OWN role as `user_role`
+// so the UI can show "your role" and tell a real member apart from someone who
+// only sees a platform org. `user_role` is null for a non-member; an owner
+// resolves to 'owner' even if the joined membership row is absent.
+describe('Organization user_role projection — GET /:id', () => {
+  let app: express.Application
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    app = buildApp()
+  })
+
+  // Single-org GET runs one query against `organizations` and terminates on
+  // `.first()`. Its left-join surfaces the caller's membership role as
+  // `orgRow.user_role`.
+  function makeOrgGetChain(orgRow: any) {
+    return {
+      select: jest.fn().mockReturnThis(),
+      leftJoin: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      first: jest.fn().mockResolvedValue(orgRow),
+    }
+  }
+
+  const baseOrg = {
+    id: ORG_ID,
+    name: 'Acme',
+    slug: 'acme',
+    parent_id: null,
+    type: 'organization',
+    settings: {},
+    metadata: {},
+    is_active: true,
+    created_at: new Date('2024-01-01').toISOString(),
+    updated_at: new Date('2024-01-01').toISOString(),
+  }
+
+  function wireOrgGet(orgRow: any) {
+    dbMock.mockImplementation((table: string) =>
+      table === 'organizations' ? makeOrgGetChain(orgRow) : makeDbQuery(null)
+    )
+  }
+
+  it('returns the caller membership role as user_role', async () => {
+    wireOrgGet({ ...baseOrg, owner_id: 'someone-else', user_role: 'admin' })
+
+    const res = await request(app).get(`/api/organizations/${ORG_ID}`)
+
+    expect(res.status).toBe(200)
+    expect(res.body.user_role).toBe('admin')
+  })
+
+  it('resolves user_role to null for a non-member (visible platform org)', async () => {
+    // No membership row → left-join yields user_role null, and the caller is
+    // not the owner, so it stays null.
+    wireOrgGet({ ...baseOrg, type: 'platform', owner_id: 'someone-else', user_role: null })
+
+    const res = await request(app).get(`/api/organizations/${ORG_ID}`)
+
+    expect(res.status).toBe(200)
+    expect(res.body.user_role).toBeNull()
+  })
+
+  it('falls back to owner when the caller owns the org but has no membership row', async () => {
+    wireOrgGet({ ...baseOrg, owner_id: USER_ID, user_role: null })
+
+    const res = await request(app).get(`/api/organizations/${ORG_ID}`)
+
+    expect(res.status).toBe(200)
+    expect(res.body.user_role).toBe('owner')
+  })
+})

--- a/frontend/src/__tests__/OrganizationPage.membership.test.tsx
+++ b/frontend/src/__tests__/OrganizationPage.membership.test.tsx
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import OrganizationPage from '../pages/OrganizationPage'
+
+// Mock the api module: importing it for real fires an axios connectivity probe
+// at module load that never settles under jsdom (same reason as the other
+// OrganizationSelector/org tests).
+const apiMocks = vi.hoisted(() => ({
+  getOrganizations: vi.fn(),
+  getOrganizationMembers: vi.fn(),
+  updateOrganization: vi.fn(),
+  deleteOrganization: vi.fn(),
+}))
+vi.mock('../services/api', () => apiMocks)
+
+const currentUser = vi.hoisted(() => ({
+  user: { id: 'u1', email: 'a@b.c' },
+  isAuthenticated: true,
+}))
+vi.mock('../lib/shared', () => ({ useCurrentUser: () => currentUser }))
+
+vi.mock('react-router-dom', () => ({ useNavigate: () => vi.fn() }))
+
+vi.mock('../components/PermissionGate', () => ({
+  PermissionGate: ({ children }: any) => children,
+}))
+
+vi.mock('../components/OrganizationSettings', () => ({
+  OrganizationSettings: () => <div data-testid="org-settings" />,
+}))
+
+// IdentityPage owns the Members/Permissions/Invitations/Tokens sub-tabs. A
+// non-member must NOT reach it (every call would 403), so its presence/absence
+// is the signal under test.
+vi.mock('@fuzefront/identity-ui', () => ({
+  IdentityPage: () => <div data-testid="identity-page" />,
+}))
+
+const baseOrg = {
+  id: 'org-1',
+  name: 'FuzeFront',
+  slug: 'fuzefront',
+  type: 'platform' as const,
+  description: 'Platform org',
+  owner_id: 'someone-else',
+  is_active: true,
+  settings: {},
+  metadata: {},
+  created_at: new Date('2024-01-01').toISOString(),
+  updated_at: new Date('2024-01-02').toISOString(),
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  apiMocks.getOrganizationMembers.mockResolvedValue([])
+})
+
+async function renderWithOrg(org: any) {
+  apiMocks.getOrganizations.mockResolvedValue([org])
+  render(<OrganizationPage />)
+  // Wait past the loading skeleton — the org name appears once loaded.
+  await screen.findByRole('heading', { name: /organization management/i })
+  return org
+}
+
+describe('OrganizationPage — membership / role visibility', () => {
+  it('shows a "not a member" state on the Members tab when user_role is null', async () => {
+    await renderWithOrg({ ...baseOrg, user_role: null })
+
+    fireEvent.click(screen.getByRole('button', { name: /members/i }))
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(/not a member of this organization/i)
+      ).toBeInTheDocument()
+    )
+    // IdentityPage must not render for a non-member — no 403-prone calls fire.
+    expect(screen.queryByTestId('identity-page')).not.toBeInTheDocument()
+  })
+
+  it('renders IdentityPage on the Members tab for an actual member', async () => {
+    await renderWithOrg({ ...baseOrg, type: 'organization', user_role: 'admin' })
+
+    fireEvent.click(screen.getByRole('button', { name: /members/i }))
+
+    await waitFor(() =>
+      expect(screen.getByTestId('identity-page')).toBeInTheDocument()
+    )
+    expect(
+      screen.queryByText(/not a member of this organization/i)
+    ).not.toBeInTheDocument()
+  })
+
+  it('shows the caller real role in the header badge for a member', async () => {
+    // Member → role badge reflects the real role (never the old fake VIEWER).
+    await renderWithOrg({ ...baseOrg, type: 'organization', user_role: 'admin' })
+    expect(screen.getByText(/ADMIN/)).toBeInTheDocument()
+    expect(screen.queryByText(/GUEST/)).not.toBeInTheDocument()
+  })
+
+  it('shows a GUEST badge (never a fake VIEWER) when user_role is null', async () => {
+    await renderWithOrg({ ...baseOrg, user_role: null })
+    expect(screen.getByText(/GUEST/)).toBeInTheDocument()
+    expect(screen.queryByText(/VIEWER/)).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/OrganizationSettings.tsx
+++ b/frontend/src/components/OrganizationSettings.tsx
@@ -16,7 +16,8 @@ interface Organization {
   metadata: Record<string, any>
   created_at: string
   updated_at: string
-  user_role?: 'owner' | 'admin' | 'member' | 'viewer'
+  // `null` when the caller is not a member of this org (see OrganizationPage).
+  user_role?: 'owner' | 'admin' | 'member' | 'viewer' | null
 }
 
 interface OrganizationSettingsProps {

--- a/frontend/src/pages/OrganizationPage.tsx
+++ b/frontend/src/pages/OrganizationPage.tsx
@@ -27,7 +27,11 @@ interface Organization {
   created_at: string
   updated_at: string
   member_count?: number
-  user_role?: 'owner' | 'admin' | 'member' | 'viewer'
+  // The caller's own role in this org. `null` means "not a member" — the org is
+  // visible only because it is a `platform`-type org, which every authenticated
+  // user can see without belonging to it. `undefined` means "unknown" (e.g. a
+  // backend that predates the `user_role` field); treat it permissively.
+  user_role?: 'owner' | 'admin' | 'member' | 'viewer' | null
 }
 
 interface OrganizationMember {
@@ -294,21 +298,39 @@ function OrganizationPage() {
                   }}
                 >
                   {currentOrg.name}
-                  <span
-                    style={{
-                      backgroundColor: getRoleBadgeColor(
-                        currentOrg.user_role || 'viewer'
-                      ),
-                      color: 'white',
-                      padding: '0.25rem 0.5rem',
-                      borderRadius: '12px',
-                      fontSize: '0.75rem',
-                      fontWeight: 'bold',
-                    }}
-                  >
-                    {getRoleIcon(currentOrg.user_role || 'viewer')}{' '}
-                    {currentOrg.user_role?.toUpperCase()}
-                  </span>
+                  {/* Show the caller's actual role. `null` = not a member of
+                      this org (a visible platform org) → a distinct "Guest"
+                      badge rather than silently mislabelling everyone 'viewer'.
+                      `undefined` = unknown role → render no badge at all. */}
+                  {currentOrg.user_role ? (
+                    <span
+                      style={{
+                        backgroundColor: getRoleBadgeColor(currentOrg.user_role),
+                        color: 'white',
+                        padding: '0.25rem 0.5rem',
+                        borderRadius: '12px',
+                        fontSize: '0.75rem',
+                        fontWeight: 'bold',
+                      }}
+                    >
+                      {getRoleIcon(currentOrg.user_role)}{' '}
+                      {currentOrg.user_role.toUpperCase()}
+                    </span>
+                  ) : currentOrg.user_role === null ? (
+                    <span
+                      style={{
+                        backgroundColor: 'var(--bg-secondary)',
+                        color: 'var(--text-secondary)',
+                        border: '1px solid var(--border-color)',
+                        padding: '0.25rem 0.5rem',
+                        borderRadius: '12px',
+                        fontSize: '0.75rem',
+                        fontWeight: 'bold',
+                      }}
+                    >
+                      👋 GUEST
+                    </span>
+                  ) : null}
                 </h2>
                 <p style={{ color: 'var(--text-tertiary)', margin: '0 0 1rem 0' }}>
                   {currentOrg.description || 'No description provided'}
@@ -460,14 +482,41 @@ function OrganizationPage() {
             </div>
           )}
 
-          {activeTab === 'members' && (
-            <IdentityPage
-              organizationId={currentOrg.id}
-              userRole={currentOrg.user_role ?? 'viewer'}
-              userId={user?.id}
-              onMembersChange={() => loadMembers(currentOrg.id)}
-            />
-          )}
+          {activeTab === 'members' &&
+            (currentOrg.user_role === null ? (
+              // Confirmed non-member of a visible platform org. Render an
+              // explicit state instead of IdentityPage — every members/roles/
+              // invitations/tokens call would 403 and surface a raw
+              // "Insufficient permissions" error in each sub-tab.
+              <div
+                style={{
+                  textAlign: 'center',
+                  padding: '3rem 2rem',
+                  color: 'var(--text-tertiary)',
+                  border: '1px solid var(--border-color)',
+                  borderRadius: '8px',
+                  backgroundColor: 'var(--bg-tertiary)',
+                }}
+              >
+                <div style={{ fontSize: '2rem', marginBottom: '0.5rem' }}>👋</div>
+                <h3 style={{ margin: '0 0 0.5rem 0', color: 'var(--text-primary)' }}>
+                  You're not a member of this organization
+                </h3>
+                <p style={{ margin: 0 }}>
+                  You can see <strong>{currentOrg.name}</strong> because it's a
+                  platform organization, but you don't have a membership here, so
+                  its members, roles, and tokens aren't available to you. Ask an
+                  organization owner or admin for an invitation to gain access.
+                </p>
+              </div>
+            ) : (
+              <IdentityPage
+                organizationId={currentOrg.id}
+                userRole={currentOrg.user_role ?? 'viewer'}
+                userId={user?.id}
+                onMembersChange={() => loadMembers(currentOrg.id)}
+              />
+            ))}
 
           {activeTab === 'settings' && (
             <PermissionGate

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -477,7 +477,8 @@ export interface Organization {
   createdAt?: string
   updatedAt?: string
   // Snake_case fields returned by the backend / consumed by the UI.
-  user_role?: string
+  // `null` when the caller is not a member of the org (visible platform org).
+  user_role?: string | null
   member_count?: number
   created_at?: string
 }


### PR DESCRIPTION
## 📋 Description

Two related gaps around organization-membership visibility, surfaced after the Members-tabs fetch fix (#511) made the underlying 403s visible:

1. **Your own role was never shown.** The security service's `GET /api/organizations` and `GET /api/organizations/:id` never returned the caller's role, so the frontend's `currentOrg.user_role` was always `undefined` and the Organization Overview **role badge silently fell back to "viewer" for everyone — owners included.** There was effectively no working UI surface that showed your actual role.

2. **A raw "permission denied" on the Members tab.** A `platform`-type org is visible to *every* authenticated user, but its members/roles/invitations/tokens endpoints `403` for non-members. The Members tab mounted `IdentityPage` regardless, so each of its four sub-tabs rendered a raw *"Insufficient permissions"* error.

**Fix:** the org list/get responses now project the caller's own `organization_memberships.role` as `user_role` (`null` when not a member; an owner resolves to `'owner'` even if a membership row is missing). The frontend shows the real role in the header badge, a **GUEST** badge (not a fake VIEWER) when `user_role` is `null`, and an explicit **"You're not a member of this organization"** state on the Members tab instead of mounting `IdentityPage`. An `undefined` role (older backend, e.g. mid-rollout) stays permissive.

## 🔄 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🧪 Test addition or improvement

## 🧪 Testing

- [x] Unit tests

**Backend** (`backend/security`, jest): 25 pass, incl. 3 new `user_role` projection cases (member role echoed, non-member → `null`, owner-without-membership-row → `'owner'`).
**Frontend** (`frontend`, vitest): new `OrganizationPage.membership.test.tsx` (4 pass) covers the non-member state, `IdentityPage` for members, and the role/GUEST badge; the 22 existing org tests still pass. Both edited backends type-check clean (`tsc --noEmit`, 0 errors) after building `@fuzefront/core` + `@fuzefront/shared`.

### Test Instructions

```bash
npm install
cd backend/security && npx jest tests/organizations.members.test.ts   # 25 passed
cd ../../frontend && npx vitest run src/__tests__/OrganizationPage.membership.test.tsx  # 4 passed
```

## 🔧 Implementation Details

### Changes Made

- **Backend Changes:**
  - `backend/security/src/routes/organizations.ts` — `GET /` and `GET /:id` select `organization_memberships.role as user_role` (via the existing caller left-join) and emit `user_role` (role | `null`, with an owner fallback).
- **Frontend Changes:**
  - `frontend/src/pages/OrganizationPage.tsx` — role badge shows the real role / GUEST / nothing; Members tab renders a non-member state when `user_role === null`.
  - `frontend/src/components/OrganizationSettings.tsx`, `frontend/src/services/api.ts` — widen `user_role` to allow `null`.
- **Tests:** `backend/security/tests/organizations.members.test.ts` (+3), `frontend/src/__tests__/OrganizationPage.membership.test.tsx` (new).

### Code Quality

- [x] Self-review of code completed
- [x] Code is commented, particularly in hard-to-understand areas
- [x] No console.log or debugging statements left in code

## 📋 Checklist

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] TypeScript strict mode passes

## 🔄 Backwards Compatibility

- [x] Fully backwards compatible — `user_role` is additive; an `undefined` value (older backend) is treated permissively by the UI.

---
_Generated by [Claude Code](https://claude.ai/code/session_017zdYnxKQVVhFyRubDa1BmK)_