### PR TITLE
fix(fuzequality): discover individual pytest scenarios

### DIFF
--- a/FuzeQuality/packages/scanner/src/index.ts
+++ b/FuzeQuality/packages/scanner/src/index.ts
@@ -50,10 +50,12 @@ const OPENAPI_CONFIG_GLOBS = [
   '**/*swagger*.{ts,js,mjs,cjs}',
 ]
 
-export const SCANNER_VERSION = '1.1.0'
+export const SCANNER_VERSION = '1.2.0'
 
 const TEST_GLOBS = [
   '**/*.{test,spec}.{ts,tsx,js,jsx,mjs,cjs,py}',
+  '**/test_*.py',
+  '**/*_test.py',
   '**/tests/**/*.{ts,tsx,js,jsx,mjs,cjs,py}',
   '**/e2e/**/*.{ts,tsx,js,jsx,mjs,cjs,py}',
 ]
@@ -89,8 +91,15 @@ function levelFor(file: string, source: string): TestCase['level'] {
 
 function extractTests(repository: Repository, file: string, source: string): TestCase[] {
   const cases: TestCase[] = []
-  const titlePattern = /\b(?:it|test)\s*\(\s*(['"`])([^\n]+?)\1/g
-  const titleMatches = [...source.matchAll(titlePattern)]
+  const titleMatches = file.endsWith('.py')
+    ? [...source.matchAll(/^[ \t]*(?:async\s+)?def\s+(test_[A-Za-z0-9_]+)\s*\(/gm)].map(match => ({
+        index: match.index ?? 0,
+        title: match[1].replace(/^test_/, '').replace(/_+/g, ' '),
+      }))
+    : [...source.matchAll(/\b(?:it|test)\s*\(\s*(['"`])([^\n]+?)\1/g)].map(match => ({
+        index: match.index ?? 0,
+        title: match[2].trim(),
+      }))
   const metadata = (segment: string) => {
     const routeMatches = [
       ...segment.matchAll(/\b(get|post|put|patch|delete)\s*\(\s*(['"`])([^'"`]+)\2/gi),
@@ -111,8 +120,8 @@ function extractTests(repository: Repository, file: string, source: string): Tes
     }
   }
   for (const [index, match] of titleMatches.entries()) {
-    const title = match[2].trim()
-    const start = match.index ?? 0
+    const title = match.title
+    const start = match.index
     const end = titleMatches[index + 1]?.index ?? source.length
     const evidence = metadata(source.slice(start, end))
     cases.push({

--- a/FuzeQuality/packages/scanner/src/scanner.test.ts
+++ b/FuzeQuality/packages/scanner/src/scanner.test.ts
@@ -64,7 +64,7 @@ paths:
     expect(result.expectations.find(item => item.kind === 'response-200')?.coverage).toBe('gap')
     expect(result.scanDetails).toMatchObject({
       sourceRevision: 'a'.repeat(40),
-      scannerVersion: '1.1.0',
+      scannerVersion: '1.2.0',
       partial: false,
       counts: {
         operations: 1,
@@ -143,6 +143,56 @@ paths:
     expect(result.expectations.find(item => item.kind === 'response-200')?.coverage).toBe('covered-explicit')
     expect(result.expectations.find(item => item.kind === 'response-404')?.coverage).toBe('covered-explicit')
     expect(result.expectations.find(item => item.kind === 'missing-path-id')?.coverage).toBe('gap')
+  })
+
+  it('discovers root-level pytest functions and preserves per-scenario evidence', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'fuzequality-pytest-'))
+    await writeFile(
+      join(root, 'openapi.yaml'),
+      `openapi: 3.0.0
+info: { title: Sample, version: 1.0.0 }
+paths:
+  /users/{id}:
+    get:
+      operationId: getUser
+      security: [{ bearerAuth: [] }]
+      parameters:
+        - { name: id, in: path, required: true, schema: { type: string } }
+      responses: { '200': { description: ok }, '401': { description: unauthenticated }, '404': { description: missing } }
+`
+    )
+    await writeFile(
+      join(root, 'test_users.py'),
+      `def test_get_user_returns_200(client):
+    # @fuzequality api api:sample:openapi.yaml:getUser
+    response = client.get('/users/42')
+    assert response.status_code == 200
+
+def test_get_user_missing_auth_returns_401(client):
+    # @fuzequality api api:sample:openapi.yaml:getUser
+    response = client.get('/users/42')
+    assert response.status_code == 401
+
+async def test_get_user_missing_id_returns_404(client):
+    # @fuzequality api api:sample:openapi.yaml:getUser
+    response = client.get('/users/')
+    assert response.status_code == 404
+`
+    )
+
+    const result = await scanRepository(repository, root)
+
+    expect(result.tests.map(test => test.title)).toEqual([
+      'get user returns 200',
+      'get user missing auth returns 401',
+      'get user missing id returns 404',
+    ])
+    expect(result.tests.every(test => test.assertionCount === 1)).toBe(true)
+    expect(result.tests.every(test => test.explicitTargets?.includes('api:sample:openapi.yaml:getUser'))).toBe(true)
+    expect(result.expectations.find(item => item.kind === 'happy-path')?.coverage).toBe('covered-explicit')
+    expect(result.expectations.find(item => item.kind === 'authentication-missing')?.coverage).toBe('covered-explicit')
+    expect(result.expectations.find(item => item.kind === 'missing-path-id')?.coverage).toBe('covered-explicit')
+    expect(result.expectations.find(item => item.kind === 'response-200')?.coverage).toBe('covered-explicit')
   })
 
   it('rejects credentials embedded in repository URLs', () => {


### PR DESCRIPTION
## Summary
- discover root-level pytest files using conventional test_*.py and *_test.py names
- create one catalog test case per sync or async pytest function
- preserve per-scenario explicit targets, assertions, and coverage evidence
- bump scanner version to 1.2.0 so exact revisions can be reprocessed

## Verification
- npx vitest run packages/scanner/src/scanner.test.ts (22 passed)
- npm run type-check