### PR TITLE
fix(ci): drop --if-present from the lerna build step so the publish can actually run

### DIFF
--- a/.github/workflows/packages-publish.yml
+++ b/.github/workflows/packages-publish.yml
@@ -71,8 +71,17 @@ jobs:
         # proves nothing about that, so assert it before shipping anything.
         run: node --test scripts/__tests__/publish-packages.test.mjs
 
-      - name: Build packages (topological, if a build script exists)
-        run: npx lerna run build --if-present
+      - name: Build packages (topological)
+        # NOT `--if-present`: lerna 10 removed it and errors with
+        # "Unknown arguments: if-present, ifPresent". That flag was inherited
+        # from this workflow's original form and had never executed — the job was
+        # gated on an owner that does not exist, so every run for the life of the
+        # file was a skip. Fixing the guard is what first ran this line.
+        #
+        # The flag is also unnecessary: `lerna run <script>` already skips
+        # packages that do not define it. Verified locally — 24 projects built,
+        # exit 0.
+        run: npx lerna run build
 
       - name: Resolve what would publish
         run: node scripts/publish-packages.mjs --dry-run


### PR DESCRIPTION
## 📋 Description

`packages-publish.yml` ran for the first time in its life after #563 fixed its owner guard — and failed immediately:

```
ERR! lerna Unknown arguments: if-present, ifPresent
```

lerna 10 removed `--if-present`. The flag was inherited from the workflow's original form and had **never executed**, because the job was gated on an owner that does not exist, so every run for the life of the file was a skip. Fixing the guard is what first ran this line.

That is the same lesson the guard itself carried, one layer down: a step that never runs is indistinguishable from a step that works.

**Three master pushes have failed on this since the merge** (`2d98dde8`, `63125dc4`, `2951376c`). Nothing has published yet.

## 🔄 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## 🧪 Testing

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Manual testing

**Test Configuration:**

- Node.js version: 22.22.2 (CI runs 24.x)
- npm version: 10.9.7
- OS: Linux
- Browser (if applicable): n/a

### Test Instructions

```bash
npx lerna run build   # 24 projects, exit 0
```

Ran against this tree: `Successfully ran target build for 24 projects`, exit 0. Also confirmed `npx lerna run --help` no longer lists `--if-present` on lerna 10.0.0, which is what CI resolves.

The flag was never needed either way — `lerna run <script>` already skips packages that do not define it.

## 🔧 Implementation Details

### Changes Made

- **Backend Changes:** none
- **Frontend Changes:** none
- **SDK Changes:** none

One line in `.github/workflows/packages-publish.yml`, plus a comment recording why the flag was there and why removing it is safe.

### Code Quality

- [x] Code follows the project's coding standards
- [x] Self-review of code completed
- [x] Code is commented, particularly in hard-to-understand areas
- [x] No console.log or debugging statements left in code

### Documentation

- [ ] Documentation has been updated (if applicable)
- [ ] API documentation updated (if applicable)
- [ ] README updated (if applicable)
- [ ] Migration guide provided (for breaking changes)

## 🚨 Breaking Changes

None.

## 📋 Checklist

### Pre-submission

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective — the fix is a CI workflow line; the publish run itself is the test
- [x] New and existing unit tests pass locally with my changes

### Code Quality

- [x] Code follows conventional commit format
- [x] TypeScript strict mode passes
- [x] ESLint passes without errors
- [x] No security vulnerabilities introduced
- [x] Performance impact considered and documented

## 🎯 Reviewers

- [ ] Whoever owns the release path — this is the last thing between the repo and its first-ever package publish

## 📝 Additional Notes

### Deployment Notes

- [ ] Requires database migration
- [ ] Requires environment variable changes
- [ ] Requires dependency updates
- [ ] Requires configuration changes

**On merge this should publish ~18 packages under `@izzywdev/fuzefront-*` for the first time.** Worth watching the run rather than assuming green means published — the 8 transform tests and the `--dry-run` step both already pass, so the remaining unknowns are the registry write itself and the `packages: write` token scope.

### Future Work

- Converting `backend/Dockerfile`, `backend/security/Dockerfile`, `frontend/Dockerfile` and `services/billing-service/Dockerfile` to `npm ci` (FFRNT-254 follow-up). #563 attempted and reverted this; master's e2e runs since confirm the revert was correct — `OIDC Plumbing` and `E2E (sign-in)` are both green again post-merge. The exemptions in `scripts/check-dockerfile-lockfile.mjs` carry the reasoning.
- Unrelated, seen in the e2e logs: `Permit sync ran WITHOUT the app registry — every self-registered product policy was omitted`, caused by `column "slug" does not exist` on `apps`. Fails soft, so products registered through the app registry silently end up with no roles in Permit.

## 🔄 Backwards Compatibility

- [x] Fully backwards compatible

---
_Generated by [Claude Code](https://claude.ai/code/session_01GLocxJ1aNrFWeAo51iHuFa)_