### PR TITLE
fix(design-first): guard the frame-stamp tool against silent loss (FFRNT-301)

### DIFF
--- a/.github/workflows/gate-frames-stamped.yml
+++ b/.github/workflows/gate-frames-stamped.yml
@@ -11,6 +11,7 @@ on:
     paths:
       - 'design/frames/**'
       - 'scripts/stamp-frames.mjs'
+      - 'scripts/__tests__/stamp-frames.test.mjs'
       - '.github/workflows/gate-frames-stamped.yml'
 
 permissions:
@@ -31,6 +32,14 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: '24.x'
+
+      # Guard the stamping TOOL itself, not just its output. This fails loudly if
+      # scripts/stamp-frames.mjs disappears (MODULE_NOT_FOUND — FFRNT-301) or if a
+      # refactor silently changes the hashing algorithm (the account-security
+      # fixture stamp stops reproducing). Run before the tree check so a broken
+      # tool reports as a broken tool, not as opaque drift on every feature.
+      - name: Self-test the stamp tool (presence + algorithm pin)
+        run: node --test scripts/__tests__/stamp-frames.test.mjs
 
       - name: Verify every feature manifest stamp is current
         run: node scripts/stamp-frames.mjs --check

--- a/package.json
+++ b/package.json
@@ -42,7 +42,10 @@
     "test:backend": "npm run test -w backend",
     "type-check:backend": "npm run type-check -w backend",
     "check:workspace-deps": "node scripts/check-workspace-deps.mjs",
-    "check:dockerfile-lockfile": "node scripts/check-dockerfile-lockfile.mjs"
+    "check:dockerfile-lockfile": "node scripts/check-dockerfile-lockfile.mjs",
+    "check:frames-stamped": "node scripts/stamp-frames.mjs --check",
+    "stamp:frames": "node scripts/stamp-frames.mjs --write",
+    "test:frames-stamped": "node --test scripts/__tests__/stamp-frames.test.mjs"
   },
   "devDependencies": {
     "@types/react": "^19.2.0",

--- a/scripts/__tests__/stamp-frames.test.mjs
+++ b/scripts/__tests__/stamp-frames.test.mjs
@@ -1,0 +1,65 @@
+/**
+ * Regression guard for scripts/stamp-frames.mjs (FFRNT-301).
+ *
+ * WHY THIS EXISTS: the frame-stamp tool is the *only* way to (re)generate the
+ * `stamp` in each design/frames/<feature>/manifest.json, and gate-frames-stamped
+ * shells out to it (`node scripts/stamp-frames.mjs --check`). If the script ever
+ * vanishes again the gate dies with MODULE_NOT_FOUND and every frames PR goes
+ * red with no way to re-stamp — which is precisely the failure FFRNT-301 reports.
+ * These tests fail loudly the moment that happens, on every PR that touches the
+ * script or its frames, instead of surfacing as an opaque module-load crash.
+ *
+ * Two invariants are pinned:
+ *   1. The script is present and `--check` is green on the committed tree.
+ *   2. The account-security fixture reproduces its ORIGINAL stamp
+ *      (4ac159cd…) byte-for-byte. This pins the hashing ALGORITHM: a refactor
+ *      of computeStamp() that changes the digest would otherwise pass --check
+ *      silently (run --write, everything re-stamps consistently, --check green)
+ *      while invalidating every approval-bound stamp already in the wild. The
+ *      known-good fixture is the tripwire for that silent drift.
+ *
+ * Run with:  node --test scripts/__tests__/stamp-frames.test.mjs
+ * (node:test — a repo-level script, no jest wiring needed.)
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const script = path.join(repoRoot, 'scripts', 'stamp-frames.mjs');
+
+// The ground-truth fixture: the account-security frames' stamp from when the
+// tool was first written. Whatever the algorithm is, it MUST reproduce this for
+// the unchanged frames — see PR #314 / #353 and FFRNT-301.
+const ACCOUNT_SECURITY_STAMP =
+  '4ac159cdb36a94855a88b9ffb8739f26267b1b1d2ef6ef214658c7fef169060e';
+
+test('stamp-frames.mjs is present in the repo', () => {
+  assert.ok(
+    existsSync(script),
+    'scripts/stamp-frames.mjs is missing — gate-frames-stamped cannot run and no manifest can be (re)stamped (FFRNT-301).',
+  );
+});
+
+test('--check is green on the committed frames tree', () => {
+  // Throws on non-zero exit, which is the assertion: every committed manifest
+  // stamp is current. stdio inherited so drift is visible in the test log.
+  execFileSync('node', [script, '--check'], { cwd: repoRoot, stdio: 'inherit' });
+});
+
+test('account-security reproduces its original stamp (algorithm pin)', () => {
+  const out = execFileSync('node', [script, '--json'], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  });
+  const stamps = JSON.parse(out);
+  assert.equal(
+    stamps['account-security'],
+    ACCOUNT_SECURITY_STAMP,
+    'account-security stamp drifted from its original value — the hashing algorithm changed. ' +
+      'Do NOT re-stamp to fix this; investigate why computeStamp() no longer matches the frozen fixture.',
+  );
+});


### PR DESCRIPTION
## FFRNT-301 — findings

The ticket reports `gate-frames-stamped` dying with `MODULE_NOT_FOUND` because `scripts/stamp-frames.mjs` is missing and there is "no way to (re)generate a manifest stamp."

**On current `master` (and `origin/master`) that does not reproduce.** The script is present, byte-for-byte identical to `origin/master`, and has existed continuously since PR #353 — there is **no deletion in its git history**:

```
$ git log --diff-filter=D --oneline -- scripts/stamp-frames.mjs   # (nothing)
$ git log --oneline -- scripts/stamp-frames.mjs
29b9e92e fix(design-approval): ... (#353)
c02772d5 feat: frame stamp tooling ... (#314)
```

`--check` is green for all 17 features, and **account-security reproduces its original stamp exactly**:

```
$ node scripts/stamp-frames.mjs --check
ok      account-security: 4ac159cdb36a94855a88b9ffb8739f26267b1b1d2ef6ef214658c7fef169060e
...
All 17 feature stamp(s) up to date.   (exit 0)
```

So the primary remediation (restore the script) is already satisfied. I did **not** fabricate a "restore" of a file that exists, and I changed **no** `design/frames/**` content or stamps.

## What this PR does — close the recurrence gap (ticket item #4)

The real remaining hole is that nothing pins the tool or its algorithm. Deletion of the script is already caught (the gate's `paths` filter includes `scripts/stamp-frames.mjs`, so removing it triggers the gate → `MODULE_NOT_FOUND` → red), but a **silent algorithm change** is not: refactor `computeStamp()`, run `--write`, every stamp updates consistently, and `--check` stays green while every approval-bound stamp in the wild is invalidated.

- **`scripts/__tests__/stamp-frames.test.mjs`** (`node:test`) — asserts (1) the script is present, (2) `--check` is green on the committed tree, and (3) the **account-security fixture reproduces its frozen stamp `4ac159cd…`**, pinning the hashing algorithm.
- **`gate-frames-stamped.yml`** — runs the self-test before the tree check, and adds the test to the `paths` triggers.
- **`package.json`** — `check:frames-stamped`, `stamp:frames` (write mode), `test:frames-stamped`.

### Verification
```
$ node --test scripts/__tests__/stamp-frames.test.mjs
✔ stamp-frames.mjs is present in the repo
✔ --check is green on the committed frames tree
✔ account-security reproduces its original stamp (algorithm pin)
ℹ tests 3   ℹ pass 3   ℹ fail 0
```

## Coordination — PR #628 (do NOT merge order-dependent on this)
Open frames PR **#628** (`feature/ffrnt-296-connected-accounts-frames`) adds `design/frames/connected-accounts/` with an **unstamped** manifest and is red on this gate. That is expected and is **out of scope here** — it is not a broken tool, it is a genuinely missing stamp. #628 must rebase on `master` and run **`node scripts/stamp-frames.mjs --write`** (or `npm run stamp:frames`) to stamp `connected-accounts` before its gate goes green. This PR touches no frames, so there is no conflict with #628.

## Notes for the reviewer
- Deploy-sensitive repo: **no auto-merge label**, no self-merge — merge in a deploy window.
- No app code / UI / design-approval changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)