### PR TITLE
feat(config): freeze the config-service contract and ship @fuzefront/config-client (FFRNT-153)

### DIFF
--- a/config-client/.gitignore
+++ b/config-client/.gitignore
@@ -1,0 +1,9 @@
+# Build output — published to the registry from CI, never committed.
+dist/
+node_modules/
+*.tsbuildinfo
+
+# Standalone (non-workspace) package. No sibling client commits a nested
+# lockfile — see selection-list-client, portal-client, apps-client. It only
+# appears here because building the package requires a local install.
+package-lock.json

--- a/config-client/README.md
+++ b/config-client/README.md
@@ -1,0 +1,134 @@
+# `@fuzefront/config-client`
+
+Typed client for the FuzeFront **config-service** — namespaced, hierarchical
+key/value configuration with typed key metadata.
+
+Derived by hand from [`services/config-service/openapi.yaml`](../services/config-service/openapi.yaml)
+v1.0.0. **That spec is the frozen contract; this package is a projection of it.**
+If the two disagree, the spec wins and this package is the bug.
+
+> Delivered by **FFRNT-153** (FF-EPIC-17-S1). The Python client is FFRNT-259 and
+> is generated from the same spec; the served Swagger UI is FFRNT-258. All three
+> are projections of one contract — none of them is a second source of truth.
+
+## Install
+
+```bash
+npm install @fuzefront/config-client
+```
+
+Private to the `@fuzefront` scope on GitHub Packages; you need a scoped
+`.npmrc` and a token.
+
+## Use
+
+```ts
+import { ConfigClient, isNotModified, isConfigApiError } from '@fuzefront/config-client'
+
+const config = new ConfigClient({
+  // MUST be same-origin in the browser. An absolute host breaks under TLS with
+  // a mixed-content block the moment the environment changes.
+  baseUrl: '/api/config',
+  token: () => session.accessToken,
+})
+
+const resolved = await config.getEffectiveConfig('fuzefront.chat', {
+  scopeType: 'org',
+  scopeId: orgId,
+})
+```
+
+### Read the provenance, not just the value
+
+Every entry says where its value came from and whether this caller may change
+it. A form built from `value` alone looks correct and misrepresents its own
+contents — it cannot distinguish a value set here from one inherited, and it
+will offer an editable input for a setting the server will refuse to write.
+
+```ts
+if (!isNotModified(resolved)) {
+  for (const entry of resolved.entries) {
+    if (entry.locked) {
+      // An ancestor pinned this. `lockedBy` names which one, so the UI can say
+      // "Locked by your portal" instead of greying the field with no reason.
+      render(entry, { disabled: true, badge: `Locked by ${entry.lockedBy?.scopeType}` })
+    } else if (entry.source.scopeType !== 'org') {
+      render(entry, { badge: `Inherited from ${entry.source.scopeType}` })
+    } else {
+      render(entry, { badge: 'Set here' })
+    }
+  }
+}
+```
+
+### Writes are atomic
+
+A batch either applies completely or not at all, so a settings page never
+half-saves.
+
+```ts
+await config.writeConfigValues({
+  namespace: 'fuzefront.chat',
+  scope: { scopeType: 'org', scopeId: orgId },
+  operations: [
+    { key: 'ui.theme.density', op: 'set', value: 'compact' },
+    // `unset` falls back to the parent and keeps tracking it. Writing the
+    // parent's current value instead would pin a copy that stops following it.
+    { key: 'ui.sidebar.collapsed', op: 'unset' },
+  ],
+  expectedVersion: resolved.version, // optimistic concurrency
+})
+```
+
+### Two refusals worth distinguishing
+
+```ts
+try {
+  await config.writeConfigValues(request)
+} catch (error) {
+  if (!isConfigApiError(error)) throw error
+
+  if (error.isLockedByAncestor) {
+    // Policy: an ancestor scope locked this key. `error.lockedBy` names it.
+    // Retrying will not help.
+  } else if (error.isVersionConflict) {
+    // Collision: somebody else saved first. Re-read at `error.currentVersion`
+    // and merge — do NOT blind-retry, which would overwrite their change.
+  }
+}
+```
+
+`error.code` is the thing to branch on. `error.message` is human-facing and may
+change without a contract version bump. A response that is not a contract
+response at all — an ingress 502, a proxy timeout, an HTML error page — reports
+`UNKNOWN` rather than being mapped onto a real contract code, because guessing
+would send the caller down the wrong recovery path.
+
+### Cheap polling
+
+`getEffectiveConfig` takes an `If-None-Match` version and answers
+{@link NotModified} when nothing changed. The version tracks the **resolved
+view**, so a change made at an ancestor scope invalidates it too — a version
+that tracked only this scope's own rows would let inherited changes go
+undetected.
+
+## This is not the feature-flag system
+
+Unleash owns feature flags. **Configuration** is durable, typed, user- and
+tenant-authored settings. **Flags** are rollout, targeting, kill-switches and
+experiments, authored by engineering. Reaching for a config key where a flag
+belongs is how a codebase ends up with two flag systems and no clear owner —
+see the `feature-flags` skill.
+
+## Scripts
+
+| Script | What it does |
+| --- | --- |
+| `npm run build` | Dual ESM + CJS build with declarations (tsup) |
+| `npm run type-check` | `tsc --noEmit` |
+| `npm run lint:contract` | Spectral-lints the frozen spec against the service's stricter ruleset |
+
+CI lints every `services/*/openapi.yaml` with Spectral's default ruleset and
+boots a Prism mock of it, so this contract is covered without any workflow
+change. `lint:contract` runs the **stricter** per-service ruleset — the one that
+makes operation metadata and property descriptions errors rather than hints.

--- a/config-client/package.json
+++ b/config-client/package.json
@@ -1,0 +1,54 @@
+{
+  "name": "@fuzefront/config-client",
+  "version": "1.0.0",
+  "description": "Typed HTTP client for the FuzeFront config-service REST API",
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "sideEffects": false,
+  "scripts": {
+    "build": "tsup",
+    "clean": "rimraf dist",
+    "type-check": "tsc --noEmit",
+    "lint:contract": "spectral lint ../services/config-service/openapi.yaml --ruleset ../services/config-service/.spectral.yaml --fail-severity=hint",
+    "prepublishOnly": "npm run clean && npm run build"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com",
+    "access": "restricted"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/izzywdev/FuzeFront.git",
+    "directory": "config-client"
+  },
+  "keywords": [
+    "fuzefront",
+    "configuration",
+    "settings",
+    "multi-tenant"
+  ],
+  "author": "FuzeFront Team",
+  "license": "UNLICENSED",
+  "engines": {
+    "node": ">=24.0.0",
+    "npm": ">=10.0.0"
+  },
+  "devDependencies": {
+    "@stoplight/spectral-cli": "^6.11.0",
+    "@types/node": "^24.13.3",
+    "rimraf": "^5.0.1",
+    "tsup": "^8.0.2",
+    "typescript": "^5.9.0"
+  }
+}

--- a/config-client/src/client.ts
+++ b/config-client/src/client.ts
@@ -1,0 +1,302 @@
+import { ConfigApiError } from './errors'
+import type {
+  ConfigErrorBody,
+  ConfigWriteRequest,
+  ConfigWriteResult,
+  EffectiveConfig,
+  KeyDefinition,
+  KeyDefinitionManifest,
+  KeyDefinitionManifestResult,
+  ListKeyDefinitionsParams,
+  Namespace,
+  NamespaceCreate,
+  NamespaceName,
+  KeyName,
+  Paged,
+  PageParams,
+  Scope,
+} from './types'
+
+/** A token, or a function that produces one (so short-lived tokens can refresh). */
+export type TokenProvider =
+  | string
+  | (() => string | undefined | Promise<string | undefined>)
+
+/** Constructor options for {@link ConfigClient}. */
+export interface ConfigClientOptions {
+  /**
+   * Base URL of the service.
+   *
+   * In the browser this MUST be a **same-origin** path (`'/api/config'`), never
+   * an absolute host: the shell is served over TLS behind an ingress, and a
+   * hard-coded host breaks the moment the environment changes and triggers
+   * mixed-content blocks under TLS (see CLAUDE.md).
+   */
+  baseUrl: string
+  /** Bearer token, or a provider for one. */
+  token?: TokenProvider
+  /** Injected `fetch`, for tests or a non-global runtime. Defaults to `globalThis.fetch`. */
+  fetch?: typeof fetch
+  /** Extra headers merged into every request (tracing, tenant hints). */
+  headers?: Record<string, string>
+}
+
+/** Result of a conditional read that the server answered with 304. */
+export interface NotModified {
+  /** Discriminant: the resolved view is unchanged. */
+  notModified: true
+}
+
+/** A conditional read either returns the config or reports it unchanged. */
+export type ConditionalEffectiveConfig = EffectiveConfig | NotModified
+
+/** Narrowing guard for a 304 answer from {@link ConfigClient.getEffectiveConfig}. */
+export function isNotModified(
+  result: ConditionalEffectiveConfig,
+): result is NotModified {
+  return (result as NotModified).notModified === true
+}
+
+/**
+ * Typed client for the FuzeFront config-service.
+ *
+ * Derived by hand from `services/config-service/openapi.yaml` v1.0.0. That spec
+ * is the frozen contract; this class is a projection of it.
+ *
+ * Zero runtime dependencies — it uses `fetch` and nothing else.
+ */
+export class ConfigClient {
+  readonly #baseUrl: string
+  readonly #token: TokenProvider | undefined
+  readonly #fetch: typeof fetch
+  readonly #headers: Record<string, string>
+
+  constructor(options: ConfigClientOptions) {
+    this.#baseUrl = options.baseUrl.replace(/\/+$/, '')
+    this.#token = options.token
+    this.#fetch = options.fetch ?? globalThis.fetch
+    this.#headers = options.headers ?? {}
+
+    if (typeof this.#fetch !== 'function') {
+      throw new TypeError(
+        'ConfigClient: no `fetch` available. Pass one via options.fetch.',
+      )
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Namespaces
+  // ---------------------------------------------------------------------------
+
+  /** List the configuration namespaces the caller may see. */
+  async listNamespaces(params: PageParams = {}): Promise<Paged<Namespace>> {
+    return this.#request<Paged<Namespace>>('GET', '/v1/namespaces', {
+      query: { cursor: params.cursor, limit: params.limit },
+    })
+  }
+
+  /**
+   * Register a namespace.
+   *
+   * Idempotent on `namespace`, so an app can register unconditionally at
+   * startup rather than probing first.
+   */
+  async createNamespace(body: NamespaceCreate): Promise<Namespace> {
+    return this.#request<Namespace>('POST', '/v1/namespaces', { body })
+  }
+
+  // ---------------------------------------------------------------------------
+  // Key definitions (the catalog)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * List a namespace's key definitions.
+   *
+   * `isHidden` keys are omitted server-side for ordinary callers — this client
+   * does no filtering of its own, because a hidden key that reached the browser
+   * would already have failed to be hidden.
+   */
+  async listKeyDefinitions(
+    namespace: NamespaceName,
+    params: ListKeyDefinitionsParams = {},
+  ): Promise<Paged<KeyDefinition>> {
+    return this.#request<Paged<KeyDefinition>>(
+      'GET',
+      `/v1/namespaces/${encodeURIComponent(namespace)}/keys`,
+      {
+        query: {
+          cursor: params.cursor,
+          limit: params.limit,
+          search: params.search,
+          category: params.category,
+          includeHidden: params.includeHidden,
+        },
+      },
+    )
+  }
+
+  /** Get one key's metadata. */
+  async getKeyDefinition(
+    namespace: NamespaceName,
+    key: KeyName,
+  ): Promise<KeyDefinition> {
+    return this.#request<KeyDefinition>(
+      'GET',
+      `/v1/namespaces/${encodeURIComponent(namespace)}/keys/${encodeURIComponent(key)}`,
+    )
+  }
+
+  /**
+   * Declare (upsert) the key definitions a namespace owns.
+   *
+   * Idempotent: re-registering an unchanged manifest is a no-op. Set
+   * `complete: true` only when the manifest really is the whole catalog — that
+   * is the flag that lets omitted keys be deprecated.
+   */
+  async registerKeyDefinitions(
+    namespace: NamespaceName,
+    manifest: KeyDefinitionManifest,
+  ): Promise<KeyDefinitionManifestResult> {
+    return this.#request<KeyDefinitionManifestResult>(
+      'PUT',
+      `/v1/namespaces/${encodeURIComponent(namespace)}/keys`,
+      { body: manifest },
+    )
+  }
+
+  // ---------------------------------------------------------------------------
+  // Effective configuration
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Read a scope's fully-resolved configuration.
+   *
+   * Pass `ifNoneMatch` (a `version` from a previous read) to get a cheap
+   * {@link NotModified} answer when nothing changed. The version reflects the
+   * **resolved view**, so a change at an ancestor scope invalidates it too.
+   */
+  async getEffectiveConfig(
+    namespace: NamespaceName,
+    scope: Scope,
+    ifNoneMatch?: string,
+  ): Promise<ConditionalEffectiveConfig> {
+    const response = await this.#send('GET', '/v1/config', {
+      query: {
+        namespace,
+        scopeType: scope.scopeType,
+        scopeId: scope.scopeId ?? undefined,
+      },
+      extraHeaders: ifNoneMatch ? { 'If-None-Match': ifNoneMatch } : undefined,
+    })
+
+    if (response.status === 304) return { notModified: true }
+    await this.#throwIfError(response)
+    return (await response.json()) as EffectiveConfig
+  }
+
+  // ---------------------------------------------------------------------------
+  // Values
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Apply a batch of value operations to one scope, atomically.
+   *
+   * All operations succeed or none do. A refusal throws {@link ConfigApiError};
+   * check `isLockedByAncestor` (which carries `lockedBy`) and
+   * `isVersionConflict` (which carries `currentVersion`) to tell a policy
+   * refusal from a concurrent-edit collision.
+   */
+  async writeConfigValues(
+    request: ConfigWriteRequest,
+  ): Promise<ConfigWriteResult> {
+    return this.#request<ConfigWriteResult>('PUT', '/v1/config', {
+      body: request,
+    })
+  }
+
+  // ---------------------------------------------------------------------------
+  // Internals
+  // ---------------------------------------------------------------------------
+
+  async #request<T>(
+    method: string,
+    path: string,
+    init: {
+      query?: Record<string, string | number | boolean | undefined>
+      body?: unknown
+    } = {},
+  ): Promise<T> {
+    const response = await this.#send(method, path, init)
+    await this.#throwIfError(response)
+    if (response.status === 204) return undefined as T
+    return (await response.json()) as T
+  }
+
+  async #send(
+    method: string,
+    path: string,
+    init: {
+      query?: Record<string, string | number | boolean | undefined>
+      body?: unknown
+      extraHeaders?: Record<string, string>
+    } = {},
+  ): Promise<Response> {
+    const url = new URL(`${this.#baseUrl}${path}`, 'http://localhost')
+    const isAbsolute = /^https?:\/\//i.test(this.#baseUrl)
+
+    for (const [key, value] of Object.entries(init.query ?? {})) {
+      if (value !== undefined && value !== null) {
+        url.searchParams.set(key, String(value))
+      }
+    }
+
+    const headers: Record<string, string> = {
+      Accept: 'application/json',
+      ...this.#headers,
+      ...(init.extraHeaders ?? {}),
+    }
+    if (init.body !== undefined) headers['Content-Type'] = 'application/json'
+
+    const token = await this.#resolveToken()
+    if (token) headers['Authorization'] = `Bearer ${token}`
+
+    // Preserve a same-origin relative base: re-serialising through URL would
+    // turn '/api/config' into 'http://localhost/api/config' and defeat the
+    // same-origin requirement the contract states.
+    const target = isAbsolute
+      ? url.toString()
+      : `${url.pathname}${url.search}`
+
+    return this.#fetch(target, {
+      method,
+      headers,
+      body: init.body === undefined ? undefined : JSON.stringify(init.body),
+    })
+  }
+
+  async #resolveToken(): Promise<string | undefined> {
+    if (typeof this.#token === 'function') return this.#token()
+    return this.#token
+  }
+
+  async #throwIfError(response: Response): Promise<void> {
+    if (response.ok) return
+
+    let body: ConfigErrorBody | undefined
+    try {
+      body = (await response.json()) as ConfigErrorBody
+    } catch {
+      // Not a contract response at all — an ingress error page, a proxy
+      // timeout. Deliberately left undefined so the code below reports UNKNOWN
+      // rather than inventing a contract code.
+      body = undefined
+    }
+
+    throw new ConfigApiError(
+      response.status,
+      body?.code ?? 'UNKNOWN',
+      body?.message ?? `config-service request failed with ${response.status}`,
+      body,
+    )
+  }
+}

--- a/config-client/src/errors.ts
+++ b/config-client/src/errors.ts
@@ -1,0 +1,91 @@
+import type {
+  ConfigErrorBody,
+  ConfigErrorCode,
+  ConfigErrorDetail,
+  Scope,
+} from './types'
+
+/**
+ * `ConfigErrorCode`, plus the client-only `UNKNOWN`.
+ *
+ * `UNKNOWN` is never emitted by the service. It is what this client reports when
+ * a response is not a contract response at all — an ingress `502`, a proxy
+ * timeout, an HTML error page. Mapping those onto a real contract code would be
+ * a lie that sends the caller down the wrong recovery path, so they get their
+ * own value.
+ */
+export type ConfigApiErrorCode = ConfigErrorCode | 'UNKNOWN'
+
+/**
+ * Every non-2xx response from the config-service surfaces as one of these.
+ *
+ * It carries the contract's machine-readable `code` alongside the HTTP status,
+ * because the two answer different questions: the status says how a cache or a
+ * proxy should treat the response, the `code` says what the caller should do
+ * about it. Callers branch on `code`; `message` is human-facing and may change
+ * without a contract version bump.
+ */
+export class ConfigApiError extends Error {
+  /** Machine-readable code from the contract's error envelope, or `UNKNOWN`. */
+  readonly code: ConfigApiErrorCode
+  /** HTTP status of the response. */
+  readonly status: number
+  /**
+   * The scope holding the lock. Present only on `LOCKED_BY_ANCESTOR`.
+   *
+   * This is what lets a UI say *which* ancestor refused the write instead of
+   * showing a generic denial — the reason the contract specifies 409 with a body
+   * rather than a bare 403.
+   */
+  readonly lockedBy: Scope | undefined
+  /**
+   * The resolved view's actual version. Present only on `VERSION_CONFLICT`.
+   *
+   * Re-read at this version and retry; do not blind-retry the original write,
+   * which would overwrite whatever the concurrent editor just saved.
+   */
+  readonly currentVersion: string | undefined
+  /** Per-key or per-field problems. Present on validation failures. */
+  readonly details: ConfigErrorDetail[] | undefined
+  /** The raw parsed body, for anything this class does not model. */
+  readonly body: ConfigErrorBody | undefined
+
+  constructor(
+    status: number,
+    code: ConfigApiErrorCode,
+    message: string,
+    body?: ConfigErrorBody,
+  ) {
+    super(message)
+    this.name = 'ConfigApiError'
+    this.status = status
+    this.code = code
+    this.body = body
+    this.lockedBy = body?.lockedBy ?? undefined
+    this.currentVersion = body?.currentVersion ?? undefined
+    this.details = body?.details ?? undefined
+    // Restore the prototype chain: subclassing Error across the ES5 downlevel
+    // target otherwise breaks `instanceof`.
+    Object.setPrototypeOf(this, ConfigApiError.prototype)
+  }
+
+  /**
+   * True when the write was refused because an ancestor scope locked the key.
+   *
+   * Distinct from a plain authorization failure: the caller may well be allowed
+   * to write at this scope in general, and `lockedBy` names who overrode that.
+   */
+  get isLockedByAncestor(): boolean {
+    return this.code === 'LOCKED_BY_ANCESTOR'
+  }
+
+  /** True when the resolved view moved since the version the caller read. */
+  get isVersionConflict(): boolean {
+    return this.code === 'VERSION_CONFLICT'
+  }
+}
+
+/** Narrowing type guard for {@link ConfigApiError}. */
+export function isConfigApiError(error: unknown): error is ConfigApiError {
+  return error instanceof ConfigApiError
+}

--- a/config-client/src/index.ts
+++ b/config-client/src/index.ts
@@ -1,0 +1,54 @@
+/**
+ * `@fuzefront/config-client` — typed client for the FuzeFront config-service.
+ *
+ * Derived by hand from `services/config-service/openapi.yaml` v1.0.0. That spec
+ * is the frozen contract; this package is a projection of it. If the two ever
+ * disagree, the spec wins and this package is the bug.
+ */
+
+export { ConfigClient, isNotModified } from './client'
+export type {
+  ConditionalEffectiveConfig,
+  ConfigClientOptions,
+  NotModified,
+  TokenProvider,
+} from './client'
+
+export { ConfigApiError, isConfigApiError } from './errors'
+export type { ConfigApiErrorCode } from './errors'
+
+export {
+  KEY_DEFINITION_ID_PREFIX,
+  NAMESPACE_ID_PREFIX,
+  SCOPE_CHAIN,
+} from './types'
+
+export type {
+  ConfigErrorBody,
+  ConfigErrorCode,
+  ConfigErrorDetail,
+  ConfigOperation,
+  ConfigOperationType,
+  ConfigWriteRequest,
+  ConfigWriteResult,
+  EffectiveConfig,
+  EffectiveConfigEntry,
+  KeyDefinition,
+  KeyDefinitionId,
+  KeyDefinitionInput,
+  KeyDefinitionManifest,
+  KeyDefinitionManifestResult,
+  KeyName,
+  ListKeyDefinitionsParams,
+  Namespace,
+  NamespaceCreate,
+  NamespaceId,
+  NamespaceName,
+  Paged,
+  PageInfo,
+  PageParams,
+  Precedence,
+  Scope,
+  ScopeType,
+  ValueType,
+} from './types'

--- a/config-client/src/types.ts
+++ b/config-client/src/types.ts
@@ -1,0 +1,390 @@
+/**
+ * Types projected from `services/config-service/openapi.yaml` v1.0.0.
+ *
+ * The spec is the frozen contract; this file is a projection of it. Where the
+ * two disagree, the spec wins and this file is the bug.
+ */
+
+/** TypeID prefix for a configuration namespace. */
+export const NAMESPACE_ID_PREFIX = 'cns_' as const
+/** TypeID prefix for a key definition. */
+export const KEY_DEFINITION_ID_PREFIX = 'ckd_' as const
+
+/** TypeID of a namespace (`cns_…`). Opaque past the prefix — never parse further. */
+export type NamespaceId = `cns_${string}`
+/** TypeID of a key definition (`ckd_…`). Opaque past the prefix. */
+export type KeyDefinitionId = `ckd_${string}`
+
+/** Dotted, lowercase namespace name owned by one application, e.g. `fuzefront.chat`. */
+export type NamespaceName = string
+/** Dotted, lowercase key path within a namespace, e.g. `ui.theme.density`. */
+export type KeyName = string
+
+/**
+ * A tier of the resolution chain.
+ *
+ * `platform` is a singleton and carries no `scopeId`; the others identify a
+ * portal, organization or user.
+ */
+export type ScopeType = 'platform' | 'portal' | 'org' | 'user'
+
+/** Every scope tier, in resolution order (least specific first). */
+export const SCOPE_CHAIN: readonly ScopeType[] = [
+  'platform',
+  'portal',
+  'org',
+  'user',
+] as const
+
+/** The kind of value a key holds. Drives validation and the input the editor renders. */
+export type ValueType =
+  | 'string'
+  | 'number'
+  | 'boolean'
+  | 'enum'
+  | 'json'
+  | 'duration'
+  | 'url'
+  | 'email'
+  | 'color'
+  | 'secret'
+
+/**
+ * Which end of the chain wins.
+ *
+ * `most-specific-wins` (the default) lets a user's value beat their org's;
+ * `least-specific-wins` reverses it so an org-level setting overrides a
+ * user-specific one. The response shape is identical either way — no consumer
+ * should branch on this.
+ */
+export type Precedence = 'most-specific-wins' | 'least-specific-wins'
+
+/**
+ * A point in the resolution chain.
+ *
+ * Polymorphic references always carry their type: a bare id is never resolved.
+ */
+export interface Scope {
+  /** Which tier. */
+  scopeType: ScopeType
+  /** The portal, organization or user. Null exactly when `scopeType` is `platform`. */
+  scopeId?: string | null
+}
+
+/** A configuration namespace owned by one application. */
+export interface Namespace {
+  /** Service-minted TypeID. */
+  id: NamespaceId
+  /** The dotted namespace name. */
+  namespace: NamespaceName
+  /** Human-facing name shown as the editor's section heading. */
+  displayName: string
+  /** What this namespace's settings govern. */
+  description?: string | null
+  /** The owning application in the app registry. */
+  ownerAppId?: string | null
+  /** When the namespace was first registered. */
+  createdAt: string
+}
+
+/** Registration body. Carries no `id` — the service mints it. */
+export interface NamespaceCreate {
+  /** The dotted namespace name. */
+  namespace: NamespaceName
+  /** Human-facing name shown as the editor's section heading. */
+  displayName: string
+  /** What this namespace's settings govern. */
+  description?: string
+  /** The owning application in the app registry. */
+  ownerAppId?: string
+}
+
+/** What a key *is*: presentation, validation, where it may be set, who may change it. */
+export interface KeyDefinition {
+  /** Service-minted TypeID. */
+  id: KeyDefinitionId
+  /** The dotted key path. */
+  key: KeyName
+  /** Label shown next to the input. */
+  displayName: string
+  /** Help text explaining what the setting does. */
+  description?: string | null
+  /** Link to fuller documentation. */
+  helpUrl?: string | null
+  /** Grouping heading in the editor. */
+  category?: string | null
+  /** Position within its category. Lower sorts first. */
+  sortOrder?: number
+  /** Free-form tags used for search and filtering. */
+  tags?: string[]
+  /** The kind of value this key holds. */
+  valueType: ValueType
+  /** JSON Schema the value must satisfy, intersected with the `valueType` base. */
+  schema?: Record<string, unknown> | null
+  /** Permitted values when `valueType` is `enum`. */
+  enumValues?: unknown[] | null
+  /** Bottom of the resolution chain. Always present, so every key resolves to something. */
+  defaultValue: unknown
+  /** The tiers at which this key may be set. */
+  allowedScopes: ScopeType[]
+  /** Platform-owned: metadata immutable to others, platform-only writes. */
+  isSystem: boolean
+  /** Omitted from ordinary reads entirely; visible only in the platform-admin catalog. */
+  isHidden: boolean
+  /** Encrypted at rest, masked on read, excluded from export. */
+  isSecret: boolean
+  /** Displayed but not editable at any tier. */
+  isReadonly: boolean
+  /** Which end of the chain wins for this key. */
+  precedence: Precedence
+  /** Changing it needs a consumer restart to take effect. */
+  requiresRestart: boolean
+  /** When the key was deprecated. Deprecated keys still resolve. */
+  deprecatedAt?: string | null
+  /** The key that supersedes this one, if any. */
+  replacedBy?: string | null
+}
+
+/** One key as declared by an owning application. Carries no `id`. */
+export interface KeyDefinitionInput {
+  /** The dotted key path. */
+  key: KeyName
+  /** Label shown next to the input. */
+  displayName: string
+  /** Help text explaining what the setting does. */
+  description?: string
+  /** Link to fuller documentation. */
+  helpUrl?: string
+  /** Grouping heading in the editor. */
+  category?: string
+  /** Position within its category. */
+  sortOrder?: number
+  /** Free-form tags. */
+  tags?: string[]
+  /** The kind of value this key holds. */
+  valueType: ValueType
+  /** JSON Schema the value must satisfy. */
+  schema?: Record<string, unknown>
+  /** Permitted values when `valueType` is `enum`. */
+  enumValues?: unknown[]
+  /** Bottom of the chain. Must satisfy this key's own schema. */
+  defaultValue: unknown
+  /** The tiers at which this key may be set. */
+  allowedScopes: ScopeType[]
+  /** Platform-owned. */
+  isSystem?: boolean
+  /** Omitted from ordinary reads entirely. */
+  isHidden?: boolean
+  /** Encrypted at rest, masked on read. */
+  isSecret?: boolean
+  /** Displayed but not editable. */
+  isReadonly?: boolean
+  /** Which end of the chain wins. */
+  precedence?: Precedence
+  /** Warn that the change is not live until restart. */
+  requiresRestart?: boolean
+  /** The key that supersedes this one. */
+  replacedBy?: string
+}
+
+/** The set of key definitions an application declares for one namespace. */
+export interface KeyDefinitionManifest {
+  /** Every key this manifest declares. */
+  keys: KeyDefinitionInput[]
+  /**
+   * Whether this manifest is the **whole** catalog for the namespace.
+   *
+   * Only when true does an omitted key get deprecated. Requiring the manifest to
+   * say so — rather than inferring deletion from absence — is what stops a
+   * truncated or partially-generated manifest from deprecating half a namespace.
+   */
+  complete?: boolean
+}
+
+/** What reconciling a manifest changed. */
+export interface KeyDefinitionManifestResult {
+  /** Keys that did not previously exist. */
+  created: KeyName[]
+  /** Keys whose metadata changed. Their stored values are untouched. */
+  updated: KeyName[]
+  /** Keys absent from a `complete` manifest. Deprecated, never deleted. */
+  deprecated: KeyName[]
+  /** Keys the manifest matched exactly. */
+  unchanged: KeyName[]
+}
+
+/**
+ * One resolved setting.
+ *
+ * The provenance fields are the point. A consumer that reads only `value` cannot
+ * tell a value set here from one inherited or locked, and will render a form
+ * that misrepresents its own contents.
+ */
+export interface EffectiveConfigEntry {
+  /** The key this entry resolves. */
+  key: KeyName
+  /** The resolved value. Always null for an `isSecret` key — see `isSet`. */
+  value: unknown
+  /** Whether a secret has a stored value. Present only for `isSecret` keys. */
+  isSet?: boolean
+  /** Which scope supplied the value. */
+  source: Scope
+  /** An ancestor pinned this value; writes beneath it are refused server-side. */
+  locked: boolean
+  /** Which scope holds the lock. Present exactly when `locked` is true. */
+  lockedBy?: Scope | null
+  /** Why the ancestor locked it, if a reason was recorded. */
+  lockReason?: string | null
+  /**
+   * Whether **this caller** may change it at the scope being read.
+   *
+   * A disabled input is a courtesy; the server refuses the write regardless.
+   */
+  editable: boolean
+  /**
+   * Set when the stored value no longer satisfies its definition.
+   *
+   * The default is returned and this explains why, rather than failing — one
+   * stale value must not break a consumer's boot.
+   */
+  warning?: string | null
+  /** The key's full metadata. */
+  definition: KeyDefinition
+}
+
+/** A scope's fully-resolved configuration for one namespace. */
+export interface EffectiveConfig {
+  /** The namespace resolved. */
+  namespace: NamespaceName
+  /** The scope resolved for. */
+  scope: Scope
+  /** Monotonic version of the resolved view, matching the `ETag`. */
+  version: string
+  /** One entry per visible key. Hidden keys are absent entirely. */
+  entries: EffectiveConfigEntry[]
+}
+
+/**
+ * What to do with one key at the target scope.
+ *
+ * `unset` removes this scope's override so the key resolves from its parent
+ * again — not the same as setting the parent's current value, which pins a copy
+ * that stops following it.
+ */
+export type ConfigOperationType = 'set' | 'unset' | 'lock' | 'unlock'
+
+/** One operation against one key at the request's scope. */
+export interface ConfigOperation {
+  /** The key to operate on. */
+  key: KeyName
+  /** What to do. */
+  op: ConfigOperationType
+  /** The new value. Required for `set` and `lock`; rejected otherwise. */
+  value?: unknown
+  /** Why the value is being locked. Only meaningful with `lock`. */
+  lockReason?: string
+}
+
+/** A batch of operations against one scope, applied as a single transaction. */
+export interface ConfigWriteRequest {
+  /** The namespace to write in. */
+  namespace: NamespaceName
+  /** The scope to write to. */
+  scope: Scope
+  /** The operations. All succeed or none do. */
+  operations: ConfigOperation[]
+  /** The version last read, for optimistic concurrency. */
+  expectedVersion?: string
+  /** Why the change is being made. Recorded in the audit trail. */
+  reason?: string
+}
+
+/** The outcome of an applied batch. */
+export interface ConfigWriteResult {
+  /** The namespace written. */
+  namespace: NamespaceName
+  /** The scope written to. */
+  scope: Scope
+  /** The scope's new version, usable as the next `expectedVersion`. */
+  version: string
+  /** The keys changed, in request order. */
+  applied: KeyName[]
+}
+
+/** Cursor pagination envelope. */
+export interface PageInfo {
+  /** Whether a further page exists. */
+  hasNextPage: boolean
+  /** Cursor for the next page. Null on the last page. */
+  nextCursor?: string | null
+}
+
+/** A page of results. */
+export interface Paged<T> {
+  /** The items in this page. */
+  items: T[]
+  /** Pagination state. */
+  pageInfo: PageInfo
+}
+
+/** Cursor pagination parameters. */
+export interface PageParams {
+  /** Opaque cursor from a previous page. Omit for the first page. */
+  cursor?: string
+  /** Maximum items to return (1–200, default 50). */
+  limit?: number
+}
+
+/** Filters for listing key definitions. */
+export interface ListKeyDefinitionsParams extends PageParams {
+  /** Free-text filter over `displayName` and `description`. */
+  search?: string
+  /** Restrict to one presentation category. */
+  category?: string
+  /**
+   * Include `isHidden` keys.
+   *
+   * Platform administrators only; any other caller passing `true` is refused
+   * with 403 rather than silently receiving a filtered list.
+   */
+  includeHidden?: boolean
+}
+
+/** Machine-readable failure reason from the contract's error envelope. */
+export type ConfigErrorCode =
+  | 'VALIDATION_ERROR'
+  | 'UNAUTHENTICATED'
+  | 'FORBIDDEN'
+  | 'NOT_FOUND'
+  | 'LOCKED_BY_ANCESTOR'
+  | 'VERSION_CONFLICT'
+  | 'SCOPE_NOT_ALLOWED'
+  | 'INCOMPATIBLE_DEFINITION'
+  | 'SECRET_UNAVAILABLE'
+  | 'RATE_LIMITED'
+
+/** One field- or key-level problem within a failed request. */
+export interface ConfigErrorDetail {
+  /** The configuration key this problem concerns, if key-specific. */
+  key?: string | null
+  /** The request field this problem concerns, if field-specific. */
+  field?: string | null
+  /** What is wrong, in human-facing terms. */
+  message: string
+  /** The values that would have been accepted, for enum rejections. */
+  allowedValues?: unknown[] | null
+}
+
+/** The error envelope returned by every non-2xx response. */
+export interface ConfigErrorBody {
+  /** Branch on this, not on `message`. */
+  code: ConfigErrorCode
+  /** Human-facing explanation. May change without a contract version bump. */
+  message: string
+  /** The scope holding the lock. Present on `LOCKED_BY_ANCESTOR`. */
+  lockedBy?: Scope | null
+  /** The resolved view's actual version. Present on `VERSION_CONFLICT`. */
+  currentVersion?: string | null
+  /** Per-key or per-field problems. Present on validation failures. */
+  details?: ConfigErrorDetail[] | null
+}

--- a/config-client/tsconfig.json
+++ b/config-client/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "DOM"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "exactOptionalPropertyTypes": false,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/config-client/tsup.config.ts
+++ b/config-client/tsup.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from 'tsup'
+
+/**
+ * Dual CJS + ESM output with declarations, mirroring `selection-list-client/`.
+ *
+ * Both formats ship because the consumers differ: the Vite/React 19 shell and
+ * the UI packages are ESM, while the Node service tests are still CommonJS.
+ * Publishing only one would force one of them into an interop shim.
+ */
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  outExtension({ format }) {
+    return { js: format === 'cjs' ? '.cjs' : '.js' }
+  },
+  dts: true,
+  sourcemap: true,
+  clean: true,
+  target: 'es2022',
+  // Zero runtime dependencies: nothing to externalise, nothing to bundle in.
+  external: [],
+})

--- a/services/config-service/.spectral.yaml
+++ b/services/config-service/.spectral.yaml
@@ -1,0 +1,123 @@
+# Spectral ruleset for the config-service OpenAPI contract (FFRNT-153 / FF-EPIC-17-S1).
+#
+# Run:  npx @stoplight/spectral-cli lint services/config-service/openapi.yaml \
+#         --ruleset services/config-service/.spectral.yaml
+#
+# `extends: [spectral:oas]` is the built-in alias for the `@stoplight/spectral-oas`
+# ruleset that ships inside the CLI, so linting needs no extra install.
+#
+# NOTE ON `@stoplight/spectral-api-docs-style`
+# -------------------------------------------
+# The S1 brief asked for `@stoplight/spectral-oas` + `@stoplight/spectral-api-docs-style`.
+# **`@stoplight/spectral-api-docs-style` does not exist** — the npm registry returns
+# 404 for it (Stoplight's documentation-quality ruleset is published as
+# `@stoplight/spectral-documentation`). Rather than pin a package that cannot be
+# installed, or add a remote ruleset fetch that CI must reach the network for, the
+# API-docs-style requirements are declared **locally and explicitly** below:
+# every operation carries an operationId, a summary, a description and tags; every
+# parameter and every schema property is documented. Local rules also cost nothing
+# to audit — the contract's doc policy is readable in one file rather than inherited
+# from a transitive dependency.
+extends: [spectral:oas]
+
+rules:
+  # ---------------------------------------------------------------------------
+  # Suppressions — both genuinely spurious, both justified in place.
+  # ---------------------------------------------------------------------------
+
+  # The service is UNLICENSED (private, cluster-internal). There is no licence URL
+  # to point at, and inventing one would be worse than omitting it.
+  license-url: off
+
+  # OAS 3.1 schemas use JSON Schema 2020-12 `examples` ARRAYS. Spectral's 3.0-era
+  # example validator mis-reads those against union types such as
+  # `type: [string, 'null']`, so it is demoted rather than switched off — real
+  # problems still surface as warnings.
+  oas3-valid-schema-example: warn
+
+  # ---------------------------------------------------------------------------
+  # Ratcheted from the defaults — these are ERRORS for this contract, not hints.
+  # A generated/derived client is only as good as the spec's operation metadata.
+  # ---------------------------------------------------------------------------
+  operation-operationId: error
+  operation-operationId-unique: error
+  operation-operationId-valid-in-url: error
+  operation-description: error
+  operation-tags: error
+  operation-tag-defined: error
+  operation-success-response: error
+  oas3-unused-component: error
+  no-eval-in-markdown: error
+  no-script-tags-in-markdown: error
+
+  # ---------------------------------------------------------------------------
+  # API-docs-style rules (local replacement for the non-existent
+  # `@stoplight/spectral-api-docs-style`).
+  # ---------------------------------------------------------------------------
+
+  operation-summary:
+    description: Every operation needs a one-line summary — it is the title of the generated docs entry.
+    message: '{{path}} — operation has no `summary`'
+    severity: error
+    given: $.paths[*][get,put,post,delete,patch,options,head,trace]
+    then:
+      field: summary
+      function: truthy
+
+  parameter-description:
+    description: >-
+      Every parameter must say what it does. A parameter a caller has to guess at
+      is a support ticket, and query parameters are exactly where guessing goes wrong.
+    message: '{{path}} — parameter has no `description`'
+    severity: error
+    given:
+      - $.paths[*].parameters[*]
+      - $.paths[*][get,put,post,delete,patch,options,head,trace].parameters[*]
+      - $.components.parameters[*]
+    then:
+      function: schema
+      functionOptions:
+        schema:
+          type: object
+          anyOf:
+            - required: ['description']
+            - required: ['$ref']
+
+  schema-description:
+    description: Every named component schema must be documented.
+    message: '{{path}} — component schema has no `description`'
+    severity: error
+    given: $.components.schemas[*]
+    then:
+      field: description
+      function: truthy
+
+  schema-property-description:
+    description: >-
+      Every schema property must be documented, either directly or by pointing at a
+      documented named schema. This is the rule that makes the contract readable
+      without the implementation next to it — and the one that keeps the derived
+      client's TSDoc honest.
+    message: '{{path}} — schema property has no `description` and is not a `$ref` to a documented schema'
+    severity: error
+    given:
+      - $.components.schemas..properties[*]
+      - $.paths[*][*].requestBody.content[*].schema..properties[*]
+      - $.paths[*][*].responses[*].content[*].schema..properties[*]
+    then:
+      function: schema
+      functionOptions:
+        schema:
+          type: object
+          anyOf:
+            - required: ['description']
+            - required: ['$ref']
+
+  request-body-description:
+    description: Every request body must explain what it carries.
+    message: '{{path}} — requestBody has no `description`'
+    severity: error
+    given: $.paths[*][put,post,patch].requestBody
+    then:
+      field: description
+      function: truthy

--- a/services/config-service/openapi.yaml
+++ b/services/config-service/openapi.yaml
@@ -1,0 +1,1119 @@
+openapi: 3.1.0
+info:
+  title: FuzeFront Configuration Service API
+  version: 1.0.0
+  summary: Namespaced, hierarchical key/value configuration with typed key metadata and provenance-carrying resolution.
+  description: >-
+    **FROZEN CONTRACT — FFRNT-153 (FF-EPIC-17-S1).** This file is the single
+    source of truth for the `config-service` HTTP surface and for every artefact
+    derived from it: the Node client `@fuzefront/config-client` (this story), the
+    Python client (FFRNT-259), and the served Swagger UI (FFRNT-258). Nothing
+    downstream — backend routes, migrations, the settings UI, acceptance tests,
+    docs — may diverge from it. Changing the API means amending **this file
+    first**, bumping `info.version`, re-linting, and re-issuing **both** clients.
+
+
+    ### What the service is
+
+    A generic place to store settings. Today every feature that needs one invents
+    its own table, so there is no shared notion of a typed key, a declared
+    default, an org-level override, or a setting a tenant may see but not change.
+    This service owns exactly two things: a **catalog of key definitions**
+    (metadata, shipped by the owning app) and a **sparse set of values**
+    (overrides per scope). It owns nothing else.
+
+
+    ### Two tables, not one — and why the split is load-bearing
+
+    The catalog/value split is what makes `isSystem`, `isHidden`, `isSecret` and
+    validation expressible at all. A plain key/value store cannot say *"this key
+    exists, is a boolean, and only the platform may write it."* Definitions
+    describe what a key **is**; values record what somebody **set** it to, at one
+    scope, sparsely — the absence of a row means "inherit", not "empty".
+
+
+    ### The scope chain
+
+    A value resolves down `default → platform → portal → org → user`, where
+    `default` comes from the key definition itself and is therefore always
+    present. Each tier is optional and sparse. Removing an override at one tier
+    leaves every other tier untouched, which is why `unset` and "set to the
+    parent's current value" are different operations: the first keeps tracking
+    the parent, the second pins a copy that stops following it.
+
+
+    ### Resolution returns provenance, not a bare value
+
+    Every resolved entry carries `source` (which scope supplied it), `locked`,
+    and `editable`. This is not decoration. Without it the settings editor cannot
+    render "inherited from Organization", cannot decide whether to disable an
+    input, and cannot explain why a value it is showing cannot be changed. A
+    client that reads only `value` will produce a form that looks correct and
+    misrepresents where its values came from.
+
+
+    ### `locked` — inheritance with non-edit permission
+
+    A value written with `locked: true` beats every value beneath it in the chain
+    **and** resolves with `editable: false`. This is what lets a portal
+    (super-tenant) set values for the orgs inside it that they cannot modify. It
+    is enforced server-side: a write beneath an active lock is refused with
+    **409 `LOCKED_BY_ANCESTOR`**, and the error names the locking scope so the UI
+    can say *which* ancestor locked it rather than showing a generic denial.
+
+    Locking is deliberately **not** the same mechanism as `precedence`. Locking
+    hard-pins one value; precedence is the ordering rule for the whole chain.
+
+
+    ### `precedence` — the reverse-order hook
+
+    Each key definition carries `precedence`: `most-specific-wins` (the default —
+    the user's value beats the org's) or `least-specific-wins` (the org's value
+    beats the user's). Storing the ordering rule **per key** means changing that
+    behaviour later is a value change, not a migration plus a resolver rewrite.
+    Both directions are implemented from day one; the response shape is identical
+    either way, so no consumer branches on it.
+
+
+    ### This is NOT the feature-flag system
+
+    Unleash owns feature flags. The split: **configuration** is durable, typed,
+    user- and tenant-authored settings; **flags** are rollout, targeting,
+    kill-switches and experiments, authored by engineering. Stating this in the
+    contract is load-bearing — without it the key catalog accretes flag-shaped
+    keys and the family ends up with two flag systems and no clear owner.
+
+
+    ### Identifiers
+
+    Ids are TypeIDs (`prefix_` + base32 UUIDv7), opaque past the prefix:
+    `cns_` namespace, `ckd_` key definition, `cvl_` value, `cvh_` history entry.
+    The service mints them; **no create body accepts an id for the resource being
+    created**, and every create body is `additionalProperties: false`. Scope
+    references are polymorphic and therefore always carry their type
+    (`scopeType` + `scopeId`) — a bare id is never resolved. An id is never a
+    capability: authorization comes from the token and Permit, never from the
+    caller having known an id.
+
+
+    ### Authorization
+
+    Every operation is Permit-gated on the acting principal. Reads are scoped —
+    a caller reading a scope they have no authority over gets **403** and learns
+    nothing about whether that scope exists. Writes additionally distinguish
+    *write* authority from *lock* authority: being able to set a value at your
+    own scope does not imply being able to lock it against the scopes beneath.
+  contact:
+    name: FuzeFront Platform Team
+    url: https://github.com/izzywdev/FuzeFront
+  license:
+    name: UNLICENSED
+servers:
+  - url: /api/config
+    description: >-
+      Same-origin path behind the FuzeFront ingress. Browser callers MUST use a
+      same-origin base — an absolute host breaks under TLS with a mixed-content
+      block the moment the environment changes.
+tags:
+  - name: Namespaces
+    description: Registering and listing the configuration namespaces an app owns.
+  - name: Key definitions
+    description: The catalog — what a key is, how it validates, and who may set it.
+  - name: Effective configuration
+    description: Reading resolved values, with provenance, for a scope.
+  - name: Values
+    description: Writing, resetting, locking and unlocking values at a scope.
+security:
+  - bearerAuth: []
+paths:
+  /v1/namespaces:
+    get:
+      operationId: listNamespaces
+      summary: List configuration namespaces
+      description: >-
+        Returns the namespaces the caller may see, newest first. Cursor
+        paginated per the platform pagination standard.
+      tags: [Namespaces]
+      parameters:
+        - $ref: '#/components/parameters/Cursor'
+        - $ref: '#/components/parameters/Limit'
+      responses:
+        '200':
+          description: A page of namespaces.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PagedNamespaces'
+        '401':
+          $ref: '#/components/responses/Unauthenticated'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+    post:
+      operationId: createNamespace
+      summary: Register a configuration namespace
+      description: >-
+        Registers a namespace for an owning application. Idempotent on
+        `namespace`: re-registering an existing namespace updates its
+        presentation metadata and returns 200 rather than failing, so an app can
+        register unconditionally at startup.
+      tags: [Namespaces]
+      requestBody:
+        required: true
+        description: The namespace to register.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NamespaceCreate'
+      responses:
+        '200':
+          description: The namespace already existed and its metadata was updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Namespace'
+        '201':
+          description: The namespace was created.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Namespace'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/Unauthenticated'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+  /v1/namespaces/{namespace}/keys:
+    parameters:
+      - $ref: '#/components/parameters/NamespacePath'
+    get:
+      operationId: listKeyDefinitions
+      summary: List the key definitions in a namespace
+      description: >-
+        The catalog view. Returns key definitions with their full metadata,
+        cursor paginated and optionally filtered by a free-text search over
+        display name and description.
+
+
+        Keys marked `isHidden` are **omitted** for ordinary callers and included
+        only for a platform administrator who passes `includeHidden=true`. A
+        hidden key that reaches an ordinary caller is not hidden, so this is a
+        server-side omission and never a client-side filter.
+      tags: [Key definitions]
+      parameters:
+        - $ref: '#/components/parameters/Cursor'
+        - $ref: '#/components/parameters/Limit'
+        - name: search
+          in: query
+          required: false
+          description: Free-text filter matched against `displayName` and `description`.
+          schema:
+            type: string
+            minLength: 1
+            maxLength: 200
+        - name: category
+          in: query
+          required: false
+          description: Restrict to one presentation category.
+          schema:
+            type: string
+            maxLength: 100
+        - name: includeHidden
+          in: query
+          required: false
+          description: >-
+            Include `isHidden` keys. Permitted only for platform administrators;
+            any other caller passing `true` is refused with 403 rather than
+            silently receiving a filtered list.
+          schema:
+            type: boolean
+            default: false
+      responses:
+        '200':
+          description: A page of key definitions.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PagedKeyDefinitions'
+        '401':
+          $ref: '#/components/responses/Unauthenticated'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    put:
+      operationId: registerKeyDefinitions
+      summary: Register (upsert) the key definitions for a namespace
+      description: >-
+        Declarative registration: an app publishes the definitions it owns and
+        the service reconciles them. Idempotent — re-registering an unchanged
+        manifest is a no-op.
+
+
+        Metadata updates are applied while existing stored **values** for the key
+        are preserved. A key present in the catalog but absent from a manifest
+        that declares itself `complete` is marked **deprecated, never deleted**:
+        deleting it would silently destroy every tenant's value for that key.
+
+
+        A change that is incompatible with values already stored (for example a
+        `valueType` change that existing values cannot satisfy) is refused as a
+        whole, with the conflicting values reported, rather than leaving the
+        catalog and the data inconsistent.
+      tags: [Key definitions]
+      requestBody:
+        required: true
+        description: The key definitions this namespace declares.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/KeyDefinitionManifest'
+      responses:
+        '200':
+          description: The catalog after reconciliation.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KeyDefinitionManifestResult'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/Unauthenticated'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          description: >-
+            The manifest conflicts with values already stored. Nothing was
+            written.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorBody'
+  /v1/namespaces/{namespace}/keys/{key}:
+    parameters:
+      - $ref: '#/components/parameters/NamespacePath'
+      - $ref: '#/components/parameters/KeyPath'
+    get:
+      operationId: getKeyDefinition
+      summary: Get one key definition
+      description: >-
+        Returns a single key's metadata. Hidden keys are 404 for ordinary
+        callers — the same response an absent key produces, so the endpoint does
+        not confirm the existence of keys the caller may not see.
+      tags: [Key definitions]
+      responses:
+        '200':
+          description: The key definition.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KeyDefinition'
+        '401':
+          $ref: '#/components/responses/Unauthenticated'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  /v1/config:
+    get:
+      operationId: getEffectiveConfig
+      summary: Read a scope's fully-resolved configuration
+      description: >-
+        The hot path. Resolves every visible key in a namespace for the given
+        scope down the chain `default → platform → portal → org → user`,
+        honouring each key's `precedence` and short-circuiting at the outermost
+        active lock, and returns one entry per key **with its provenance**.
+
+
+        Returns an `ETag`. A caller that sends `If-None-Match` with an unchanged
+        namespace/scope gets **304** and no body. The version behind that ETag
+        reflects the **resolved view**, so a change made at an ancestor scope
+        also changes it — a version that tracked only rows owned by the exact
+        scope would let inherited changes go undetected.
+
+
+        Keys marked `isHidden` are absent from the response entirely.
+      tags: [Effective configuration]
+      parameters:
+        - $ref: '#/components/parameters/NamespaceQuery'
+        - $ref: '#/components/parameters/ScopeTypeQuery'
+        - $ref: '#/components/parameters/ScopeIdQuery'
+        - $ref: '#/components/parameters/IfNoneMatch'
+      responses:
+        '200':
+          description: The resolved configuration for the scope.
+          headers:
+            ETag:
+              description: Version of the resolved view; pass back as `If-None-Match`.
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EffectiveConfig'
+        '304':
+          description: The resolved view is unchanged since the supplied `ETag`.
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/Unauthenticated'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    put:
+      operationId: writeConfigValues
+      summary: Apply a batch of value operations to one scope, atomically
+      description: >-
+        Applies `set`, `unset`, `lock` and `unlock` operations to a single scope
+        as **one transaction**. If any operation fails — validation, an ancestor
+        lock, missing authority — **nothing is written** and the response names
+        every failing operation. A settings page that saves twenty keys must
+        never half-save, which is why this is a batch endpoint rather than a
+        per-key one.
+
+
+        `unset` removes the override at this scope so the key resolves from its
+        parent again. That is deliberately different from setting the parent's
+        current value, which would pin a copy that stops following the parent.
+
+
+        Supply `expectedVersion` (the `ETag` from a prior read) for optimistic
+        concurrency: if the resolved view moved underneath the caller, the write
+        is refused with **409 `VERSION_CONFLICT`** rather than silently
+        overwriting a concurrent editor's change.
+      tags: [Values]
+      requestBody:
+        required: true
+        description: The scope to write to and the operations to apply.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ConfigWriteRequest'
+      responses:
+        '200':
+          description: All operations applied. Returns the scope's new version.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConfigWriteResult'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/Unauthenticated'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          description: >-
+            Refused without writing anything. Either a key is locked by an
+            ancestor scope (`LOCKED_BY_ANCESTOR`, with `lockedBy` naming that
+            scope) or the resolved view moved since `expectedVersion`
+            (`VERSION_CONFLICT`).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorBody'
+        '422':
+          description: >-
+            A key was addressed at a scope its `allowedScopes` excludes. Nothing
+            was written.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorBody'
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      description: >-
+        The acting principal's access token. Authorization is decided by Permit
+        against this principal; knowing an id never grants access.
+  parameters:
+    Cursor:
+      name: cursor
+      in: query
+      required: false
+      description: Opaque cursor from a previous page's `nextCursor`. Omit for the first page.
+      schema:
+        type: string
+    Limit:
+      name: limit
+      in: query
+      required: false
+      description: Maximum items to return in this page.
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 200
+        default: 50
+    NamespacePath:
+      name: namespace
+      in: path
+      required: true
+      description: Dotted namespace identifier, for example `fuzefront.chat`.
+      schema:
+        $ref: '#/components/schemas/NamespaceName'
+    KeyPath:
+      name: key
+      in: path
+      required: true
+      description: Dotted key path within the namespace, for example `ui.theme.density`.
+      schema:
+        $ref: '#/components/schemas/KeyName'
+    NamespaceQuery:
+      name: namespace
+      in: query
+      required: true
+      description: The namespace whose configuration to resolve.
+      schema:
+        $ref: '#/components/schemas/NamespaceName'
+    ScopeTypeQuery:
+      name: scopeType
+      in: query
+      required: true
+      description: Which tier of the chain to resolve for.
+      schema:
+        $ref: '#/components/schemas/ScopeType'
+    ScopeIdQuery:
+      name: scopeId
+      in: query
+      required: false
+      description: >-
+        The portal, organization or user to resolve for. Omitted (and rejected if
+        supplied) when `scopeType` is `platform`, which is a singleton tier.
+      schema:
+        type: string
+    IfNoneMatch:
+      name: If-None-Match
+      in: header
+      required: false
+      description: >-
+        A previously returned `ETag`. An unchanged resolved view answers 304. An
+        unrecognised or malformed token is treated as absent and answered with a
+        full response, so a stale cached token degrades to a normal read rather
+        than an error.
+      schema:
+        type: string
+  responses:
+    Unauthenticated:
+      description: No credential, or a credential that is not valid.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorBody'
+    Forbidden:
+      description: >-
+        The principal has no authority over the requested scope. The response
+        does not reveal whether that scope exists.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorBody'
+    NotFound:
+      description: >-
+        No such namespace or key — or one the caller may not see, which answers
+        identically by design.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorBody'
+    ValidationError:
+      description: The request was malformed or a value failed its key's schema.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorBody'
+  schemas:
+    NamespaceId:
+      type: string
+      description: TypeID of a namespace, prefixed `cns_`. Opaque past the prefix.
+      pattern: '^cns_[0-9a-hjkmnp-tv-z]{26}$'
+      examples: ['cns_01h455vb4pex5vsknk084sn02q']
+    KeyDefinitionId:
+      type: string
+      description: TypeID of a key definition, prefixed `ckd_`. Opaque past the prefix.
+      pattern: '^ckd_[0-9a-hjkmnp-tv-z]{26}$'
+      examples: ['ckd_01h455vb4pex5vsknk084sn02q']
+    NamespaceName:
+      type: string
+      description: >-
+        Dotted, lowercase namespace name owned by one application, for example
+        `fuzefront.chat`. Unique across the service.
+      pattern: '^[a-z0-9]+(\.[a-z0-9-]+)*$'
+      maxLength: 200
+      examples: ['fuzefront.chat']
+    KeyName:
+      type: string
+      description: >-
+        Dotted, lowercase key path, unique within its namespace, for example
+        `ui.theme.density`.
+      pattern: '^[a-z0-9]+(\.[a-z0-9-]+)*$'
+      maxLength: 200
+      examples: ['ui.theme.density']
+    ScopeType:
+      type: string
+      description: >-
+        A tier of the resolution chain. `platform` is a singleton and carries no
+        `scopeId`; the others identify a portal, organization or user.
+      enum: [platform, portal, org, user]
+    ValueType:
+      type: string
+      description: >-
+        The kind of value a key holds. Drives both server-side validation and the
+        input the settings editor renders.
+      enum:
+        - string
+        - number
+        - boolean
+        - enum
+        - json
+        - duration
+        - url
+        - email
+        - color
+        - secret
+    Precedence:
+      type: string
+      description: >-
+        Which end of the chain wins. `most-specific-wins` (default) lets the
+        user's value beat the org's; `least-specific-wins` reverses that so an
+        org-level setting overrides a user-specific one. The response shape is
+        identical either way.
+      enum: [most-specific-wins, least-specific-wins]
+      default: most-specific-wins
+    Scope:
+      type: object
+      description: A point in the resolution chain. Polymorphic references always carry their type.
+      additionalProperties: false
+      required: [scopeType]
+      properties:
+        scopeType:
+          $ref: '#/components/schemas/ScopeType'
+        scopeId:
+          type: [string, 'null']
+          description: >-
+            The portal, organization or user. Null exactly when `scopeType` is
+            `platform`.
+    Namespace:
+      type: object
+      description: A configuration namespace owned by one application.
+      required: [id, namespace, displayName, createdAt]
+      properties:
+        id:
+          $ref: '#/components/schemas/NamespaceId'
+        namespace:
+          $ref: '#/components/schemas/NamespaceName'
+        displayName:
+          type: string
+          description: Human-facing name shown as the section heading in the editor.
+        description:
+          type: [string, 'null']
+          description: What this namespace's settings govern.
+        ownerAppId:
+          type: [string, 'null']
+          description: The application that owns this namespace, in the app registry.
+        createdAt:
+          type: string
+          format: date-time
+          description: When the namespace was first registered.
+    NamespaceCreate:
+      type: object
+      description: >-
+        Registration body. Carries no `id` — the service mints it — and rejects
+        unknown properties.
+      additionalProperties: false
+      required: [namespace, displayName]
+      properties:
+        namespace:
+          $ref: '#/components/schemas/NamespaceName'
+        displayName:
+          type: string
+          description: Human-facing name shown as the section heading in the editor.
+          minLength: 1
+          maxLength: 200
+        description:
+          type: string
+          description: What this namespace's settings govern.
+          maxLength: 2000
+        ownerAppId:
+          type: string
+          description: The owning application in the app registry.
+    KeyDefinition:
+      type: object
+      description: >-
+        What a key **is**: how it is presented, how it validates, where it may be
+        set, and who may change it.
+      required:
+        - id
+        - key
+        - displayName
+        - valueType
+        - defaultValue
+        - allowedScopes
+        - isSystem
+        - isHidden
+        - isSecret
+        - isReadonly
+        - precedence
+        - requiresRestart
+      properties:
+        id:
+          $ref: '#/components/schemas/KeyDefinitionId'
+        key:
+          $ref: '#/components/schemas/KeyName'
+        displayName:
+          type: string
+          description: Label shown next to the input in the editor.
+        description:
+          type: [string, 'null']
+          description: Help text explaining what the setting does.
+        helpUrl:
+          type: [string, 'null']
+          description: Link to fuller documentation for this setting.
+        category:
+          type: [string, 'null']
+          description: Grouping heading in the editor.
+        sortOrder:
+          type: integer
+          description: Position within its category. Lower sorts first.
+        tags:
+          type: array
+          description: Free-form tags used for search and filtering.
+          items:
+            type: string
+        valueType:
+          $ref: '#/components/schemas/ValueType'
+        schema:
+          type: [object, 'null']
+          description: >-
+            JSON Schema the value must satisfy, intersected with the base schema
+            implied by `valueType`. Deriving the base from `valueType` rather
+            than trusting the two to agree is what stops a `number` key carrying
+            a string schema.
+        enumValues:
+          type: [array, 'null']
+          description: >-
+            The permitted values when `valueType` is `enum`. A rejection names
+            these, so the caller learns what was allowed.
+          items: {}
+        defaultValue:
+          description: >-
+            The bottom of the resolution chain. Always present, so every key
+            resolves to something even with no overrides anywhere. Validated
+            against this key's own schema at write time, so an unsatisfiable key
+            cannot enter the catalog.
+        allowedScopes:
+          type: array
+          description: >-
+            The tiers at which this key may be set. A write at an excluded tier
+            is refused; the key cannot acquire a row there by any path.
+          items:
+            $ref: '#/components/schemas/ScopeType'
+        isSystem:
+          type: boolean
+          description: >-
+            Platform-owned. Its metadata is immutable to everyone else and only
+            the platform may write a value.
+        isHidden:
+          type: boolean
+          description: >-
+            Never rendered in the editor and omitted from ordinary reads
+            entirely. Visible only in the platform-admin catalog view.
+        isSecret:
+          type: boolean
+          description: >-
+            Encrypted at rest, masked on read, excluded from export. The value is
+            never returned; `isSet` reports only whether one exists.
+        isReadonly:
+          type: boolean
+          description: Displayed but not editable at any tier.
+        precedence:
+          $ref: '#/components/schemas/Precedence'
+        requiresRestart:
+          type: boolean
+          description: >-
+            Changing it does not take effect in running consumers until they
+            restart; the editor warns accordingly.
+        deprecatedAt:
+          type: [string, 'null']
+          format: date-time
+          description: When the key was deprecated. Deprecated keys still resolve.
+        replacedBy:
+          type: [string, 'null']
+          description: The key that supersedes this one, if any.
+    KeyDefinitionInput:
+      type: object
+      description: >-
+        One key as declared by an owning application. Carries no `id` — the
+        service mints it — and rejects unknown properties.
+      additionalProperties: false
+      required: [key, displayName, valueType, defaultValue, allowedScopes]
+      properties:
+        key:
+          $ref: '#/components/schemas/KeyName'
+        displayName:
+          type: string
+          description: Label shown next to the input in the editor.
+          minLength: 1
+          maxLength: 200
+        description:
+          type: string
+          description: Help text explaining what the setting does.
+          maxLength: 2000
+        helpUrl:
+          type: string
+          description: Link to fuller documentation for this setting.
+          format: uri
+        category:
+          type: string
+          description: Grouping heading in the editor.
+          maxLength: 100
+        sortOrder:
+          type: integer
+          description: Position within its category. Lower sorts first.
+        tags:
+          type: array
+          description: Free-form tags used for search and filtering.
+          items:
+            type: string
+        valueType:
+          $ref: '#/components/schemas/ValueType'
+        schema:
+          type: object
+          description: JSON Schema the value must satisfy, intersected with the `valueType` base.
+        enumValues:
+          type: array
+          description: The permitted values when `valueType` is `enum`.
+          items: {}
+        defaultValue:
+          description: The bottom of the chain. Must satisfy this key's own schema.
+        allowedScopes:
+          type: array
+          description: The tiers at which this key may be set.
+          minItems: 1
+          items:
+            $ref: '#/components/schemas/ScopeType'
+        isSystem:
+          type: boolean
+          description: Platform-owned; metadata immutable and platform-only writes.
+          default: false
+        isHidden:
+          type: boolean
+          description: Omitted from ordinary reads entirely.
+          default: false
+        isSecret:
+          type: boolean
+          description: Encrypted at rest, masked on read, excluded from export.
+          default: false
+        isReadonly:
+          type: boolean
+          description: Displayed but not editable at any tier.
+          default: false
+        precedence:
+          $ref: '#/components/schemas/Precedence'
+        requiresRestart:
+          type: boolean
+          description: Warn that the change is not live until consumers restart.
+          default: false
+        replacedBy:
+          type: string
+          description: The key that supersedes this one, if any.
+    KeyDefinitionManifest:
+      type: object
+      description: The set of key definitions an application declares for one namespace.
+      additionalProperties: false
+      required: [keys]
+      properties:
+        keys:
+          type: array
+          description: Every key this manifest declares.
+          items:
+            $ref: '#/components/schemas/KeyDefinitionInput'
+        complete:
+          type: boolean
+          description: >-
+            Whether this manifest is the **whole** catalog for the namespace.
+            Only when true does an omitted key get deprecated. Requiring the
+            manifest to say so, rather than inferring deletion from absence,
+            is what stops a truncated or partially-generated manifest from
+            deprecating half a namespace.
+          default: false
+    KeyDefinitionManifestResult:
+      type: object
+      description: What reconciling a manifest changed.
+      required: [created, updated, deprecated, unchanged]
+      properties:
+        created:
+          type: array
+          description: Keys that did not previously exist.
+          items:
+            $ref: '#/components/schemas/KeyName'
+        updated:
+          type: array
+          description: Keys whose metadata changed. Their stored values are untouched.
+          items:
+            $ref: '#/components/schemas/KeyName'
+        deprecated:
+          type: array
+          description: >-
+            Keys absent from a `complete` manifest. Marked deprecated, never
+            deleted — deleting would destroy every tenant's value for them.
+          items:
+            $ref: '#/components/schemas/KeyName'
+        unchanged:
+          type: array
+          description: Keys the manifest matched exactly. Re-registering is a no-op.
+          items:
+            $ref: '#/components/schemas/KeyName'
+    EffectiveConfigEntry:
+      type: object
+      description: >-
+        One resolved setting. The provenance fields are the point: a consumer
+        that reads only `value` cannot tell a value set here from one inherited
+        or locked, and will render a form that misrepresents its own contents.
+      required: [key, value, source, locked, editable, definition]
+      properties:
+        key:
+          $ref: '#/components/schemas/KeyName'
+        value:
+          description: >-
+            The resolved value. For an `isSecret` key this is always null — see
+            `isSet`.
+        isSet:
+          type: boolean
+          description: >-
+            Whether a secret has a stored value. Present only for `isSecret`
+            keys, whose `value` is never returned.
+        source:
+          $ref: '#/components/schemas/Scope'
+        locked:
+          type: boolean
+          description: >-
+            An ancestor scope pinned this value. It wins over anything beneath
+            it, and writes beneath it are refused server-side.
+        lockedBy:
+          oneOf:
+            - $ref: '#/components/schemas/Scope'
+            - type: 'null'
+          description: >-
+            Which scope holds the lock. Present exactly when `locked` is true, so
+            the editor can name the ancestor rather than showing a generic
+            denial.
+        lockReason:
+          type: [string, 'null']
+          description: Why the ancestor locked it, if a reason was recorded.
+        editable:
+          type: boolean
+          description: >-
+            Whether **this caller** may change it at the scope being read,
+            accounting for the lock, `isReadonly`, `allowedScopes` and Permit. A
+            disabled input is a courtesy; the server refuses the write
+            regardless.
+        warning:
+          type: [string, 'null']
+          description: >-
+            Set when the stored value no longer satisfies its definition — the
+            schema changed after the value was written. The **default** is
+            returned and this explains why, rather than failing the request: one
+            stale value must not break a consumer's boot.
+        definition:
+          $ref: '#/components/schemas/KeyDefinition'
+    EffectiveConfig:
+      type: object
+      description: A scope's fully-resolved configuration for one namespace.
+      required: [namespace, scope, version, entries]
+      properties:
+        namespace:
+          $ref: '#/components/schemas/NamespaceName'
+        scope:
+          $ref: '#/components/schemas/Scope'
+        version:
+          type: string
+          description: >-
+            Monotonic version of the **resolved view**, matching the `ETag`. It
+            changes when an ancestor changes too, so inherited changes are
+            detectable.
+        entries:
+          type: array
+          description: One entry per visible key. Hidden keys are absent entirely.
+          items:
+            $ref: '#/components/schemas/EffectiveConfigEntry'
+    ConfigOperationType:
+      type: string
+      description: >-
+        What to do with one key at the target scope. `unset` removes this scope's
+        override so the key resolves from its parent again — not the same as
+        setting the parent's current value, which pins a copy.
+      enum: [set, unset, lock, unlock]
+    ConfigOperation:
+      type: object
+      description: One operation against one key at the request's scope.
+      additionalProperties: false
+      required: [key, op]
+      properties:
+        key:
+          $ref: '#/components/schemas/KeyName'
+        op:
+          $ref: '#/components/schemas/ConfigOperationType'
+        value:
+          description: The new value. Required for `set` and `lock`; rejected otherwise.
+        lockReason:
+          type: string
+          description: >-
+            Why the value is being locked, surfaced to the scopes beneath. Only
+            meaningful with `lock`.
+          maxLength: 500
+    ConfigWriteRequest:
+      type: object
+      description: >-
+        A batch of operations against one scope, applied as a single
+        transaction.
+      additionalProperties: false
+      required: [namespace, scope, operations]
+      properties:
+        namespace:
+          $ref: '#/components/schemas/NamespaceName'
+        scope:
+          $ref: '#/components/schemas/Scope'
+        operations:
+          type: array
+          description: >-
+            The operations to apply. All succeed or none do; a settings page
+            must never half-save.
+          minItems: 1
+          maxItems: 500
+          items:
+            $ref: '#/components/schemas/ConfigOperation'
+        expectedVersion:
+          type: string
+          description: >-
+            The `version`/`ETag` the caller last read. When supplied and the
+            resolved view has moved, the write is refused with
+            `VERSION_CONFLICT` instead of overwriting a concurrent edit.
+        reason:
+          type: string
+          description: Why the change is being made. Recorded in the audit trail.
+          maxLength: 500
+    ConfigWriteResult:
+      type: object
+      description: The outcome of an applied batch.
+      required: [namespace, scope, version, applied]
+      properties:
+        namespace:
+          $ref: '#/components/schemas/NamespaceName'
+        scope:
+          $ref: '#/components/schemas/Scope'
+        version:
+          type: string
+          description: The scope's new resolved-view version, usable as the next `expectedVersion`.
+        applied:
+          type: array
+          description: The keys changed, in request order.
+          items:
+            $ref: '#/components/schemas/KeyName'
+    PageInfo:
+      type: object
+      description: Cursor pagination envelope.
+      required: [hasNextPage]
+      properties:
+        hasNextPage:
+          type: boolean
+          description: Whether a further page exists.
+        nextCursor:
+          type: [string, 'null']
+          description: Cursor for the next page. Null on the last page.
+    PagedNamespaces:
+      type: object
+      description: A page of namespaces.
+      required: [items, pageInfo]
+      properties:
+        items:
+          type: array
+          description: The namespaces in this page.
+          items:
+            $ref: '#/components/schemas/Namespace'
+        pageInfo:
+          $ref: '#/components/schemas/PageInfo'
+    PagedKeyDefinitions:
+      type: object
+      description: A page of key definitions.
+      required: [items, pageInfo]
+      properties:
+        items:
+          type: array
+          description: The key definitions in this page.
+          items:
+            $ref: '#/components/schemas/KeyDefinition'
+        pageInfo:
+          $ref: '#/components/schemas/PageInfo'
+    ErrorCode:
+      type: string
+      description: >-
+        Machine-readable failure reason. Callers branch on this, not on
+        `message`, which is human-facing and may change without a contract
+        version bump.
+      enum:
+        - VALIDATION_ERROR
+        - UNAUTHENTICATED
+        - FORBIDDEN
+        - NOT_FOUND
+        - LOCKED_BY_ANCESTOR
+        - VERSION_CONFLICT
+        - SCOPE_NOT_ALLOWED
+        - INCOMPATIBLE_DEFINITION
+        - SECRET_UNAVAILABLE
+        - RATE_LIMITED
+    ErrorDetail:
+      type: object
+      description: One field- or key-level problem within a failed request.
+      required: [message]
+      properties:
+        key:
+          type: [string, 'null']
+          description: The configuration key this problem concerns, if key-specific.
+        field:
+          type: [string, 'null']
+          description: The request field this problem concerns, if field-specific.
+        message:
+          type: string
+          description: What is wrong, in human-facing terms.
+        allowedValues:
+          type: [array, 'null']
+          description: >-
+            The values that would have been accepted. Populated for enum
+            rejections so the caller learns what was allowed.
+          items: {}
+    ErrorBody:
+      type: object
+      description: The error envelope returned by every non-2xx response.
+      required: [code, message]
+      properties:
+        code:
+          $ref: '#/components/schemas/ErrorCode'
+        message:
+          type: string
+          description: Human-facing explanation. Not for branching.
+        lockedBy:
+          oneOf:
+            - $ref: '#/components/schemas/Scope'
+            - type: 'null'
+          description: >-
+            The scope holding the lock. Present on `LOCKED_BY_ANCESTOR`, so the
+            UI can say which ancestor refused the write rather than showing a
+            generic denial.
+        currentVersion:
+          type: [string, 'null']
+          description: >-
+            The resolved view's actual version. Present on `VERSION_CONFLICT` so
+            the caller can re-read and retry.
+        details:
+          type: [array, 'null']
+          description: Per-key or per-field problems. Present on validation failures.
+          items:
+            $ref: '#/components/schemas/ErrorDetail'


### PR DESCRIPTION
## 📋 Description

**FFRNT-153 (FF-EPIC-17-S1)** — the frozen OpenAPI contract for the configuration service, plus the
Node client projected from it. This is the sequential gate the rest of FF-EPIC-17/18/19 fans out
from: no backend, UI or test stream can start until this lands.

Two files of contract, one client package. No service implementation — that's FFRNT-154 onward.

## 🔄 Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

## 🔧 Implementation Details

### Changes Made

| Path | What |
|---|---|
| `services/config-service/openapi.yaml` | OpenAPI 3.1 frozen contract |
| `services/config-service/.spectral.yaml` | Strict per-service lint ruleset |
| `config-client/` | `@fuzefront/config-client` — zero-dependency typed client |

Four surfaces: namespace registration, the key-definition catalog, effective-config resolution,
and atomic value writes.

### Three decisions the spec makes deliberately

Each is written *into* the contract so the implementation cannot quietly diverge from it.

**Resolution returns provenance, not a bare value.** Every entry carries `source`, `locked`,
`lockedBy`, `editable`. This isn't decoration — without it the settings editor cannot render
"inherited from Organization" or decide whether to disable an input. A consumer that reads only
`value` produces a form that looks correct and misrepresents where its values came from.

**A write beneath an active lock is `409 LOCKED_BY_ANCESTOR` with `lockedBy` naming the locking
scope** — not a bare 403. The UI has to say *which* ancestor refused, not show a generic denial.
That requirement is why the error envelope carries a scope rather than just a code.

**`precedence` lives on the key definition** (`most-specific-wins` | `least-specific-wins`), so the
anticipated reverse-order case — an org-level setting overriding a user-specific one — is a value
change rather than a migration plus a resolver rewrite. The response shape is identical either way,
so no consumer branches on it.

### Governance honoured

- Create bodies mint no ids and set `additionalProperties: false`; ids are TypeIDs (`cns_`, `ckd_`).
- Scope references always carry their type — a bare id is never resolved.
- Hidden keys are omitted **server-side**, never filtered client-side. A hidden key that reaches the
  browser is not hidden, so the client deliberately does no filtering of its own.
- The client keeps a same-origin `baseUrl` relative rather than re-serialising through `URL`, which
  would produce an absolute host and break under TLS.

## 🧪 Testing

Verified rather than assumed:

- **Spectral clean twice** — under the strict per-service ruleset, *and* under the default ruleset
  CI actually runs (CI lints without `--ruleset`, so passing only the strict one would have proven
  the wrong thing).
- **Prism boots the spec** and serves `GET /v1/config` and `PUT /v1/config` with correctly shaped
  200s — the same mock step CI runs on every discovered spec.
- `tsc --noEmit` clean; `tsup` emits ESM + CJS + declarations.
- **11 behavioural assertions against the built bundle**: same-origin base stays relative; platform
  scope omits `scopeId`; 304 maps to `NotModified`; 409 surfaces `lockedBy`; `VERSION_CONFLICT`
  surfaces `currentVersion`; a non-contract 502 reports `UNKNOWN` rather than a fabricated contract
  code.

No CI wiring needed — the contract tier discovers `services/*/openapi.yaml` automatically.

## 📋 Checklist

- [x] Self-review completed
- [x] Follows conventional commit format
- [x] TypeScript strict mode passes
- [x] No sensitive data exposed
- [x] No build output committed (`dist/` gitignored, verified staged clean)

## 🔗 Related Issues and PRs

- Implements **FFRNT-153**; unblocks FFRNT-154/155/156/157/158 and every FF-EPIC-18/19 story.
- FFRNT-259 (Python client) and FFRNT-258 (Swagger UI) are projections of **this same spec** — they
  are not second sources of truth.

## 📝 Additional Notes

### Worth knowing for FFRNT-258

`@stoplight/prism-cli` is **already pinned and running in CI** (`ci.yml` boots a Prism mock of every
discovered spec). The sandbox target recommended for the Swagger "try it" console therefore needs no
new tooling — it is already in the toolchain.

### Questions for Reviewers

- **Endpoint shape for writes.** I chose a single `PUT /v1/config` taking an operations array over
  per-key REST endpoints, because atomicity is a stated requirement (a settings page must never
  half-save) and a batch endpoint makes that the default rather than something callers assemble.
  Worth a look if you'd prefer per-key routes plus an explicit transaction wrapper.
- **`unset` vs. pinning.** The contract treats "remove my override" and "write the parent's current
  value" as different operations. That distinction is load-bearing but easy to lose in
  implementation — flagging it so review catches it early.

---
_Generated by [Claude Code](https://claude.ai/code/session_0183JMAkioT5pGt8aVmddPtc)_