### PR TITLE
fix(packages): point GitHub Packages at the @izzywdev scope that actually exists

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,25 @@
-# Private registry for @fuzefront/* packages (GitHub Packages, restricted access).
-# Public deps still resolve from the default npm registry.
-@fuzefront:registry=https://npm.pkg.github.com
+# GitHub Packages registry mapping. Public deps still resolve from the default
+# npm registry.
+#
+# THE SCOPE IS @izzywdev, NOT @fuzefront — and it has to be.
+# GitHub Packages requires an npm scope to match the account that OWNS the
+# packages. There is no `fuzefront` GitHub organisation; everything lives under
+# the personal account **izzywdev**. `@fuzefront:registry=...` therefore pointed
+# a scope at a registry that has no such owner — it could never resolve or
+# publish. The one package actually published from this repo is already under
+# the personal scope (`@izzywdev/fuzefront-auth-ui`), which is the working
+# pattern:
+#
+#     published cross-repo   ->  @izzywdev/fuzefront-<thing>
+#     internal to this repo  ->  @fuzefront/<thing>   (npm workspace, never published)
+#
+# @fuzefront/* names are npm WORKSPACES declared in the root package.json. npm
+# links them from the working tree, so they never touch a registry and need no
+# mapping here. That is why the broken mapping went unnoticed for so long — and
+# why `Cannot find module '@fuzefront/shared'` (#538) turned out to be a Docker
+# packaging bug rather than a registry one.
+#
+# If a `fuzefront` org is ever created, move the packages to it and flip this
+# scope back. See FuzeSDLC CLAUDE.baseline.md for the standing rule.
+@izzywdev:registry=https://npm.pkg.github.com
 //npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}

--- a/design-system/package.json
+++ b/design-system/package.json
@@ -49,7 +49,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/fuzefront/FuzeFront.git",
+    "url": "https://github.com/izzywdev/FuzeFront.git",
     "directory": "design-system"
   }
 }

--- a/packages/account-security-ui/package.json
+++ b/packages/account-security-ui/package.json
@@ -41,5 +41,5 @@
     "vitest": "^2.1.0"
   },
   "publishConfig": { "registry": "https://npm.pkg.github.com", "access": "restricted" },
-  "repository": { "type": "git", "url": "https://github.com/fuzefront/FuzeFront.git", "directory": "packages/account-security-ui" }
+  "repository": { "type": "git", "url": "https://github.com/izzywdev/FuzeFront.git", "directory": "packages/account-security-ui" }
 }

--- a/packages/auth-ui/package.json
+++ b/packages/auth-ui/package.json
@@ -42,5 +42,5 @@
     "vitest": "^2.1.0"
   },
   "publishConfig": { "registry": "https://npm.pkg.github.com", "access": "restricted" },
-  "repository": { "type": "git", "url": "https://github.com/fuzefront/FuzeFront.git", "directory": "packages/auth-ui" }
+  "repository": { "type": "git", "url": "https://github.com/izzywdev/FuzeFront.git", "directory": "packages/auth-ui" }
 }

--- a/packages/identity-ui/package.json
+++ b/packages/identity-ui/package.json
@@ -46,5 +46,5 @@
     "vitest": "^2.1.0"
   },
   "publishConfig": { "registry": "https://npm.pkg.github.com", "access": "restricted" },
-  "repository": { "type": "git", "url": "https://github.com/fuzefront/FuzeFront.git", "directory": "packages/identity-ui" }
+  "repository": { "type": "git", "url": "https://github.com/izzywdev/FuzeFront.git", "directory": "packages/identity-ui" }
 }

--- a/packages/portal-branding-ui/package.json
+++ b/packages/portal-branding-ui/package.json
@@ -42,5 +42,5 @@
     "vitest": "^2.1.0"
   },
   "publishConfig": { "registry": "https://npm.pkg.github.com", "access": "restricted" },
-  "repository": { "type": "git", "url": "https://github.com/fuzefront/FuzeFront.git", "directory": "packages/portal-branding-ui" }
+  "repository": { "type": "git", "url": "https://github.com/izzywdev/FuzeFront.git", "directory": "packages/portal-branding-ui" }
 }


### PR DESCRIPTION
## The problem

GitHub Packages requires an npm scope to **match the account that owns the packages**. There is no `fuzefront` GitHub organisation — everything lives under the personal account **izzywdev**. Two independent consequences, both silent:

1. **`.npmrc` mapped `@fuzefront:` at `npm.pkg.github.com`** — a scope that registry has no owner for. It could never resolve or publish.
2. **5 of 14 `package.json` files pointed `repository.url` at `github.com/fuzefront/FuzeFront.git`**, which does not exist. GitHub Packages resolves a package's owning repo from that field, so this was a second blocker even if the scope were right. The other 9 already said `izzywdev`; this makes all 14 consistent.

Net effect: all 14 packages carry `publishConfig` → GitHub Packages with `access: restricted`, and **not one of them can publish.**

## The pattern, now written down

The one package actually published from this repo is already under the personal scope — `@izzywdev/fuzefront-auth-ui`. That working convention was folklore; it is now stated in `.npmrc`:

```
published cross-repo   ->  @izzywdev/fuzefront-<thing>
internal to this repo  ->  @fuzefront/<thing>   (npm workspace, never published)
```

## Verified safe

Dropping the `@fuzefront:` mapping could in principle send an `@fuzefront/*` dependency to npmjs.org instead. It cannot here:

```
workspace-provided @fuzefront names:                     23
depended-on @fuzefront pkgs NOT provided by a workspace:  0
```

Every `@fuzefront/*` name is an npm **workspace** declared in the root `package.json`. npm links them from the working tree and never contacts a registry for that scope, so resolution is unchanged.

That is also *why this stayed hidden for so long* — and why `Cannot find module '@fuzefront/shared'` (#538) turned out to be a Docker packaging bug rather than a registry one. Worth stating, because the scope mismatch is a very reasonable first guess for that crash and it was the wrong one.

## Deliberately NOT done here

**The 14 packages keep their `@fuzefront/*` names.** Renaming them to `@izzywdev/*` is what publishing would actually require — but it rewrites every import across the monorepo, and needs a coordinated consumer + CI change. That is not something to bundle into a config fix, and none of these packages is published today, so nothing is currently broken by the names.

If you want them publishable, that rename is the real task and should be its own PR. Flagging it rather than half-doing it. The alternative — creating a `fuzefront` GitHub org and moving the packages there — would let the names stand as-is; `.npmrc` documents how to flip back if you go that way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
