### PR TITLE
feat(authz): expose FuzeFinance Permit roles (admin, finance-officer)

### DIFF
--- a/backend/security/src/permit/products/fuzefinance.policy.ts
+++ b/backend/security/src/permit/products/fuzefinance.policy.ts
@@ -1,0 +1,87 @@
+import { ProductPolicy } from '../product-policy'
+
+// FuzeFinance consumer product's authorization policy (#490). FuzeFinance is
+// hosted as a Module-Federation portal inside FuzeFront (like FuzeMarket) —
+// it uses the existing FuzeFront session, so no dedicated Authentik OIDC
+// provider is needed; only the Permit resource/role mapping below.
+//
+// Submitted with BARE keys (Invoice/LedgerEntry/Report/Payout,
+// admin/finance-officer). The platform namespaces them to
+// fuzefinance.Invoice, …, fuzefinance.admin, … on merge (see
+// ../product-policy.ts) so they never collide with the platform's own
+// resources/roles or with another product's.
+//
+// Role intent (Enterprise Pro tier):
+//   finance-officer — day-to-day finance operations: create/read/update/send
+//                     invoices, record/read ledger entries, read+export
+//                     reports, read payouts. Cannot void an invoice or
+//                     approve a payout — both move/reverse real money and are
+//                     reserved for admin.
+//   admin           — full control of every fuzefinance resource within the
+//                     tenant, including voiding invoices and approving payouts.
+export const fuzefinancePolicy: ProductPolicy = {
+  product: 'fuzefinance',
+  name: 'FuzeFinance',
+  resources: [
+    {
+      key: 'Invoice',
+      name: 'Invoice',
+      actions: {
+        create: { name: 'Create' },
+        read: { name: 'Read' },
+        update: { name: 'Update' },
+        send: { name: 'Send' },
+        void: { name: 'Void' },
+      },
+    },
+    {
+      key: 'LedgerEntry',
+      name: 'Ledger Entry',
+      actions: {
+        create: { name: 'Create' },
+        read: { name: 'Read' },
+        reconcile: { name: 'Reconcile' },
+      },
+    },
+    {
+      key: 'Report',
+      name: 'Report',
+      actions: {
+        read: { name: 'Read' },
+        export: { name: 'Export' },
+      },
+    },
+    {
+      key: 'Payout',
+      name: 'Payout',
+      actions: {
+        read: { name: 'Read' },
+        approve: { name: 'Approve' },
+      },
+    },
+  ],
+  roles: [
+    {
+      key: 'finance-officer',
+      name: 'Finance Officer',
+      permissions: [
+        'Invoice:create', 'Invoice:read', 'Invoice:update', 'Invoice:send',
+        'LedgerEntry:create', 'LedgerEntry:read', 'LedgerEntry:reconcile',
+        'Report:read', 'Report:export',
+        'Payout:read',
+      ],
+    },
+    {
+      key: 'admin',
+      name: 'Admin',
+      permissions: [
+        'Invoice:create', 'Invoice:read', 'Invoice:update', 'Invoice:send', 'Invoice:void',
+        'LedgerEntry:create', 'LedgerEntry:read', 'LedgerEntry:reconcile',
+        'Report:read', 'Report:export',
+        'Payout:read', 'Payout:approve',
+      ],
+    },
+  ],
+}
+
+export default fuzefinancePolicy

--- a/backend/src/permit/products/fuzefinance.policy.ts
+++ b/backend/src/permit/products/fuzefinance.policy.ts
@@ -1,0 +1,87 @@
+import { ProductPolicy } from '../product-policy'
+
+// FuzeFinance consumer product's authorization policy (#490). FuzeFinance is
+// hosted as a Module-Federation portal inside FuzeFront (like FuzeMarket) —
+// it uses the existing FuzeFront session, so no dedicated Authentik OIDC
+// provider is needed; only the Permit resource/role mapping below.
+//
+// Submitted with BARE keys (Invoice/LedgerEntry/Report/Payout,
+// admin/finance-officer). The platform namespaces them to
+// fuzefinance.Invoice, …, fuzefinance.admin, … on merge (see
+// ../product-policy.ts) so they never collide with the platform's own
+// resources/roles or with another product's.
+//
+// Role intent (Enterprise Pro tier):
+//   finance-officer — day-to-day finance operations: create/read/update/send
+//                     invoices, record/read ledger entries, read+export
+//                     reports, read payouts. Cannot void an invoice or
+//                     approve a payout — both move/reverse real money and are
+//                     reserved for admin.
+//   admin           — full control of every fuzefinance resource within the
+//                     tenant, including voiding invoices and approving payouts.
+export const fuzefinancePolicy: ProductPolicy = {
+  product: 'fuzefinance',
+  name: 'FuzeFinance',
+  resources: [
+    {
+      key: 'Invoice',
+      name: 'Invoice',
+      actions: {
+        create: { name: 'Create' },
+        read: { name: 'Read' },
+        update: { name: 'Update' },
+        send: { name: 'Send' },
+        void: { name: 'Void' },
+      },
+    },
+    {
+      key: 'LedgerEntry',
+      name: 'Ledger Entry',
+      actions: {
+        create: { name: 'Create' },
+        read: { name: 'Read' },
+        reconcile: { name: 'Reconcile' },
+      },
+    },
+    {
+      key: 'Report',
+      name: 'Report',
+      actions: {
+        read: { name: 'Read' },
+        export: { name: 'Export' },
+      },
+    },
+    {
+      key: 'Payout',
+      name: 'Payout',
+      actions: {
+        read: { name: 'Read' },
+        approve: { name: 'Approve' },
+      },
+    },
+  ],
+  roles: [
+    {
+      key: 'finance-officer',
+      name: 'Finance Officer',
+      permissions: [
+        'Invoice:create', 'Invoice:read', 'Invoice:update', 'Invoice:send',
+        'LedgerEntry:create', 'LedgerEntry:read', 'LedgerEntry:reconcile',
+        'Report:read', 'Report:export',
+        'Payout:read',
+      ],
+    },
+    {
+      key: 'admin',
+      name: 'Admin',
+      permissions: [
+        'Invoice:create', 'Invoice:read', 'Invoice:update', 'Invoice:send', 'Invoice:void',
+        'LedgerEntry:create', 'LedgerEntry:read', 'LedgerEntry:reconcile',
+        'Report:read', 'Report:export',
+        'Payout:read', 'Payout:approve',
+      ],
+    },
+  ],
+}
+
+export default fuzefinancePolicy

--- a/backend/src/permit/sync-permit-schema.ts
+++ b/backend/src/permit/sync-permit-schema.ts
@@ -354,6 +354,7 @@ export function loadLegacyProductPolicies(): ProductPolicy[] {
   return [
     require('./products/fuzemarket.policy').default,
     require('./products/mendys-datasets.policy').default,
+    require('./products/fuzefinance.policy').default,
   ]
   /* eslint-enable @typescript-eslint/no-var-requires */
 }

--- a/backend/tests/product-policy.test.ts
+++ b/backend/tests/product-policy.test.ts
@@ -15,6 +15,8 @@ import {
 } from '../src/permit/product-policy'
 import { fuzemarketPolicy } from '../src/permit/products/fuzemarket.policy'
 import { mendysDatasetsPolicy } from '../src/permit/products/mendys-datasets.policy'
+import { fuzefinancePolicy } from '../src/permit/products/fuzefinance.policy'
+import { loadLegacyProductPolicies } from '../src/permit/sync-permit-schema'
 
 // Same fake control-plane client as permit-schema.test.ts, extended to capture
 // the full payloads (so we can assert ReBAC relations/roles are forwarded).
@@ -293,5 +295,62 @@ describe('MendysRobotics datasets policy', () => {
     expect(ns.roles.map(r => r.key)).toEqual(
       expect.arrayContaining(['mendys-datasets_talent', 'mendys-datasets_buyer', 'mendys-datasets_admin'])
     )
+  })
+})
+
+describe('FuzeFinance policy (#490)', () => {
+  it('is a valid product policy', () => {
+    expect(() => validateProductPolicy(fuzefinancePolicy)).not.toThrow()
+  })
+
+  it('declares Invoice/LedgerEntry/Report/Payout and finance-officer/admin', () => {
+    expect(fuzefinancePolicy.product).toBe('fuzefinance')
+    expect(fuzefinancePolicy.resources.map(r => r.key).sort()).toEqual(
+      ['Invoice', 'LedgerEntry', 'Payout', 'Report']
+    )
+    expect(fuzefinancePolicy.roles.map(r => r.key).sort()).toEqual(
+      ['admin', 'finance-officer']
+    )
+  })
+
+  it('finance-officer manages invoices/ledger/reports but cannot void invoices or approve payouts', () => {
+    const officer = fuzefinancePolicy.roles.find(r => r.key === 'finance-officer')!
+    expect(officer.permissions).toEqual(
+      expect.arrayContaining([
+        'Invoice:create', 'Invoice:read', 'Invoice:update', 'Invoice:send',
+        'LedgerEntry:create', 'LedgerEntry:read', 'LedgerEntry:reconcile',
+        'Report:read', 'Report:export',
+        'Payout:read',
+      ])
+    )
+    expect(officer.permissions).not.toContain('Invoice:void')
+    expect(officer.permissions).not.toContain('Payout:approve')
+  })
+
+  it('admin holds every declared action on every declared resource', () => {
+    const admin = fuzefinancePolicy.roles.find(r => r.key === 'admin')!
+    const allPerms = fuzefinancePolicy.resources.flatMap(r =>
+      Object.keys(r.actions).map(a => `${r.key}:${a}`)
+    )
+    expect(admin.permissions.slice().sort()).toEqual(allPerms.sort())
+  })
+
+  it('namespaces cleanly', () => {
+    const ns = namespaceProductPolicy(fuzefinancePolicy)
+    expect(ns.resources.map(r => r.key)).toEqual(
+      expect.arrayContaining(['fuzefinance_Invoice', 'fuzefinance_LedgerEntry', 'fuzefinance_Report', 'fuzefinance_Payout'])
+    )
+    expect(ns.roles.map(r => r.key)).toEqual(
+      expect.arrayContaining(['fuzefinance_finance-officer', 'fuzefinance_admin'])
+    )
+  })
+
+  it('is registered in loadLegacyProductPolicies()', () => {
+    const products = loadLegacyProductPolicies().map(p => p.product)
+    expect(products).toContain('fuzefinance')
+  })
+
+  it('syncs alongside the other legacy products without a namespace collision', () => {
+    expect(() => buildEnvSchema(...loadLegacyProductPolicies())).not.toThrow()
   })
 })

--- a/services/app-registry-service/seed/fuzefinance.manifest.json
+++ b/services/app-registry-service/seed/fuzefinance.manifest.json
@@ -1,0 +1,25 @@
+{
+  "manifestVersion": "1",
+  "slug": "fuzefinance",
+  "name": "FuzeFinance",
+  "menuLabel": "Finance",
+  "description": "Enterprise finance & accounting dashboard — invoices, ledger, reporting, and payouts for corporate tenants.",
+  "icon": { "kind": "emoji", "value": "💰" },
+  "mode": "portal",
+  "builtin": false,
+  "integration": {
+    "type": "module-federation",
+    "remoteEntry": "https://fuzefinance.fuze.internal/dist/remoteEntry.js",
+    "scope": "fuzefinance",
+    "module": "./App"
+  },
+  "chrome": {
+    "menu": "host",
+    "topbar": "host"
+  },
+  "routing": {
+    "path": "/fuzefinance"
+  },
+  "visibility": "organization",
+  "roles": []
+}


### PR DESCRIPTION
## 📋 Description

Exposes custom authorization mappings for the FuzeFinance product's Enterprise Pro roles ('admin', 'finance_officer').

Fixes #490

## 🔄 Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

## 🔧 Implementation Details

### Architecture decision

Before implementing, I confirmed with the repo owner whether FuzeFinance needs its own dedicated Authentik OIDC provider (like `mendys-datasets` → its own backend at `marketplace.mendysrobotics.com`) or is Module-Federation-hosted inside FuzeFront using the existing session (like `fuzemarket`). Answer: **Module-Federation hosted**, like fuzemarket — so no new Authentik OIDC provider/blueprint is needed; this PR is scoped to the Permit role/resource mapping + app-registry manifest.

### Changes Made

- **Backend changes:**
  - `backend/src/permit/products/fuzefinance.policy.ts` (+ `backend/security/src/permit/products/` mirror) — declares the FuzeFinance product's bare Permit resources (`Invoice`, `LedgerEntry`, `Report`, `Payout`) and its Enterprise Pro roles:
    - `admin` — every action on every FuzeFinance resource.
    - `finance-officer` — day-to-day invoice/ledger/report operations, but **not** `Invoice:void` or `Payout:approve` (both move/reverse real money and stay admin-only).

    Note: Permit's bare-key charset (`^[A-Za-z][A-Za-z0-9-]*$`) forbids `_` — it's reserved as the product-namespace separator (`PRODUCT_NS_SEP`). The issue's literal `finance_officer` is therefore registered as **`finance-officer`**, matching the same hyphenated-compound-role convention already used by `fuzemarket`'s `market-admin`.
  - `backend/src/permit/sync-permit-schema.ts` — registered the new policy in `loadLegacyProductPolicies()`, so it's included in every Permit schema sync alongside `fuzemarket`/`mendys-datasets`, namespaced to `fuzefinance_*` on merge.
- **App registry:** `services/app-registry-service/seed/fuzefinance.manifest.json` — the product manifest (`mode: portal`, `integration.type: module-federation`), following the exact shape of `fuzemarket.manifest.json`. Validated against the real `appManifestSchema` (Zod `safeParse` → `VALID`) before committing.

## 🧪 Testing

- [x] Unit: `PERMIT_API_KEY=... npx jest tests/product-policy.test.ts tests/permit-schema.test.ts` — 40/40 pass, including 7 new tests: policy validity, resource/role declarations, `finance-officer`'s destructive-action denial (`Invoice:void`, `Payout:approve`), `admin`'s full resource coverage, clean namespacing, registration in `loadLegacyProductPolicies()`, and a no-collision merge alongside the other legacy products.
- [x] `npx tsc --noEmit` — clean, no new errors.
- [x] Manifest validated directly against `appManifestSchema.safeParse()` (ts-node script, not committed) — `VALID`.

### Code Quality

- [x] Self-review of code completed
- [x] No console.log/debugging statements left in code

## 🔗 Related Issues and PRs

- Closes #490

## 📝 Additional Notes

No changes to `tenants.ts` or anything in scope of #434 ("multi-tenant IdP broker") — that issue is about giving different tenants their own Authentik instance/database (MendysRobotics's own silo); FuzeFinance is a consumer product inside the existing FuzeFront tenant, an unrelated and independent concern.

---
_Generated by [Claude Code](https://claude.ai/code/session_013tMciHkPE8To7V67CsgKKc)_