### PR TITLE
fix(ci): resolve the 401 that has blocked every security-client publish

### DIFF
--- a/.github/workflows/security-packages-publish.yml
+++ b/.github/workflows/security-packages-publish.yml
@@ -54,8 +54,26 @@ jobs:
       - name: Publish @izzywdev/fuzefront-security-client
         working-directory: packages/security
         env:
+          # Both names, deliberately — this is what the 401 was.
+          # npm resolves .npmrc from the package dir UPWARD, and the repo-root
+          # .npmrc is project-level, so it outranks the user-level file
+          # setup-node writes. The root file authenticates with ${GITHUB_TOKEN};
+          # this step only ever set NODE_AUTH_TOKEN, so the variable expanded
+          # EMPTY and every run since 2026-07-31 died with:
+          #   npm error 401 Unauthorized - PUT .../@izzywdev%2ffuzefront-security-client
+          #   unauthenticated: User cannot be authenticated with the token provided
+          # Setting both means auth resolves whichever config wins precedence.
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # Pin an explicit .npmrc in the package dir as the closest (winning)
+          # config, so registry + auth are deterministic regardless of ambient
+          # files. Mirrors auth-ui-packages-publish.yml, the one publisher in
+          # this repo that has actually shipped a package.
+          cat > .npmrc <<'NPMRC'
+          @izzywdev:registry=https://npm.pkg.github.com
+          //npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}
+          NPMRC
           VERSION=$(npm pkg get version | tr -d '"')
           npm pkg set name=@izzywdev/fuzefront-security-client
           if npm view "@izzywdev/fuzefront-security-client@${VERSION}" version --registry=https://npm.pkg.github.com >/dev/null 2>&1; then


### PR DESCRIPTION
Unblocks **[FuzeHub#68](https://github.com/izzywdev/FuzeHub/pull/68)** without needing the FuzeOne org transfer.

## The bug

`security-packages-publish.yml` has failed on **every run since 2026-07-31**:

```
npm error 401 Unauthorized - PUT https://npm.pkg.github.com/@izzywdev%2ffuzefront-security-client
npm error unauthenticated: User cannot be authenticated with the token provided.
```

It reads as a permissions problem. It is a config problem.

npm resolves `.npmrc` from the package directory **upward**. The repo-root `.npmrc` is *project-level*, so it outranks the *user-level* file `setup-node` writes. The root file authenticates with `${GITHUB_TOKEN}` — but this step only ever set `NODE_AUTH_TOKEN`, so the variable expanded **empty** and npm published with no credential at all. The build succeeded every time; only the final publish died, which is what made it look like a token-scope issue.

## The fix

`auth-ui-packages-publish.yml` already solves exactly this, and its own comments explain why — it is also the **only publisher in this repo that has ever shipped a package** (`@izzywdev/fuzefront-auth-ui`). This mirrors it:

- set **both** `NODE_AUTH_TOKEN` and `GITHUB_TOKEN`, so auth resolves whichever config wins precedence;
- pin an explicit `.npmrc` in the package dir as the closest (winning) config, so registry + auth are deterministic regardless of ambient files.

## Why this matters well beyond one red workflow

Because this publisher never worked, **`@izzywdev/fuzefront-security-client` has never existed**. That is the direct cause of FuzeHub carrying *two verbatim copies* of the security contract — `frontend/lib/security/contract.ts` and `backend/lib/security/contract.ts` — each with a header stating it is vendored only because the package is not installable. The contract therefore lives in three places, and drift between them is invisible.

Publishing the package lets FuzeHub#68 consume it and delete both copies. That PR is currently red purely on `npm ci` 404-ing for the client — nothing else about it is wrong; its other seven checks pass.

## Verification — and its limit

- YAML parses; the heredoc renders with its terminator at column 0; both env vars present in the step.
- **Not verified: an actual publish.** This workflow only runs on push to `master`, so the real proof comes on merge. If it still 401s afterwards, the next suspect is the `packages: write` permission against a *user-scoped* package rather than the `.npmrc` precedence — but the auth-ui precedent argues strongly against that.

Scope: one step in one workflow. No package renames, no consumer changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
