### PR TITLE
ci: stop the stranded-branch detector losing the push-then-open race

### DIFF
--- a/.github/workflows/claude-auto-pr.yml
+++ b/.github/workflows/claude-auto-pr.yml
@@ -51,6 +51,14 @@ permissions:
   pull-requests: write
   issues: write   # required for gh label create (repo-level labels API)
 
+# One waiter per branch. The step below sits in a grace window for up to five
+# minutes, and an agent that pushes three times in a row would otherwise stack
+# three overlapping waiters all asking the same question. Only the newest push
+# reflects the branch's current state, so cancel the older ones.
+concurrency:
+  group: stranded-branch-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   open-pr:
     runs-on: ubuntu-latest
@@ -91,17 +99,42 @@ jobs:
             exit 0
           fi
 
-          # RE-CHECK before declaring the branch stranded. The check at the top of this
-          # step and the create above are not atomic, and the agent is REQUIRED to open
-          # its own PR — so the normal, correct sequence races this job: push starts the
-          # workflow, the agent opens its PR moments later, and by the time we attempt
-          # the create the PR exists. `gh pr create` then fails with "a pull request for
-          # branch ... already exists", which is the SUCCESS condition, and we reported
-          # it as stranded. That false positive fires precisely when the process is
-          # followed correctly, which is the worst possible time for it.
+          # WAIT before declaring the branch stranded. The agent is REQUIRED to open its
+          # own PR, so the normal, correct sequence races this job: the push starts the
+          # workflow, and the agent opens its PR seconds to minutes later.
+          #
+          # A single immediate re-check used to sit here and was not enough — it ran
+          # within ~5s of the push and lost the race every time. Measured on three
+          # consecutive PRs (#563, #571, #583): the job ran 11:51:13-11:51:19 while the
+          # PR appeared at 11:51:38, so the re-check was ~20s early. Every one of those
+          # was a red X that cleared on a manual re-run, i.e. a false positive that
+          # fired precisely BECAUSE the process was followed correctly.
+          #
+          # So poll instead of peeking once. A live agent gets its PR seen; an agent
+          # that died still fails, just $GRACE_SECONDS later. That delay costs nothing
+          # real — this job is seconds of runner time, `governance-nightly` is the
+          # backstop for anything missed, and a stranded branch is not an emergency
+          # measured in minutes. A detector that cries wolf on the happy path gets
+          # ignored, which is the actual failure mode worth engineering against.
+          GRACE_SECONDS=300
+          INTERVAL=20
+          waited=0
+          while [ "$waited" -lt "$GRACE_SECONDS" ]; do
+            existing=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number' 2>/dev/null || true)
+            if [ -n "$existing" ]; then
+              echo "PR #$existing appeared after ${waited}s — the agent did its job. Nothing to do."
+              exit 0
+            fi
+            sleep "$INTERVAL"
+            waited=$((waited + INTERVAL))
+            echo "No PR for $BRANCH yet (waited ${waited}s of ${GRACE_SECONDS}s) — still within the agent's grace window."
+          done
+
+          # Final check after the window closes, so a PR opened during the last
+          # interval is not missed.
           existing=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number' 2>/dev/null || true)
           if [ -n "$existing" ]; then
-            echo "PR #$existing was opened while this job was running — the agent did its job. Nothing to do."
+            echo "PR #$existing appeared just as the grace window closed — nothing to do."
             exit 0
           fi
 
@@ -119,9 +152,10 @@ jobs:
             echo "\`$BASE\`)."
             echo ""
             echo "**The agent that pushed this branch was supposed to open its own PR and"
-            echo "did not** — most likely it died mid-run. The work is safe on the remote"
-            echo "but invisible, and \`governance-nightly\` will reap the branch if it stays"
-            echo "that way."
+            echo "did not** — most likely it died mid-run. No PR appeared in the"
+            echo "${GRACE_SECONDS}s after the push, so this is not the usual push-then-open"
+            echo "race. The work is safe on the remote but invisible, and"
+            echo "\`governance-nightly\` will reap the branch if it stays that way."
             echo ""
             echo "**To salvage:** \`gh pr create --base $BASE --head $BRANCH --fill --label auto-merge\`"
           } | tee -a "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## 📋 Description

`claude-auto-pr.yml` (workflow name: *Stranded-branch detector*) fires on every push to an agent branch and, finding no PR, declares the branch stranded. But agents are **required** to open their own PR (CLAUDE.md, branch lifecycle), and they push *first* — so the correct sequence races this job and loses.

A single immediate re-check was already in place for exactly this race, with a comment describing it. It was not enough: it runs within seconds of the push, while the PR lands tens of seconds later. Measured on #583 — the job ran 11:51:13–11:51:19, the PR was created at 11:51:38, so the re-check was ~20s early. #563, #571 and #583 all got a red X that cleared on a manual re-run.

**The false positive fires precisely because the process was followed correctly**, which is the worst possible time for it — and a detector that cries wolf on the happy path gets ignored, which is the failure mode actually worth engineering against.

## 🔄 Type of Change

- 🐛 Bug fix (non-breaking change which fixes an issue)

## 🔧 Implementation Details

### Changes Made

Single file: `.github/workflows/claude-auto-pr.yml`.

- **Poll instead of peek.** Replaced the one-shot re-check with a `GRACE_SECONDS=300` / `INTERVAL=20` loop, plus a final check after the window closes so a PR opened during the last interval is not missed. A live agent gets its PR seen; a dead agent still fails, just five minutes later.
- **Per-branch concurrency.** Added `concurrency: stranded-branch-${{ github.ref }}` with `cancel-in-progress: true`. Without it an agent pushing three times in a row stacks three overlapping five-minute waiters, all asking the same question — only the newest push reflects the branch's current state.
- **Honest reporting.** The stranded-branch step summary now states that no PR appeared within the grace window, so the report distinguishes a genuinely dead agent from the ordinary race.

### Why the delay is free

This job is seconds of runner time; `governance-nightly` is the backstop for anything missed; and a stranded branch is not an emergency measured in minutes. Nothing gates on this check, so waiting costs nothing real.

### What is deliberately unchanged

The best-effort `gh pr create` before the wait stays. It cannot succeed on this repo (`can_approve_pull_request_reviews` is false by design), but it costs one failed call and starts working with no edit if a scoped PAT/App token is ever wired in.

### Code Quality

- Self-review of code completed
- Comments explain the race and the measurement that drove the numbers
- No debugging statements left in

## 🧪 Testing

- Manual testing

**Test Configuration:**

- Node.js version: n/a (shell + YAML only)
- OS: Linux

### Test Instructions

```bash
# 1. The workflow still parses
python3 -c "import yaml; yaml.safe_load(open('.github/workflows/claude-auto-pr.yml')); print('yaml OK')"
```

The polling loop was extracted and run against a stub `gh` in both directions:

| Scenario | Result |
|---|---|
| PR appears on the 3rd poll | `PR #999 appeared after 4s — the agent did its job.` → exit 0 |
| PR never appears | falls through the window → stranded report → exit 1 |

Both paths behave as intended, so the change fixes the false positive without disarming the detector.

## 🚨 Breaking Changes

None.

## 🔗 Related Issues and PRs

- Related to #563, #571, #583 — the three PRs whose `open-pr` check went red on this race.

## 📝 Additional Notes

### Deployment Notes

None — no migration, env var, dependency or config change.

### Future Work

If the grace window turns out to be too short for a slow agent, the fix is the constant, not the shape. `governance-nightly` remains the real backstop for a branch that never gets a PR.

## 🔄 Backwards Compatibility

- Fully backwards compatible

---
_Generated by [Claude Code](https://claude.ai/code/session_01GLocxJ1aNrFWeAo51iHuFa)_