### PR TITLE
fix(ci): apply the #558 auth fix to the design-system and chat publishers

### DIFF
--- a/.github/workflows/chat-packages-publish.yml
+++ b/.github/workflows/chat-packages-publish.yml
@@ -62,8 +62,19 @@ jobs:
       - name: Publish @izzywdev/fuzefront-chat-client
         working-directory: packages/chat-client
         env:
+          # Both names: setup-node's .npmrc uses NODE_AUTH_TOKEN, but the repo-root
+          # .npmrc is project-level and outranks it, and that one references
+          # ${GITHUB_TOKEN}. Setting only NODE_AUTH_TOKEN made it expand EMPTY and
+          # every publish 401'd. See FuzeFront#558.
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # Pin an explicit .npmrc in the package dir as the closest (winning)
+          # config, so registry + auth are deterministic regardless of ambient files.
+          cat > .npmrc <<'NPMRC'
+          @izzywdev:registry=https://npm.pkg.github.com
+          //npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}
+          NPMRC
           VERSION=$(npm pkg get version | tr -d '"')
           npm pkg set name=@izzywdev/fuzefront-chat-client
           if npm view "@izzywdev/fuzefront-chat-client@${VERSION}" version --registry=https://npm.pkg.github.com >/dev/null 2>&1; then
@@ -75,8 +86,19 @@ jobs:
       - name: Publish @izzywdev/fuzefront-chat-ui
         working-directory: packages/chat-ui
         env:
+          # Both names: setup-node's .npmrc uses NODE_AUTH_TOKEN, but the repo-root
+          # .npmrc is project-level and outranks it, and that one references
+          # ${GITHUB_TOKEN}. Setting only NODE_AUTH_TOKEN made it expand EMPTY and
+          # every publish 401'd. See FuzeFront#558.
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # Pin an explicit .npmrc in the package dir as the closest (winning)
+          # config, so registry + auth are deterministic regardless of ambient files.
+          cat > .npmrc <<'NPMRC'
+          @izzywdev:registry=https://npm.pkg.github.com
+          //npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}
+          NPMRC
           VERSION=$(npm pkg get version | tr -d '"')
           npm pkg set name=@izzywdev/fuzefront-chat-ui
           if npm view "@izzywdev/fuzefront-chat-ui@${VERSION}" version --registry=https://npm.pkg.github.com >/dev/null 2>&1; then

--- a/.github/workflows/design-system-packages-publish.yml
+++ b/.github/workflows/design-system-packages-publish.yml
@@ -62,8 +62,19 @@ jobs:
       - name: Publish @izzywdev/fuzefront-design-system
         working-directory: design-system
         env:
+          # Both names: setup-node's .npmrc uses NODE_AUTH_TOKEN, but the repo-root
+          # .npmrc is project-level and outranks it, and that one references
+          # ${GITHUB_TOKEN}. Setting only NODE_AUTH_TOKEN made it expand EMPTY and
+          # every publish 401'd. See FuzeFront#558.
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # Pin an explicit .npmrc in the package dir as the closest (winning)
+          # config, so registry + auth are deterministic regardless of ambient files.
+          cat > .npmrc <<'NPMRC'
+          @izzywdev:registry=https://npm.pkg.github.com
+          //npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}
+          NPMRC
           VERSION=$(npm pkg get version | tr -d '"')
           npm pkg set name=@izzywdev/fuzefront-design-system
           if npm view "@izzywdev/fuzefront-design-system@${VERSION}" version --registry=https://npm.pkg.github.com >/dev/null 2>&1; then


### PR DESCRIPTION
Extends the fix proven in **#558** to the two remaining GitHub Packages publishers. This unblocks the stuck consumer PRs across the family **without the FuzeOne org transfer**.

## Same defect, three more steps

npm resolves `.npmrc` from the package dir **upward**, so the repo-root `.npmrc` is *project-level* and outranks the *user-level* file `setup-node` writes. The root file authenticates with `${GITHUB_TOKEN}` — but these steps only set `NODE_AUTH_TOKEN`, so it expanded **empty** and every publish `401`'d. Builds succeeded every time; only the publish died, which is why it read as a permissions problem.

Every remaining GitHub Packages publisher had it, and every last run failed:

| workflow | last run |
|---|---|
| `design-system-packages-publish` | 2026-08-04 — failure |
| `chat-packages-publish` | 2026-07-29 — failure |

**This is not theory.** #558 applied exactly this to `security-packages-publish`, and a manual dispatch then published `@izzywdev/fuzefront-security-client@0.2.0` — which is now in the registry.

## Why these two matter most

They are the packages consumers actually need, and their absence is the direct cause of the duplication across the family:

- **`@izzywdev/fuzefront-design-system`** — FuzeBI declares a design-system dependency that has never been resolvable, and FuzeSales reimplements the tokens locally with hardcoded hex fallbacks.
- **`@izzywdev/fuzefront-chat-{client,ui}`** — MendysRobotics ships **two committed `.tgz` tarballs** in `frontend/vendor/`, whose README states they exist because "the package is not installable today", complete with a removal plan.

## Deliberately not touched

**`sdk-publish.yml`.** It targets **public npmjs.org** with `NPM_TOKEN`, not GitHub Packages — a different mechanism and a different failure. Fixing it is a separate question and I did not guess at it.

## Verification, and its limit

- Both files parse as YAML; each of the three patched steps has **both** token env vars; each rendered `run` script contains the heredoc with its `NPMRC` terminator at column 0 (validated by rendering the block scalar, not by eyeballing indentation).
- Committed blobs are LF (`i/lf`) — git offered CRLF again on both files, which `gate-line-endings` would have caught.
- **Not verified: an actual publish.** These workflows are path-filtered on push to `master`, so like #558 they need a merge plus a manual dispatch to prove it. I can dispatch them once this merges, as I did for security.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
