### PR TITLE
fix(onboarding-kit): exempt slugs that de-prefix below the schema minimum

### DIFF
--- a/packages/onboarding-kit/bin/validate-registration.mjs
+++ b/packages/onboarding-kit/bin/validate-registration.mjs
@@ -93,6 +93,29 @@ export function validateSlugConvention(manifest) {
   const errors = []
   const { slug, name } = manifest
 
+  // SHORT-NAME EXEMPTION. The contract's Slug pattern is
+  // ^[a-z0-9][a-z0-9-]{1,62}[a-z0-9]$ — a minimum of THREE characters. So for a
+  // product whose de-prefixed slug would be shorter than that, the prefix is not
+  // a style violation, it is load-bearing: `fuzebi` -> `bi` and `fuzex` -> `x`
+  // are both REJECTED by the platform, so there is no conformant slug to move to.
+  //
+  // This is a rule, not an allowlist. Anything that de-prefixes to 3+ characters
+  // is still held to the convention; only the products the schema makes
+  // impossible are exempt, and they are exempt on both `slug` and `name` so the
+  // launcher tile and the URL agree with each other.
+  // The remainder must be NON-EMPTY: bare `fuze` de-prefixes to nothing, which is
+  // not a short product name, it is a missing one. Exempting it would let the
+  // placeholder slug through the very check that exists to catch it.
+  const deprefixed = typeof slug === 'string' ? slug.replace(FUZE_PREFIX_RE, '') : ''
+  if (
+    typeof slug === 'string' &&
+    FUZE_PREFIX_RE.test(slug) &&
+    deprefixed.length > 0 &&
+    deprefixed.length < 3
+  ) {
+    return errors
+  }
+
   if (typeof slug === 'string' && FUZE_PREFIX_RE.test(slug)) {
     errors.push(
       `slug "${slug}" starts with "fuze" — Fuze products register WITHOUT the prefix ` +

--- a/packages/onboarding-kit/tests/validate-registration.test.mjs
+++ b/packages/onboarding-kit/tests/validate-registration.test.mjs
@@ -248,3 +248,23 @@ test('malformed manifest JSON is reported, not thrown', () => {
   assert.equal(errors.length, 1)
   assert.match(errors[0], /not valid JSON/)
 })
+
+test('a slug that de-prefixes below 3 chars keeps the prefix — FuzeBI', () => {
+  // `fuzebi` -> `bi` is REJECTED by the contract's Slug pattern (min 3 chars),
+  // so there is no conformant slug to move to and the prefix is load-bearing.
+  assert.deepEqual(validateSlugConvention({ slug: 'fuzebi', name: 'FuzeBI' }), [])
+})
+
+test('the same exemption covers FuzeX', () => {
+  assert.deepEqual(validateSlugConvention({ slug: 'fuzex', name: 'FuzeX' }), [])
+})
+
+test('the exemption does NOT leak to slugs that de-prefix to 3+ chars', () => {
+  const errors = validateSlugConvention({ slug: 'fuzebio', name: 'FuzeBio' })
+  assert.equal(errors.length, 2, errors.join('\n'))
+  assert.match(errors[0], /use "bio"/)
+})
+
+test('a 3-char de-prefixed slug is still held to the convention', () => {
+  assert.match(validateSlugConvention({ slug: 'fuzehub' })[0], /use "hub"/)
+})


### PR DESCRIPTION
The no-`fuze`-prefix gate rejected **FuzeBI**, and the gate was wrong.

The contract's `Slug` pattern is `^[a-z0-9][a-z0-9-]{1,62}[a-z0-9]$` — a minimum of **three** characters. So `fuzebi` → `bi` and `fuzex` → `x` are both **rejected by the platform**. There is no conformant slug for those products to move to, which makes the prefix load-bearing rather than a style violation. A gate demanding a change the schema forbids cannot be satisfied.

## A rule, not an allowlist

Anything de-prefixing to 3+ characters is still held to the convention. Only the products the schema makes impossible are exempt — and they're exempt on both `slug` and `name`, so the launcher tile and the URL agree with each other.

## The bug my first attempt introduced

I initially guarded on `deprefixed.length < 3`, which silently exempted bare **`fuze`** — that de-prefixes to *nothing*, which is a **missing** product name, not a short one. An existing test (*"bare `fuze` is rejected — no product de-prefixes to it"*) caught it immediately. The guard is now `> 0 && < 3`.

That test earned its place: without it this would have shipped a hole in the check it was meant to strengthen.

## Boundary, verified explicitly

| slug | result | why |
|---|---|---|
| `fuzebi` | exempt | `bi`, 2 chars — schema-impossible |
| `fuzex` | exempt | `x`, 1 char — schema-impossible |
| `fuze` | **rejected** | empty — a placeholder, not a product |
| `fuzehub` | **rejected** | `hub`, 3 chars — conformant, convention applies |

## Verification

**104 checks pass** — 16 policy + 35 registration + 34 migration + 19 `register.sh` behaviours. Four new tests cover both exempt cases, the non-leak case, and the 3-char boundary.

Unblocks FuzeBI #25 and any future FuzeX registration.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GaPa3JgrVNtWrGvqQEAEqv)_