### PR TITLE
fix(release): gate every image tag bump on that image's build outcome

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,6 +106,7 @@ jobs:
           cache-to: type=gha,mode=max,scope=frontend-root
 
       - name: Build and push email-service
+        id: email_image
         # Ancillary services are disabled in prod (only billing is enabled). They
         # must NEVER block the core backend+frontend deploy — a failed build here
         # is non-fatal; the bump+deploy still proceeds.
@@ -122,6 +123,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Build and push sms-service
+        id: sms_image
         continue-on-error: true
         uses: docker/build-push-action@v7
         with:
@@ -135,6 +137,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Build and push provisioning-service
+        id: provisioning_image
         continue-on-error: true
         uses: docker/build-push-action@v7
         with:
@@ -148,6 +151,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Build and push billing-service
+        id: billing_image
         continue-on-error: true
         uses: docker/build-push-action@v7
         with:
@@ -161,6 +165,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Build & push security-service
+        id: security_image
         continue-on-error: true
         uses: docker/build-push-action@v7
         with:
@@ -174,6 +179,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Build & push applications-service
+        id: applications_image
         continue-on-error: true
         uses: docker/build-push-action@v7
         with:
@@ -235,6 +241,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Build & push clock-app (built-in MF remote)
+        id: clock_image
         # Built-in reference Module-Federation remote, served same-origin at
         # app.fuzefront.com/apps/clock/. Self-contained Dockerfile => context is clock-app/.
         continue-on-error: true
@@ -272,21 +279,37 @@ jobs:
         run: |
           set -euo pipefail
           SHA="${{ steps.tag.outputs.sha }}"
-          # chat-service builds with continue-on-error, so its image may NOT
-          # exist even though this step runs. Only bump its tag when the build
-          # actually succeeded — otherwise values-prod would pin a tag that was
-          # never pushed (today masked only by chatService.enabled: false).
-          # The expected-rewrite count moves with it so the guard stays exact.
-          CHAT_OK=0
-          if [ "${{ steps.chat_image.outcome }}" = "success" ]; then CHAT_OK=1; fi
-          # Same treatment for notification-service: continue-on-error, so only
-          # bump its tag when the image actually got pushed.
-          NOTIF_OK=0
-          if [ "${{ steps.notification_image.outcome }}" = "success" ]; then NOTIF_OK=1; fi
-          # 9 always-built images (incl. billing-service + provisioning-service,
-          # added in #442) plus the two continue-on-error ones.
-          EXPECTED=$((9 + CHAT_OK + NOTIF_OK))
-          echo "chat-service image built: ${CHAT_OK}, notification-service: ${NOTIF_OK} — expecting ${EXPECTED} tag rewrites"
+          # EVERY auxiliary build step above is continue-on-error, so ANY of
+          # their images may be missing even though this step runs. Bump a tag
+          # only when that image actually got pushed — otherwise values-prod
+          # pins a tag that does not exist, Argo applies a Deployment whose pods
+          # can never pull, the old ReplicaSet keeps serving, and the release
+          # still reports success. That is exactly what happened at 44d9a5a0192b:
+          # the applications-service build failed, its tag was bumped anyway, and
+          # the new ReplicaSet sat in ImagePullBackOff for 12h through 3,174 pull
+          # attempts while the release was green. See #539 / FuzeInfra#501.
+          #
+          # This guard used to cover ONLY chat-service and notification-service.
+          # The other seven were assumed "always built" — but continue-on-error
+          # means none of them is. backend and frontend are the only genuinely
+          # unconditional images (no continue-on-error: a failure there fails the
+          # job), which is why EXPECTED starts at 2 and everything else is gated.
+          ok() { [ "$1" = "success" ] && echo 1 || echo 0; }
+          EMAIL_OK=$(ok "${{ steps.email_image.outcome }}")
+          SMS_OK=$(ok "${{ steps.sms_image.outcome }}")
+          PROV_OK=$(ok "${{ steps.provisioning_image.outcome }}")
+          BILLING_OK=$(ok "${{ steps.billing_image.outcome }}")
+          SECURITY_OK=$(ok "${{ steps.security_image.outcome }}")
+          APPS_OK=$(ok "${{ steps.applications_image.outcome }}")
+          CLOCK_OK=$(ok "${{ steps.clock_image.outcome }}")
+          CHAT_OK=$(ok "${{ steps.chat_image.outcome }}")
+          NOTIF_OK=$(ok "${{ steps.notification_image.outcome }}")
+          EXPECTED=$((2 + EMAIL_OK + SMS_OK + PROV_OK + BILLING_OK + SECURITY_OK + APPS_OK + CLOCK_OK + CHAT_OK + NOTIF_OK))
+          echo "built: email=${EMAIL_OK} sms=${SMS_OK} provisioning=${PROV_OK} billing=${BILLING_OK} security=${SECURITY_OK} applications=${APPS_OK} clock=${CLOCK_OK} chat=${CHAT_OK} notification=${NOTIF_OK}"
+          echo "expecting ${EXPECTED} tag rewrites (backend + frontend are always built)"
+          if [ "${APPS_OK}${SECURITY_OK}${EMAIL_OK}${BILLING_OK}" != "1111" ]; then
+            echo "::warning::one or more auxiliary images failed to build; their values-prod tags are left pinned to the last good release"
+          fi
           mkdir -p ~/.ssh
           printf '%s\n' "$SSH_KEY" > ~/.ssh/release_bump
           chmod 600 ~/.ssh/release_bump
@@ -316,7 +339,10 @@ jobs:
           # manually restored LF. Rewritten tag lines preserve the line's
           # original ending so a CRLF file round-trips without a spurious
           # whole-file diff.
-          awk -v sha="$SHA" -v chat="$CHAT_OK" -v notif="$NOTIF_OK" '
+          awk -v sha="$SHA" -v chat="$CHAT_OK" -v notif="$NOTIF_OK" \
+              -v email="$EMAIL_OK" -v sms="$SMS_OK" -v prov="$PROV_OK" \
+              -v billing="$BILLING_OK" -v security="$SECURITY_OK" \
+              -v apps="$APPS_OK" -v clock="$CLOCK_OK" '
             hot {
               hot=0
               if ($0 ~ /^[[:space:]]*tag:/) {
@@ -328,13 +354,13 @@ jobs:
             }
             /repository: ghcr\.io\/izzywdev\/fuzefront-backend\r?$/ { hot=1 }
             /repository: ghcr\.io\/izzywdev\/fuzefront-frontend\r?$/ { hot=1 }
-            /repository: ghcr\.io\/izzywdev\/fuzefront-security-service\r?$/ { hot=1 }
-            /repository: ghcr\.io\/izzywdev\/fuzefront-applications-service\r?$/ { hot=1 }
-            /repository: ghcr\.io\/izzywdev\/fuzefront-clock-app\r?$/ { hot=1 }
-            /repository: ghcr\.io\/izzywdev\/fuzefront-email-service\r?$/ { hot=1 }
-            /repository: ghcr\.io\/izzywdev\/fuzefront-sms-service\r?$/ { hot=1 }
-            /repository: ghcr\.io\/izzywdev\/fuzefront-billing-service\r?$/ { hot=1 }
-            /repository: ghcr\.io\/izzywdev\/fuzefront-provisioning-service\r?$/ { hot=1 }
+            security == 1 && /repository: ghcr\.io\/izzywdev\/fuzefront-security-service\r?$/ { hot=1 }
+            apps == 1 && /repository: ghcr\.io\/izzywdev\/fuzefront-applications-service\r?$/ { hot=1 }
+            clock == 1 && /repository: ghcr\.io\/izzywdev\/fuzefront-clock-app\r?$/ { hot=1 }
+            email == 1 && /repository: ghcr\.io\/izzywdev\/fuzefront-email-service\r?$/ { hot=1 }
+            sms == 1 && /repository: ghcr\.io\/izzywdev\/fuzefront-sms-service\r?$/ { hot=1 }
+            billing == 1 && /repository: ghcr\.io\/izzywdev\/fuzefront-billing-service\r?$/ { hot=1 }
+            prov == 1 && /repository: ghcr\.io\/izzywdev\/fuzefront-provisioning-service\r?$/ { hot=1 }
             chat == 1 && /repository: ghcr\.io\/izzywdev\/fuzefront-chat-service\r?$/ { hot=1 }
             notif == 1 && /repository: ghcr\.io\/izzywdev\/fuzefront-notification-service\r?$/ { hot=1 }
             { print }


### PR DESCRIPTION
Fixes #539.

## The bug

Release `44d9a5a0192b` rewrote **all 11** image tags in `values-prod.yaml`, but `fuzefront-applications-service` was never pushed at that SHA (its newest tag in GHCR is `31c250c25297`). Argo applied a Deployment pinned to an image that does not exist. The new ReplicaSet sat in `ImagePullBackOff` for 12 h across **3,174 pull attempts** while the previous ReplicaSet kept serving — and the release reported **success** the whole time.

Same class of silent failure as FuzeInfra#501: *green pipeline, prod unchanged.*

## Cause

**Every** auxiliary build step is `continue-on-error: true`, so any of their images can be missing while the job still succeeds. But only two of them carried an `id`:

```
Build and push email-service              id=NONE  <-- unguardable
Build and push sms-service                id=NONE  <-- unguardable
Build and push provisioning-service       id=NONE  <-- unguardable
Build and push billing-service            id=NONE  <-- unguardable
Build & push security-service             id=NONE  <-- unguardable
Build & push applications-service         id=NONE  <-- unguardable
Build & push clock-app                    id=NONE  <-- unguardable
Build & push chat-service                 id=chat_image          ✅
Build & push notification-service         id=notification_image  ✅
```

Without an `id`, the bump step cannot read `steps.<id>.outcome`, so those seven were counted as *"9 always-built images"* in `EXPECTED`. `continue-on-error` makes that assumption false — a failed build was indistinguishable from a successful one at bump time.

The guard the workflow already documents for chat-service ("*otherwise values-prod would pin a tag that was never pushed*") was exactly right. It just wasn't applied to the other seven.

## The change

- `id` on all seven remaining `continue-on-error` steps.
- Each awk tag-rewrite anchor gated on its image's outcome, exactly as chat/notification already were.
- `EXPECTED` starts at **2** — backend and frontend are the only steps *without* `continue-on-error`, so the only genuinely unconditional images — plus one per image that actually built. The existing count guard stays exact, so layout drift still fails the release.

A failed auxiliary build now leaves its tag pinned to the last good release rather than pointing at nothing, and the step logs which images built.

## Verification

The awk program was extracted **verbatim from this workflow** (so the test can't drift from what CI runs) and executed against the real `values-prod.yaml`:

| scenario | rewrites | `backend` | `applications-service` |
|---|---|---|---|
| all images built | **11** | bumped | bumped |
| **applications failed** | **10** | bumped | **`44d9a5a0192b` — unchanged** |
| all auxiliary failed | **2** | bumped | unchanged |

`EXPECTED` matches the rewrite count in all three cases. The middle row is the bug this fixes: previously that run bumped the tag anyway.

Also confirmed the committed blob is **LF-only (0 CR bytes)** — this file's own comments record a CRLF rewrite that once broke every release until a human restored it by hand.

## Note

The one-off harness that produced the table above isn't included — this step has broken silently twice before (the CRLF incident and the missing-anchor incident both noted in its comments), so a permanent regression test for it seems worth having, but it needs a home and CI wiring that's beyond this fix. Happy to land it separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
