### PR TITLE
ci: shorten codeql-triage dismissed_comment to ≤280 chars (GH API limit)

### DIFF
--- a/.github/workflows/codeql-triage.yml
+++ b/.github/workflows/codeql-triage.yml
@@ -39,7 +39,7 @@ jobs:
           # Rules considered legacy-noise/by-design IN THOSE FILES ONLY.
           DISMISS_RULES='js/tainted-format-string js/log-injection js/missing-rate-limiting js/user-controlled-bypass js/clear-text-logging javascript.lang.security.audit.unsafe-formatstring.unsafe-formatstring fuze-auth-local-password-store semgrep.fuze-auth-local-password-store fuze-auth-self-minted-user-token semgrep.fuze-auth-self-minted-user-token'
 
-          COMMENT='Pre-existing legacy pattern (predates the SDLC gates; re-anchored into the PR diff by fingerprint drift). The local-auth machinery is the intentional machine/break-glass path; organizations.ts missing-rate-limiting alerts exist on all routes (pre-existing, not introduced by the current PR). Tracked for dedicated cleanup.'
+          COMMENT='Pre-existing legacy alert (fingerprint-drifted into PR diff). Local-auth is intentional break-glass path; organizations.ts rate-limiting is pre-existing. Tracked for cleanup.'
 
           PAGE=1
           DISMISSED=0


### PR DESCRIPTION
## Description

The `codeql-triage.yml` workflow was failing with HTTP 422 when trying to dismiss legacy CodeQL alerts:

```
gh: Invalid request.
Only 280 characters are allowed; 322 were supplied. (HTTP 422)
```

The `dismissed_comment` value was 322 chars; GitHub's code-scanning PATCH API enforces a 280-char max. Shortened from 322 → 174 chars with the same intent.

## Root Cause

PR #622 added `organizations.ts` to `LEGACY_PATHS` and updated the comment to explain both the local-auth path and the organizations.ts fingerprint drift. The combined explanation exceeded 280 chars.

## Fix

Shortened `COMMENT` to 174 chars (well under the 280-char limit).

## Next Step

After this merges, re-trigger `codeql-triage.yml` with `dry_run=false` on master to actually dismiss the fingerprint-drifted alerts blocking PR #611.

---
_Generated by [Claude Code](https://claude.ai/code/session_018PKRvNfpskTKPUfDc8X1G1)_