### PR TITLE
fix(authentik): add grant_types to mendys-platform blueprint (main set) — FuzeInfra#495

### DIFF
--- a/deploy/helm/fuzefront/authentik/blueprints/provider-oidc-mendys-platform.yaml
+++ b/deploy/helm/fuzefront/authentik/blueprints/provider-oidc-mendys-platform.yaml
@@ -1,11 +1,11 @@
-# Authentik Blueprint — MendysRobotics Platform OIDC provider + Application
+# Authentik Blueprint -- MendysRobotics Platform OIDC provider + Application
 #
 # Creates the OIDC provider and Application for the `mendys-platform`
-# consumer product (the MendysRobotics platform — live.mendysrobotics.com +
+# consumer product (the MendysRobotics platform -- live.mendysrobotics.com +
 # marketplace.mendysrobotics.com). Modeled on provider-oidc-mendys-datasets.yaml.
 #
 # client_secret is injected at blueprint-apply time via Authentik's !Env
-# YAML tag — it reads AUTHENTIK_MENDYS_PLATFORM_CLIENT_SECRET from the
+# YAML tag -- it reads AUTHENTIK_MENDYS_PLATFORM_CLIENT_SECRET from the
 # worker pod's environment (sourced from the chart Secret via an OPTIONAL
 # secretKeyRef; key MENDYS_PLATFORM_CLIENT_SECRET). No secret value is
 # stored in this file or in the ConfigMap.
@@ -16,7 +16,7 @@
 # re-applying.
 #
 # DESIGN: All objects this blueprint needs are defined inline (flow, scope
-# mappings) — no !Find references to system-blueprint objects NOR to another
+# mappings) -- no !Find references to system-blueprint objects NOR to another
 # custom blueprint's objects. Authentik's Celery blueprint runner applies
 # blueprints concurrently; a !Find that references an object committed by a
 # DIFFERENT blueprint would silently abort the entry if that object isn't yet
@@ -26,8 +26,16 @@ metadata:
   name: MendysRobotics Platform OIDC Provider
   labels:
     blueprints.goauthentik.io/instantiate: "true"
+    # RE-APPLY MARKER (FuzeInfra#495 / main-blueprints fix): bumping this label's
+    # value changes the blueprint content hash and forces Authentik's runner to
+    # RE-APPLY (upsert) the entries below. The provider was originally created
+    # without grant_types (missing in the 2026-07-28 apply), so authorize returned
+    # `invalid_request`. PR #522 fixed blueprints-mendys/ (the unused silo); this
+    # fixes the live path (blueprints/ -> auth.fuzefront.com). To force another
+    # re-apply in future, bump the date suffix.
+    fuzefront.io/blueprint-reapply: "2026-08-10-grant-types-495"
 entries:
-  # ── Authorization flow (implicit consent) ────────────────────────────────────
+  # -- Authorization flow (implicit consent) ------------------------------------
   - model: authentik_flows.flow
     state: present
     identifiers:
@@ -40,7 +48,7 @@ entries:
       authentication: require_authenticated
       policy_engine_mode: all
 
-  # ── Scope mappings (inline — no cross-blueprint dependency) ──────────────────
+  # -- Scope mappings (inline -- no cross-blueprint dependency) -----------------
   - model: authentik_providers_oauth2.scopemapping
     state: present
     identifiers:
@@ -79,7 +87,7 @@ entries:
             "groups": [g.name for g in request.user.ak_groups.all()],
         }
 
-  # ── OIDC / OAuth2 provider ────────────────────────────────────────────────────
+  # -- OIDC / OAuth2 provider ---------------------------------------------------
   - model: authentik_providers_oauth2.oauth2provider
     state: present
     identifiers:
@@ -87,6 +95,13 @@ entries:
     attrs:
       name: MendysRobotics Platform
       client_type: confidential
+      # Required since Authentik 2026.x: fresh providers default to NO allowed
+      # grant types and reject every authorize request with `invalid_request`.
+      # The provider was created on 2026-07-28 from a blueprint that lacked
+      # this field, so it has been rejecting authorize ever since (FuzeInfra#495).
+      grant_types:
+        - authorization_code
+        - refresh_token
       client_id: "mendys-platform-oidc-client"
       client_secret: !Env [AUTHENTIK_MENDYS_PLATFORM_CLIENT_SECRET, ""]
       redirect_uris:
@@ -103,7 +118,7 @@ entries:
       authorization_flow: !Find [authentik_flows.flow, [slug, mendys-platform-authorization-implicit-consent]]
       invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
 
-  # ── Application ───────────────────────────────────────────────────────────────
+  # -- Application --------------------------------------------------------------
   - model: authentik_core.application
     state: present
     identifiers:


### PR DESCRIPTION
## Root cause

PR #522 fixed \`blueprints-mendys/provider-oidc-mendys-platform.yaml\` — the MendysRobotics silo that is **\`enabled: false\`** in prod. The live provider lives on **\`auth.fuzefront.com\`** and is driven by **\`blueprints/provider-oidc-mendys-platform.yaml\`** (the main set). That file was **missing \`grant_types\`**, so every OIDC authorize request has returned \`invalid_request\` since the provider was first created on 2026-07-28.

## Fix

- Add \`grant_types: [authorization_code, refresh_token]\` to the provider attrs
- Add \`fuzefront.io/blueprint-reapply: "2026-08-10-grant-types-495"\` so the content hash changes and the Authentik worker re-applies the entry with the corrected fields
- After merge: run \`prod-authentik-ops.yml phase=apply blueprints=provider-oidc-mendys-platform\` to force-confirm

## Verification plan

1. Merge → Argo syncs ConfigMap → blueprint worker re-applies provider
2. Run \`prod-authentik-ops.yml phase=apply blueprints=provider-oidc-mendys-platform\` to confirm \`last_applied\` timestamp refreshes with \`status=successful\`
3. Probe authorize: \`curl -sI "https://auth.fuzefront.com/application/o/authorize/?..."\` — must redirect to login, not return \`error=invalid_request\`

Closes FuzeInfra#495

🤖 Generated with [Claude Code](https://claude.com/claude-code)