### PR TITLE
fix(security): route OIDC discovery in-cluster — the last Cloudflare hairpin in sign-in

### DIFF
--- a/backend/security/src/services/oidc.ts
+++ b/backend/security/src/services/oidc.ts
@@ -87,36 +87,56 @@ class OIDCService {
       // and jwks — not just the one call that happened to fail first.
       custom.setHttpOptionsDefaults({ timeout: OIDC_HTTP_TIMEOUT_MS });
 
-      // Discover the issuer
-      const issuer = await Issuer.discover(this.config.issuerUrl);
-      logger.info({ issuer: issuer.metadata.issuer }, 'oidc: discovered issuer');
-
-      // Route the SERVER-SIDE OIDC calls (token / userinfo / jwks) over in-cluster
-      // DNS instead of hairpinning out to app.fuzefront.com via Cloudflare (which
-      // made login 15-28s and intermittently 401). Safe because the provider's
-      // issuer_mode is `per_provider` — the `iss` claim is fixed to the external
-      // issuer regardless of the request host, so token validation still matches.
-      // The authorization_endpoint stays EXTERNAL (it is browser-facing).
-      let effectiveIssuer = issuer;
       // Per-tenant in-cluster base. Reading this from the tenant rather than
       // the environment is what keeps each tenant's server-side calls pointed
       // at ITS OWN authentik Service (authentik-server vs
       // authentik-mendys-server) instead of whichever one the process happened
       // to be configured with.
       const internalBase = this.tenant.baseUrl || undefined;
+
+      // Rewrite a browser-facing Authentik URL's protocol+host onto the
+      // in-cluster base, path/query untouched. Used BOTH to route the discovery
+      // fetch in-cluster (immediately below) and to normalise the discovered
+      // token/userinfo/jwks endpoint URLs. A no-op when there is no internal base
+      // (dev/legacy without AUTHENTIK_BASE_URL) — discovery then stays external.
+      const toInternal = (u?: string): string | undefined => {
+        if (!u || !internalBase) return u;
+        try {
+          const url = new URL(u);
+          const ib = new URL(internalBase);
+          url.protocol = ib.protocol;
+          url.host = ib.host;
+          return url.toString();
+        } catch {
+          return u;
+        }
+      };
+
+      // Discover against the IN-CLUSTER host when we have one, instead of the
+      // browser-facing issuer (app.fuzefront.com) — a public name that resolves
+      // to Cloudflare, so discovery would hairpin pod -> internet -> CF edge ->
+      // tunnel -> back to authentik-server. Discovery was the LAST server-side
+      // OIDC call still doing that: token/userinfo/jwks are rewritten in-cluster
+      // below, but the discovery fetch that PRECEDES (and gates) them was not —
+      // so every client init / self-heal, and thus the first sign-in on each
+      // fresh pod, paid a full Cloudflare round-trip (the same "17-34s" hairpin
+      // documented for JWKS/discovery in values-prod.yaml).
+      //
+      // `iss` identity is unchanged. Whatever host answers discovery, the
+      // resulting issuer is passed through the SAME toInternal() normalisation as
+      // the endpoints below, so effectiveIssuer.issuer ends up byte-for-byte what
+      // it was before this change — and it MUST stay the internal value, because
+      // Authentik derives the token's `iss` from the request host and the token
+      // endpoint is hit in-cluster, so client.callback()'s iss check matches only
+      // against the internal issuer.
+      const discoveryUrl = toInternal(this.config.issuerUrl) ?? this.config.issuerUrl;
+      const issuer = await Issuer.discover(discoveryUrl);
+      logger.info({ issuer: issuer.metadata.issuer, discoveryUrl }, 'oidc: discovered issuer');
+
+      // Route the SERVER-SIDE OIDC calls (token / userinfo / jwks) over in-cluster
+      // DNS. The authorization_endpoint stays EXTERNAL (it is browser-facing).
+      let effectiveIssuer = issuer;
       if (internalBase) {
-        const toInternal = (u?: string): string | undefined => {
-          if (!u) return u;
-          try {
-            const url = new URL(u);
-            const ib = new URL(internalBase);
-            url.protocol = ib.protocol;
-            url.host = ib.host;
-            return url.toString();
-          } catch {
-            return u;
-          }
-        };
         effectiveIssuer = new Issuer({
           ...issuer.metadata,
           // Authentik derives `iss` from the request host even in per_provider


### PR DESCRIPTION
## 📋 Description

Third in the sign-in-latency thread (#455, #459, #494). Those routed the per-login token/userinfo/jwks calls in-cluster and pooled the connection. This closes the **one remaining server-side OIDC call that still hairpinned through Cloudflare: discovery.**

### Root cause

`oidc.ts` `initialize()` did `Issuer.discover(this.config.issuerUrl)` where `issuerUrl` = `https://app.fuzefront.com/application/o/fuzefront/` (values-prod.yaml:409) — a **public** name that resolves to Cloudflare. So discovery hairpinned `pod → internet → CF edge → tunnel → back to authentik-server`, the exact 17-34s hairpin `values-prod.yaml:416-421` already documents for in-cluster JWKS/discovery. The token/userinfo/jwks endpoints were already rewritten to `http://authentik-server:9000` via `toInternal()` — but the discovery fetch that **precedes and gates** them was not. Discovery runs on every client init / self-heal, so the **first sign-in on each fresh pod** paid a full Cloudflare round-trip (bounded at `OIDC_HTTP_TIMEOUT_MS` = 15s).

### Fix

Discovery now targets the in-cluster base when one is configured (the same `tenant.baseUrl` the endpoint rewrite already uses), by running the issuer URL through the existing `toInternal()` before `Issuer.discover()`. `toInternal()` is hoisted above the discover call and reused; the endpoint-rewrite block below is unchanged.

**`iss` identity is provably unchanged.** Whatever host answers discovery, the resulting issuer is passed through the *same* `toInternal()` normalisation as before, so `effectiveIssuer.issuer` is byte-for-byte identical to today's value — and it stays the internal value, which is what `client.callback()`'s `iss` check must match (Authentik derives the token's `iss` from the request host, and the token endpoint is already hit in-cluster). When no internal base is set (dev/legacy without `AUTHENTIK_BASE_URL`) discovery stays external — unchanged.

## 🔄 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ⚡ Performance improvement

## 🧪 Testing

- [x] Unit tests
- [ ] Manual testing — not possible from this environment (network policy blocks `app.fuzefront.com`); same limitation as #455/#459/#494

### Test Instructions

```bash
npm run type-check -w backend/security
npm test -w backend/security
```

Results:

- **`oidc.ts` type-checks clean.** The 8 pre-existing `tsc` errors (`@fuzefront/core` missing exports in `index.ts`/`organizations.ts`/`outboxRelay.ts`, a workspace build-order artifact) are identical with and without this change — verified by `git stash` A/B — and none are in `oidc.ts`.
- **87 OIDC / login-path tests pass** across `oidc-code-exchange`, `oidc-google-signin`, `oidc-lazy-reinit`, `oidc-state`, `tenant-session-roundtrip`, `authentik-password-login`. No test asserts the discovery URL, and the discover mocks ignore their argument, so routing discovery internally is behavior-preserving in the suite.

## 🔧 Implementation Details

- **Backend Changes:** `backend/security/src/services/oidc.ts` — hoist `toInternal()` above `Issuer.discover()`; discover against `toInternal(issuerUrl)` when a tenant `baseUrl` is set. Adds `discoveryUrl` to the "discovered issuer" log line for observability.
- No API, request, or response shape change.

## 🚨 Breaking Changes

None. Only the network destination of the discovery *fetch* moves (external → in-cluster); the resulting client — issuer identity, endpoints, token validation — is identical.

## 📝 Additional Notes

### Deployment Notes

`master` is deploy-on-push — **merge in a deploy window** per the repo's hardening convention.

The observable win is on the **`oidc: discovered issuer`** log line: `discoveryUrl` should now read `http://authentik-server:9000/...` in prod, and the init/first-login latency spike after a pod restart should disappear. This does **not** reduce the per-login hop *count* — that's the separate flow-stage-collapse work — it removes the one remaining external round-trip from client init.

### Follow-up

Reducing the sequential hop *count* (collapsing Authentik's identification + password stages) is an Authentik auth-flow change, tracked separately.

## 🔄 Backwards Compatibility

- [x] Fully backwards compatible

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhfKNASYBD9aS3Wu6RUPfZ)_