### PR TITLE
ci(mcp-maintain): allow bot actors so it stops failing on agent PRs

### DIFF
--- a/.github/workflows/mcp-maintain.yml
+++ b/.github/workflows/mcp-maintain.yml
@@ -75,6 +75,13 @@ jobs:
         uses: anthropics/claude-code-action@428971d2ecd6e3a7cb0ee0da2a3a8b33fdb3678d  # v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Every FuzeFront agent PR is authored by the `claude` bot; dependabot and
+          # github-actions[bot] (governance-sync commit-back) also open/push PRs. Without
+          # this, claude-code-action's actor check hard-fails those runs with
+          # "Workflow initiated by non-human actor ... Add bot to allowed_bots list or use
+          # '*'", turning mcp-maintain red on every bot-authored PR. Allow all bots so the
+          # MCP upkeep stream runs (or no-ops) instead of blocking the PR — mirrors a2a-maintain.
+          allowed_bots: "*"
           prompt: |
             You are the **mcp-maintainer** for this repo (follow `.claude/agents/mcp-maintainer.md`
             exactly — same scope, boundaries, and done-contract). This is an automated CI run on


### PR DESCRIPTION
## 📋 Description

`mcp-maintain` turns **red on every agent-authored PR** (e.g. #589, #590) even when nothing about the MCP surface changed. Root cause (from the job log):

```
##[error]Action failed with error: Workflow initiated by non-human actor: claude (type: Bot).
Add bot to allowed_bots list or use '*' to allow all bots.
```

The workflow runs `anthropics/claude-code-action`, whose actor check hard-fails when the PR is opened by the `claude` GitHub App bot (and likewise for dependabot / `github-actions[bot]` push-backs). Its sibling **`a2a-maintain.yml` already sets `allowed_bots: "*"`** (with a comment explaining exactly this), which is why `a2a-maintain` passes while `mcp-maintain` fails on the same PRs.

**Fix:** add `allowed_bots: "*"` to `mcp-maintain.yml`'s `claude-code-action` step, mirroring `a2a-maintain`. The MCP upkeep stream then runs (or cleanly no-ops) instead of failing the PR.

## 🔄 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🔧 CI / workflow fix

## 🧪 Testing

- [x] This PR's own `mcp-maintain` run exercises the fix (the workflow version on the PR head is used for `pull_request` events), so a green `mcp-maintain` here is the verification.

## 🔧 Implementation Details

- `.github/workflows/mcp-maintain.yml` — add `allowed_bots: "*"` under the `claude-code-action` `with:` block, matching `a2a-maintain.yml`.

## 🔄 Backwards Compatibility

- [x] Fully backwards compatible — only widens which actors the maintenance job accepts; no behavior change for human-authored PRs.

---
_Generated by [Claude Code](https://claude.ai/code/session_017zdYnxKQVVhFyRubDa1BmK)_