### PR TITLE
feat(ci): seal-consumer-secret workflow for app-registry auth

### DIFF
--- a/.github/workflows/seal-consumer-secret.yml
+++ b/.github/workflows/seal-consumer-secret.yml
@@ -1,0 +1,118 @@
+name: Seal CONSUMER_REGISTRATION_SECRET
+
+# Generates and seals a CONSUMER_REGISTRATION_SECRET value into
+# deploy/contabo/sealed/fuzefront-secrets.yaml and commits it.
+#
+# Run ONCE after first cluster setup (or to rotate the secret).
+# Requires: KUBE_CONFIG repo secret (base64 kubeconfig for the Contabo k3s cluster).
+#
+# Safety: sealing merges only the CONSUMER_REGISTRATION_SECRET key into the
+# existing SealedSecret — every other key (DB_PASSWORD, JWT_SECRET, etc.)
+# is preserved. A wrong ciphertext for ONE key does not take down the whole
+# Secret: sealed-secrets decrypts each key independently.
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Print sealed YAML to log without committing"
+        required: false
+        default: "false"
+        type: choice
+        options: ["false", "true"]
+
+permissions:
+  contents: write
+
+jobs:
+  seal:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check if already sealed
+        id: check
+        run: |
+          if grep -q 'CONSUMER_REGISTRATION_SECRET' deploy/contabo/sealed/fuzefront-secrets.yaml 2>/dev/null; then
+            echo "already_sealed=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::CONSUMER_REGISTRATION_SECRET already present in fuzefront-secrets.yaml — skipping"
+          else
+            echo "already_sealed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up kubectl
+        if: steps.check.outputs.already_sealed == 'false'
+        uses: azure/setup-kubectl@v4
+
+      - name: Write kubeconfig
+        if: steps.check.outputs.already_sealed == 'false'
+        run: |
+          mkdir -p ~/.kube
+          echo "${{ secrets.KUBE_CONFIG }}" | base64 -d > ~/.kube/config
+          chmod 600 ~/.kube/config
+
+      - name: Install kubeseal
+        if: steps.check.outputs.already_sealed == 'false'
+        run: |
+          KSVER=0.27.3
+          curl -sSL \
+            "https://github.com/bitnami-labs/sealed-secrets/releases/download/v${KSVER}/kubeseal-${KSVER}-linux-amd64.tar.gz" \
+            | tar xz -C /usr/local/bin kubeseal
+          kubeseal --version
+
+      - name: Generate and seal secret
+        if: steps.check.outputs.already_sealed == 'false'
+        id: seal
+        run: |
+          SECRET_VALUE=$(openssl rand -hex 32)
+          printf '%s' "$SECRET_VALUE" > /tmp/consumer-reg-secret.txt
+
+          # Fetch the cluster's current public cert (no decrypt key needed)
+          kubeseal --fetch-cert \
+            --controller-namespace kube-system \
+            --controller-name sealed-secrets-controller \
+            > /tmp/sealed-secrets-cert.pem
+          echo "::notice::Fetched sealed-secrets public cert"
+
+          # Seal and merge into the existing SealedSecret (preserves all other keys)
+          kubectl create secret generic fuzefront-secrets \
+            -n fuzefront \
+            --from-file=CONSUMER_REGISTRATION_SECRET=/tmp/consumer-reg-secret.txt \
+            --dry-run=client -o yaml \
+          | kubeseal \
+              --cert /tmp/sealed-secrets-cert.pem \
+              --format yaml \
+              --merge-into deploy/contabo/sealed/fuzefront-secrets.yaml
+
+          echo "::notice::CONSUMER_REGISTRATION_SECRET sealed and merged"
+          rm -f /tmp/consumer-reg-secret.txt
+
+      - name: Show diff (dry run)
+        if: steps.check.outputs.already_sealed == 'false' && inputs.dry_run == 'true'
+        run: |
+          git diff deploy/contabo/sealed/fuzefront-secrets.yaml
+
+      - name: Commit sealed secret
+        if: steps.check.outputs.already_sealed == 'false' && inputs.dry_run == 'false'
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add deploy/contabo/sealed/fuzefront-secrets.yaml
+          git commit -m "feat(secrets): seal consumer-registration-secret for app-registry auth"
+          git push origin HEAD:master
+          echo "::notice::Committed to master — ArgoCD will sync within ~60s"
+
+      - name: Summary
+        run: |
+          echo "## Result" >> "$GITHUB_STEP_SUMMARY"
+          if [ "${{ steps.check.outputs.already_sealed }}" = "true" ]; then
+            echo "- Already present — no action taken" >> "$GITHUB_STEP_SUMMARY"
+          elif [ "${{ inputs.dry_run }}" = "true" ]; then
+            echo "- Dry run — sealed YAML NOT committed (see diff in step output)" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "- Sealed and committed to master" >> "$GITHUB_STEP_SUMMARY"
+            echo "- ArgoCD syncs fuzefront-secrets within ~60s" >> "$GITHUB_STEP_SUMMARY"
+            echo "- Once the pod restarts with CONSUMER_REGISTRATION_SECRET set, FuzeHub can self-register" >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/seal-consumer-secret.yml
+++ b/.github/workflows/seal-consumer-secret.yml
@@ -28,7 +28,7 @@ jobs:
   seal:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608  # v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -44,7 +44,7 @@ jobs:
 
       - name: Set up kubectl
         if: steps.check.outputs.already_sealed == 'false'
-        uses: azure/setup-kubectl@v4
+        uses: azure/setup-kubectl@3e0aec4d80787158d6fc5badc4a6d671057d7b45  # v4
 
       - name: Write kubeconfig
         if: steps.check.outputs.already_sealed == 'false'
@@ -105,11 +105,14 @@ jobs:
           echo "::notice::Committed to master — ArgoCD will sync within ~60s"
 
       - name: Summary
+        env:
+          ALREADY_SEALED: ${{ steps.check.outputs.already_sealed }}
+          DRY_RUN: ${{ inputs.dry_run }}
         run: |
           echo "## Result" >> "$GITHUB_STEP_SUMMARY"
-          if [ "${{ steps.check.outputs.already_sealed }}" = "true" ]; then
+          if [ "$ALREADY_SEALED" = "true" ]; then
             echo "- Already present — no action taken" >> "$GITHUB_STEP_SUMMARY"
-          elif [ "${{ inputs.dry_run }}" = "true" ]; then
+          elif [ "$DRY_RUN" = "true" ]; then
             echo "- Dry run — sealed YAML NOT committed (see diff in step output)" >> "$GITHUB_STEP_SUMMARY"
           else
             echo "- Sealed and committed to master" >> "$GITHUB_STEP_SUMMARY"

--- a/backend/applications/src/app-registry/manifest.schema.ts
+++ b/backend/applications/src/app-registry/manifest.schema.ts
@@ -169,6 +169,102 @@ export const heartbeatRequestSchema = z
   })
   .strict()
 
+// ── onboarding: ProductPolicy / BillingProfile ────────────────────────────────
+// 1:1 with the ProductPolicy / BillingProfile schemas in
+// services/app-registry-service/openapi.yaml. Keys are BARE here on purpose —
+// the platform namespaces them by slug (`Listing` → `<slug>_Listing`) at merge
+// time, so `_` is reserved as the namespace separator and rejected in keys.
+const bareKeySchema = z
+  .string()
+  .regex(
+    /^[A-Za-z][A-Za-z0-9-]*$/,
+    'must be a bare key ([A-Za-z][A-Za-z0-9-]*) — `_` is the namespace separator'
+  )
+
+export const productResourceDeclSchema = z
+  .object({
+    key: bareKeySchema,
+    name: z.string(),
+    actions: z.record(z.string(), z.object({ name: z.string() }).strict()),
+  })
+  .strict()
+
+export const productRoleDeclSchema = z
+  .object({
+    key: bareKeySchema,
+    name: z.string(),
+    permissions: z.array(
+      z
+        .string()
+        .regex(
+          /^[A-Za-z][A-Za-z0-9-]*:[A-Za-z][A-Za-z0-9_-]*$/,
+          'must be `<BareResource>:<action>`'
+        )
+    ),
+  })
+  .strict()
+
+export const productPolicySchema = z
+  .object({
+    // Implied by the path slug. Accepted in the body only so a product can be
+    // explicit; the route rejects it when it disagrees with the path — otherwise
+    // write access to one app would install a policy namespaced to another.
+    product: slugSchema.optional(),
+    name: z.string().optional(),
+    resources: z.array(productResourceDeclSchema),
+    roles: z.array(productRoleDeclSchema),
+  })
+  .strict()
+  // Referential integrity, per the contract: "Every referenced resource/action
+  // must exist in this same document." A permission naming an undeclared
+  // resource or action does not fail at sync time — it namespaces cleanly to
+  // `<slug>_Listing:delete` and is simply never matched by anything, so the role
+  // silently grants nothing. Catching it at deploy turns an invisible authz hole
+  // into a registration failure the product team can see.
+  .superRefine((policy, ctx) => {
+    const declared = new Map(
+      policy.resources.map(r => [r.key, new Set(Object.keys(r.actions))])
+    )
+    policy.roles.forEach((role, roleIndex) => {
+      role.permissions.forEach((permission, permIndex) => {
+        const [resourceKey, actionKey] = permission.split(':')
+        const actions = declared.get(resourceKey)
+        if (!actions) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ['roles', roleIndex, 'permissions', permIndex],
+            message: `resource '${resourceKey}' is not declared in this policy`,
+          })
+          return
+        }
+        if (!actions.has(actionKey)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ['roles', roleIndex, 'permissions', permIndex],
+            message: `action '${actionKey}' is not declared on resource '${resourceKey}'`,
+          })
+        }
+      })
+    })
+  })
+
+export const billingProfileSchema = z
+  .object({
+    productKey: z
+      .string()
+      .min(1)
+      .max(100)
+      .regex(/^[a-z0-9][a-z0-9-]*$/, 'must match ^[a-z0-9][a-z0-9-]*$'),
+    currencies: z
+      .array(z.string().regex(/^[a-z]{3}$/, 'must be a lowercase ISO-4217 code'))
+      .optional(),
+    maxTotalCents: z.number().int().min(1).optional(),
+  })
+  .strict()
+
+export type ProductPolicy = z.infer<typeof productPolicySchema>
+export type BillingProfile = z.infer<typeof billingProfileSchema>
+
 export interface ValidationFieldError {
   path: string
   message: string

--- a/backend/applications/src/middleware/consumer-auth.ts
+++ b/backend/applications/src/middleware/consumer-auth.ts
@@ -1,19 +1,56 @@
-// Consumer-registration middleware.
+// Unified app-registry authentication: pre-shared consumer token OR JWT session.
 //
-// Accepts a pre-shared CONSUMER_REGISTRATION_SECRET as a Bearer token on the
-// self-registration routes (POST /apps, POST /apps/:slug/activate). When the
-// token matches, the request is treated as a platform-admin service call —
-// isPlatformAdmin: true in resolveCaller — so all Permit checks are bypassed.
+// The app-registry is called by TWO different kinds of caller and both must work
+// on every route:
 //
-// If the token does NOT match (or CONSUMER_REGISTRATION_SECRET is unset), the
-// middleware passes through to the next handler (normally authenticateToken),
-// so human OIDC sessions still work unchanged on the same route.
+//   1. CONSUMER PRODUCTS (FuzeHub, FuzeSales, …) running `register.sh` as a
+//      Kubernetes init container. They have no human, no OIDC session, and no way
+//      to obtain a JWT — they present the pre-shared CONSUMER_REGISTRATION_SECRET
+//      as a Bearer token. A match is treated as a platform-admin service call
+//      (isPlatformAdmin: true via resolveCaller), so Permit checks are bypassed.
+//
+//   2. HUMANS / ADMIN UI, carrying an Authentik-issued JWT, validated by
+//      authenticateToken from @fuzefront/core.
+//
+// Order matters: the constant-time consumer-secret comparison runs FIRST and only
+// falls through to JWT validation on a miss, so a JWT caller is never charged the
+// secret comparison's failure path and a consumer never hits JWKS.
+//
+// WHY THIS IS ON EVERY ROUTE, NOT JUST POST /apps. register.sh's FIRST call is
+// `GET /apps/:slug` (the idempotency probe: 200 = already registered, 404 =
+// register now) and it re-PUTs the manifest on every redeploy so manifest edits
+// are not frozen at first registration. It also PUTs policy.json and
+// billing-profile.json. With the consumer token accepted on only POST /apps and
+// POST /apps/:slug/activate, the probe 401s and the script's `401|403) die` arm
+// CrashLoopBackOffs the consumer's pod before it ever reaches the register call.
+//
+// FAIL-SAFE: when CONSUMER_REGISTRATION_SECRET is unset (the current prod state —
+// the key is absent from the sealed fuzefront-secrets and the env var is mounted
+// `optional: true`), this degrades to plain JWT auth. That is why every token an
+// operator tried against prod returned 401: there was no secret to match, so the
+// consumer branch was never reachable.
 import type { Request, Response, NextFunction } from 'express'
 import { authenticateToken } from './auth'
 
+// Shaped to satisfy @fuzefront/core's User. `email` is required there; this
+// caller is a service, not a person, so it carries a non-routable sentinel
+// address rather than anything that could collide with a real account.
 const SYNTHETIC_CONSUMER_USER = {
   id: 'consumer-registration',
+  email: 'consumer-registration@fuzefront.invalid',
   roles: ['admin'] as string[],
+}
+
+/**
+ * Length-independent constant-time-ish comparison. Returning early on a length
+ * mismatch leaks only the length, which is not secret; the byte loop below does
+ * not short-circuit, so a correct prefix is not distinguishable by timing.
+ */
+function safeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false
+  let diff = 0
+  for (let i = 0; i < a.length; i++) diff |= a.charCodeAt(i) ^ b.charCodeAt(i)
+  return diff === 0
 }
 
 export function authenticateConsumerOrSession(
@@ -24,10 +61,14 @@ export function authenticateConsumerOrSession(
   const secret = process.env.CONSUMER_REGISTRATION_SECRET
   if (secret) {
     const auth = req.headers.authorization
-    if (auth?.startsWith('Bearer ') && auth.slice(7) === secret) {
+    if (auth?.startsWith('Bearer ') && safeEqual(auth.slice(7), secret)) {
       req.user = SYNTHETIC_CONSUMER_USER
-      return next()
+      next()
+      return
     }
   }
-  return authenticateToken(req as any, res, next)
+  // Not the consumer secret (or none configured) → ordinary JWT session auth.
+  // authenticateToken returns a Response when it rejects; this middleware's
+  // contract is void, so the result is deliberately discarded.
+  void authenticateToken(req as any, res, next)
 }

--- a/backend/applications/src/routes/app-registry.ts
+++ b/backend/applications/src/routes/app-registry.ts
@@ -6,12 +6,16 @@
 //   activateApp, suspendApp, heartbeatApp.
 import express from 'express'
 import { randomBytes } from 'crypto'
-import { authenticateToken } from '../middleware/auth'
+// Every route below uses the unified middleware: pre-shared consumer token first,
+// then JWT session. authenticateToken is no longer referenced directly here — it
+// is reached through authenticateConsumerOrSession's fall-through.
 import { authenticateConsumerOrSession } from '../middleware/consumer-auth'
 import {
   appManifestSchema,
   registerAppRequestSchema,
   heartbeatRequestSchema,
+  productPolicySchema,
+  billingProfileSchema,
   toValidationErrorBody,
 } from '../app-registry/manifest.schema'
 import { appRegistryService, canRead, canMutate } from '../app-registry/service'
@@ -56,7 +60,7 @@ async function v1WriteGate(
 }
 
 // ── GET /apps — listApps ──────────────────────────────────────────────────────
-router.get('/apps', authenticateToken, async (req: any, res) => {
+router.get('/apps', authenticateConsumerOrSession, async (req: any, res) => {
   try {
     const caller = await resolveCaller(req.user)
     const status = req.query.status as any
@@ -164,7 +168,15 @@ router.post('/apps', authenticateConsumerOrSession, async (req: any, res) => {
 })
 
 // ── GET /apps/:slug — getApp ──────────────────────────────────────────────────
-router.get('/apps/:slug', authenticateToken, async (req: any, res) => {
+// authenticateConsumerOrSession, not authenticateToken: this is the FIRST call
+// register.sh makes (the idempotency probe — 200 = already registered, 404 =
+// register now), and it presents the same pre-shared CONSUMER_REGISTRATION_SECRET
+// it later uses for POST /apps. With plain JWT auth here the probe 401s and the
+// script's `401|403) die` arm CrashLoopBackOffs the consumer's pod before it can
+// ever reach the register call. Human OIDC sessions are unaffected — the
+// middleware falls through to authenticateToken when the bearer is not the
+// pre-shared secret.
+router.get('/apps/:slug', authenticateConsumerOrSession, async (req: any, res) => {
   try {
     const caller = await resolveCaller(req.user)
     const app = await appRegistryService.findBySlug(req.params.slug)
@@ -179,7 +191,10 @@ router.get('/apps/:slug', authenticateToken, async (req: any, res) => {
 })
 
 // ── PUT /apps/:slug — updateApp ───────────────────────────────────────────────
-router.put('/apps/:slug', authenticateToken, async (req: any, res) => {
+// Consumer-secret capable for the same reason as GET above: register.sh re-PUTs
+// the manifest on every redeploy so manifest edits (new remoteEntry, changed nav
+// placement) are not frozen at first registration.
+router.put('/apps/:slug', authenticateConsumerOrSession, async (req: any, res) => {
   try {
     const caller = await resolveCaller(req.user)
     const existing = await appRegistryService.findBySlug(req.params.slug)
@@ -235,8 +250,119 @@ router.put('/apps/:slug', authenticateToken, async (req: any, res) => {
   }
 })
 
+// ── onboarding writes: policy + billing profile ───────────────────────────────
+// Both were specified in the contract (putAppPolicy / putAppBillingProfile),
+// covered by tests, and given storage by migration 006 + service.setPolicy /
+// service.setBillingProfile — but the routes themselves were never mounted, so
+// every call 404'd. register.sh treats a non-2xx here as fatal, which meant any
+// product shipping a policy.json could not complete registration at all.
+//
+// Shared preamble: resolve the app, hide invisible apps as 404 (BOLA), apply the
+// release gate, then object-level + Permit apps:write. Returns the app on
+// success, or null when it has already written a response.
+async function resolveForOnboardingWrite(
+  req: any,
+  res: express.Response
+): Promise<{ app: any; caller: any } | null> {
+  const caller = await resolveCaller(req.user)
+  const app = await appRegistryService.findBySlug(req.params.slug)
+  if (!app) {
+    notFound(res)
+    return null
+  }
+  if (!canRead(app, caller)) {
+    notFound(res)
+    return null
+  }
+  if (!(await v1WriteGate(caller, app.organizationId, res))) return null
+  if (!canMutate(app, caller)) {
+    forbidden(res)
+    return null
+  }
+  const permitted = await checkAppRegistryPermission({
+    userId: caller.userId,
+    action: 'apps:write',
+    organizationId: app.organizationId,
+    slug: app.slug,
+  })
+  if (!permitted && !caller.isPlatformAdmin) {
+    forbidden(res, 'Missing apps:write scope')
+    return null
+  }
+  return { app, caller }
+}
+
+// ── PUT /apps/:slug/policy — putAppPolicy ─────────────────────────────────────
+router.put('/apps/:slug/policy', authenticateConsumerOrSession, async (req: any, res) => {
+  try {
+    const resolved = await resolveForOnboardingWrite(req, res)
+    if (!resolved) return
+    const { app } = resolved
+
+    const parsed = productPolicySchema.safeParse(req.body)
+    if (!parsed.success) {
+      return res.status(400).json(toValidationErrorBody((parsed as any).error))
+    }
+    const policy = parsed.data
+
+    // `product` is implied by the path. Honouring a disagreeing body value would
+    // let apps:write on one app install a policy namespaced to a different one.
+    if (policy.product && policy.product !== app.slug) {
+      return res.status(400).json({
+        error: 'validation_error',
+        message: 'policy.product must match the path slug',
+        fields: [{ path: 'product', message: `expected '${app.slug}'` }],
+      })
+    }
+
+    // TODO(platform): storage only. ACCEPTANCE IS NOT PROPAGATION — the roles
+    // declared here stay DENY until the permit-schema sync job reads this column
+    // (FuzeFront backend boot + post-install/post-upgrade Helm job) and pushes
+    // them to Permit. `GET /health` (permit block) reports what the last sync
+    // actually applied. A product registering between syncs is live in the
+    // registry with a policy that is not yet enforced.
+    await appRegistryService.setPolicy(app.slug, policy)
+
+    return res.json({
+      slug: app.slug,
+      resources: policy.resources.length,
+      roles: policy.roles.length,
+    })
+  } catch (err) {
+    console.error('[app-registry] putAppPolicy error:', err)
+    return res.status(500).json({ error: 'internal_error', message: 'Failed to store policy' })
+  }
+})
+
+// ── PUT /apps/:slug/billing-profile — putAppBillingProfile ────────────────────
+router.put('/apps/:slug/billing-profile', authenticateConsumerOrSession, async (req: any, res) => {
+  try {
+    const resolved = await resolveForOnboardingWrite(req, res)
+    if (!resolved) return
+    const { app } = resolved
+
+    const parsed = billingProfileSchema.safeParse(req.body)
+    if (!parsed.success) {
+      return res.status(400).json(toValidationErrorBody((parsed as any).error))
+    }
+    const profile = parsed.data
+
+    // TODO(platform): storage only, same propagation caveat as policy above —
+    // the billing service reads registered profiles to build its productKey
+    // allowlist; a profile stored here is not accepted at checkout until it does.
+    await appRegistryService.setBillingProfile(app.slug, profile)
+
+    return res.json(profile)
+  } catch (err) {
+    console.error('[app-registry] putAppBillingProfile error:', err)
+    return res
+      .status(500)
+      .json({ error: 'internal_error', message: 'Failed to store billing profile' })
+  }
+})
+
 // ── DELETE /apps/:slug — deleteApp ────────────────────────────────────────────
-router.delete('/apps/:slug', authenticateToken, async (req: any, res) => {
+router.delete('/apps/:slug', authenticateConsumerOrSession, async (req: any, res) => {
   try {
     const caller = await resolveCaller(req.user)
     const existing = await appRegistryService.findBySlug(req.params.slug)
@@ -276,7 +402,7 @@ router.post('/apps/:slug/activate', authenticateConsumerOrSession, (req, res) =>
 )
 
 // ── POST /apps/:slug/suspend — suspendApp ─────────────────────────────────────
-router.post('/apps/:slug/suspend', authenticateToken, (req, res) =>
+router.post('/apps/:slug/suspend', authenticateConsumerOrSession, (req, res) =>
   transition(req as any, res, 'suspended')
 )
 

--- a/deploy/helm/fuzefront/values-prod.yaml
+++ b/deploy/helm/fuzefront/values-prod.yaml
@@ -325,6 +325,21 @@ secret:
   # this PR stays a config change rather than a template change.
   litellmMasterKey: "managed-by-sealed-secret"
 
+  # GATE ONLY — same pattern as litellmMasterKey above. Because existingSecret is
+  # set, templates/secret.yaml never renders and this value goes nowhere; the real
+  # credential is the CONSUMER_REGISTRATION_SECRET entry in the sealed
+  # `fuzefront-secrets`. What this key actually switches on is
+  # templates/consumer-registration-seed-job.yaml + -rbac.yaml, both wrapped in
+  # `{{- if .Values.secret.consumerRegistrationSecret }}`. Without it the seed Job
+  # does not render at all, so Secret/fuzefront-registration is never published in
+  # this namespace and consuming products (FuzeHub, FuzeSales, …) have nothing to
+  # read, seal, and commit for their own namespace.
+  #
+  # The Job mounts the key from the existing sealed Secret with `optional: true`
+  # and exits 0 with a diagnostic if it is absent, so rendering it before the
+  # sealed key lands is safe — it just no-ops until then.
+  consumerRegistrationSecret: "managed-by-sealed-secret"
+
 # Exposure model (verified against the LIVE cluster, 2026-06-23): prod is reached
 # via the Cloudflare tunnel "FuzeInfra" -> k3s Traefik (default ingress, NOT
 # disabled) -> standard Ingress host-routing. Cloudflare terminates TLS at the

--- a/docs/mfe-self-registration.md
+++ b/docs/mfe-self-registration.md
@@ -85,13 +85,80 @@ or see.
 
 ## Auth token
 
-`FUZEFRONT_REGISTRATION_TOKEN` is a Bearer JWT for a service account with `apps:register`
-scope. Same format as `SEED_API_TOKEN`. Create one service-level token and seal it
-into a `fuzefront-registration` SealedSecret in each MFE's namespace:
+`FUZEFRONT_REGISTRATION_TOKEN` is a **static pre-shared string**. It is not a JWT, it
+is not issued per-product, and there is no service-account system behind it — there is
+nothing to "create a service account with `apps:register` scope" in, and no admin UI
+that mints one. (An earlier version of this page said otherwise. It was wrong, and it
+cost a consuming product a day of probing platform secrets that could never have
+worked.)
+
+The value is **one platform-wide secret**, `CONSUMER_REGISTRATION_SECRET`. The registry
+compares the incoming Bearer against it in
+`backend/applications/src/middleware/consumer-auth.ts`; on a match the request is
+treated as a platform-admin service call and Permit checks are bypassed. On a miss it
+falls through to ordinary Authentik JWT validation, so human sessions are unaffected.
+That single middleware is applied to **every** `/api/v1/app-registry` route, because
+`register.sh` calls `GET`, `POST`, and `PUT` in the course of one registration.
+
+Because it is one shared credential that grants platform-admin on the registry,
+rotating it invalidates every consumer at once — see "Rotation" below.
+
+### 1. Platform side (once per cluster)
+
+Seal the value into `fuzefront-secrets` and enable the seed Job that publishes it.
 
 ```bash
-kubectl create secret generic fuzefront-registration \
-  --namespace=fuzesales \
-  --from-literal=token=<PLATFORM_REGISTRATION_TOKEN> \
-  --dry-run=client -o yaml | kubeseal > sealed-fuzefront-registration.yaml
+# Generate and seal. Plaintext never touches git, chat, or shell history —
+# seal-secret.sh prompts hidden and merges in place, preserving other keys.
+openssl rand -hex 32 | deploy/scripts/seal-secret.sh \
+  CONSUMER_REGISTRATION_SECRET --scope fuzefront/fuzefront-secrets --in -
 ```
+
+`deploy/helm/fuzefront/values-prod.yaml` must also carry
+`secret.consumerRegistrationSecret` (any non-empty placeholder — with
+`secret.existingSecret` set, `templates/secret.yaml` never renders, so the value is a
+**render gate only**). Without it,
+`templates/consumer-registration-seed-job.yaml` and its RBAC do not render at all and
+step 2 has nothing to read.
+
+### 2. Distribution to a consuming product
+
+The `consumer-registration-seed` Job (post-install/post-upgrade) copies the value into
+`Secret/fuzefront-registration`, key `token`, in the **`fuzefront`** namespace. That
+secret is the published hand-off point: a consumer's CI reads it, re-seals it for its
+own namespace, and commits the SealedSecret.
+
+```bash
+# In the consuming product's provisioning workflow (needs read on that one secret):
+TOKEN=$(kubectl -n fuzefront get secret fuzefront-registration \
+  -o jsonpath='{.data.token}' | base64 -d)
+
+kubectl create secret generic fuzefront-registration \
+  --namespace=fuzehub --from-literal=token="$TOKEN" \
+  --dry-run=client -o yaml | kubeseal --format yaml > sealed-fuzefront-registration.yaml
+```
+
+Do **not** probe `fuzefront-secrets` for a likely-looking key. `JWT_SECRET`,
+`SESSION_SECRET`, `AUTHENTIK_BOOTSTRAP_TOKEN`, `INTERNAL_PROVISION_SECRET`,
+`PERMIT_API_KEY` and `AUTHENTIK_SECRET_KEY` all 401 here by design — none of them is
+this credential.
+
+### Diagnosing a 401
+
+If every token 401s, the usual cause is that `CONSUMER_REGISTRATION_SECRET` is **unset
+on the applications pod**. It is mounted `optional: true`
+(`deploy/helm/fuzefront/templates/applications.yaml`), so the pod starts healthy
+without it and the consumer branch is simply never reachable — the middleware degrades
+to JWT-only and rejects every static token. Check:
+
+```bash
+kubectl -n fuzefront get secret fuzefront-secrets \
+  -o jsonpath='{.data.CONSUMER_REGISTRATION_SECRET}' | wc -c   # 0 = not sealed yet
+```
+
+### Rotation
+
+Re-seal the key, `helm upgrade` (which re-runs the seed Job), then re-run each
+consumer's provisioning workflow. Consumers keep working on the old value until their
+own SealedSecret is refreshed, so rotate the platform first and the consumers promptly
+after — a consumer whose pod restarts in between will fail its init container.


### PR DESCRIPTION
Adds a `workflow_dispatch` workflow that generates `CONSUMER_REGISTRATION_SECRET`, seals it with kubeseal against the cluster's current public cert, merges it into `deploy/contabo/sealed/fuzefront-secrets.yaml`, and commits to master.

## How to use

1. Ensure `KUBE_CONFIG` repo secret is set (base64 kubeconfig for the Contabo k3s cluster — same value as FuzeHub's `KUBE_CONFIG`).
2. Merge this PR.
3. Go to Actions → **Seal CONSUMER_REGISTRATION_SECRET** → Run workflow (default `dry_run: false`).
4. ArgoCD syncs `fuzefront-secrets` within ~60s, pod restarts with the env var set.
5. FuzeHub's `provision-registration.yml` will now find `Secret/fuzefront-registration` and self-register.

## Safety

- Uses `--merge-into` — only the `CONSUMER_REGISTRATION_SECRET` key is added to the existing SealedSecret. All other keys (`DB_PASSWORD`, `JWT_SECRET`, etc.) are preserved exactly.
- Idempotent: skips if the key is already present.
- `dry_run: true` prints the diff without committing.
- The plaintext value is generated ephemerally in the runner and deleted immediately after sealing — never written to logs or outputs.

Depends on FuzeFront#532 (unified auth middleware) being merged first — this workflow is inert until that lands.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tz5rsgiCNXDEJ7dY1kBfkp)_