### PR TITLE
fix(applications): package express-rate-limit into image (Dockerfile copies all workspace manifests + npm ci)

### DIFF
--- a/backend/applications/Dockerfile
+++ b/backend/applications/Dockerfile
@@ -9,13 +9,43 @@ FROM node:24-alpine AS build
 WORKDIR /app
 RUN apk add --no-cache python3 make g++
 
+# Copy EVERY workspace manifest referenced by the root "workspaces" array before
+# installing. npm resolves/hoists against the full set of workspace manifests;
+# omitting any of them makes `npm install` compute a DIFFERENT hoist tree than the
+# committed package-lock.json. That is exactly how express-rate-limit went missing
+# from the image: backend/security pins express-rate-limit@7.2.0 (exact) while the
+# other consumers allow ^7.2.0, producing a lockfile doppelganger
+# (root express-rate-limit@7.5.1 + backend/node_modules/express-rate-limit@7.2.0).
+# With those manifests absent, npm re-resolved and express-rate-limit never landed
+# in /app/node_modules, so the copied production node_modules lacked it.
+# Copy all manifests and use `npm ci`, which installs EXACTLY the committed
+# lockfile (deterministic hoist) and fails loudly if lock and manifests drift.
 COPY package.json package-lock.json ./
-COPY shared/package.json ./shared/
+COPY backend/package.json ./backend/
 COPY backend/core/package.json ./backend/core/
-COPY packages/feature-flags/package.json ./packages/feature-flags/
+COPY backend/security/package.json ./backend/security/
 COPY backend/applications/package.json ./backend/applications/
+COPY shared/package.json ./shared/
+COPY billing-client/package.json ./billing-client/
+COPY custom-hostname-client/package.json ./custom-hostname-client/
+COPY packages/billing-ui/package.json ./packages/billing-ui/
+COPY packages/chat-client/package.json ./packages/chat-client/
+COPY packages/chat-ui/package.json ./packages/chat-ui/
+COPY packages/identity-ui/package.json ./packages/identity-ui/
+COPY packages/auth-ui/package.json ./packages/auth-ui/
+COPY packages/account-security-ui/package.json ./packages/account-security-ui/
+COPY packages/portal-branding-ui/package.json ./packages/portal-branding-ui/
+COPY portal-client/package.json ./portal-client/
+COPY packages/i18n/package.json ./packages/i18n/
+COPY packages/i18n-translate/package.json ./packages/i18n-translate/
+COPY packages/feature-flags/package.json ./packages/feature-flags/
+COPY packages/security/package.json ./packages/security/
+COPY design-system/package.json ./design-system/
+COPY services/chat-service/package.json ./services/chat-service/
+COPY services/email-service/package.json ./services/email-service/
+COPY services/notification-service/package.json ./services/notification-service/
 
-RUN npm install
+RUN npm ci
 
 # Copy source
 COPY shared/ ./shared/


### PR DESCRIPTION
## Problem
`fuzefront-applications` (applications-service) crashloops in prod:

```
Error: Cannot find module 'express-rate-limit'
Require stack:
- /app/backend/applications/dist/routes/app-installations.js
```

Latent packaging gap exposed by #553, which added `import rateLimit from 'express-rate-limit'` to `app-installations.ts`.

## Root cause
Packaging bug in `backend/applications/Dockerfile` (build context = repo root), **not** a missing dependency — `express-rate-limit` is declared in `backend/applications/package.json` and hoisted in `package-lock.json` (`node_modules/express-rate-limit@7.5.1`).

The build stage copied only 5 of the repo's ~23 workspace `package.json` files before `RUN npm install`. npm hoists against the full workspace set, so with most manifests absent it computed a **different** hoist tree than the committed lockfile. `backend/security` pins `express-rate-limit` to **exact `7.2.0`** while other consumers allow `^7.2.0`, giving the lockfile a doppelganger (`node_modules/express-rate-limit@7.5.1` + `backend/node_modules/express-rate-limit@7.2.0`). With `backend`/`backend/security` manifests omitted, npm re-resolved and `express-rate-limit` never landed in the `/app/node_modules` copied into the production stage.

## Fix
Copy **every** workspace manifest referenced by the root `workspaces` array before install, and switch `npm install` → `npm ci` (installs exactly the committed lockfile; deterministic hoist; fails loudly on drift). Closes the whole class of "a workspace dep didn't land in the copied node_modules because hoisting differed from the lockfile."

No `prepare`/`postinstall`/`install` scripts exist in any workspace (only `prepublishOnly`, which doesn't run on `npm ci`), so copying all manifests is safe — nothing tries to build un-copied source.

## Verification (empirical — `docker build -f backend/applications/Dockerfile .` from repo root)
| | before | after |
|---|---|---|
| `require('express-rate-limit')` | FAILS `MODULE_NOT_FOUND` | OK |
| `/app/node_modules/express-rate-limit` | absent | present, `7.5.1` (matches lockfile) |
| app boot | crashloop | reaches runtime DB-wait (past module loading) |

Image size grows ~875MB → ~1.15GB (build stage now installs all workspaces' devDeps). Acceptable tradeoff for a deterministic, correct build during a crashloop hotfix; can be trimmed later with a dedicated `--omit=dev` production-deps stage.

Fixes #560
