### PR TITLE
fix(frontend): install native-build toolchain in the image build stage (unblocks E2E)

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -12,6 +12,19 @@ FROM node:24-bookworm-slim AS build
 
 WORKDIR /app
 
+# Native-module build toolchain (python3 + make + g++). The ROOT `npm install`
+# below installs the whole workspace, which includes native deps (sqlite3,
+# bcrypt, …). When prebuild-install finds no prebuilt binary for this Node/napi
+# target it falls back to `node-gyp rebuild`, which needs Python + a C++
+# toolchain — and node:24-bookworm-slim ships none of them, so the install dies
+# with "gyp ERR! find Python  Could not find any Python installation to use".
+# Installing them here makes the compile-from-source fallback reliable instead of
+# depending on a prebuilt-binary fetch succeeding. BUILD stage only — the
+# nginx:alpine runtime stage below never inherits these packages.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends python3 make g++ \
+    && rm -rf /var/lib/apt/lists/*
+
 # No GitHub Packages token is needed: every @fuzefront/* package resolves from the
 # local workspace (members + file: deps + vite source aliases), so the install never
 # hits the private registry. (Verified by a clean local build with no token.) This


### PR DESCRIPTION
## 📋 Description

The frontend image build (`frontend/Dockerfile`, used by both `docker-compose.e2e.yml` and `release.yml`) is failing at the root `npm install`, which takes down every E2E job that builds it — surfaced on #605 as a red **"Playwright sign-in flow"**, but it is **not** specific to that PR; it reproduces on any PR that rebuilds the frontend image.

### Root cause

The build stage runs a **root** `npm install` to hoist the whole workspace's deps. That pulls native modules (`sqlite3`, `bcrypt`, …). When `prebuild-install` finds no prebuilt binary for this Node/napi target it falls back to `node-gyp rebuild`, which needs Python + a C/C++ toolchain — and `node:24-bookworm-slim` ships none:

```
npm error path /app/node_modules/sqlite3
npm error command sh -c prebuild-install -r napi || node-gyp rebuild
npm error prebuild-install warn install No prebuilt binaries found (target=6 runtime=napi arch=x64 libc= platform=linux)
npm error gyp ERR! find Python  Could not find any Python installation to use
target frontend: failed to solve: process "/bin/sh -c rm -f package-lock.json && npm install" did not complete successfully: exit code: 1
```

### Fix

Add `python3 make g++` to the **build stage** so the compile-from-source fallback works reliably instead of depending on a prebuilt-binary fetch succeeding.

## 🔄 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🔨 Build system or dependency update

## 🧪 Testing

- [x] The fix is verified by **this PR's own CI**: the "Playwright sign-in flow" job builds this exact image, so a green run here proves the build now succeeds and the sign-in tests actually run.
- [ ] No local Docker in the authoring environment (no daemon), so the build is verified in CI rather than locally.

**No test is skipped, relaxed, or de-required.** This makes the image *build* so the existing tests run — it does not touch any test or gate.

## 🔧 Implementation Details

### Changes Made

- **`frontend/Dockerfile`** — in the `build` stage (`node:24-bookworm-slim`), `apt-get install --no-install-recommends python3 make g++` before the install steps, then clear apt lists.

### Why it doesn't bloat the runtime image

The Dockerfile is multi-stage. The toolchain is added only to the `build` stage; the runtime stage is `nginx:alpine` and copies only `/app/frontend/dist`. It never inherits these packages, so the shipped image is unchanged in size and contents — the produced `dist/` bundle is byte-for-byte what it was (the toolchain only affects whether native deps *compile*, and none of them are in the frontend bundle).

## 🚨 Breaking Changes

None.

## 📝 Additional Notes

### Deployment Notes

- [ ] No database migration.
- On merge, `release.yml` rebuilds the frontend image — the produced bundle is identical; only the build reliability changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhfKNASYBD9aS3Wu6RUPfZ)_