### PR TITLE
fix(authentik-ops): stop Cloudflare from blocking the diagnose/apply path

### DIFF
--- a/deploy/helm/fuzefront/authentik/ops.py
+++ b/deploy/helm/fuzefront/authentik/ops.py
@@ -22,7 +22,14 @@ def api(path, method='GET', body=None):
     req = urllib.request.Request(
         f'{AK}/api/v3{path}', method=method,
         headers={'Authorization': f'Bearer {TOK}', 'Accept': 'application/json',
-                 'Content-Type': 'application/json'},
+                 'Content-Type': 'application/json',
+                 # Without this, urllib sends its default "Python-urllib/3.x" UA,
+                 # which Cloudflare's bot heuristics block at the tunnel edge with
+                 # error 1010 ("browser signature ban") before Authentik ever sees
+                 # the request — the admin API and the token are never reached.
+                 # prod-authentik-probe.yml hits the same host successfully because
+                 # it uses curl, whose UA isn't flagged. See #507.
+                 'User-Agent': 'FuzeFront-authentik-ops/1.0 (+github-actions)'},
         data=json.dumps(body).encode() if body is not None else None)
     try:
         with urllib.request.urlopen(req, timeout=30) as r:


### PR DESCRIPTION
Closes the loop on FuzeInfra#507. The token mirror there was correct — this is what was blocking it from actually working.

## The bug

`prod-authentik-ops.yml phase=diagnose` failed immediately:

```
- version endpoint: HTTP 403 — {"error": "{\"type\":\".../cloudflare-1xxx-errors/error-1010/\", ...
**Authentik admin API unreachable or token rejected — aborting.**
```

**Error 1010 is Cloudflare's own definition of a client-signature ban** — a WAF/bot block at the tunnel edge. It fires before the request reaches Authentik, so neither the token nor Authentik's config was ever evaluated.

`ops.py` calls `urllib.request.Request()` with no `User-Agent` header, so Python sends its default `Python-urllib/3.x` — one of the most commonly flagged bot signatures, since it announces itself as a script rather than a normal client.

## Why this was hard to see

`FuzeInfra#507` documents `prod-authentik-probe.yml` succeeding against the **same host**, twice. That workflow uses `curl` — an unflagged signature. Two different clients hitting `auth.fuzefront.com`, one blocked and one not, is exactly the signature a UA-based heuristic produces. There's no WAF/bot-mode terraform resource for this zone in FuzeInfra, so this is Cloudflare's default heuristic, not a deliberately configured rule — nobody had allowlisted a bare Python script before now.

## The fix

One header:

```python
'User-Agent': 'FuzeFront-authentik-ops/1.0 (+github-actions)'
```

## Verification

- `ast.parse` — syntax valid.
- Re-running `phase=diagnose` after this merges is the real verification (Cloudflare's edge behavior can only be confirmed live); I'll do that immediately after merge and report the result on FuzeInfra#507.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
