### PR TITLE
fix(authentik): add stock-apply phase to ops.py (FuzeInfra#514)

### DIFF
--- a/.github/workflows/prod-authentik-ops.yml
+++ b/.github/workflows/prod-authentik-ops.yml
@@ -19,7 +19,7 @@ on:
   workflow_dispatch:
     inputs:
       phase:
-        description: 'diagnose | apply'
+        description: 'diagnose | apply | stock-apply'
         required: true
         default: 'diagnose'
       blueprints:

--- a/deploy/helm/fuzefront/authentik/ops.py
+++ b/deploy/helm/fuzefront/authentik/ops.py
@@ -101,6 +101,80 @@ else:
                 f'last_applied {last}{"" if confirmed else " (UNCONFIRMED — apply not observed)"}'
             )
 
+    elif PHASE == 'stock-apply':
+        # Force re-apply of stock (system/default) Authentik blueprints that are
+        # stuck in error status — e.g. after a version upgrade changes the schema.
+        # We call POST /apply/ on each stuck instance; the worker re-reads its
+        # own embedded content and re-applies. We also query the event log to
+        # surface the original error message for each failing blueprint.
+        #
+        # FuzeInfra#514: four stock blueprints have been in error since 2026-08-04
+        # (authentik Bootstrap, Default - Authentication flow, Default - Events
+        # Transport & Rules, Default - Out-of-box-experience flow). This recovers them.
+        import time as _time
+        st_l, listing = api('/managed/blueprints/?page_size=100')
+        if st_l != 200:
+            failed = True
+            report.append(f'Blueprint listing failed: HTTP {st_l}')
+        else:
+            report.append('### Stock blueprint re-apply (FuzeInfra#514)')
+            all_insts = listing.get('results', [])
+            report.append('')
+            report.append('**Pre-apply state:**')
+            for i in all_insts:
+                report.append(
+                    f"- `{i.get('name')}` path=`{i.get('path')}` "
+                    f"status=**{i.get('status')}** last_applied={i.get('last_applied')}")
+            # Stock blueprints live under system/ or default/; FuzeFront-owned
+            # blueprints live under blueprints/. Identify stuck stock ones.
+            stock_error = [
+                i for i in all_insts
+                if i.get('status') == 'error'
+                and not str(i.get('path', '')).startswith('blueprints/')
+            ]
+            if not stock_error:
+                report.append('')
+                report.append('**No stock blueprints in error — nothing to do.**')
+            else:
+                report.append('')
+                report.append(f'**Re-applying {len(stock_error)} stuck stock blueprint(s):**')
+                # Pull recent blueprint events once for context
+                _st_ev, _ev_resp = api('/events/events/?action=blueprints_apply&page_size=20')
+                ev_list = _ev_resp.get('results', []) if _st_ev == 200 else []
+                for i in stock_error:
+                    name = i.get('name', '')
+                    pk = i.get('pk')
+                    prev_applied = i.get('last_applied')
+                    # Find an event entry mentioning this blueprint
+                    ev_detail = ''
+                    for ev in ev_list:
+                        ctx = ev.get('context', {})
+                        if name.lower() in json.dumps(ctx).lower():
+                            ev_detail = json.dumps(ctx)[:200]
+                            break
+                    # Force re-apply — no body needed; stock blueprints own their content
+                    st_a, _ = api(f'/managed/blueprints/{pk}/apply/', 'POST', {})
+                    status, last = '?', '?'
+                    confirmed = False
+                    for _ in range(18):  # poll up to ~90s
+                        _st_g, after = api(f'/managed/blueprints/{pk}/')
+                        status = after.get('status', '?')
+                        last = after.get('last_applied', '?')
+                        if (_st_g == 200 and last != prev_applied
+                                and status in ('successful', 'warning', 'error', 'orphaned')):
+                            confirmed = True
+                            break
+                        _time.sleep(5)
+                    if status in ('error', 'orphaned') or not confirmed:
+                        failed = True
+                    ev_line = f' prev_err={ev_detail}' if ev_detail else ''
+                    report.append(
+                        f"- `{name}` ({i.get('path')}): apply HTTP {st_a},"
+                        f" status **{status}**, last_applied {last}"
+                        f"{'' if confirmed else ' (UNCONFIRMED)'}{ev_line}"
+                    )
+
+
     report.append('')
     report.append('### State')
     st_b, brands = api('/core/brands/?page_size=50')


### PR DESCRIPTION
## Summary

Adds `phase=stock-apply` to `prod-authentik-ops.yml` / `ops.py`.

Four stock Authentik blueprints have been stuck in `error` status since the 2026.5.5 upgrade on 2026-08-04: `authentik Bootstrap`, `Default - Authentication flow`, `Default - Events Transport & Rules`, `Default - Out-of-box-experience flow`. The fix is to force-reapply them via `POST /api/v3/managed/blueprints/{pk}/apply/` — the worker re-reads its embedded content without needing external input.

The new phase:
- Lists all blueprint instances, identifies stock ones (path starts with `system/` or `default/`) with `status=error`
- Queries the event log to surface the original error message for each
- POSTs to `/apply/` for each stuck instance and polls for status change (same pattern as the existing `apply` phase)
- Reports success/error per blueprint; posts to issue #218 as usual

## Changes

- `ops.py`: new `elif PHASE == 'stock-apply':` block
- `prod-authentik-ops.yml`: document new phase in input description

## Test plan

After merge, trigger `prod-authentik-ops.yml` with `phase=stock-apply` and confirm all 4 blueprint instances flip from `error` → `successful`.

Closes FuzeInfra#514 (pending workflow confirmation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude claude-sonnet-4-6 <noreply@anthropic.com>
Claude-Session-Id: 94bc36eb-1f92-4270-8c73-085913a64127