### PR TITLE
fix(chart): restore NetworkPolicy port/namespace values dropped by #523 (unblocks all prod deploys)

### DIFF
--- a/deploy/helm/fuzefront/templates/authentik-networkpolicy.yaml
+++ b/deploy/helm/fuzefront/templates/authentik-networkpolicy.yaml
@@ -21,6 +21,12 @@
 */}}
 {{- if and .Values.authentik.enabled .Values.authentik.networkPolicy.enabled }}
 {{- $np := .Values.authentik.networkPolicy }}
+{{- /* Every $np lookup below carries an inline `default`. An invalid NetworkPolicy
+     (e.g. `port: 0` from a missing value) is rejected by the API server and fails the
+     ENTIRE Argo sync of this application, so no Deployment rolls — which is exactly how
+     a values.yaml rewrite that dropped these keys froze prod for days (FuzeInfra#501).
+     A defaulted-but-wrong policy has a blast radius of one policy; an unrenderable one
+     stops every deploy. Keep the defaults in sync with values.yaml. */}}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -40,23 +46,23 @@ spec:
     - from:
         - namespaceSelector:
             matchLabels:
-              kubernetes.io/metadata.name: {{ $np.ingressControllerNamespace | quote }}
+              kubernetes.io/metadata.name: {{ $np.ingressControllerNamespace | default "kube-system" | quote }}
       ports:
         - protocol: TCP
-          port: {{ $np.port | int }}
+          port: {{ $np.port | default 9000 | int }}
     # Intra-fuzefront: any pod in this namespace (backend/security OIDC discovery, etc.).
     - from:
         - podSelector: {}
       ports:
         - protocol: TCP
-          port: {{ $np.port | int }}
+          port: {{ $np.port | default 9000 | int }}
     # NEW — the reason this policy exists: fuzeagent A2A pods fetch JWKS/discovery
     # in-cluster (avoids the Cloudflare-tunnel hairpin timeout).
     - from:
         - namespaceSelector:
             matchLabels:
-              kubernetes.io/metadata.name: {{ $np.fuzeagentNamespace | quote }}
+              kubernetes.io/metadata.name: {{ $np.fuzeagentNamespace | default "fuzeagent" | quote }}
       ports:
         - protocol: TCP
-          port: {{ $np.port | int }}
+          port: {{ $np.port | default 9000 | int }}
 {{- end }}

--- a/deploy/helm/fuzefront/templates/security-networkpolicy.yaml
+++ b/deploy/helm/fuzefront/templates/security-networkpolicy.yaml
@@ -25,6 +25,12 @@
 */}}
 {{- if and .Values.securityService.enabled .Values.securityService.networkPolicy.enabled }}
 {{- $np := .Values.securityService.networkPolicy }}
+{{- /* Every $np lookup below carries an inline `default`. An invalid NetworkPolicy
+     (e.g. `port: 0` from a missing value) is rejected by the API server and fails the
+     ENTIRE Argo sync of this application, so no Deployment rolls — which is exactly how
+     a values.yaml rewrite that dropped these keys froze prod for days (FuzeInfra#501).
+     A defaulted-but-wrong policy has a blast radius of one policy; an unrenderable one
+     stops every deploy. Keep the defaults in sync with values.yaml. */}}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -45,24 +51,24 @@ spec:
     - from:
         - namespaceSelector:
             matchLabels:
-              kubernetes.io/metadata.name: {{ $np.ingressControllerNamespace | quote }}
+              kubernetes.io/metadata.name: {{ $np.ingressControllerNamespace | default "kube-system" | quote }}
       ports:
         - protocol: TCP
-          port: {{ $np.port | int }}
+          port: {{ $np.port | default 3002 | int }}
     # Intra-fuzefront: any pod in this namespace (e.g. provisioning-service's
     # server-side session verification call).
     - from:
         - podSelector: {}
       ports:
         - protocol: TCP
-          port: {{ $np.port | int }}
+          port: {{ $np.port | default 3002 | int }}
     # NEW — the reason this policy exists: mendys-prod's datasets-service
     # authenticates against fuzefront-security in-cluster.
     - from:
         - namespaceSelector:
             matchLabels:
-              kubernetes.io/metadata.name: {{ $np.mendysProdNamespace | quote }}
+              kubernetes.io/metadata.name: {{ $np.mendysProdNamespace | default "mendys-prod" | quote }}
       ports:
         - protocol: TCP
-          port: {{ $np.port | int }}
+          port: {{ $np.port | default 3002 | int }}
 {{- end }}

--- a/deploy/helm/fuzefront/values.yaml
+++ b/deploy/helm/fuzefront/values.yaml
@@ -176,8 +176,23 @@ backend:
 # values-local (Phases 1-3) and values-prod (Phase 3) once the images are built.
 securityService:
   enabled: false
+  # See templates/security-networkpolicy.yaml. port/*Namespace were dropped by the
+  # values.yaml rewrite in 8dedb865 (#523) and are restored here — without them the
+  # template renders `port: 0`, which the API server rejects (FuzeInfra#501).
+  # NOTE: #497 shipped this default-ON; 8dedb865 also flipped it to false. It is
+  # left OFF here deliberately: the policy has never actually been applied in prod
+  # (Argo syncs were already failing when #497 landed), so enabling it is a
+  # separate deploy-window change, not part of an outage fix. See FuzeInfra#501.
   networkPolicy:
     enabled: false
+    port: 3002
+    # Namespace where Traefik (k3s ingress) runs — source of the
+    # /api/v1/security, /api/auth, /api/organizations, /api/internal
+    # reverse-proxy path (ingress.yaml routes directly to this Service).
+    ingressControllerNamespace: kube-system
+    # mendys-prod's datasets-service authenticates against this Service
+    # in-cluster (session verify + authz check/grants). Issue: FuzeFront#493.
+    mendysProdNamespace: mendys-prod
   image:
     repository: fuzefront/security-service
     tag: local
@@ -571,8 +586,21 @@ authentik:
     className: ""
     host: ""
     annotations: {}
+  # Default OFF so a chart bump alone can never flip the policy on unverified. Enable
+  # in a deploy window and verify BOTH (a) a fuzeagent pod can curl authentik-server
+  # and (b) the Authentik login UI via the tunnel still works. See values-prod.yaml.
+  #
+  # port/*Namespace were dropped by the values.yaml rewrite in 8dedb865 (#523) and
+  # are restored here. values-prod.yaml sets enabled: true, so without them the
+  # template rendered `port: 0` — rejected by the API server, which failed every
+  # Argo sync of the whole application for days (FuzeInfra#501). Do not remove.
   networkPolicy:
     enabled: false
+    port: 9000
+    # Namespace where Traefik (k3s ingress) runs — source of the login-UI proxy path.
+    ingressControllerNamespace: kube-system
+    # Namespace whose pods may reach authentik-server in-cluster (A2A JWKS fetch).
+    fuzeagentNamespace: fuzeagent
   # Placement for the Authentik server + worker (empty → global.scheduling).
   nodeSelector: {}
   affinity: {}


### PR DESCRIPTION
Fixes the root cause behind **FuzeInfra#501** — "Argo is not rolling FuzeFront prod; releases have shipped nothing for days".

## Root cause

Commit `8dedb865` (#523, *"automated MFE self-registration token bootstrap"*) rewrote `deploy/helm/fuzefront/values.yaml` wholesale — **+141 / −397** in a commit whose stated purpose had nothing to do with values hygiene. Comments were stripped, keys reordered, and several keys **deleted**, including:

| block | keys deleted |
|---|---|
| `authentik.networkPolicy` | `port: 9000`, `ingressControllerNamespace: kube-system`, `fuzeagentNamespace: fuzeagent` |
| `securityService.networkPolicy` | `port: 3002`, `ingressControllerNamespace: kube-system`, `mendysProdNamespace: mendys-prod` — and `enabled` flipped `true` → `false` |

`values-prod.yaml` sets `authentik.networkPolicy.enabled: true`, so `templates/authentik-networkpolicy.yaml` then rendered `port: {{ $np.port | int }}` with `$np.port` nil:

```
port: 0
```

which the API server rejects:

```
NetworkPolicy.networking.k8s.io "authentik-server-ingress" is invalid:
[spec.ingress[0].ports[0].port: Invalid value: 0: must be between 1 and 65535, inclusive, ...]
```

**One invalid manifest fails the sync of the entire Application**, and Argo's automated-sync guard then makes it sticky per revision:

```
Skipping auto-sync: failed previous sync attempt to [6cdbd287…] and will not retry for [6cdbd287…]
```

So every subsequent release built images, pushed to GHCR, committed the `values-prod.yaml` tag bump, reported green — and shipped nothing.

## The change

1. **Restore the deleted values.** The restored authentik values are verified byte-identical in effect to the policy live in prod today (`kube-system` / intra-namespace / `fuzeagent`, TCP 9000) — this is a no-op against the running cluster, not a behaviour change.
2. **Give every `$np` lookup an inline `default`** in both NetworkPolicy templates. Rationale in the template comment: a defaulted-but-wrong policy has a blast radius of one policy; an *unrenderable* one stops every deploy in the application. A values edit must not be able to do that again.

## Deliberately NOT changed

`securityService.networkPolicy.enabled` stays `false`, even though `8dedb865` is what flipped it off. That policy (#497, landed 2026-08-02) has **never actually been applied in prod** — Argo syncs were already failing when it merged, and `kubectl -n fuzefront get netpol` shows only `authentik-server-ingress`. Turning it on would create a new default-deny surface on `fuzefront-security` and belongs in its own verified deploy window, not bundled into an outage fix. Flagged so it is not lost.

## Verification

- `helm template fuzefront . -f values-prod.yaml` → all three ingress rules render `port: 9000` (was `port: 0`).
- `kubectl -n fuzefront apply --dry-run=server` of the rendered policy against **prod** → `networkpolicy.networking.k8s.io/authentik-server-ingress configured` — accepted, and a no-op diff versus live.

## Out of scope — NOT fixed here, filed separately

- The rest of the `8dedb865` values.yaml rewrite damage (lost comments/reordering) is untouched; reverting the file wholesale would undo the legitimate #523 changes.
- Two live prod workload failures unrelated to this defect, which will surface once syncs pass: `fuzefront-chat-service` CrashLoopBackOff (`MODULE_NOT_FOUND` at `dist/billing/emitter.js`) and a `fuzefront-applications` ReplicaSet in ImagePullBackOff.
- The false-green health gate in `prod-post-deploy.yml` (asserts only HTTP 200, so it passes against a pod that never rolled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
