### PR TITLE
fix(chat-service): stop rate-limiter crashing the pod when Redis is absent (#510)

### DIFF
--- a/services/chat-service/src/middleware/ratelimit.ts
+++ b/services/chat-service/src/middleware/ratelimit.ts
@@ -2,8 +2,26 @@
 //
 // Uses express-rate-limit 7.x with an optional Redis backing store
 // (rate-limit-redis 4.x). Falls back gracefully when Redis is unavailable:
-// the limiter is constructed successfully (no crash at startup); if the
-// RedisStore itself errors it reverts to the default in-memory store behavior.
+// the limiter is constructed successfully (no crash at startup) and rate
+// limiting degrades to the in-memory store.
+//
+// Redis is OPT-IN via the REDIS_URL environment variable. When REDIS_URL is
+// unset (as in prod — see deploy/helm/fuzefront/templates/chat-service.yaml,
+// which deliberately does not mount it) NO Redis client is created and the
+// limiter uses express-rate-limit's default MemoryStore. Rate limiting is then
+// per-pod, which the current low replica count makes acceptable. Wiring a
+// shared Redis (for cross-replica limits) is a separate enhancement.
+//
+// Two crash modes this file must never fall into again — both took the pod
+// down in prod (fuzefront-chat-service CrashLoopBackOff, FuzeFront #510):
+//   1. Defaulting to redis://localhost:6379 when REDIS_URL is unset: nothing
+//      serves that address in the pod, so every command fails.
+//   2. Constructing the client with `enableOfflineQueue: false`:
+//      rate-limit-redis runs a `SCRIPT LOAD` inside `new RedisStore()`, BEFORE
+//      this client has connected. With the offline queue disabled that command
+//      rejects immediately; rate-limit-redis never awaits the promise, so the
+//      rejection is unhandled and Node terminates the process. A try/catch
+//      around `new RedisStore()` cannot catch an async rejection.
 //
 // Key generator: req.userId (set by auth middleware) with IP as fallback.
 // This means unauthenticated requests (hitting routes before auth runs, e.g.
@@ -67,18 +85,30 @@ function getDefaultRedisClient(): RedisClient {
   if (_defaultRedisAttempted) return _defaultRedisClient;
   _defaultRedisAttempted = true;
 
+  // Redis is opt-in. Without an explicit REDIS_URL we use the in-memory store —
+  // NEVER a localhost default, which has nothing behind it in the pod and turns
+  // every rate-limit command into a failure (crash mode #1 above).
+  const redisUrl = process.env.REDIS_URL;
+  if (!redisUrl) {
+    _defaultRedisClient = null;
+    return _defaultRedisClient;
+  }
+
   try {
     // Dynamic require keeps ioredis out of the test tree when mocking.
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const IoRedis = require('ioredis');
-    const redisUrl = process.env.REDIS_URL || 'redis://localhost:6379';
     const client = new IoRedis(redisUrl, {
-      // Do not crash the process on connection failure.
-      lazyConnect: true,
-      enableOfflineQueue: false,
-      maxRetriesPerRequest: 0,
+      // enableOfflineQueue MUST stay true (crash mode #2 above): the SCRIPT LOAD
+      // that rate-limit-redis fires inside `new RedisStore()` happens before the
+      // socket is up. Queuing it until the connection is ready keeps startup
+      // crash-free; disabling the queue rejects it into an unhandled rejection
+      // that kills the process. ioredis's default retryStrategy reconnects
+      // indefinitely, so a transient outage never rejects a queued command.
+      enableOfflineQueue: true,
     });
-    // Swallow connection errors silently — rate limiting degrades to in-memory.
+    // Swallow connection errors silently — rate limiting degrades to in-memory
+    // behavior rather than crashing the process.
     client.on('error', () => {/* intentionally silent */});
     _defaultRedisClient = {
       sendCommand: (...args: string[]) =>

--- a/services/chat-service/tests/middleware/ratelimit.test.ts
+++ b/services/chat-service/tests/middleware/ratelimit.test.ts
@@ -45,3 +45,55 @@ describe('createGlobalLimiter exports a rate-limiter factory', () => {
     expect(() => createGlobalLimiter(null)).not.toThrow();
   });
 });
+
+// Regression for FuzeFront #510: the DEFAULT (no-arg) factory path must never
+// crash the process — neither when REDIS_URL is unset (prod) nor when it points
+// at an unreachable host. Before the fix, the no-arg path defaulted to
+// redis://localhost:6379 and built the client with enableOfflineQueue:false, so
+// rate-limit-redis's constructor-time SCRIPT LOAD rejected into an unhandled
+// rejection and took the pod down (chat-service CrashLoopBackOff in prod).
+//
+// These cases exercise the module-level getDefaultRedisClient(), so each uses
+// jest.isolateModules() with resetModules to defeat its one-shot memoization.
+describe('default limiter factory does not crash the process (FuzeFront #510)', () => {
+  const ORIGINAL_REDIS_URL = process.env.REDIS_URL;
+
+  afterEach(() => {
+    if (ORIGINAL_REDIS_URL === undefined) delete process.env.REDIS_URL;
+    else process.env.REDIS_URL = ORIGINAL_REDIS_URL;
+    jest.resetModules();
+  });
+
+  it('uses the in-memory store (no Redis client) when REDIS_URL is unset', () => {
+    delete process.env.REDIS_URL;
+    jest.isolateModules(() => {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const mod = require('../../src/middleware/ratelimit');
+      expect(() => mod.createGlobalLimiter()).not.toThrow();
+    });
+  });
+
+  it('does not throw or emit an unhandled rejection when REDIS_URL is unreachable', async () => {
+    // Port 1 is reserved/closed — the client can never connect.
+    process.env.REDIS_URL = 'redis://127.0.0.1:1';
+
+    const rejections: unknown[] = [];
+    const onUnhandled = (err: unknown) => rejections.push(err);
+    process.on('unhandledRejection', onUnhandled);
+
+    try {
+      jest.isolateModules(() => {
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        const mod = require('../../src/middleware/ratelimit');
+        // Constructing the store fires rate-limit-redis's eager SCRIPT LOAD.
+        expect(() => mod.createGlobalLimiter()).not.toThrow();
+      });
+
+      // Give any floating promise from the constructor a few ticks to settle.
+      await new Promise((resolve) => setTimeout(resolve, 500));
+      expect(rejections).toHaveLength(0);
+    } finally {
+      process.off('unhandledRejection', onUnhandled);
+    }
+  }, 10000);
+});


### PR DESCRIPTION
Closes the last open acceptance criterion of #510 — get `fuzefront-chat-service` running and the umbrella `fuzefront` Argo app back to Synced/Healthy.

## Where #510 actually stands (verified live in contabo-prod, 2026-08-04)

The migration root cause in #510 was already fixed by #519, and the follow-on packaging crash (#538) by #540. With the #540 image (`cdb615770134`) now deployed, chat-service gets **past** both of those — `@fuzefront/shared` resolves — and crashes on a **third, newly-surfaced** failure:

```
[chat-service] Listening on port 3006
Error: Stream isn't writeable and enableOfflineQueue options is false
    at RedisStore.sendCommand (dist/middleware/ratelimit.js:74)
    at new RedisStore (rate-limit-redis/dist/index.cjs:95)
    at createGlobalLimiter (dist/middleware/ratelimit.js:95)
    at createApp (dist/app.js)
```

Both chat-service pods are `CrashLoopBackOff`; Argo `fuzefront` is `OutOfSync / Degraded`.

## Root cause

`ratelimit.ts` is meant to degrade to an in-memory limiter when Redis is unavailable, but two things defeat that:

1. **No `REDIS_URL` in the pod.** `deploy/helm/fuzefront/templates/chat-service.yaml` deliberately does not mount `REDIS_URL`, so `getDefaultRedisClient()` fell back to `redis://localhost:6379` — nothing serves that inside the pod.
2. **The fallback can't catch its own failure.** `rate-limit-redis` 4.x runs a `SCRIPT LOAD` *inside* `new RedisStore()`, before the client has connected. With `enableOfflineQueue: false` that command rejects immediately; rate-limit-redis never awaits the promise, so it becomes an **unhandled rejection** and Node 24 terminates the process. The `try/catch` around `new RedisStore()` cannot catch an async rejection — so "no crash at startup" never held.

Net: the pod could never boot regardless of Redis state.

## Fix

`services/chat-service/src/middleware/ratelimit.ts`:
- **Redis is opt-in.** No `REDIS_URL` → no client → express-rate-limit's default in-memory `MemoryStore`. No more `localhost:6379` default. This is what unblocks prod (rate limiting becomes per-pod, which the documented design already accepts at the current replica count).
- **When `REDIS_URL` *is* set**, construct the ioredis client with `enableOfflineQueue: true` so the constructor-time `SCRIPT LOAD` **queues until connected** instead of rejecting; connection errors stay swallowed by the silent `error` handler. A transient outage no longer crashes the pod.

Regression test (`tests/middleware/ratelimit.test.ts`): the default (no-arg) factory must not throw **and must not emit an `unhandledRejection`** when `REDIS_URL` is unset or points at an unreachable host.

## After merge
Release bumps the chat image tag in `values-prod.yaml` → Argo syncs → chat-service boots on the in-memory limiter → `fuzefront` returns to Synced/Healthy. Landing via Git→Argo, no manual prod change.

## Follow-up (out of scope)
Wiring a shared Redis to chat-service (`REDIS_URL` + a NetworkPolicy admitting `fuzefront → fuzeinfra` redis:6379) would give cross-replica rate limits. Not required to satisfy #510 and intentionally left as a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
