### PR TITLE
fix(permit): stop schema-sync Job crash-looping on the apps.policy migration race

### DIFF
--- a/backend/src/permit/sync-permit-schema.ts
+++ b/backend/src/permit/sync-permit-schema.ts
@@ -271,6 +271,40 @@ export async function loadRegisteredPolicyResult(
     /* eslint-disable @typescript-eslint/no-var-requires */
     const { db } = require('../config/database')
     /* eslint-enable @typescript-eslint/no-var-requires */
+
+    // The `apps.slug` and `apps.policy` columns are provisioned by the
+    // APPLICATIONS-service migration chain (006_add_app_policy_and_billing,
+    // recorded under knex_migrations_apps) — NOT by this (backend) image, whose
+    // chain only creates the base `apps` table (002_create_apps_table). On a
+    // fresh install or a coordinated upgrade the permit-schema-sync post-upgrade
+    // hook can run before the applications service has landed that migration.
+    //
+    // When the column is genuinely absent, NO product has been able to register
+    // a policy yet, so the correct result is "registry available, zero
+    // registered policies" (available: true) — NOT "registry unavailable". The
+    // distinction matters because the CLI job treats `available: false` as fatal
+    // (exit 1): letting the SELECT throw `column "policy" does not exist` here
+    // turned a benign deploy-ordering window into a crash-looping Job.
+    //
+    // The hard-fail stays reserved for a REAL registry outage: if the DB is
+    // unreachable, `hasTable`/`hasColumn` themselves reject and land in the
+    // catch below → available: false → the job exits non-zero, exactly as
+    // designed. We only downgrade to "empty" when we can POSITIVELY confirm the
+    // storage does not exist, never when we simply failed to read it.
+    const hasApps = await db.schema.hasTable('apps')
+    const hasPolicyStorage =
+      hasApps &&
+      (await db.schema.hasColumn('apps', 'slug')) &&
+      (await db.schema.hasColumn('apps', 'policy'))
+    if (!hasPolicyStorage) {
+      log(
+        'App-registry policy storage not present yet (apps.policy column ' +
+          'unmigrated) — no product has registered a policy; syncing the base + ' +
+          'legacy schema only'
+      )
+      return { available: true, policies: [], rejected, error: null }
+    }
+
     const rows = await db('apps')
       .whereNotNull('slug')
       .whereNotNull('policy')

--- a/backend/tests/permit-sync-registry.test.ts
+++ b/backend/tests/permit-sync-registry.test.ts
@@ -73,19 +73,34 @@ function makeFakeClient(opts: { failOn?: string } = {}) {
  */
 // eslint-disable-next-line prefer-const
 let mockRegistryRows: any[] | (() => never) = []
-jest.mock('../src/config/database', () => ({
-  db: () => ({
+// Whether the mocked platform DB reports the apps table / policy-storage columns
+// as present. Defaults to present so the existing read-path cases are unaffected;
+// the migration-race cases flip these to false. Prefixed `mock*` so the hoisted
+// jest.mock factory may close over it.
+// eslint-disable-next-line prefer-const
+let mockSchemaPresence = { hasTable: true, hasColumn: true }
+jest.mock('../src/config/database', () => {
+  const db: any = () => ({
     whereNotNull: () => ({
       whereNotNull: () => ({
         select: async () =>
           typeof mockRegistryRows === 'function' ? mockRegistryRows() : mockRegistryRows,
       }),
     }),
-  }),
-}))
+  })
+  db.schema = {
+    hasTable: async () => mockSchemaPresence.hasTable,
+    hasColumn: async () => mockSchemaPresence.hasColumn,
+  }
+  return { db }
+})
 
 function stubRegistry(rows: any[] | (() => never)) {
   mockRegistryRows = rows
+}
+
+function stubSchemaPresence(presence: { hasTable: boolean; hasColumn: boolean }) {
+  mockSchemaPresence = presence
 }
 
 const silent = () => undefined
@@ -105,6 +120,7 @@ const fuzeservicePolicy = {
 beforeEach(() => {
   resetPermitSyncStatus()
   mockRegistryRows = []
+  mockSchemaPresence = { hasTable: true, hasColumn: true }
 })
 
 // ── the happy path a product actually depends on ──────────────────────────────
@@ -288,13 +304,80 @@ describe('loadRegisteredPolicyResult', () => {
       policies: [],
       error: null,
     })
+    // A genuine read failure against present storage is still unavailable.
     stubRegistry(() => {
-      throw new Error('relation "apps" does not exist')
+      throw new Error('ECONNREFUSED 127.0.0.1:5432')
     })
     await expect(loadRegisteredPolicyResult(silent)).resolves.toMatchObject({
       available: false,
       policies: [],
     })
+  })
+
+  // The apps.slug/apps.policy columns are provisioned by the applications-service
+  // migration, which the backend-image permit-schema-sync hook can outrun on a
+  // fresh install/upgrade. A missing column means NO product has registered a
+  // policy yet — that is an empty registry (available: true), not an outage —
+  // otherwise the CLI job exits non-zero and the deploy crash-loops.
+  it('treats the not-yet-migrated policy column as an empty registry, not an outage', async () => {
+    stubSchemaPresence({ hasTable: true, hasColumn: false })
+    // The read must never even be attempted once the column is known absent.
+    stubRegistry(() => {
+      throw new Error('column "policy" does not exist')
+    })
+    await expect(loadRegisteredPolicyResult(silent)).resolves.toMatchObject({
+      available: true,
+      policies: [],
+      error: null,
+    })
+  })
+
+  it('treats a missing apps table the same way — nothing registered, not an outage', async () => {
+    stubSchemaPresence({ hasTable: false, hasColumn: true })
+    await expect(loadRegisteredPolicyResult(silent)).resolves.toMatchObject({
+      available: true,
+      policies: [],
+      error: null,
+    })
+  })
+
+  it('a real DB outage while probing the schema is still reported unavailable', async () => {
+    // If the DB is unreachable, hasTable itself rejects — that must NOT be
+    // downgraded to "empty"; it is the fatal case the job is meant to catch.
+    const boom = () => {
+      throw new Error('ECONNREFUSED 127.0.0.1:5432')
+    }
+    const db: any = require('../src/config/database').db
+    const original = db.schema.hasTable
+    db.schema.hasTable = boom
+    try {
+      await expect(loadRegisteredPolicyResult(silent)).resolves.toMatchObject({
+        available: false,
+        policies: [],
+      })
+    } finally {
+      db.schema.hasTable = original
+    }
+  })
+})
+
+describe('the migration-race that crash-looped the permit-schema-sync Job', () => {
+  it('syncs base + legacy and reports ok when apps.policy is not migrated yet', async () => {
+    // Reproduces the deploy-ordering window: apps table exists (backend migrated)
+    // but the applications-service has not yet added apps.policy. The job must
+    // push the base + legacy schema and exit 0, not fail.
+    stubSchemaPresence({ hasTable: true, hasColumn: false })
+    const { client, created } = makeFakeClient()
+
+    const status = await syncPermitSchemaFromRegistry(client, [fuzemarketPolicy], silent)
+
+    expect(status.outcome).toBe('ok')
+    expect(status.registeredProducts).toEqual([])
+    expect(status.legacyProducts).toEqual(['fuzemarket'])
+    // Base schema + the legacy in-tree policy both went out.
+    expect(created.map(r => r.key)).toEqual(
+      expect.arrayContaining(['Organization', 'fuzemarket_Listing'])
+    )
   })
 })
 


### PR DESCRIPTION
## 📋 Description

The `fuzefront-permit-schema-sync` Job (reported failing-and-retrying on deploy) crash-loops during a deploy-ordering window. It runs the **backend** image and reads registered product policies from `apps.slug` / `apps.policy`, but those columns are provisioned by the **applications-service** migration chain (`006_add_app_policy_and_billing`, tracked under `knex_migrations_apps`) — **not** by the backend chain, which only creates the base `apps` table (`002_create_apps_table`).

On a fresh install or a coordinated upgrade, the `post-upgrade` hook can run before the applications service has landed that migration. The registry read then threw `column "policy" does not exist`, which the fail-soft catch reported as `registry_unavailable` — a state the CLI job treats as **fatal (`exit 1`)**. Net effect: the Job fails and retries on every deploy until the applications migration happens to catch up, and stays `Failed` whenever it doesn't.

A missing column means **no product has been able to register a policy yet**, so the correct outcome is an *empty registry* (`available: true`, zero policies) → the job syncs the base + legacy schema and exits `0` — **not** an outage.

## 🔄 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🧪 Test addition or improvement

## 🔧 Implementation Details

### Changes Made

- **Backend Changes:**
  - `backend/src/permit/sync-permit-schema.ts` — `loadRegisteredPolicyResult()` now probes `db.schema.hasTable('apps')` + `hasColumn('apps', {slug,policy})` **before** the `SELECT`. When it can *positively confirm* the storage is absent, it returns `{ available: true, policies: [] }` and logs a clear message, instead of letting the query throw and being misclassified as an outage.
  - The hard-fail stays reserved for a **real** outage: an unreachable DB makes the schema probe itself reject and still lands in the existing `catch` → `available: false` → `exit 1`, exactly as designed. We only downgrade to "empty" when the storage is confirmed missing, never when we merely failed to read it.

### Design intent preserved

The original fatal-on-`registry_unavailable` behavior exists so a real DB misconfiguration can't silently push base-schema-only while **dropping** registered product policies (products appearing role-less). That guarantee is intact: when the `policy` column doesn't exist, there are no registered policies to drop, so pushing base + legacy is fully correct.

## 🧪 Testing

- [x] Unit tests

Added regression cases to `backend/tests/permit-sync-registry.test.ts`:
- the not-yet-migrated `apps.policy` column → empty registry, not an outage (and the read is never attempted);
- a missing `apps` table → same;
- a real DB outage while probing the schema → still `available: false`;
- full `syncPermitSchemaFromRegistry` path reports `ok` and syncs base + legacy when the column is unmigrated.

**Test Configuration:**

- Node.js version: 24.x
- OS: Linux

### Test Instructions

```bash
cd backend && npm install
PERMIT_API_KEY=ci-no-real-permit-calls npx jest tests/permit-sync-registry.test.ts
```

Result locally: **21 passed** (plus `permit-schema` + `product-policy` suites: 33 passed).

## 🚨 Breaking Changes

None. `backend/dist/` is not tracked (the image rebuilds from source), so no build artifact changes are included.

---
_Generated by [Claude Code](https://claude.ai/code/session_01J8jA7MSRs2qmjt2XY89NUr)_