### PR TITLE
fix(app-registry): stop 500ing every consumer registration

### DIFF
--- a/backend/applications/src/app-registry/caller.ts
+++ b/backend/applications/src/app-registry/caller.ts
@@ -4,6 +4,7 @@
 // organization_memberships; platform admin is the `admin` platform role.
 import { db } from '../config/database'
 import { AppCaller } from './service'
+import { SYNTHETIC_CONSUMER_USER_ID } from '../middleware/consumer-auth'
 
 interface SessionUser {
   id: string
@@ -34,6 +35,40 @@ export async function getRolesInOrg(
 
 export async function resolveCaller(user: SessionUser): Promise<AppCaller> {
   const roles = user.roles || []
+
+  // THE SERVICE CALLER HAS NO `users` ROW, AND MUST NOT BE LOOKED UP AS IF IT DID.
+  //
+  // Consumer products register via an init container presenting the pre-shared
+  // CONSUMER_REGISTRATION_SECRET; consumer-auth then attaches a synthetic user
+  // whose id is the string 'consumer-registration'. That is not a UUID, and
+  // `organization_memberships.user_id` is `table.uuid(...)` — so passing it to
+  // getMemberOrgIds made Postgres throw `invalid input syntax for type uuid`,
+  // which the routes' try/catch turned into `500 {"error":"internal_error"}`.
+  //
+  // This broke the ENTIRE consumer registration path, not one product. GET
+  // /apps/:slug is the first call register.sh makes (the idempotency probe), so
+  // every consumer 500'd on its first request, retried five times, and then
+  // hard-failed by design — leaving the pod in Init:CrashLoopBackOff and the
+  // product absent from the portal. Observed in prod on FuzeHub: 1619 restarts
+  // over 6d11h, all of them
+  //   GET /api/v1/app-registry/apps/fuzehub -> 500 {"message":"Failed to get app"}
+  //
+  // It reads as a consumer bug — the consumer's pod is the thing crash-looping —
+  // which is why it survived: the fault is here, in the platform.
+  //
+  // A service caller belongs to no organization, so the correct answer is an
+  // empty org list, not a query. `isPlatformAdmin` still comes from `roles`
+  // below, exactly as before; the consumer's `admin` role is what authorises it,
+  // and nothing about that changes.
+  if (user.id === SYNTHETIC_CONSUMER_USER_ID) {
+    return {
+      userId: user.id,
+      organizationIds: [],
+      roles,
+      isPlatformAdmin: roles.includes('admin'),
+    }
+  }
+
   const organizationIds = await getMemberOrgIds(user.id)
   return {
     userId: user.id,

--- a/backend/applications/src/middleware/consumer-auth.ts
+++ b/backend/applications/src/middleware/consumer-auth.ts
@@ -35,8 +35,20 @@ import { authenticateToken } from './auth'
 // Shaped to satisfy @fuzefront/core's User. `email` is required there; this
 // caller is a service, not a person, so it carries a non-routable sentinel
 // address rather than anything that could collide with a real account.
+//
+// `id` is DELIBERATELY NOT A UUID — there is no `users` row for a service — and
+// that is load-bearing rather than incidental. Anything that treats this id as a
+// real user id and puts it in a query against a `uuid` column will throw
+// `invalid input syntax for type uuid` in Postgres. `users.id`,
+// `organization_memberships.user_id` and friends are all `table.uuid(...)`.
+//
+// It is exported so the one place that needs to know — resolveCaller — can
+// recognise the service caller by identity instead of by shape-guessing, and so
+// this coupling is greppable rather than implicit.
+export const SYNTHETIC_CONSUMER_USER_ID = 'consumer-registration'
+
 const SYNTHETIC_CONSUMER_USER = {
-  id: 'consumer-registration',
+  id: SYNTHETIC_CONSUMER_USER_ID,
   email: 'consumer-registration@fuzefront.invalid',
   roles: ['admin'] as string[],
 }

--- a/backend/applications/tests/app-registry.consumer-caller.test.ts
+++ b/backend/applications/tests/app-registry.consumer-caller.test.ts
@@ -1,0 +1,157 @@
+// The consumer registration path must never reach the database with a synthetic
+// user id.
+//
+// WHAT THIS GUARDS, AND WHY IT IS WORTH A TEST OF ITS OWN
+//
+// Consumer products (FuzeHub, FuzeSales, …) register from a Kubernetes init
+// container running register.sh. They have no human and no OIDC session, so they
+// present the pre-shared CONSUMER_REGISTRATION_SECRET; consumer-auth attaches a
+// SYNTHETIC user whose id is the string 'consumer-registration'.
+//
+// That id is not a UUID. `organization_memberships.user_id` is `table.uuid(...)`
+// (backend/src/migrations/005_create_organization_memberships_table.ts). So
+// resolveCaller's `getMemberOrgIds(user.id)` produced
+//
+//   select "organization_id" from "organization_memberships"
+//     where "user_id" = 'consumer-registration'
+//
+// which Postgres rejects with `invalid input syntax for type uuid`. The routes'
+// try/catch turned that into `500 {"error":"internal_error"}`.
+//
+// The blast radius is the whole consumer registration path, not one product:
+// GET /apps/:slug is the FIRST call register.sh makes, so every consumer 500'd
+// immediately, retried five times, then hard-failed by design — leaving the pod
+// in Init:CrashLoopBackOff and the product missing from the portal menu.
+// Measured in prod on FuzeHub: 1619 restarts over 6d11h, every one of them
+//   GET /api/v1/app-registry/apps/fuzehub -> 500 {"message":"Failed to get app"}
+//
+// It is worth a regression test because of how it presents: the crash-looping
+// pod belongs to the CONSUMER, so it reads as the consumer's bug, while the
+// fault is here in the platform. Nothing on the FuzeFront side went red.
+//
+// The assertion is on the QUERY, not just the status code. A 200 could be
+// reached while still issuing a doomed query on some other path, and it is the
+// query that is fatal.
+import express from 'express'
+import request from 'supertest'
+
+const CONSUMER_SECRET = 'test-consumer-secret'
+
+// Records every table the route layer touches, so the test can assert that the
+// consumer path performs NO membership lookup at all.
+const queriedTables: string[] = []
+
+jest.mock('../src/config/database', () => ({
+  db: jest.fn((table: string) => {
+    queriedTables.push(table)
+    // Mirror the real failure: a non-UUID against a uuid column throws. Without
+    // the fix the route hits this and 500s, exactly as prod did.
+    const chain: any = {
+      where: () => chain,
+      select: () =>
+        Promise.reject(
+          new Error(
+            'invalid input syntax for type uuid: "consumer-registration"'
+          )
+        ),
+    }
+    return chain
+  }),
+}))
+
+// Stub ONLY the data access. `canRead` is the real implementation on purpose:
+// it is the visibility rule this route depends on, and replacing it would make
+// the status assertions meaningless. (An earlier version of this mock omitted
+// it entirely, which produced a 500 from `canRead is not a function` — a
+// self-inflicted failure that looked exactly like the bug under test. Hence
+// also the query-level assertion below, which that artefact could not fake.)
+jest.mock('../src/app-registry/service', () => ({
+  ...jest.requireActual('../src/app-registry/service'),
+  appRegistryService: {
+    findBySlug: jest.fn().mockResolvedValue({
+      slug: 'fuzehub',
+      organizationId: null,
+      status: 'activated',
+      manifest: { name: 'Hub' },
+    }),
+  },
+}))
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const appRegistryRouter = require('../src/routes/app-registry').default
+
+function buildApp() {
+  const app = express()
+  app.use(express.json())
+  app.use('/api/v1/app-registry', appRegistryRouter)
+  return app
+}
+
+const asConsumer = (r: request.Test) =>
+  r.set('Authorization', `Bearer ${CONSUMER_SECRET}`)
+
+describe('consumer registration caller', () => {
+  const originalSecret = process.env.CONSUMER_REGISTRATION_SECRET
+
+  beforeAll(() => {
+    process.env.CONSUMER_REGISTRATION_SECRET = CONSUMER_SECRET
+  })
+  afterAll(() => {
+    if (originalSecret === undefined) delete process.env.CONSUMER_REGISTRATION_SECRET
+    else process.env.CONSUMER_REGISTRATION_SECRET = originalSecret
+  })
+  beforeEach(() => {
+    queriedTables.length = 0
+  })
+
+  it('GET /apps/:slug does not 500 for the consumer — the prod FuzeHub failure', async () => {
+    const res = await asConsumer(
+      request(buildApp()).get('/api/v1/app-registry/apps/fuzehub')
+    )
+
+    // The exact response prod returned, and the reason FuzeHub CrashLooped.
+    expect(res.status).not.toBe(500)
+    expect(res.body).not.toMatchObject({ error: 'internal_error' })
+  })
+
+  it('never queries organization_memberships for a service caller', async () => {
+    // The root cause, asserted directly. A service belongs to no organization,
+    // so the lookup is not merely unsafe — it is meaningless.
+    await asConsumer(request(buildApp()).get('/api/v1/app-registry/apps/fuzehub'))
+
+    expect(queriedTables).not.toContain('organization_memberships')
+  })
+
+  it('still resolves the consumer as a platform admin', async () => {
+    // The fix must not quietly cost the consumer its authority: `admin` comes
+    // from the synthetic user's roles, and bypassing Permit for service
+    // registration depends on it. Without this, returning an unprivileged caller
+    // would also make the 500 go away — and break registration a different way.
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { resolveCaller } = require('../src/app-registry/caller')
+    const caller = await resolveCaller({
+      id: 'consumer-registration',
+      roles: ['admin'],
+    })
+
+    expect(caller.isPlatformAdmin).toBe(true)
+    expect(caller.organizationIds).toEqual([])
+    expect(queriedTables).not.toContain('organization_memberships')
+  })
+
+  it('a REAL user id still goes to the database', async () => {
+    // The guard must be scoped to the synthetic service id, not a blanket skip.
+    // If it widened to every caller, org scoping — and with it the BOLA
+    // protection on these routes — would silently stop working.
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { resolveCaller } = require('../src/app-registry/caller')
+    await expect(
+      resolveCaller({
+        id: '11111111-2222-3333-4444-555555555555',
+        roles: ['user'],
+      })
+    ).rejects.toThrow(/invalid input syntax for type uuid|uuid/)
+
+    expect(queriedTables).toContain('organization_memberships')
+  })
+})


### PR DESCRIPTION
## The registry 500s on the first call every consuming product makes

This is why products are missing from the portal menu — and the fault is **here in the platform**, not in the products.

## What happens

Consumer products register from a Kubernetes init container running `register.sh`. They have no human and no OIDC session, so they present the pre-shared `CONSUMER_REGISTRATION_SECRET`, and `consumer-auth` attaches a synthetic user:

```js
{ id: 'consumer-registration', email: '…@fuzefront.invalid', roles: ['admin'] }
```

That id is **not a UUID**. `organization_memberships.user_id` is `table.uuid(...)`. `resolveCaller` passed it straight into `getMemberOrgIds`, producing

```sql
select "organization_id" from "organization_memberships"
  where "user_id" = 'consumer-registration'
```

which Postgres rejects with `invalid input syntax for type uuid`. The routes' `try/catch` turns that into `500 {"error":"internal_error"}`.

## Blast radius: the entire consumer registration path

`GET /apps/:slug` is the **first** call `register.sh` makes — the idempotency probe. So every consumer 500s on request one, retries five times, then hard-fails by design, leaving the pod in `Init:CrashLoopBackOff` and the product absent from the portal.

Measured in prod on FuzeHub (read-only `kubectl` via FuzeInfra's `cluster-query`):

```
fuzehub-backend-6799c7cc-f8v5m   Init:CrashLoopBackOff   1619 restarts   6d11h

[fuzefront-register] GET …/app-registry/apps/fuzehub -> 500 (attempt 1/5), retrying in 2s
[fuzefront-register] …attempts 2–5…
[fuzefront-register] FATAL: unexpected response looking up fuzehub:
                     HTTP 500 {"error":"internal_error","message":"Failed to get app"}
```

## Why it survived six days

The crash-looping pod belongs to the **consumer**, so it reads as the consumer's bug. Nothing on the FuzeFront side goes red: the registry answers 500 to a caller nobody is watching, and the platform's own health stays green. The consumer gets blamed for a platform fault.

## The fix

`resolveCaller` short-circuits for the synthetic service id — a service belongs to no organization, so the correct answer is an empty org list, not a query. The id is exported from `consumer-auth` as `SYNTHETIC_CONSUMER_USER_ID` so the coupling is greppable rather than implicit, and the comment there now records that its non-UUID shape is load-bearing.

`isPlatformAdmin` still derives from `roles` exactly as before. Returning an unprivileged caller would *also* have made the 500 disappear, while breaking registration a different way — the test pins against that.

## Verification

`tests/app-registry.consumer-caller.test.ts`, and it is **load-bearing**:

```
with the short-circuit removed:  3 failed, 1 passed
with it:                         4 passed
```

It asserts on the **query**, not only the status code — a 200 could be reached while still issuing a doomed query elsewhere, and it is the query that is fatal. The fourth case is a control in the other direction: a real UUID caller must still hit the database, so the guard cannot widen into a blanket skip and silently disable org scoping (and with it the BOLA protection on these routes).

One note on the test itself: an earlier version of its mock omitted `canRead`, which produced a 500 from `canRead is not a function` — an artefact that looked exactly like the bug under test. That is precisely why the query-level assertion is there; it could not be faked by the artefact. The mock now keeps the real `canRead`.

**No regression:**

| | `tsc --noEmit` | `npx jest` |
|---|---|---|
| without this change | 2 errors (`scopeLevel`, `src/routes/apps.ts`) | 27 failed / 75 passed |
| with this change | **same 2** | 27 failed / **79** passed |

The 27 are pre-existing — `app-installations.test.ts` needs a live database. Neither `scopeLevel` error is in a file this PR touches.

### Not verified

No cluster operation, nothing redeployed. That FuzeHub actually registers once this ships is unproven until the image carrying it is running. The init container retries on its own, so it self-heals rather than needing intervention.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GaPa3JgrVNtWrGvqQEAEqv)_