### PR TITLE
fix(ci): make alias publishes idempotent, drop the ignored .npmrc

### DIFF
--- a/.github/workflows/auth-ui-packages-publish.yml
+++ b/.github/workflows/auth-ui-packages-publish.yml
@@ -70,16 +70,25 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Pin an explicit .npmrc in the package dir as the closest (winning)
-          # config, so registry+auth are deterministic regardless of ambient files.
-          cat > .npmrc <<'NPMRC'
-          @izzywdev:registry=https://npm.pkg.github.com
-          //npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}
-          NPMRC
           VERSION=$(npm pkg get version | tr -d '"')
           npm pkg set name=@izzywdev/fuzefront-auth-ui
           if npm view "@izzywdev/fuzefront-auth-ui@${VERSION}" version --registry=https://npm.pkg.github.com >/dev/null 2>&1; then
             echo "@izzywdev/fuzefront-auth-ui@${VERSION} already published — skipping."
           else
-            npm publish --registry=https://npm.pkg.github.com
+            # A failing `npm view` does NOT prove the version is absent (auth blips,
+            # workspace-config quirks). Without this, that case republishes an existing
+            # version, fails the step, and aborts the job before sibling packages get
+            # their turn — which is what blocked chat-ui@1.2.0 behind an unchanged
+            # chat-client@1.1.0. The registry's own refusal is the authoritative signal.
+            set +e
+            OUT=$(npm publish --registry=https://npm.pkg.github.com 2>&1); RC=$?
+            set -e
+            echo "$OUT"
+            if [ "$RC" -ne 0 ]; then
+              if echo "$OUT" | grep -q "cannot publish over"; then
+                echo "already published at this version - treating as success."
+              else
+                exit "$RC"
+              fi
+            fi
           fi

--- a/.github/workflows/chat-packages-publish.yml
+++ b/.github/workflows/chat-packages-publish.yml
@@ -69,18 +69,27 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Pin an explicit .npmrc in the package dir as the closest (winning)
-          # config, so registry + auth are deterministic regardless of ambient files.
-          cat > .npmrc <<'NPMRC'
-          @izzywdev:registry=https://npm.pkg.github.com
-          //npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}
-          NPMRC
           VERSION=$(npm pkg get version | tr -d '"')
           npm pkg set name=@izzywdev/fuzefront-chat-client
           if npm view "@izzywdev/fuzefront-chat-client@${VERSION}" version --registry=https://npm.pkg.github.com >/dev/null 2>&1; then
             echo "@izzywdev/fuzefront-chat-client@${VERSION} already published — skipping."
           else
-            npm publish --registry=https://npm.pkg.github.com
+            # A failing `npm view` does NOT prove the version is absent (auth blips,
+            # workspace-config quirks). Without this, that case republishes an existing
+            # version, fails the step, and aborts the job before sibling packages get
+            # their turn — which is what blocked chat-ui@1.2.0 behind an unchanged
+            # chat-client@1.1.0. The registry's own refusal is the authoritative signal.
+            set +e
+            OUT=$(npm publish --registry=https://npm.pkg.github.com 2>&1); RC=$?
+            set -e
+            echo "$OUT"
+            if [ "$RC" -ne 0 ]; then
+              if echo "$OUT" | grep -q "cannot publish over"; then
+                echo "already published at this version - treating as success."
+              else
+                exit "$RC"
+              fi
+            fi
           fi
 
       - name: Publish @izzywdev/fuzefront-chat-ui
@@ -93,16 +102,25 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Pin an explicit .npmrc in the package dir as the closest (winning)
-          # config, so registry + auth are deterministic regardless of ambient files.
-          cat > .npmrc <<'NPMRC'
-          @izzywdev:registry=https://npm.pkg.github.com
-          //npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}
-          NPMRC
           VERSION=$(npm pkg get version | tr -d '"')
           npm pkg set name=@izzywdev/fuzefront-chat-ui
           if npm view "@izzywdev/fuzefront-chat-ui@${VERSION}" version --registry=https://npm.pkg.github.com >/dev/null 2>&1; then
             echo "@izzywdev/fuzefront-chat-ui@${VERSION} already published — skipping."
           else
-            npm publish --registry=https://npm.pkg.github.com
+            # A failing `npm view` does NOT prove the version is absent (auth blips,
+            # workspace-config quirks). Without this, that case republishes an existing
+            # version, fails the step, and aborts the job before sibling packages get
+            # their turn — which is what blocked chat-ui@1.2.0 behind an unchanged
+            # chat-client@1.1.0. The registry's own refusal is the authoritative signal.
+            set +e
+            OUT=$(npm publish --registry=https://npm.pkg.github.com 2>&1); RC=$?
+            set -e
+            echo "$OUT"
+            if [ "$RC" -ne 0 ]; then
+              if echo "$OUT" | grep -q "cannot publish over"; then
+                echo "already published at this version - treating as success."
+              else
+                exit "$RC"
+              fi
+            fi
           fi

--- a/.github/workflows/design-system-packages-publish.yml
+++ b/.github/workflows/design-system-packages-publish.yml
@@ -69,16 +69,25 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Pin an explicit .npmrc in the package dir as the closest (winning)
-          # config, so registry + auth are deterministic regardless of ambient files.
-          cat > .npmrc <<'NPMRC'
-          @izzywdev:registry=https://npm.pkg.github.com
-          //npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}
-          NPMRC
           VERSION=$(npm pkg get version | tr -d '"')
           npm pkg set name=@izzywdev/fuzefront-design-system
           if npm view "@izzywdev/fuzefront-design-system@${VERSION}" version --registry=https://npm.pkg.github.com >/dev/null 2>&1; then
             echo "@izzywdev/fuzefront-design-system@${VERSION} already published — skipping."
           else
-            npm publish --registry=https://npm.pkg.github.com
+            # A failing `npm view` does NOT prove the version is absent (auth blips,
+            # workspace-config quirks). Without this, that case republishes an existing
+            # version, fails the step, and aborts the job before sibling packages get
+            # their turn — which is what blocked chat-ui@1.2.0 behind an unchanged
+            # chat-client@1.1.0. The registry's own refusal is the authoritative signal.
+            set +e
+            OUT=$(npm publish --registry=https://npm.pkg.github.com 2>&1); RC=$?
+            set -e
+            echo "$OUT"
+            if [ "$RC" -ne 0 ]; then
+              if echo "$OUT" | grep -q "cannot publish over"; then
+                echo "already published at this version - treating as success."
+              else
+                exit "$RC"
+              fi
+            fi
           fi

--- a/.github/workflows/security-packages-publish.yml
+++ b/.github/workflows/security-packages-publish.yml
@@ -66,18 +66,25 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Pin an explicit .npmrc in the package dir as the closest (winning)
-          # config, so registry + auth are deterministic regardless of ambient
-          # files. Mirrors auth-ui-packages-publish.yml, the one publisher in
-          # this repo that has actually shipped a package.
-          cat > .npmrc <<'NPMRC'
-          @izzywdev:registry=https://npm.pkg.github.com
-          //npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}
-          NPMRC
           VERSION=$(npm pkg get version | tr -d '"')
           npm pkg set name=@izzywdev/fuzefront-security-client
           if npm view "@izzywdev/fuzefront-security-client@${VERSION}" version --registry=https://npm.pkg.github.com >/dev/null 2>&1; then
             echo "@izzywdev/fuzefront-security-client@${VERSION} already published — skipping."
           else
-            npm publish --registry=https://npm.pkg.github.com
+            # A failing `npm view` does NOT prove the version is absent (auth blips,
+            # workspace-config quirks). Without this, that case republishes an existing
+            # version, fails the step, and aborts the job before sibling packages get
+            # their turn — which is what blocked chat-ui@1.2.0 behind an unchanged
+            # chat-client@1.1.0. The registry's own refusal is the authoritative signal.
+            set +e
+            OUT=$(npm publish --registry=https://npm.pkg.github.com 2>&1); RC=$?
+            set -e
+            echo "$OUT"
+            if [ "$RC" -ne 0 ]; then
+              if echo "$OUT" | grep -q "cannot publish over"; then
+                echo "already published at this version - treating as success."
+              else
+                exit "$RC"
+              fi
+            fi
           fi


### PR DESCRIPTION
Two defects in the alias publishers — **one of them mine, from #559.**

## 1. The `.npmrc` pinning in #559 is dead code

npm says so outright, in the run log:

```
npm warn config ignoring workspace config at
/home/runner/work/FuzeFront/FuzeFront/packages/chat-client/.npmrc
```

**A `.npmrc` inside a workspace package is ignored.** I copied that block from `auth-ui-packages-publish.yml` in #559 believing it was what made auth-ui the one publisher that had ever worked. It wasn't. The effective fix was setting **both** `GITHUB_TOKEN` and `NODE_AUTH_TOKEN` — which is retained everywhere. The dead block is removed from all four publishers so it doesn't get copied a fifth time.

## 2. The idempotence guard is not idempotent

It skips publishing only when `npm view <pkg>@<ver>` **succeeds**. But a failing `npm view` does not prove the version is absent — auth blips and workspace-config quirks make it error too. On failure it falls through to publish, and the registry refuses:

```
npm error You cannot publish over the previously published versions: 1.1.0
```

That fails the **step**, which aborts the **entire job**. Which is exactly what just happened: `chat-client@1.1.0` was unchanged and already published, so its step died — and **`chat-ui@1.2.0` never published**, even though it was the whole point of the run (it carries the widened React peer from #567 that unblocks MendysRobotics#274).

The registry's own refusal is now treated as the authoritative already-published signal, so a re-run is a no-op rather than a blocker. **Any other publish failure still fails the step** — this narrows what counts as success, it doesn't swallow errors.

## Why this keeps happening

Every publisher failure in this sequence has reported as something other than its cause: `401` for "no token on the step", `404` for "publisher never ran", and now "cannot publish over" for "an unrelated sibling package is unchanged". The guard existed precisely to prevent this last one and didn't, because it inferred absence from a command failing.

## Verification

- All four workflows parse as YAML.
- **5/5** publish steps carry the new guard; **0** leftover `.npmrc` blocks; **5/5** retain both token env vars.
- Committed blobs are LF.

Not verified: a live publish — these are `workflow_dispatch`/path-filtered, so it needs a merge plus a dispatch. I'll dispatch chat immediately after merge to get `chat-ui@1.2.0` out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
