### PR TITLE
fix(chat-ui): publish the client peer under the resolvable alias scope

### DIFF
--- a/.github/workflows/chat-packages-publish.yml
+++ b/.github/workflows/chat-packages-publish.yml
@@ -104,6 +104,17 @@ jobs:
         run: |
           VERSION=$(npm pkg get version | tr -d '"')
           npm pkg set name=@izzywdev/fuzefront-chat-ui
+          # chat-ui peers on @fuzefront/chat-client, a scope that cannot be published
+          # (GitHub Packages requires the scope to match the owning account). Left as-is,
+          # npm resolves that peer from the PUBLIC registry and consumers get
+          #   404 Not Found - GET https://registry.npmjs.org/@fuzefront%2fchat-client
+          # even though they installed the client fine under an alias. The source keeps
+          # the @fuzefront name so the in-repo workspace link still resolves; only the
+          # PUBLISHED artifact is rewritten — same treatment the package name already
+          # gets one line above. @fuzeone/* is the name consumers install under, and is
+          # what the canonical scope becomes after the org transfer.
+          npm pkg delete peerDependencies.@fuzefront/chat-client
+          npm pkg set peerDependencies.@fuzeone/chat-client='^1.1.0'
           if npm view "@izzywdev/fuzefront-chat-ui@${VERSION}" version --registry=https://npm.pkg.github.com >/dev/null 2>&1; then
             echo "@izzywdev/fuzefront-chat-ui@${VERSION} already published — skipping."
           else

--- a/packages/chat-ui/package.json
+++ b/packages/chat-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fuzefront/chat-ui",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Design-system-first React chat UI for the FuzeFront chat-service (SSE streaming, RAG citations, agent confirmation prompts).",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
The last thing blocking **MendysRobotics#274**. Found by installing, not by reading.

## The bug

`chat-ui` peers on `@fuzefront/chat-client` — a scope that **cannot be published**, since GitHub Packages requires the npm scope to match the owning account and there is no `fuzefront` org.

A consumer who installs the client *correctly* (under an `npm:` alias) still fails, because npm resolves the **peer** from the public registry:

```
npm error 404 Not Found - GET https://registry.npmjs.org/@fuzefront%2fchat-client
npm error 404  '@fuzefront/chat-client@^1.1.0' is not in this registry.
```

This surfaced on MendysRobotics#274 the moment #567 cleared the React conflict — the `react@^19` error disappeared and this took its place. I flagged it in #567 as deliberately out of scope; this is that follow-up.

## The fix

The publish step **already rewrites the package name** to the alias (`npm pkg set name=@izzywdev/fuzefront-chat-ui`). It now rewrites this peer the same way:

```yaml
npm pkg delete peerDependencies.@fuzefront/chat-client
npm pkg set peerDependencies.@fuzeone/chat-client='^1.1.0'
```

**Source is unchanged** — it keeps the `@fuzefront` name so the in-repo workspace link still resolves. Only the *published artifact* is rewritten, which is the same split the package name already uses. `@fuzeone/*` is what consumers install under today, and is what the canonical scope becomes after the org transfer.

## Why the version bump matters here

`1.2.0` → `1.2.1`, and this is load-bearing rather than cosmetic: `1.2.0` is already published, and the idempotence guard added in #568 would (correctly) skip a republish of the same version. **Without the bump, the corrected peer would never actually ship** — the workflow would report success and change nothing. That is precisely the silent-success class this sequence has been about, so it seemed worth calling out rather than quietly bumping.

## Verification

- Workflow parses; the rewrite is on the `Publish @izzywdev/fuzefront-chat-ui` step (confirmed by inspecting the parsed step, after an initial check mistakenly matched the `Build chat-ui` step).
- The React half is already proven: `chat-ui@1.2.0` published and the `react@^19` peer conflict is gone from the Mendys install.

Not verified: the published artifact's peer — that needs this merged plus a dispatch, which I'll do next, then #274 installs cleanly and drops its two vendored `.tgz` files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
