### PR TITLE
ci(release): close notification/payment path gaps; build payment-service image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,13 @@ on:
       # failure mode the packages/** comment above describes, just for a
       # different path. This was live for every commit between #432 and now.
       - 'services/chat-service/**'
+      # notification-service/** and payment-service/** were both missing here,
+      # the same silent-ship gap the chat-service comment above describes: a
+      # change confined to one of those service dirs would merge green and never
+      # trigger a release, so the image would keep the old code (or, for the
+      # never-built payment-service, stay absent entirely).
+      - 'services/notification-service/**'
+      - 'services/payment-service/**'
       - 'clock-app/**'
       - 'deploy/helm/fuzefront/**'
       - '.github/workflows/release.yml'
@@ -161,6 +168,25 @@ jobs:
           tags: |
             ghcr.io/izzywdev/fuzefront-billing-service:${{ steps.tag.outputs.sha }}
             ghcr.io/izzywdev/fuzefront-billing-service:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build & push payment-service
+        # Self-contained Dockerfile (no @fuzefront/shared dep) => context is
+        # services/payment-service/, like clock-app — NOT the repo root the
+        # workspace services use. Scaffold gateway, disabled in prod; this build
+        # only makes the image EXIST so paymentService.image.tag can be bumped
+        # off "" and a future go-live is a values flip, not a missing image.
+        id: payment_image
+        continue-on-error: true
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: services/payment-service
+          file: services/payment-service/Dockerfile
+          push: true
+          tags: |
+            ghcr.io/izzywdev/fuzefront-payment-service:${{ steps.tag.outputs.sha }}
+            ghcr.io/izzywdev/fuzefront-payment-service:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -303,8 +329,9 @@ jobs:
           CLOCK_OK=$(ok "${{ steps.clock_image.outcome }}")
           CHAT_OK=$(ok "${{ steps.chat_image.outcome }}")
           NOTIF_OK=$(ok "${{ steps.notification_image.outcome }}")
-          EXPECTED=$((2 + EMAIL_OK + SMS_OK + PROV_OK + BILLING_OK + SECURITY_OK + APPS_OK + CLOCK_OK + CHAT_OK + NOTIF_OK))
-          echo "built: email=${EMAIL_OK} sms=${SMS_OK} provisioning=${PROV_OK} billing=${BILLING_OK} security=${SECURITY_OK} applications=${APPS_OK} clock=${CLOCK_OK} chat=${CHAT_OK} notification=${NOTIF_OK}"
+          PAYMENT_OK=$(ok "${{ steps.payment_image.outcome }}")
+          EXPECTED=$((2 + EMAIL_OK + SMS_OK + PROV_OK + BILLING_OK + SECURITY_OK + APPS_OK + CLOCK_OK + CHAT_OK + NOTIF_OK + PAYMENT_OK))
+          echo "built: email=${EMAIL_OK} sms=${SMS_OK} provisioning=${PROV_OK} billing=${BILLING_OK} security=${SECURITY_OK} applications=${APPS_OK} clock=${CLOCK_OK} chat=${CHAT_OK} notification=${NOTIF_OK} payment=${PAYMENT_OK}"
           echo "expecting ${EXPECTED} tag rewrites (backend + frontend are always built)"
           if [ "${APPS_OK}${SECURITY_OK}${EMAIL_OK}${BILLING_OK}" != "1111" ]; then
             echo "::warning::one or more auxiliary images failed to build; their values-prod tags are left pinned to the last good release"
@@ -341,7 +368,7 @@ jobs:
           awk -v sha="$SHA" -v chat="$CHAT_OK" -v notif="$NOTIF_OK" \
               -v email="$EMAIL_OK" -v sms="$SMS_OK" -v prov="$PROV_OK" \
               -v billing="$BILLING_OK" -v security="$SECURITY_OK" \
-              -v apps="$APPS_OK" -v clock="$CLOCK_OK" '
+              -v apps="$APPS_OK" -v clock="$CLOCK_OK" -v payment="$PAYMENT_OK" '
             hot {
               hot=0
               if ($0 ~ /^[[:space:]]*tag:/) {
@@ -362,6 +389,7 @@ jobs:
             prov == 1 && /repository: ghcr\.io\/izzywdev\/fuzefront-provisioning-service\r?$/ { hot=1 }
             chat == 1 && /repository: ghcr\.io\/izzywdev\/fuzefront-chat-service\r?$/ { hot=1 }
             notif == 1 && /repository: ghcr\.io\/izzywdev\/fuzefront-notification-service\r?$/ { hot=1 }
+            payment == 1 && /repository: ghcr\.io\/izzywdev\/fuzefront-payment-service\r?$/ { hot=1 }
             { print }
             END { print n+0 > "/tmp/bump-count" }
           ' /tmp/vp-current.yaml > /tmp/vp-new.yaml


### PR DESCRIPTION
## 📋 Description

Two related fixes to the release pipeline, batched. **No app-logic change**, and **payment-service stays `enabled: false`** — this only makes its image *exist* so a future go-live is a values flip, not a missing-image scramble. Follow-up to #565.

## 🔄 Type of Change

- [x] 🐛 Bug fix (release-trigger path gaps)
- [x] 🔨 Build system (new image build + tag-bump wiring)

## 🔧 Implementation Details

### 1. Missing release-trigger paths
`release.yml`'s `push.paths` listed `services/{email,sms,provisioning,billing,chat}-service/**` but **not** `notification-service/**` or `payment-service/**` — the exact silent-ship gap the file already documents for chat-service (a change confined to one of those dirs merges green and never rebuilds the image). Added both.

### 2. payment-service was never built
It had no build step, so its image never existed and `paymentService.image.tag` sat at `""` (→ `InvalidImageName` if ever enabled). Added a **Build & push payment-service** step (self-contained context, like clock-app) and wired it through the GitOps tag-bump guard: `PAYMENT_OK`, the `EXPECTED` count, the `awk payment` var, and the repository anchor — exactly as the bump step's own comment demands when a build step is added.

## 🧪 Testing

- [x] `release.yml` parses as YAML.
- [x] **Simulated the bump `awk`** against the real `values-prod.yaml`: with all builds succeeding it rewrites **12** tags (`2 + 10` gated services), matching the new `EXPECTED`; payment's `tag: ""` correctly becomes the SHA. If the payment build fails (`continue-on-error`), its anchor is guarded off and `COUNT` still equals `EXPECTED`, so the guard holds either way.
- [ ] ⚠️ No local `docker build` in this sandbox (no daemon). Payment's build is `continue-on-error`, so a failure is non-fatal — it leaves the tag pinned rather than breaking the release.

## 📝 Deployment Notes

- [x] Merging triggers a release (it edits `release.yml`), which builds payment-service and bumps its tag off `""`. **payment-service still won't render** — `enabled: false`. Enabling it remains a separate deploy-window decision (needs Stripe secrets + product sign-off).
- [x] Like any release, this rolls the already-deployed services to a fresh build of the same code — routine, but it is a prod roll, so **merge in a deploy window**.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hc8XVgyLJkyeMsRysJYCqP)_