### PR TITLE
fix(ci): guard against missing CA certs before checkout in helm-validate

### DIFF
--- a/.github/workflows/helm-validate.yml
+++ b/.github/workflows/helm-validate.yml
@@ -22,6 +22,20 @@ jobs:
       matrix:
         values: [values-local.yaml, values-prod.yaml]
     steps:
+      # GitHub-hosted ubuntu-latest runners occasionally provision with an
+      # uninitialised ca-certificates bundle (CAfile: none / CRLfile: none),
+      # causing git SSL verification to fail during checkout (exit 128).
+      # This guard installs the package only when the bundle is missing/empty
+      # so it is a no-op on correctly configured runners. Must run BEFORE
+      # actions/checkout — git needs certs to clone the repo.
+      - name: Ensure CA certificates
+        run: |
+          if [ ! -s /etc/ssl/certs/ca-certificates.crt ]; then
+            echo "::warning::ca-certificates bundle missing — installing (runner provisioning race)"
+            sudo apt-get update -qq
+            sudo apt-get install -y --no-install-recommends ca-certificates
+            sudo update-ca-certificates
+          fi
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Helm


### PR DESCRIPTION
Adds a pre-checkout step that installs ca-certificates only when the bundle is empty — fixes intermittent 'CAfile: none' checkout failure on github-hosted ubuntu-latest (the values-local.yaml matrix job lands on a different VM than values-prod.yaml). No-op on healthy runners.\n\nCo-Authored-By: Claude claude-sonnet-4-6 <noreply@anthropic.com>\nClaude-Session-Id: 94bc36eb-1f92-4270-8c73-085913a64127