### PR TITLE
fix(app-registry): unified JWT+consumer-token auth middleware on all routes

### DIFF
--- a/backend/applications/src/app-registry/manifest.schema.ts
+++ b/backend/applications/src/app-registry/manifest.schema.ts
@@ -169,6 +169,102 @@ export const heartbeatRequestSchema = z
   })
   .strict()
 
+// ── onboarding: ProductPolicy / BillingProfile ────────────────────────────────
+// 1:1 with the ProductPolicy / BillingProfile schemas in
+// services/app-registry-service/openapi.yaml. Keys are BARE here on purpose —
+// the platform namespaces them by slug (`Listing` → `<slug>_Listing`) at merge
+// time, so `_` is reserved as the namespace separator and rejected in keys.
+const bareKeySchema = z
+  .string()
+  .regex(
+    /^[A-Za-z][A-Za-z0-9-]*$/,
+    'must be a bare key ([A-Za-z][A-Za-z0-9-]*) — `_` is the namespace separator'
+  )
+
+export const productResourceDeclSchema = z
+  .object({
+    key: bareKeySchema,
+    name: z.string(),
+    actions: z.record(z.string(), z.object({ name: z.string() }).strict()),
+  })
+  .strict()
+
+export const productRoleDeclSchema = z
+  .object({
+    key: bareKeySchema,
+    name: z.string(),
+    permissions: z.array(
+      z
+        .string()
+        .regex(
+          /^[A-Za-z][A-Za-z0-9-]*:[A-Za-z][A-Za-z0-9_-]*$/,
+          'must be `<BareResource>:<action>`'
+        )
+    ),
+  })
+  .strict()
+
+export const productPolicySchema = z
+  .object({
+    // Implied by the path slug. Accepted in the body only so a product can be
+    // explicit; the route rejects it when it disagrees with the path — otherwise
+    // write access to one app would install a policy namespaced to another.
+    product: slugSchema.optional(),
+    name: z.string().optional(),
+    resources: z.array(productResourceDeclSchema),
+    roles: z.array(productRoleDeclSchema),
+  })
+  .strict()
+  // Referential integrity, per the contract: "Every referenced resource/action
+  // must exist in this same document." A permission naming an undeclared
+  // resource or action does not fail at sync time — it namespaces cleanly to
+  // `<slug>_Listing:delete` and is simply never matched by anything, so the role
+  // silently grants nothing. Catching it at deploy turns an invisible authz hole
+  // into a registration failure the product team can see.
+  .superRefine((policy, ctx) => {
+    const declared = new Map(
+      policy.resources.map(r => [r.key, new Set(Object.keys(r.actions))])
+    )
+    policy.roles.forEach((role, roleIndex) => {
+      role.permissions.forEach((permission, permIndex) => {
+        const [resourceKey, actionKey] = permission.split(':')
+        const actions = declared.get(resourceKey)
+        if (!actions) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ['roles', roleIndex, 'permissions', permIndex],
+            message: `resource '${resourceKey}' is not declared in this policy`,
+          })
+          return
+        }
+        if (!actions.has(actionKey)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ['roles', roleIndex, 'permissions', permIndex],
+            message: `action '${actionKey}' is not declared on resource '${resourceKey}'`,
+          })
+        }
+      })
+    })
+  })
+
+export const billingProfileSchema = z
+  .object({
+    productKey: z
+      .string()
+      .min(1)
+      .max(100)
+      .regex(/^[a-z0-9][a-z0-9-]*$/, 'must match ^[a-z0-9][a-z0-9-]*$'),
+    currencies: z
+      .array(z.string().regex(/^[a-z]{3}$/, 'must be a lowercase ISO-4217 code'))
+      .optional(),
+    maxTotalCents: z.number().int().min(1).optional(),
+  })
+  .strict()
+
+export type ProductPolicy = z.infer<typeof productPolicySchema>
+export type BillingProfile = z.infer<typeof billingProfileSchema>
+
 export interface ValidationFieldError {
   path: string
   message: string

--- a/backend/applications/src/middleware/consumer-auth.ts
+++ b/backend/applications/src/middleware/consumer-auth.ts
@@ -1,19 +1,56 @@
-// Consumer-registration middleware.
+// Unified app-registry authentication: pre-shared consumer token OR JWT session.
 //
-// Accepts a pre-shared CONSUMER_REGISTRATION_SECRET as a Bearer token on the
-// self-registration routes (POST /apps, POST /apps/:slug/activate). When the
-// token matches, the request is treated as a platform-admin service call —
-// isPlatformAdmin: true in resolveCaller — so all Permit checks are bypassed.
+// The app-registry is called by TWO different kinds of caller and both must work
+// on every route:
 //
-// If the token does NOT match (or CONSUMER_REGISTRATION_SECRET is unset), the
-// middleware passes through to the next handler (normally authenticateToken),
-// so human OIDC sessions still work unchanged on the same route.
+//   1. CONSUMER PRODUCTS (FuzeHub, FuzeSales, …) running `register.sh` as a
+//      Kubernetes init container. They have no human, no OIDC session, and no way
+//      to obtain a JWT — they present the pre-shared CONSUMER_REGISTRATION_SECRET
+//      as a Bearer token. A match is treated as a platform-admin service call
+//      (isPlatformAdmin: true via resolveCaller), so Permit checks are bypassed.
+//
+//   2. HUMANS / ADMIN UI, carrying an Authentik-issued JWT, validated by
+//      authenticateToken from @fuzefront/core.
+//
+// Order matters: the constant-time consumer-secret comparison runs FIRST and only
+// falls through to JWT validation on a miss, so a JWT caller is never charged the
+// secret comparison's failure path and a consumer never hits JWKS.
+//
+// WHY THIS IS ON EVERY ROUTE, NOT JUST POST /apps. register.sh's FIRST call is
+// `GET /apps/:slug` (the idempotency probe: 200 = already registered, 404 =
+// register now) and it re-PUTs the manifest on every redeploy so manifest edits
+// are not frozen at first registration. It also PUTs policy.json and
+// billing-profile.json. With the consumer token accepted on only POST /apps and
+// POST /apps/:slug/activate, the probe 401s and the script's `401|403) die` arm
+// CrashLoopBackOffs the consumer's pod before it ever reaches the register call.
+//
+// FAIL-SAFE: when CONSUMER_REGISTRATION_SECRET is unset (the current prod state —
+// the key is absent from the sealed fuzefront-secrets and the env var is mounted
+// `optional: true`), this degrades to plain JWT auth. That is why every token an
+// operator tried against prod returned 401: there was no secret to match, so the
+// consumer branch was never reachable.
 import type { Request, Response, NextFunction } from 'express'
 import { authenticateToken } from './auth'
 
+// Shaped to satisfy @fuzefront/core's User. `email` is required there; this
+// caller is a service, not a person, so it carries a non-routable sentinel
+// address rather than anything that could collide with a real account.
 const SYNTHETIC_CONSUMER_USER = {
   id: 'consumer-registration',
+  email: 'consumer-registration@fuzefront.invalid',
   roles: ['admin'] as string[],
+}
+
+/**
+ * Length-independent constant-time-ish comparison. Returning early on a length
+ * mismatch leaks only the length, which is not secret; the byte loop below does
+ * not short-circuit, so a correct prefix is not distinguishable by timing.
+ */
+function safeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false
+  let diff = 0
+  for (let i = 0; i < a.length; i++) diff |= a.charCodeAt(i) ^ b.charCodeAt(i)
+  return diff === 0
 }
 
 export function authenticateConsumerOrSession(
@@ -24,10 +61,14 @@ export function authenticateConsumerOrSession(
   const secret = process.env.CONSUMER_REGISTRATION_SECRET
   if (secret) {
     const auth = req.headers.authorization
-    if (auth?.startsWith('Bearer ') && auth.slice(7) === secret) {
+    if (auth?.startsWith('Bearer ') && safeEqual(auth.slice(7), secret)) {
       req.user = SYNTHETIC_CONSUMER_USER
-      return next()
+      next()
+      return
     }
   }
-  return authenticateToken(req as any, res, next)
+  // Not the consumer secret (or none configured) → ordinary JWT session auth.
+  // authenticateToken returns a Response when it rejects; this middleware's
+  // contract is void, so the result is deliberately discarded.
+  void authenticateToken(req as any, res, next)
 }

--- a/backend/applications/src/routes/app-registry.ts
+++ b/backend/applications/src/routes/app-registry.ts
@@ -6,12 +6,16 @@
 //   activateApp, suspendApp, heartbeatApp.
 import express from 'express'
 import { randomBytes } from 'crypto'
-import { authenticateToken } from '../middleware/auth'
+// Every route below uses the unified middleware: pre-shared consumer token first,
+// then JWT session. authenticateToken is no longer referenced directly here — it
+// is reached through authenticateConsumerOrSession's fall-through.
 import { authenticateConsumerOrSession } from '../middleware/consumer-auth'
 import {
   appManifestSchema,
   registerAppRequestSchema,
   heartbeatRequestSchema,
+  productPolicySchema,
+  billingProfileSchema,
   toValidationErrorBody,
 } from '../app-registry/manifest.schema'
 import { appRegistryService, canRead, canMutate } from '../app-registry/service'
@@ -56,7 +60,7 @@ async function v1WriteGate(
 }
 
 // ── GET /apps — listApps ──────────────────────────────────────────────────────
-router.get('/apps', authenticateToken, async (req: any, res) => {
+router.get('/apps', authenticateConsumerOrSession, async (req: any, res) => {
   try {
     const caller = await resolveCaller(req.user)
     const status = req.query.status as any
@@ -164,7 +168,15 @@ router.post('/apps', authenticateConsumerOrSession, async (req: any, res) => {
 })
 
 // ── GET /apps/:slug — getApp ──────────────────────────────────────────────────
-router.get('/apps/:slug', authenticateToken, async (req: any, res) => {
+// authenticateConsumerOrSession, not authenticateToken: this is the FIRST call
+// register.sh makes (the idempotency probe — 200 = already registered, 404 =
+// register now), and it presents the same pre-shared CONSUMER_REGISTRATION_SECRET
+// it later uses for POST /apps. With plain JWT auth here the probe 401s and the
+// script's `401|403) die` arm CrashLoopBackOffs the consumer's pod before it can
+// ever reach the register call. Human OIDC sessions are unaffected — the
+// middleware falls through to authenticateToken when the bearer is not the
+// pre-shared secret.
+router.get('/apps/:slug', authenticateConsumerOrSession, async (req: any, res) => {
   try {
     const caller = await resolveCaller(req.user)
     const app = await appRegistryService.findBySlug(req.params.slug)
@@ -179,7 +191,10 @@ router.get('/apps/:slug', authenticateToken, async (req: any, res) => {
 })
 
 // ── PUT /apps/:slug — updateApp ───────────────────────────────────────────────
-router.put('/apps/:slug', authenticateToken, async (req: any, res) => {
+// Consumer-secret capable for the same reason as GET above: register.sh re-PUTs
+// the manifest on every redeploy so manifest edits (new remoteEntry, changed nav
+// placement) are not frozen at first registration.
+router.put('/apps/:slug', authenticateConsumerOrSession, async (req: any, res) => {
   try {
     const caller = await resolveCaller(req.user)
     const existing = await appRegistryService.findBySlug(req.params.slug)
@@ -235,8 +250,119 @@ router.put('/apps/:slug', authenticateToken, async (req: any, res) => {
   }
 })
 
+// ── onboarding writes: policy + billing profile ───────────────────────────────
+// Both were specified in the contract (putAppPolicy / putAppBillingProfile),
+// covered by tests, and given storage by migration 006 + service.setPolicy /
+// service.setBillingProfile — but the routes themselves were never mounted, so
+// every call 404'd. register.sh treats a non-2xx here as fatal, which meant any
+// product shipping a policy.json could not complete registration at all.
+//
+// Shared preamble: resolve the app, hide invisible apps as 404 (BOLA), apply the
+// release gate, then object-level + Permit apps:write. Returns the app on
+// success, or null when it has already written a response.
+async function resolveForOnboardingWrite(
+  req: any,
+  res: express.Response
+): Promise<{ app: any; caller: any } | null> {
+  const caller = await resolveCaller(req.user)
+  const app = await appRegistryService.findBySlug(req.params.slug)
+  if (!app) {
+    notFound(res)
+    return null
+  }
+  if (!canRead(app, caller)) {
+    notFound(res)
+    return null
+  }
+  if (!(await v1WriteGate(caller, app.organizationId, res))) return null
+  if (!canMutate(app, caller)) {
+    forbidden(res)
+    return null
+  }
+  const permitted = await checkAppRegistryPermission({
+    userId: caller.userId,
+    action: 'apps:write',
+    organizationId: app.organizationId,
+    slug: app.slug,
+  })
+  if (!permitted && !caller.isPlatformAdmin) {
+    forbidden(res, 'Missing apps:write scope')
+    return null
+  }
+  return { app, caller }
+}
+
+// ── PUT /apps/:slug/policy — putAppPolicy ─────────────────────────────────────
+router.put('/apps/:slug/policy', authenticateConsumerOrSession, async (req: any, res) => {
+  try {
+    const resolved = await resolveForOnboardingWrite(req, res)
+    if (!resolved) return
+    const { app } = resolved
+
+    const parsed = productPolicySchema.safeParse(req.body)
+    if (!parsed.success) {
+      return res.status(400).json(toValidationErrorBody((parsed as any).error))
+    }
+    const policy = parsed.data
+
+    // `product` is implied by the path. Honouring a disagreeing body value would
+    // let apps:write on one app install a policy namespaced to a different one.
+    if (policy.product && policy.product !== app.slug) {
+      return res.status(400).json({
+        error: 'validation_error',
+        message: 'policy.product must match the path slug',
+        fields: [{ path: 'product', message: `expected '${app.slug}'` }],
+      })
+    }
+
+    // TODO(platform): storage only. ACCEPTANCE IS NOT PROPAGATION — the roles
+    // declared here stay DENY until the permit-schema sync job reads this column
+    // (FuzeFront backend boot + post-install/post-upgrade Helm job) and pushes
+    // them to Permit. `GET /health` (permit block) reports what the last sync
+    // actually applied. A product registering between syncs is live in the
+    // registry with a policy that is not yet enforced.
+    await appRegistryService.setPolicy(app.slug, policy)
+
+    return res.json({
+      slug: app.slug,
+      resources: policy.resources.length,
+      roles: policy.roles.length,
+    })
+  } catch (err) {
+    console.error('[app-registry] putAppPolicy error:', err)
+    return res.status(500).json({ error: 'internal_error', message: 'Failed to store policy' })
+  }
+})
+
+// ── PUT /apps/:slug/billing-profile — putAppBillingProfile ────────────────────
+router.put('/apps/:slug/billing-profile', authenticateConsumerOrSession, async (req: any, res) => {
+  try {
+    const resolved = await resolveForOnboardingWrite(req, res)
+    if (!resolved) return
+    const { app } = resolved
+
+    const parsed = billingProfileSchema.safeParse(req.body)
+    if (!parsed.success) {
+      return res.status(400).json(toValidationErrorBody((parsed as any).error))
+    }
+    const profile = parsed.data
+
+    // TODO(platform): storage only, same propagation caveat as policy above —
+    // the billing service reads registered profiles to build its productKey
+    // allowlist; a profile stored here is not accepted at checkout until it does.
+    await appRegistryService.setBillingProfile(app.slug, profile)
+
+    return res.json(profile)
+  } catch (err) {
+    console.error('[app-registry] putAppBillingProfile error:', err)
+    return res
+      .status(500)
+      .json({ error: 'internal_error', message: 'Failed to store billing profile' })
+  }
+})
+
 // ── DELETE /apps/:slug — deleteApp ────────────────────────────────────────────
-router.delete('/apps/:slug', authenticateToken, async (req: any, res) => {
+router.delete('/apps/:slug', authenticateConsumerOrSession, async (req: any, res) => {
   try {
     const caller = await resolveCaller(req.user)
     const existing = await appRegistryService.findBySlug(req.params.slug)
@@ -276,7 +402,7 @@ router.post('/apps/:slug/activate', authenticateConsumerOrSession, (req, res) =>
 )
 
 // ── POST /apps/:slug/suspend — suspendApp ─────────────────────────────────────
-router.post('/apps/:slug/suspend', authenticateToken, (req, res) =>
+router.post('/apps/:slug/suspend', authenticateConsumerOrSession, (req, res) =>
   transition(req as any, res, 'suspended')
 )
 

--- a/deploy/helm/fuzefront/values-prod.yaml
+++ b/deploy/helm/fuzefront/values-prod.yaml
@@ -325,6 +325,21 @@ secret:
   # this PR stays a config change rather than a template change.
   litellmMasterKey: "managed-by-sealed-secret"
 
+  # GATE ONLY — same pattern as litellmMasterKey above. Because existingSecret is
+  # set, templates/secret.yaml never renders and this value goes nowhere; the real
+  # credential is the CONSUMER_REGISTRATION_SECRET entry in the sealed
+  # `fuzefront-secrets`. What this key actually switches on is
+  # templates/consumer-registration-seed-job.yaml + -rbac.yaml, both wrapped in
+  # `{{- if .Values.secret.consumerRegistrationSecret }}`. Without it the seed Job
+  # does not render at all, so Secret/fuzefront-registration is never published in
+  # this namespace and consuming products (FuzeHub, FuzeSales, …) have nothing to
+  # read, seal, and commit for their own namespace.
+  #
+  # The Job mounts the key from the existing sealed Secret with `optional: true`
+  # and exits 0 with a diagnostic if it is absent, so rendering it before the
+  # sealed key lands is safe — it just no-ops until then.
+  consumerRegistrationSecret: "managed-by-sealed-secret"
+
 # Exposure model (verified against the LIVE cluster, 2026-06-23): prod is reached
 # via the Cloudflare tunnel "FuzeInfra" -> k3s Traefik (default ingress, NOT
 # disabled) -> standard Ingress host-routing. Cloudflare terminates TLS at the

--- a/docs/mfe-self-registration.md
+++ b/docs/mfe-self-registration.md
@@ -85,13 +85,80 @@ or see.
 
 ## Auth token
 
-`FUZEFRONT_REGISTRATION_TOKEN` is a Bearer JWT for a service account with `apps:register`
-scope. Same format as `SEED_API_TOKEN`. Create one service-level token and seal it
-into a `fuzefront-registration` SealedSecret in each MFE's namespace:
+`FUZEFRONT_REGISTRATION_TOKEN` is a **static pre-shared string**. It is not a JWT, it
+is not issued per-product, and there is no service-account system behind it — there is
+nothing to "create a service account with `apps:register` scope" in, and no admin UI
+that mints one. (An earlier version of this page said otherwise. It was wrong, and it
+cost a consuming product a day of probing platform secrets that could never have
+worked.)
+
+The value is **one platform-wide secret**, `CONSUMER_REGISTRATION_SECRET`. The registry
+compares the incoming Bearer against it in
+`backend/applications/src/middleware/consumer-auth.ts`; on a match the request is
+treated as a platform-admin service call and Permit checks are bypassed. On a miss it
+falls through to ordinary Authentik JWT validation, so human sessions are unaffected.
+That single middleware is applied to **every** `/api/v1/app-registry` route, because
+`register.sh` calls `GET`, `POST`, and `PUT` in the course of one registration.
+
+Because it is one shared credential that grants platform-admin on the registry,
+rotating it invalidates every consumer at once — see "Rotation" below.
+
+### 1. Platform side (once per cluster)
+
+Seal the value into `fuzefront-secrets` and enable the seed Job that publishes it.
 
 ```bash
-kubectl create secret generic fuzefront-registration \
-  --namespace=fuzesales \
-  --from-literal=token=<PLATFORM_REGISTRATION_TOKEN> \
-  --dry-run=client -o yaml | kubeseal > sealed-fuzefront-registration.yaml
+# Generate and seal. Plaintext never touches git, chat, or shell history —
+# seal-secret.sh prompts hidden and merges in place, preserving other keys.
+openssl rand -hex 32 | deploy/scripts/seal-secret.sh \
+  CONSUMER_REGISTRATION_SECRET --scope fuzefront/fuzefront-secrets --in -
 ```
+
+`deploy/helm/fuzefront/values-prod.yaml` must also carry
+`secret.consumerRegistrationSecret` (any non-empty placeholder — with
+`secret.existingSecret` set, `templates/secret.yaml` never renders, so the value is a
+**render gate only**). Without it,
+`templates/consumer-registration-seed-job.yaml` and its RBAC do not render at all and
+step 2 has nothing to read.
+
+### 2. Distribution to a consuming product
+
+The `consumer-registration-seed` Job (post-install/post-upgrade) copies the value into
+`Secret/fuzefront-registration`, key `token`, in the **`fuzefront`** namespace. That
+secret is the published hand-off point: a consumer's CI reads it, re-seals it for its
+own namespace, and commits the SealedSecret.
+
+```bash
+# In the consuming product's provisioning workflow (needs read on that one secret):
+TOKEN=$(kubectl -n fuzefront get secret fuzefront-registration \
+  -o jsonpath='{.data.token}' | base64 -d)
+
+kubectl create secret generic fuzefront-registration \
+  --namespace=fuzehub --from-literal=token="$TOKEN" \
+  --dry-run=client -o yaml | kubeseal --format yaml > sealed-fuzefront-registration.yaml
+```
+
+Do **not** probe `fuzefront-secrets` for a likely-looking key. `JWT_SECRET`,
+`SESSION_SECRET`, `AUTHENTIK_BOOTSTRAP_TOKEN`, `INTERNAL_PROVISION_SECRET`,
+`PERMIT_API_KEY` and `AUTHENTIK_SECRET_KEY` all 401 here by design — none of them is
+this credential.
+
+### Diagnosing a 401
+
+If every token 401s, the usual cause is that `CONSUMER_REGISTRATION_SECRET` is **unset
+on the applications pod**. It is mounted `optional: true`
+(`deploy/helm/fuzefront/templates/applications.yaml`), so the pod starts healthy
+without it and the consumer branch is simply never reachable — the middleware degrades
+to JWT-only and rejects every static token. Check:
+
+```bash
+kubectl -n fuzefront get secret fuzefront-secrets \
+  -o jsonpath='{.data.CONSUMER_REGISTRATION_SECRET}' | wc -c   # 0 = not sealed yet
+```
+
+### Rotation
+
+Re-seal the key, `helm upgrade` (which re-runs the seed Job), then re-run each
+consumer's provisioning workflow. Consumers keep working on the old value until their
+own SealedSecret is refreshed, so rotate the platform first and the consumers promptly
+after — a consumer whose pod restarts in between will fail its init container.


### PR DESCRIPTION
Consuming products (FuzeHub, FuzeSales, …) cannot self-register today: **every** token returns 401 on `/api/v1/app-registry`. This is three separate defects on one path, plus an operational gap.

## Root cause of the 401s

`CONSUMER_REGISTRATION_SECRET` **does not exist in prod.** It is absent from the sealed `fuzefront-secrets` (22 keys, not one of them), and `applications.yaml` mounts it `optional: true` — so the pod starts perfectly healthy with the env var unset, `consumer-auth.ts`'s `if (secret)` is false, and every request silently degrades to JWT-only auth. That is why `AUTHENTIK_BOOTSTRAP_TOKEN`, `INTERNAL_PROVISION_SECRET`, `JWT_SECRET`, `SESSION_SECRET`, `PERMIT_API_KEY` and `AUTHENTIK_SECRET_KEY` all 401 — none of them is the credential, and there was no credential to match.

## What changed

**1. Auth was applied inconsistently → now unified on every route.**

`authenticateConsumerOrSession` (pre-shared secret first, then Authentik JWT) was mounted on only `POST /apps` and `POST /apps/:slug/activate`. But `register.sh`'s *first* call is `GET /apps/:slug` — the idempotency probe — and it re-`PUT`s the manifest on every redeploy. Both were JWT-only, so the probe 401s and the script's `401|403) die` arm CrashLoopBackOffs the consumer's pod **before it ever reaches the register call**. Even a perfectly correct token could not have worked.

All registry routes now use the one middleware (`GET /apps`, `GET /apps/:slug`, `POST /apps`, `PUT /apps/:slug`, both onboarding PUTs, `DELETE`, `activate`, `suspend`). `heartbeat` is left alone — it has its own per-app token scheme.

**2. `PUT /apps/:slug/policy` and `PUT /apps/:slug/billing-profile` did not exist.**

They were specified in the frozen contract (`putAppPolicy`/`putAppBillingProfile`), covered by an already-written test suite, and given storage by migration 006 plus `service.setPolicy`/`setBillingProfile`. Only the routes were missing — so every call 404'd, and `register.sh` treats a non-2xx there as fatal. Any product shipping a `policy.json` (FuzeHub does) could not complete registration.

Since the storage layer was already present, these are **implemented against the existing tests rather than stubbed** — a stub returning `200 {}` on an *authorization* endpoint would discard the product's policy while telling it "authz policy submitted", which is precisely the half-registered-but-serving state the init-container design exists to prevent. Added: zod `ProductPolicy`/`BillingProfile` schemas mirroring the OpenAPI doc, path-vs-body `product` agreement (otherwise `apps:write` on one app installs a policy namespaced to another), and the contract's referential-integrity rule — a permission naming an undeclared resource/action is rejected at deploy instead of shipping a role that silently grants nothing.

Both carry a `TODO(platform)` noting **acceptance is not propagation**: stored policies stay DENY until the permit-schema sync job runs.

**3. `consumer-auth.ts` did not compile.**

`SYNTHETIC_CONSUMER_USER` was missing the required `email` field, and the `authenticateToken` fall-through returned a value from a `void` function. Two TS errors that took the entire `app-registry.routes` suite down before it ran a single test — which is why none of the above was caught. Also swapped the secret comparison to a non-short-circuiting one.

**4. Prod render gate.** `values-prod.yaml` now sets `secret.consumerRegistrationSecret` (gate only — with `existingSecret` set, `templates/secret.yaml` never renders, same pattern as `litellmMasterKey`). Without it `consumer-registration-seed-job.yaml` and its RBAC **do not render at all**, so `Secret/fuzefront-registration` is never published and consumers have nothing to read. The Job mounts the key `optional: true` and no-ops with a diagnostic if the sealed key is not there yet, so merging this before the value is sealed is safe.

**5. Docs.** `docs/mfe-self-registration.md` said the token is "a Bearer JWT for a service account with `apps:register` scope". That is false in every particular — it is a static pre-shared string, there is no service-account system, and no admin UI mints one. That sentence sent a consuming product on a day of probing platform secrets that could never have worked. Rewritten to cover the real mechanism, the seed-Job hand-off, how to diagnose a 401, and rotation.

## Verification

- `app-registry.routes.test.ts`: **48/48 passing** (suite previously failed to compile).
- `tsc --noEmit`: clean.
- `app-registry.unit.test.ts` still fails to compile on an unrelated pre-existing zod `SafeParse` narrowing error at line 107 — **identical on master**, left alone.
- `helm template` not run: no helm binary and the proxy blocks `get.helm.sh`. The change is a truthy value behind an `{{- if }}`; `helm-validate.yml` will cover it here.

## ⚠️ Not done — needs a human with cluster access

**The `CONSUMER_REGISTRATION_SECRET` value is not sealed.** `deploy/contabo/sealed/fuzefront-secrets.yaml` is deliberately untouched: sealing needs the cluster's public cert and this environment cannot reach `sealed-secrets.prod.fuzefront.com` (proxy 403). Committing a fabricated ciphertext blob would make the controller fail to decrypt **the whole SealedSecret**, taking down every service that reads `DB_PASSWORD`/`JWT_SECRET` — a prod outage, so it was not attempted.

Run this before/with the merge:

```bash
openssl rand -hex 32 | deploy/scripts/seal-secret.sh \
  CONSUMER_REGISTRATION_SECRET --scope fuzefront/fuzefront-secrets --in -
```

Until that lands, this PR is inert-but-safe: auth is unified and the routes exist, the seed Job renders and no-ops, and registration still 401s exactly as it does today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tz5rsgiCNXDEJ7dY1kBfkp

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tz5rsgiCNXDEJ7dY1kBfkp)_