### PR TITLE
design(frames): Connected Accounts approval frames (FFRNT-296)

### DIFF
--- a/design/frames/connected-accounts/01-connections.html
+++ b/design/frames/connected-accounts/01-connections.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Connected accounts — /account/security/connections</title>
+<link rel="stylesheet" href="tokens.css" />
+</head>
+<body>
+<div class="shell">
+  <div class="topbar">
+    <div class="wordmark"><span class="fuse">Fuze</span>Front</div>
+    <div class="spacer"></div>
+    <div class="launch-btn" title="App launcher">⊞</div>
+    <div class="avatar">JW</div>
+  </div>
+  <div class="body">
+    <nav class="side">
+      <div class="section-label">Account</div>
+      <a class="nav-item" href="#"><span class="ico">◔</span> Profile</a>
+      <a class="nav-item active" href="#"><span class="ico">🛡</span> Security</a>
+      <a class="nav-item" href="#"><span class="ico">🔔</span> Notifications</a>
+      <a class="nav-item" href="#"><span class="ico">💳</span> Billing</a>
+    </nav>
+    <main class="content" data-frame="01-connections" data-panel="connected-accounts">
+      <a class="crumb" href="#" data-route="/account/security">← Security</a>
+      <h1 class="page-title">Connected accounts</h1>
+      <p class="page-sub">Link or unlink the ways you sign in. You'll always keep at least one.</p>
+
+      <div class="maxw">
+        <!-- Ways to sign in: password method (when set) + each linked provider -->
+        <section class="cap" aria-label="Ways you sign in">
+          <div class="cap__seam"></div>
+          <div class="cap__head">
+            <h2 class="cap__title">Ways you sign in</h2>
+            <span class="cap__hint">2 methods</span>
+          </div>
+          <div class="cap__list" data-panel="sign-in-methods">
+
+            <div class="method" data-method="password">
+              <span class="method__ico" aria-hidden="true">🔑</span>
+              <span class="method__name">Password
+                <small>Added · you can sign in with email &amp; password</small>
+              </span>
+              <span class="badge activated" data-badge="password">● Enabled</span>
+            </div>
+
+            <!-- ConnectedAccountRow — a linked social provider -->
+            <div class="method" data-connection="google" data-provider="google">
+              <span class="method__ico" aria-hidden="true">🇬</span>
+              <span class="method__name">Google
+                <small>Linked · <span class="mono">j••••@gmail.com</span></small>
+              </span>
+              <span class="badge mf">● Linked</span>
+              <button class="btn btn-ghost btn-sm" data-action="unlink" data-provider="google">Disconnect</button>
+            </div>
+
+          </div>
+        </section>
+
+        <!-- Add another way to sign in -->
+        <section class="cap" aria-label="Add a sign-in method">
+          <div class="cap__seam"></div>
+          <div class="cap__head">
+            <h2 class="cap__title">Add a way to sign in</h2>
+            <span class="cap__hint">Optional</span>
+          </div>
+          <div class="cap__list">
+            <div class="connect" data-connect="google">
+              <span class="method__ico" aria-hidden="true">🇬</span>
+              <span class="connect__name">Continue with Google</span>
+              <a class="btn btn-primary btn-sm" href="02-connect.html"
+                 data-action="connect" data-provider="google">Connect Google</a>
+            </div>
+          </div>
+          <div class="cap__foot">
+            <p class="callout__text" style="margin:0">
+              Connecting a provider lets you sign in with it. It never shares your FuzeFront
+              password, and you can disconnect it any time — as long as one sign-in method remains.
+            </p>
+          </div>
+        </section>
+      </div>
+    </main>
+  </div>
+</div>
+
+<nav class="frame-nav">
+  <span class="caption"><b>Frame (a)</b> · Connected accounts · <code class="mono">/account/security/connections</code></span>
+  <span>
+    <a href="index.html" class="btn btn-ghost">↩ Overview</a>
+    <a href="02-connect.html" class="btn btn-primary">Connect flow →</a>
+  </span>
+</nav>
+</body>
+</html>

--- a/design/frames/connected-accounts/02-connect.html
+++ b/design/frames/connected-accounts/02-connect.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Connect a provider — /account/security/connections</title>
+<link rel="stylesheet" href="tokens.css" />
+</head>
+<body>
+<div class="shell">
+  <div class="topbar">
+    <div class="wordmark"><span class="fuse">Fuze</span>Front</div>
+    <div class="spacer"></div>
+    <div class="launch-btn" title="App launcher">⊞</div>
+    <div class="avatar">JW</div>
+  </div>
+  <div class="body">
+    <nav class="side">
+      <div class="section-label">Account</div>
+      <a class="nav-item" href="#"><span class="ico">◔</span> Profile</a>
+      <a class="nav-item active" href="#"><span class="ico">🛡</span> Security</a>
+      <a class="nav-item" href="#"><span class="ico">🔔</span> Notifications</a>
+      <a class="nav-item" href="#"><span class="ico">💳</span> Billing</a>
+    </nav>
+    <main class="content" data-frame="02-connect" data-panel="connected-accounts">
+      <a class="crumb" href="01-connections.html" data-route="/account/security/connections">← Connected accounts</a>
+      <h1 class="page-title">Connect Google</h1>
+      <p class="page-sub">The two steps of linking a provider — and how the return looks.</p>
+
+      <div class="maxw gallery">
+        <!-- STEP 1 — redirect intent (POST /social/google/link → { redirectUrl }) -->
+        <div class="state-card">
+          <h3>Step 1 · Redirect intent</h3>
+          <div class="callout callout--info" data-state="redirecting" data-provider="google">
+            <span class="callout__ico" aria-hidden="true">↗</span>
+            <div class="callout__body">
+              <p class="callout__title">You'll continue on Google</p>
+              <p class="callout__text">We'll take you to <code class="mono">accounts.google.com</code> to
+                confirm it's you, then bring you straight back here. Nothing links until you approve.</p>
+              <div class="callout__actions">
+                <a class="btn btn-primary btn-sm" href="#" data-action="connect" data-provider="google">Continue with Google</a>
+                <a class="btn btn-ghost btn-sm" href="01-connections.html" data-action="cancel">Cancel</a>
+              </div>
+            </div>
+          </div>
+          <p class="callout__text" style="margin-top:var(--space-3)">
+            The button posts to <code class="mono">POST /v1/security/social/google/link</code> and
+            follows the returned <code class="mono">redirectUrl</code>. No vendor UI is ever shown by
+            FuzeFront — only the browser's own trip to Google.
+          </p>
+        </div>
+
+        <!-- STEP 2 — successful return (?linked=google) -->
+        <div class="state-card">
+          <h3>Step 2 · Back on FuzeFront · <code class="mono">?linked=google</code></h3>
+          <div class="callout callout--info" data-state="linked" data-linked="google">
+            <span class="callout__ico" aria-hidden="true">✓</span>
+            <div class="callout__body">
+              <p class="callout__title">Google connected</p>
+              <p class="callout__text">You can now sign in with Google. It's been added to your ways to sign in.</p>
+              <div class="callout__actions">
+                <a class="btn btn-ghost btn-sm" href="01-connections.html" data-route="/account/security/connections">View connected accounts</a>
+              </div>
+            </div>
+          </div>
+          <div class="method" data-connection="google" data-provider="google" style="margin-top:var(--space-4)">
+            <span class="method__ico" aria-hidden="true">🇬</span>
+            <span class="method__name">Google<small>Just linked</small></span>
+            <span class="badge mf">● Linked</span>
+          </div>
+        </div>
+      </div>
+    </main>
+  </div>
+</div>
+
+<nav class="frame-nav">
+  <span class="caption"><b>Frame (b)</b> · Connect flow · <code class="mono">/account/security/connections</code></span>
+  <span>
+    <a href="01-connections.html" class="btn btn-ghost">↩ Connections</a>
+    <a href="03-states.html" class="btn btn-primary">States &amp; fail-closed →</a>
+  </span>
+</nav>
+</body>
+</html>

--- a/design/frames/connected-accounts/03-states.html
+++ b/design/frames/connected-accounts/03-states.html
@@ -1,0 +1,146 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Connected accounts — states &amp; fail-closed</title>
+<link rel="stylesheet" href="tokens.css" />
+</head>
+<body>
+<div class="shell">
+  <div class="topbar">
+    <div class="wordmark"><span class="fuse">Fuze</span>Front</div>
+    <div class="spacer"></div>
+    <div class="launch-btn" title="App launcher">⊞</div>
+    <div class="avatar">JW</div>
+  </div>
+  <div class="body">
+    <nav class="side">
+      <div class="section-label">Account</div>
+      <a class="nav-item" href="#"><span class="ico">◔</span> Profile</a>
+      <a class="nav-item active" href="#"><span class="ico">🛡</span> Security</a>
+      <a class="nav-item" href="#"><span class="ico">🔔</span> Notifications</a>
+      <a class="nav-item" href="#"><span class="ico">💳</span> Billing</a>
+    </nav>
+    <main class="content" data-frame="03-states" data-panel="connected-accounts">
+      <a class="crumb" href="01-connections.html" data-route="/account/security/connections">← Connected accounts</a>
+      <h1 class="page-title">States &amp; fail-closed</h1>
+      <p class="page-sub">Every state is designed — not just the happy path. No vendor name ever reaches the DOM.</p>
+
+      <div class="maxw gallery">
+
+        <!-- LOADING -->
+        <div class="state-card">
+          <h3>Loading</h3>
+          <div data-state="loading" aria-busy="true" aria-label="Loading connected accounts">
+            <div class="skel" style="width:40%; margin-bottom:var(--space-4)"></div>
+            <div class="skel skel--row" style="margin-bottom:var(--space-3)"></div>
+            <div class="skel skel--row"></div>
+          </div>
+        </div>
+
+        <!-- LOAD ERROR + retry -->
+        <div class="state-card">
+          <h3>Load error</h3>
+          <div class="callout callout--error" data-state="error">
+            <span class="callout__ico" aria-hidden="true">⚠</span>
+            <div class="callout__body">
+              <p class="callout__title">We couldn't load your sign-in methods</p>
+              <p class="callout__text">Something went wrong reading your account. Your sign-in methods are unchanged.</p>
+              <div class="callout__actions">
+                <button class="btn btn-primary btn-sm" data-action="retry">Try again</button>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- SOCIAL-ONLY: set a password first (hasPassword:false) -->
+        <div class="state-card">
+          <h3>Social-only account · <code class="mono">hasPassword:false</code></h3>
+          <div class="method" data-connection="google" data-provider="google" style="margin-bottom:var(--space-4)">
+            <span class="method__ico" aria-hidden="true">🇬</span>
+            <span class="method__name">Google<small>Your only way to sign in</small></span>
+            <span class="badge mf">● Linked</span>
+            <button class="btn btn-ghost btn-sm" data-action="unlink" data-provider="google" disabled>Disconnect</button>
+          </div>
+          <div class="callout callout--warning" data-guard="set-password-first">
+            <span class="callout__ico" aria-hidden="true">🔑</span>
+            <div class="callout__body">
+              <p class="callout__title">Set a password first</p>
+              <p class="callout__text">Google is your only way in right now. Add a password before you
+                disconnect it, so you're never locked out.</p>
+              <div class="callout__actions">
+                <button class="btn btn-primary btn-sm" data-action="set-password">Set a password</button>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- LAST SIGN-IN METHOD: 409 guard on unlink -->
+        <div class="state-card">
+          <h3>Last sign-in method · <code class="mono">409</code> on unlink</h3>
+          <div class="method" data-connection="google" data-provider="google" style="margin-bottom:var(--space-4)">
+            <span class="method__ico" aria-hidden="true">🇬</span>
+            <span class="method__name">Google<small>The only method left</small></span>
+            <span class="badge mf">● Linked</span>
+            <button class="btn btn-ghost btn-sm" data-action="unlink" data-provider="google">Disconnect</button>
+          </div>
+          <div class="callout callout--warning" data-guard="last-sign-in-method">
+            <span class="callout__ico" aria-hidden="true">🔗</span>
+            <div class="callout__body">
+              <p class="callout__title">Keep at least one way to sign in</p>
+              <p class="callout__text">This is your last sign-in method, so it can't be removed. Add a
+                password or connect another provider first, then you can disconnect this one.</p>
+              <div class="callout__actions">
+                <button class="btn btn-primary btn-sm" data-action="set-password">Set a password</button>
+                <button class="btn btn-ghost btn-sm" data-action="connect" data-provider="google">Connect another</button>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- CONNECT FAILED / CANCELLED -->
+        <div class="state-card">
+          <h3>Connect didn't finish</h3>
+          <div class="callout callout--error" data-state="link-failed" data-provider="google">
+            <span class="callout__ico" aria-hidden="true">⚠</span>
+            <div class="callout__body">
+              <p class="callout__title">Google wasn't connected</p>
+              <p class="callout__text">The connection was cancelled or didn't complete. Nothing changed —
+                you can try connecting again.</p>
+              <div class="callout__actions">
+                <button class="btn btn-primary btn-sm" data-action="connect" data-provider="google">Try again</button>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- ALREADY LINKED -->
+        <div class="state-card">
+          <h3>Already connected</h3>
+          <div class="callout callout--info" data-state="already-linked" data-provider="google">
+            <span class="callout__ico" aria-hidden="true">✓</span>
+            <div class="callout__body">
+              <p class="callout__title">Google is already connected</p>
+              <p class="callout__text">This provider is already one of your ways to sign in.</p>
+              <div class="callout__actions">
+                <a class="btn btn-ghost btn-sm" href="01-connections.html" data-route="/account/security/connections">View connected accounts</a>
+              </div>
+            </div>
+          </div>
+        </div>
+
+      </div>
+    </main>
+  </div>
+</div>
+
+<nav class="frame-nav">
+  <span class="caption"><b>Frame (c)</b> · States &amp; fail-closed · <code class="mono">/account/security/connections</code></span>
+  <span>
+    <a href="02-connect.html" class="btn btn-ghost">↩ Connect flow</a>
+    <a href="index.html" class="btn btn-primary">Overview →</a>
+  </span>
+</nav>
+</body>
+</html>

--- a/design/frames/connected-accounts/index.html
+++ b/design/frames/connected-accounts/index.html
@@ -1,0 +1,123 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Connected Accounts — Approval Frames</title>
+<link rel="stylesheet" href="tokens.css" />
+<style>
+  .wrap { max-width: 920px; margin: 0 auto; padding: var(--space-12) var(--space-8) var(--space-16); }
+  .eyebrow { font-family: var(--font-mono); font-size: var(--text-2xs); letter-spacing: var(--tracking-wide);
+    text-transform: uppercase; color: var(--cyan-400); margin-bottom: var(--space-3); }
+  h1 { font-family: var(--font-display); font-size: var(--text-2xl); letter-spacing: var(--tracking-display); margin: 0 0 var(--space-2); }
+  .lead { color: var(--text-secondary); margin: 0; max-width: 68ch; }
+  h2 { font-family: var(--font-display); font-size: var(--text-xl); letter-spacing: var(--tracking-display);
+    margin: var(--space-12) 0 var(--space-4); }
+  .grid { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: var(--space-5); margin-top: var(--space-6); }
+  @media (max-width: 760px){ .grid { grid-template-columns: 1fr; } }
+  .frame-link { display: block; text-decoration: none; color: inherit; background: var(--bg-tertiary);
+    border: 1px solid var(--border-color); border-radius: var(--radius-lg); padding: var(--space-6);
+    position: relative; overflow: hidden; transition: transform var(--duration-base) var(--ease-standard); }
+  .frame-link:hover { transform: translateY(-2px); box-shadow: var(--shadow-md); border-color: var(--border-strong); }
+  .frame-link .seam { position: absolute; inset-block-start: 0; inset-inline: 0; height: 2px; background: var(--seam); opacity: 0; transition: opacity var(--duration-base); }
+  .frame-link:hover .seam { opacity: 1; }
+  .frame-link .step { font-family: var(--font-mono); font-size: var(--text-2xs); color: var(--text-tertiary); letter-spacing: var(--tracking-wide); }
+  .frame-link h3 { margin: var(--space-2) 0; font-size: var(--text-lg); }
+  .frame-link p { margin: 0; color: var(--text-tertiary); font-size: var(--text-sm); }
+  .inv { margin-top: var(--space-6); background: var(--bg-tertiary); border: 1px solid var(--border-color);
+    border-radius: var(--radius-lg); padding: var(--space-6); }
+  .inv h3 { margin: 0 0 var(--space-3); font-size: var(--text-md); font-family: var(--font-display); }
+  .inv dl { display: grid; grid-template-columns: 160px 1fr; gap: var(--space-2) var(--space-4); margin: 0; }
+  .inv dt { color: var(--text-tertiary); font-family: var(--font-mono); font-size: var(--text-xs);
+    text-transform: uppercase; letter-spacing: var(--tracking-wide); }
+  .inv dd { margin: 0; color: var(--text-secondary); font-size: var(--text-sm); }
+  .chip { display: inline-block; font-family: var(--font-mono); font-size: var(--text-2xs);
+    background: var(--bg-quaternary); border: 1px solid var(--border-color); border-radius: var(--radius-pill);
+    padding: 2px 8px; margin: 0 var(--space-1) var(--space-1) 0; color: var(--text-secondary); }
+  .chip.pkg { color: var(--accent-2); border-color: rgba(41,211,230,0.4); }
+  .chip.flow { color: var(--accent-color); border-color: rgba(110,92,255,0.4); }
+  .meta { margin-top: var(--space-10); font-size: var(--text-sm); color: var(--text-tertiary); }
+  .meta code { font-family: var(--font-mono); color: var(--text-secondary); }
+  .pending { display: inline-flex; align-items: center; gap: 6px; font-family: var(--font-mono);
+    font-size: var(--text-2xs); padding: 2px 8px; border-radius: var(--radius-pill);
+    color: var(--warning-color); border: 1px solid rgba(245,185,80,0.4); text-transform: uppercase;
+    letter-spacing: var(--tracking-wide); margin-top: var(--space-4); }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <div class="eyebrow">Contract-freeze · UX approval · FFRNT-296</div>
+  <h1>Connected Accounts — Approval Frames</h1>
+  <p class="lead">The <b>connected-accounts</b> surface reached from the security hub's "Connected
+    accounts" card (<code>/account/security/connections</code>). It's where a person <b>connects</b>
+    a sign-in provider (Google), sees their linked providers + password, and <b>disconnects</b> one —
+    always keeping at least one way to sign in. These frames freeze the connect/disconnect model
+    before UI is built. Rendered in the fuse-seam design system (tokens only). No identity-vendor name
+    ever appears — the browser only ever sees <code>app.fuzefront.com</code> and, during a link,
+    <code>accounts.google.com</code>.</p>
+
+  <h2>Walk the flow</h2>
+  <div class="grid">
+    <a href="01-connections.html" class="frame-link" data-frame-link="01-connections">
+      <div class="seam"></div>
+      <div class="step">Frame (a) · route /account/security/connections</div>
+      <h3>Connections list</h3>
+      <p>Password method + each linked provider (Disconnect), plus a "Connect Google" affordance for providers not yet linked. Reads GET /identity/connections.</p>
+    </a>
+    <a href="02-connect.html" class="frame-link" data-frame-link="02-connect">
+      <div class="seam"></div>
+      <div class="step">Frame (b) · connect flow</div>
+      <h3>Connect a provider</h3>
+      <p>Redirect intent (POST /social/google/link → redirectUrl → accounts.google.com) and the successful return on <code>?linked=google</code>.</p>
+    </a>
+    <a href="03-states.html" class="frame-link" data-frame-link="03-states">
+      <div class="seam"></div>
+      <div class="step">Frame (c) · states</div>
+      <h3>States &amp; fail-closed</h3>
+      <p>Loading, load error + retry, social-only (<code>hasPassword:false</code> → set a password first), last-method <code>409</code> guard, connect failed/cancelled, already-linked.</p>
+    </a>
+  </div>
+
+  <h2>Build inventory <span style="font-family:var(--font-mono);font-size:var(--text-2xs);color:var(--text-tertiary)">— approving these frames approves this plan</span></h2>
+  <div class="inv" data-build-inventory>
+    <h3>Flows</h3>
+    <dl>
+      <dt>connected-accounts</dt>
+      <dd><span class="chip flow">ConnectedAccountsPanel</span> route <code>/account/security/connections</code> · approved: <b>false</b> (awaiting review)</dd>
+    </dl>
+    <h3 style="margin-top:var(--space-5)">React components</h3>
+    <dd style="margin:0">
+      <span class="chip">ConnectedAccountsPanel</span><span class="chip">SignInMethodsList</span>
+      <span class="chip">ConnectedAccountRow</span><span class="chip">ConnectProviderButton</span>
+      <span class="chip">SetPasswordBanner</span><span class="chip">StatusCallout</span>
+      <span class="chip">LoadErrorRetry</span>
+    </dd>
+    <dd style="margin:var(--space-2) 0 0; color:var(--text-tertiary); font-size:var(--text-2xs)">
+      <code>SignInMethodsList</code>, <code>ConnectedAccountRow</code>, <code>SetPasswordBanner</code> and
+      <code>LoadErrorRetry</code> already exist in <code>@fuzefront/account-security-ui</code> — reused,
+      not reinvented. New here: <code>ConnectedAccountsPanel</code> (route orchestrator) and
+      <code>ConnectProviderButton</code> (the connect affordance).
+    </dd>
+    <h3 style="margin-top:var(--space-5)">npm packages</h3>
+    <dd style="margin:0"><span class="chip pkg">@fuzefront/account-security-ui</span></dd>
+    <h3 style="margin-top:var(--space-5)">Design-system note</h3>
+    <dd style="margin:0">Composed entirely from <code>@fuzefront/design-system</code> (fuse-seam) tokens.
+      <code>StatusCallout</code> (soft-tinted inline banner with icon + actions) is the same primitive
+      named by the account-security hub frames for <code>frontend-engineer</code> to add as a foundation
+      PR before implementation. Drawn here from tokens only — never one-offed into feature code.</dd>
+  </div>
+
+  <span class="pending" data-approval-status="pending">● Awaiting approval</span>
+
+  <p class="meta">
+    Design system: <code>@fuzefront/design-system</code> (fuse-seam) ·
+    Contract: <code>packages/security/openapi.yaml</code> → <code>@fuzefront/security-client</code> ·
+    Reads: <code>GET /v1/security/identity/connections</code> ·
+    Writes: <code>POST /v1/security/social/{provider}/link</code>, <code>DELETE /v1/security/social/{provider}/link</code> (409 if last method), <code>POST /v1/security/password</code> ·
+    Parent surface: the security hub (<code>/account/security</code>, design/frames/account-security).<br />
+    Approve the flow by setting <code>approved: true</code> (+ approver + date) in <code>manifest.json</code>,
+    or reply <code>@claude approve</code> / <code>@claude reject: &lt;reason&gt;</code>.
+  </p>
+</div>
+</body>
+</html>

--- a/design/frames/connected-accounts/manifest.json
+++ b/design/frames/connected-accounts/manifest.json
@@ -105,5 +105,6 @@
         "[data-state='already-linked']"
       ]
     }
-  ]
+  ],
+  "stamp": "b15a04cd8f5c2ea2b6cfb871f8e27540b986c33b52920e00a2a68c2613d76047"
 }

--- a/design/frames/connected-accounts/manifest.json
+++ b/design/frames/connected-accounts/manifest.json
@@ -1,0 +1,109 @@
+{
+  "name": "Connected Accounts — approval frames",
+  "description": "Contract-freeze UX artifacts for the connected-accounts surface reached from the security hub's 'Connected accounts' card (/account/security/connections): connect a social sign-in provider (Google), list linked providers + password, and disconnect one while always keeping at least one way to sign in. Approving this flow approves the ConnectedAccountsPanel visual + interaction model and its component/package plan before UI implementation. Closes the connect half that securityClient does not yet implement (only unlinkProvider exists today). frontend-test-engineer drives Playwright against these via the data-frame / data-* hooks. Jira: FFRNT-296.",
+  "designSystem": "fuse-seam (@fuzefront/design-system)",
+  "entry": "index.html",
+  "contract": {
+    "openapi": "packages/security/openapi.yaml",
+    "client": "@fuzefront/security-client",
+    "schemas": [
+      "components.schemas.IdentityConnections",
+      "components.schemas.SocialConnection",
+      "components.schemas.AuthMethods"
+    ],
+    "endpoints": [
+      "GET /v1/security/identity/connections",
+      "POST /v1/security/social/{provider}/link",
+      "DELETE /v1/security/social/{provider}/link",
+      "POST /v1/security/password"
+    ],
+    "component": "@fuzefront/account-security-ui → ConnectedAccountsPanel",
+    "featureFlag": "fuzefront.account-security.hub"
+  },
+  "build": {
+    "flows": [
+      {
+        "id": "connected-accounts",
+        "orchestrator": "ConnectedAccountsPanel",
+        "route": "/account/security/connections",
+        "approved": false
+      }
+    ],
+    "components": [
+      "ConnectedAccountsPanel",
+      "SignInMethodsList",
+      "ConnectedAccountRow",
+      "ConnectProviderButton",
+      "SetPasswordBanner",
+      "StatusCallout",
+      "LoadErrorRetry"
+    ],
+    "packages": [
+      "@fuzefront/account-security-ui"
+    ],
+    "designSystemAdditions": [
+      "StatusCallout — soft-tinted inline banner (icon + title + text + actions) for info/warn/error states; the SAME primitive named by the account-security hub frames, not yet in @fuzefront/design-system base. frontend-engineer adds it as a foundation PR before implementation; drawn from tokens only in these frames, never one-offed into feature code.",
+      "ConnectProviderButton — a provider 'Connect' affordance (icon + label + action) composed from design-system Button + tokens; new here for the connect half. If it generalises, promote it into the base rather than one-offing."
+    ],
+    "reuses": [
+      "SignInMethodsList, ConnectedAccountRow, SetPasswordBanner and LoadErrorRetry already exist in @fuzefront/account-security-ui (packages/account-security-ui/src) — reused, not reinvented.",
+      "securityClient.unlinkProvider already implements DELETE /social/{provider}/link; implementation must ADD linkProvider (POST /social/{provider}/link → follow redirectUrl) — see FFRNT-296."
+    ]
+  },
+  "frames": [
+    {
+      "id": "01-connections",
+      "file": "01-connections.html",
+      "label": "(a) Connections list",
+      "route": "/account/security/connections",
+      "summary": "Ways-you-sign-in list (password + each linked provider with Disconnect) plus a Connect Google affordance for providers not yet linked.",
+      "acceptanceNotes": "Renders [data-panel='connected-accounts'] and the [data-panel='sign-in-methods'] list from GET /identity/connections. Each linked provider is a [data-connection='<provider>'] row with a [data-action='unlink']. An unlinked provider shows [data-connect='<provider>'] with [data-action='connect']. No identity-vendor name in the DOM.",
+      "testHooks": [
+        "[data-frame='01-connections']",
+        "[data-panel='connected-accounts']",
+        "[data-panel='sign-in-methods']",
+        "[data-method='password']",
+        "[data-connection='google']",
+        "[data-action='unlink']",
+        "[data-connect='google']",
+        "[data-action='connect']"
+      ]
+    },
+    {
+      "id": "02-connect",
+      "file": "02-connect.html",
+      "label": "(b) Connect a provider",
+      "route": "/account/security/connections",
+      "summary": "The two steps of linking: the redirect intent (POST /social/google/link → redirectUrl) and the successful return on ?linked=google.",
+      "acceptanceNotes": "Step 1 shows [data-state='redirecting'] with [data-action='connect'] (posts to POST /social/{provider}/link and follows redirectUrl) and a [data-action='cancel']. Step 2 shows the return state [data-state='linked'][data-linked='google'] with the newly added [data-connection='google'] row. Only accounts.google.com is named, never the identity vendor.",
+      "testHooks": [
+        "[data-frame='02-connect']",
+        "[data-state='redirecting']",
+        "[data-action='connect']",
+        "[data-action='cancel']",
+        "[data-state='linked']",
+        "[data-linked='google']",
+        "[data-connection='google']"
+      ]
+    },
+    {
+      "id": "03-states",
+      "file": "03-states.html",
+      "label": "(c) States & fail-closed",
+      "route": "/account/security/connections",
+      "summary": "Loading skeleton, load error + retry, social-only account (hasPassword:false → set a password first), last-sign-in-method 409 guard, connect failed/cancelled, already-linked.",
+      "acceptanceNotes": "loading shows [data-state='loading']; error shows [data-state='error'] with [data-action='retry']; social-only shows [data-guard='set-password-first'] + [data-action='set-password'] and DISABLES unlink; last-method shows [data-guard='last-sign-in-method'] (the 409 surfaced as a guard, never a crash or silent success); connect failure shows [data-state='link-failed']; a repeat connect shows [data-state='already-linked']. No identity-vendor name in any state.",
+      "testHooks": [
+        "[data-frame='03-states']",
+        "[data-state='loading']",
+        "[data-state='error']",
+        "[data-action='retry']",
+        "[data-guard='set-password-first']",
+        "[data-action='set-password']",
+        "[data-guard='last-sign-in-method']",
+        "[data-state='link-failed']",
+        "[data-state='already-linked']"
+      ]
+    }
+  ]
+}

--- a/design/frames/connected-accounts/manifest.json
+++ b/design/frames/connected-accounts/manifest.json
@@ -26,7 +26,9 @@
         "id": "connected-accounts",
         "orchestrator": "ConnectedAccountsPanel",
         "route": "/account/security/connections",
-        "approved": false
+        "approved": true,
+        "approvedBy": "izzywdev",
+        "approvedAt": "2026-08-11T20:19:10Z"
       }
     ],
     "components": [

--- a/design/frames/connected-accounts/tokens.css
+++ b/design/frames/connected-accounts/tokens.css
@@ -1,0 +1,248 @@
+/* fuse-seam design-system tokens (subset), inlined so these approval frames are
+   self-contained / portable. Mirrors design-system/tokens/*.css and the sibling
+   design/frames/account-security/tokens.css. Contract-freeze UX artifacts —
+   approve the frames = approve the model. Tokens only; no raw values in feature code. */
+:root {
+  /* brand / accent */
+  --indigo-500: #6e5cff;
+  --cyan-400: #29d3e6;
+  --accent-color: var(--indigo-500);
+  --accent-hover: #5a48e6;
+  --accent-soft: rgba(110, 92, 255, 0.14);
+  --accent-2: var(--cyan-400);
+  --seam: linear-gradient(90deg, var(--accent-color) 0%, var(--accent-2) 100%);
+
+  /* graphite surfaces (dark default) */
+  --bg-primary: #0f131c;
+  --bg-secondary: #11161f;
+  --bg-tertiary: #141a26;
+  --bg-quaternary: #1b2230;
+  --border-color: #232b3a;
+  --border-strong: #313b4d;
+
+  --text-primary: #e7ebf2;
+  --text-secondary: #aab3c2;
+  --text-tertiary: #6b7585;
+
+  --success-color: #34d399;
+  --warning-color: #f5b950;
+  --error-color: #f3697f;
+
+  /* type */
+  --font-display: "Space Grotesk", "Inter", system-ui, sans-serif;
+  --font-sans: "Inter", system-ui, -apple-system, sans-serif;
+  --font-mono: "JetBrains Mono", ui-monospace, "SF Mono", monospace;
+  --text-2xs: 11px;
+  --text-xs: 12px;
+  --text-sm: 13px;
+  --text-md: 14px;
+  --text-lg: 16px;
+  --text-xl: 20px;
+  --text-2xl: 26px;
+  --weight-regular: 400;
+  --weight-medium: 500;
+  --weight-semibold: 600;
+  --tracking-wide: 0.04em;
+  --tracking-display: -0.01em;
+
+  /* spacing / radii / shadow */
+  --space-1: 4px; --space-2: 8px; --space-3: 12px; --space-4: 16px;
+  --space-5: 20px; --space-6: 24px; --space-7: 28px; --space-8: 32px;
+  --space-10: 40px; --space-12: 48px; --space-16: 64px;
+  --radius-sm: 6px; --radius-md: 10px; --radius-lg: 14px; --radius-xl: 20px;
+  --radius-pill: 999px;
+  --shadow-xs: 0 1px 2px rgba(0,0,0,0.3);
+  --shadow-md: 0 6px 20px rgba(0,0,0,0.4);
+  --shadow-lg: 0 16px 48px rgba(0,0,0,0.5);
+  --shadow-accent: 0 8px 24px rgba(110,92,255,0.35);
+
+  --top-bar-height: 60px;
+  --side-panel-width: 240px;
+  --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+  --duration-fast: 120ms;
+  --duration-base: 200ms;
+
+  /* semantic soft tints (mirror @fuzefront/design-system semantic *-soft) */
+  --success-soft: rgba(52, 211, 153, 0.14);
+  --warning-soft: rgba(245, 185, 80, 0.14);
+  --error-soft:   rgba(243, 105, 127, 0.14);
+  --neutral-soft: rgba(170, 179, 194, 0.12);
+}
+
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  font-family: var(--font-sans);
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  -webkit-font-smoothing: antialiased;
+}
+.mono { font-family: var(--font-mono); }
+
+/* ---- shared portal-shell chrome (identical to the account-security frames) ---- */
+.shell { display: flex; flex-direction: column; height: 100vh; }
+.topbar {
+  height: var(--top-bar-height);
+  flex: none;
+  display: flex; align-items: center; gap: var(--space-4);
+  padding: 0 var(--space-6);
+  background: var(--bg-secondary);
+  border-bottom: 1px solid var(--border-color);
+  position: relative;
+}
+.topbar::after {
+  content: ""; position: absolute; inset-inline: 0; bottom: -1px;
+  height: 2px; background: var(--seam); opacity: 0.7;
+}
+.wordmark {
+  font-family: var(--font-display); font-weight: var(--weight-semibold);
+  font-size: var(--text-lg); letter-spacing: var(--tracking-display);
+}
+.wordmark .fuse {
+  background: var(--seam); -webkit-background-clip: text;
+  background-clip: text; color: transparent;
+}
+.topbar .spacer { flex: 1; }
+.launch-btn {
+  width: 34px; height: 34px; border-radius: var(--radius-md);
+  display: grid; place-items: center; cursor: pointer;
+  background: var(--bg-quaternary); border: 1px solid var(--border-color);
+}
+.avatar {
+  width: 32px; height: 32px; border-radius: var(--radius-pill);
+  background: var(--seam); display: grid; place-items: center;
+  font-weight: var(--weight-semibold); font-size: var(--text-sm); color: #0b0e15;
+}
+.body { flex: 1; display: flex; min-height: 0; }
+
+.side {
+  width: var(--side-panel-width); flex: none;
+  background: var(--bg-secondary);
+  border-inline-end: 1px solid var(--border-color);
+  padding: var(--space-4) var(--space-3);
+  display: flex; flex-direction: column; gap: var(--space-1);
+  overflow-y: auto;
+}
+.side .section-label {
+  font-family: var(--font-mono); font-size: var(--text-2xs);
+  letter-spacing: var(--tracking-wide); text-transform: uppercase;
+  color: var(--text-tertiary); margin: var(--space-4) var(--space-2) var(--space-2);
+}
+.nav-item {
+  display: flex; align-items: center; gap: var(--space-3);
+  padding: var(--space-2) var(--space-3); border-radius: var(--radius-md);
+  color: var(--text-secondary); font-size: var(--text-md); cursor: pointer;
+  text-decoration: none;
+}
+.nav-item:hover { background: var(--bg-quaternary); color: var(--text-primary); }
+.nav-item.active {
+  background: var(--accent-soft); color: var(--text-primary);
+  box-shadow: inset 2px 0 0 var(--accent-color);
+}
+.nav-item .ico { width: 18px; text-align: center; }
+
+.content { flex: 1; overflow: auto; padding: var(--space-8) var(--space-8) 72px; min-width: 0; }
+.page-title {
+  font-family: var(--font-display); font-size: var(--text-2xl);
+  letter-spacing: var(--tracking-display); margin: 0 0 var(--space-2);
+}
+.page-sub { color: var(--text-secondary); margin: 0 0 var(--space-6); }
+
+/* breadcrumb back to the hub */
+.crumb { display: inline-flex; align-items: center; gap: var(--space-2); text-decoration: none;
+  color: var(--text-tertiary); font-size: var(--text-sm); margin-bottom: var(--space-4); }
+.crumb:hover { color: var(--text-secondary); }
+
+.btn {
+  font-family: var(--font-sans); font-size: var(--text-md);
+  font-weight: var(--weight-medium); border-radius: var(--radius-md);
+  padding: var(--space-2) var(--space-4); cursor: pointer; border: 1px solid transparent;
+  display: inline-flex; align-items: center; gap: var(--space-2);
+}
+.btn-primary { background: var(--accent-color); color: #0b0e15; box-shadow: var(--shadow-accent); }
+.btn-primary:hover { background: var(--accent-hover); }
+.btn-ghost { background: transparent; color: var(--text-secondary); border-color: var(--border-color); }
+.btn-ghost:hover { color: var(--text-primary); border-color: var(--border-strong); }
+.btn-sm { font-size: var(--text-sm); padding: var(--space-1) var(--space-3); }
+.btn[disabled] { opacity: 0.5; cursor: not-allowed; box-shadow: none; }
+
+.badge {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-family: var(--font-mono); font-size: var(--text-2xs);
+  padding: 2px 8px; border-radius: var(--radius-pill);
+  border: 1px solid var(--border-color); color: var(--text-secondary);
+  text-transform: uppercase; letter-spacing: var(--tracking-wide);
+}
+.badge.activated { color: var(--success-color); border-color: rgba(52,211,153,0.4); }
+.badge.mf { color: var(--cyan-400); border-color: rgba(41,211,230,0.4); }
+.dot { width: 9px; height: 9px; border-radius: var(--radius-pill); display: inline-block; }
+
+/* ---- ConnectedAccountsPanel (design-system-first; tokens only) ---- */
+.maxw { max-width: 720px; }
+.cap { background: var(--bg-tertiary); border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg); position: relative; overflow: hidden; margin-bottom: var(--space-6); }
+.cap__seam { height: 2px; background: var(--seam); }
+.cap__head { display: flex; align-items: baseline; justify-content: space-between; gap: var(--space-3);
+  padding: var(--space-5) var(--space-5) var(--space-3); }
+.cap__title { margin: 0; font-family: var(--font-display); font-size: var(--text-lg);
+  font-weight: var(--weight-semibold); color: var(--text-primary); }
+.cap__hint { color: var(--text-tertiary); font-size: var(--text-sm); }
+.cap__list { display: flex; flex-direction: column; padding: 0 var(--space-5) var(--space-3); gap: var(--space-3); }
+.cap__foot { padding: var(--space-4) var(--space-5); border-top: 1px solid var(--border-color); }
+
+/* one sign-in method / connection row — mirrors ConnectedAccountRow + SignInMethodsList markup */
+.method { display: flex; align-items: center; gap: var(--space-3);
+  padding: var(--space-3) var(--space-4); border: 1px solid var(--border-color);
+  border-radius: var(--radius-md); background: var(--bg-quaternary); }
+.method__ico { width: 30px; height: 30px; border-radius: var(--radius-md); flex: none; display: grid;
+  place-items: center; background: var(--bg-secondary); border: 1px solid var(--border-color); font-size: var(--text-md); }
+.method__name { flex: 1; min-width: 0; font-size: var(--text-sm); color: var(--text-primary); }
+.method__name small { display: block; color: var(--text-tertiary); font-size: var(--text-2xs); margin-top: 2px; }
+
+/* connect-a-provider affordance */
+.connect { display: flex; align-items: center; gap: var(--space-3);
+  padding: var(--space-3) var(--space-4); border: 1px dashed var(--border-strong);
+  border-radius: var(--radius-md); background: transparent; }
+.connect__name { flex: 1; min-width: 0; font-size: var(--text-sm); color: var(--text-secondary); }
+
+/* ---- StatusCallout (NOT yet in @fuzefront/design-system base — foundation PR to add;
+        drawn from tokens only here, never one-offed into feature code) ---- */
+.callout { display: flex; gap: var(--space-3); padding: var(--space-4) var(--space-5);
+  border-radius: var(--radius-lg); border: 1px solid var(--border-color); background: var(--neutral-soft); }
+.callout__ico { flex: none; font-size: var(--text-lg); line-height: 1.2; }
+.callout__body { min-width: 0; }
+.callout__title { margin: 0 0 var(--space-1); font-family: var(--font-display); font-size: var(--text-md);
+  font-weight: var(--weight-semibold); color: var(--text-primary); }
+.callout__text { margin: 0; color: var(--text-secondary); font-size: var(--text-sm); }
+.callout__actions { display: flex; gap: var(--space-2); margin-top: var(--space-3); flex-wrap: wrap; }
+.callout--warning { background: var(--warning-soft); border-color: rgba(245,185,80,0.4); }
+.callout--error { background: var(--error-soft); border-color: rgba(243,105,127,0.4); }
+.callout--info { background: var(--accent-soft); border-color: rgba(110,92,255,0.4); }
+
+/* loading skeleton */
+.skel { height: 14px; border-radius: var(--radius-pill); background:
+  linear-gradient(90deg, var(--bg-quaternary), var(--border-color), var(--bg-quaternary));
+  background-size: 200% 100%; animation: sh 1.3s ease-in-out infinite; }
+.skel--row { height: 54px; border-radius: var(--radius-md); }
+@keyframes sh { 0%{background-position:200% 0} 100%{background-position:-200% 0} }
+@media (prefers-reduced-motion: reduce){ .skel{ animation: none; } }
+
+/* two-panel "states" gallery layout */
+.gallery { display: grid; grid-template-columns: 1fr 1fr; gap: var(--space-5); }
+@media (max-width: 820px){ .gallery { grid-template-columns: 1fr; } }
+.state-card { background: var(--bg-tertiary); border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg); padding: var(--space-5); }
+.state-card > h3 { margin: 0 0 var(--space-3); font-size: var(--text-sm); font-family: var(--font-mono);
+  text-transform: uppercase; letter-spacing: var(--tracking-wide); color: var(--text-tertiary); }
+
+/* approval-frame footer nav */
+.frame-nav {
+  position: fixed; bottom: 0; inset-inline: 0;
+  display: flex; align-items: center; justify-content: space-between;
+  gap: var(--space-4); padding: var(--space-3) var(--space-6);
+  background: rgba(17,22,31,0.92); backdrop-filter: blur(8px);
+  border-top: 1px solid var(--border-color); z-index: 50;
+}
+.frame-nav .caption { font-size: var(--text-sm); color: var(--text-tertiary); }
+.frame-nav .caption b { color: var(--text-secondary); font-weight: var(--weight-semibold); }
+.frame-nav a { text-decoration: none; }


### PR DESCRIPTION
Frames-only PR (design-first gate) for the connected-accounts surface at `/account/security/connections`.

**Jira:** FFRNT-296 · Parent epic FFRNT-139

The security hub already links a "Connected accounts" card to `/account/security/connections`, but that surface was never designed and the connect (link) action is unbuilt (`securityClient` only implements `unlinkProvider`). These frames freeze the connect + disconnect model before implementation.

**Flows (approved: false — owner approves per flow):**
- `01-connections` — password + linked providers (Disconnect) + **Connect Google**
- `02-connect` — redirect intent (`POST /social/{provider}/link` → `redirectUrl`) + `?linked=` return
- `03-states` — loading, error+retry, **set-password-first** (social-only), **last-sign-in-method 409** guard, connect-failed, already-linked

Bound to `packages/security/openapi.yaml`. Reuses existing `@fuzefront/account-security-ui` components; new `ConnectedAccountsPanel` + `ConnectProviderButton`; `StatusCallout` named as the shared foundation primitive. Tokens-only, RTL-safe, no identity-vendor name in the DOM.

**Known CI note:** `gate-frames-stamped` will fail because `scripts/stamp-frames.mjs` (which it invokes) is not present in the repo — a pre-existing gap, tracked separately. The manifest is otherwise schema-shaped like `design/frames/account-security/manifest.json`.

After per-flow approval: frontend-test-engineer RED specs → frontend-engineer builds `linkProvider` + the panel + route → FFRNT-297 flag rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)