### PR TITLE
feat(portals): read-only vs no-access authorization for adminPortals (Portals Directory S5)

### DIFF
--- a/backend/src/routes/adminPortals.ts
+++ b/backend/src/routes/adminPortals.ts
@@ -16,6 +16,7 @@ import {
 } from '../repositories/portalRepository'
 import { provisionPortal, SlugTakenError } from '../services/portalProvisioning'
 import { isPortalsDirectoryEnabled } from '../utils/portalsDirectoryFlag'
+import { resolvePortalReadManageCapabilities } from '../utils/portalReadManageCapabilities'
 
 type Middleware = (request: Request, response: Response, next: NextFunction) => unknown
 
@@ -182,7 +183,7 @@ export function createAdminPortalRouter(deps: {
     message: { error: 'Too many requests. Try again shortly.' },
   })
 
-  router.get('/', adminRateLimiter, authenticate, authorize, async (request, response) => {
+  function parseListQuery(request: Request) {
     const limit = Math.min(100, Math.max(1, Number.parseInt(String(request.query.limit ?? '25'), 10) || 25))
     const status = typeof request.query.status === 'string'
       ? request.query.status as PortalStatus
@@ -191,27 +192,99 @@ export function createAdminPortalRouter(deps: {
       ? request.query.q.slice(0, 200)
       : undefined
     const cursor = typeof request.query.cursor === 'string' ? request.query.cursor : undefined
-    const result = await store.list({ status, query, limit, cursor })
+    return { limit, status, query, cursor }
+  }
 
-    // Portals Directory (backend slice S1) — `identityMode` + `launchUrl` are
-    // NEW fields, gated behind the release flag (default OFF). When OFF this
-    // response must be byte-identical to the pre-flag shape: strip
-    // `identityMode` (the store always attaches it — see AdminPortalListItem)
-    // and never compute `launchUrl` at all. This never widens the existing
-    // requireRole(['admin']) gate above — it only changes what an ALREADY
-    // authorized caller sees.
+  // Portals Directory (backend slice S1 + S5 read-vs-no-access refinement) —
+  // `GET /` is gated by the SAME release flag (`fuzefront.platform.portals-directory`,
+  // default OFF) at TWO layers now:
+  //   - S1 (response shape): `identityMode`/`launchUrl` only ever appear when
+  //     ON.
+  //   - S5 (authorization): flag OFF keeps the pre-existing blanket
+  //     `requireRole(['admin'])` gate (`authorize` below) — byte-identical to
+  //     pre-S5 behavior, including its 403 body. Flag ON REPLACES that gate
+  //     with a per-portal Permit `read`/`manage` check on each portal's
+  //     owning organization (`resolvePortalReadManageCapabilities`): a
+  //     caller with `read` (not `manage`) now gets 200 with read-only rows
+  //     instead of a hard 403; a caller with `read` over NONE of the
+  //     portals this query would otherwise return still gets the same 403
+  //     no-access response the blanket gate used to produce. A portal the
+  //     caller cannot `read` is NEVER returned (BOLA-safe filtering, not
+  //     after-the-fact leakage) — see `docs/planning` BOLA convention used
+  //     throughout this file's sibling routes.
+  // `authorize` is therefore deliberately NOT in this route's middleware
+  // array — it is invoked manually, only on the flag-OFF branch, so the
+  // flag-ON branch can admit a non-admin caller with real Permit `read`
+  // authority.
+  router.get('/', adminRateLimiter, authenticate, async (request, response) => {
+    const { limit, status, query, cursor } = parseListQuery(request)
     const directoryEnabled = await isPortalsDirectoryEnabled({
       userId: request.user?.id,
     })
-    const items = directoryEnabled
-      ? result.items.map(item => ({
-          ...item,
-          identityMode: item.identityMode ?? 'soft',
-          launchUrl: getPortalLaunchUrl(item),
-        }))
-      : result.items.map(({ identityMode, ...rest }) => rest)
 
-    response.status(200).json({
+    if (!directoryEnabled) {
+      // Flag OFF: byte-identical to pre-S5 behavior — blanket admin-role
+      // gate (synchronous `requireRole`/injected `authorize`), no
+      // capability fields, `identityMode` stripped (the store always
+      // attaches it — see AdminPortalListItem).
+      let authorized = false
+      authorize(request, response, () => {
+        authorized = true
+      })
+      if (!authorized) return // authorize() already sent 401/403
+
+      const result = await store.list({ status, query, limit, cursor })
+      const items = result.items.map(({ identityMode, ...rest }) => rest)
+      return response.status(200).json({
+        items,
+        page: { nextCursor: result.nextCursor },
+      })
+    }
+
+    // Flag ON (S5): per-portal read-vs-manage refinement.
+    if (!request.user?.id) {
+      return response.status(401).json({ error: 'Authentication required' })
+    }
+
+    const result = await store.list({ status, query, limit, cursor })
+    const capabilities = await resolvePortalReadManageCapabilities(
+      request.user.id,
+      result.items.map(item => item.organizationId)
+    )
+    const readableItems = result.items.filter(
+      item => capabilities.get(item.organizationId)?.canRead === true
+    )
+
+    if (result.items.length > 0 && readableItems.length === 0) {
+      // No portal this query would otherwise return is readable by this
+      // caller — the SAME no-access response the blanket
+      // requireRole(['admin']) gate used to produce. Never a leaked
+      // "page exists but every row was filtered" 200.
+      return response.status(403).json({ error: 'Insufficient permissions' })
+    }
+
+    const items = readableItems.map(item => {
+      const capability = capabilities.get(item.organizationId)
+      const canManage = capability?.canManage === true
+      // `canOpen` — authority to LAUNCH the portal. No separate Permit
+      // `open`/`launch` action exists on `Organization` today (see
+      // `permit/schema.ts`), so this intentionally mirrors `canManage`;
+      // kept as its own field so a future distinct launch authority is
+      // additive, not a contract break.
+      const canOpen = canManage
+      const { identityMode, ...rest } = item
+      return {
+        ...rest,
+        identityMode: identityMode ?? 'soft',
+        canManage,
+        canOpen,
+        // Only include `launchUrl` when the caller may actually open the
+        // portal — a read-only viewer must never receive the launch host.
+        ...(canOpen ? { launchUrl: getPortalLaunchUrl(item) } : {}),
+      }
+    })
+
+    return response.status(200).json({
       items,
       page: { nextCursor: result.nextCursor },
     })

--- a/backend/src/utils/portalReadManageCapabilities.ts
+++ b/backend/src/utils/portalReadManageCapabilities.ts
@@ -1,0 +1,70 @@
+/**
+ * Portals Directory read-vs-no-access refinement (backend slice S5).
+ *
+ * Resolves, per portal-owning organization, whether the caller holds Permit
+ * `read` and/or `manage` authority on the existing `Organization` resource
+ * (`src/permit/schema.ts`) — including the parent-org `org-admin` ReBAC
+ * derivation that already grants platform/master admins `manage` on every
+ * child tenant org without a per-org assignment (see
+ * `src/permit/schema.ts`'s `Organization.roles['org-admin']` and
+ * `src/utils/scopeToPortal.ts`'s `defaultIsPlatformAdmin` for the same
+ * derivation used elsewhere). This module adds NO new authorization model —
+ * it is a thin, batched wrapper over the EXISTING `bulkCheckPermissions`.
+ *
+ * ONLY consumed by `routes/adminPortals.ts`'s `GET /` handler, and ONLY when
+ * `fuzefront.platform.portals-directory` is ON. Flag OFF keeps the pre-S5
+ * blanket `requireRole(['admin'])` gate and never calls this module.
+ *
+ * Fail-closed: `bulkCheckPermissions` already fails closed per-check (falls
+ * back to individual `checkPermission` calls, each of which returns `false`
+ * on any Permit error) — see `permission-check.ts`. This module adds a
+ * defensive `?? false` on every lookup so a missing/short result array can
+ * never be misread as granted.
+ */
+import { bulkCheckPermissions, type PermissionCheck } from './permit/permission-check'
+
+export interface PortalCapability {
+  canRead: boolean
+  canManage: boolean
+}
+
+/**
+ * Resolves `{ canRead, canManage }` for `userId` against every organization
+ * in `organizationIds` (deduplicated — one Permit round trip covers however
+ * many portal rows share an org). Missing/duplicate ids are handled
+ * transparently; the returned map only ever contains resolved (fail-closed
+ * to `false`) entries.
+ */
+export async function resolvePortalReadManageCapabilities(
+  userId: string,
+  organizationIds: string[]
+): Promise<Map<string, PortalCapability>> {
+  const uniqueOrgIds = Array.from(new Set(organizationIds.filter(Boolean)))
+  const capabilities = new Map<string, PortalCapability>()
+  if (uniqueOrgIds.length === 0) return capabilities
+
+  const checks: PermissionCheck[] = []
+  for (const organizationId of uniqueOrgIds) {
+    checks.push({
+      user: userId,
+      action: 'read',
+      resource: { type: 'Organization', tenant: organizationId },
+    })
+    checks.push({
+      user: userId,
+      action: 'manage',
+      resource: { type: 'Organization', tenant: organizationId },
+    })
+  }
+
+  const results = await bulkCheckPermissions(checks)
+
+  uniqueOrgIds.forEach((organizationId, index) => {
+    capabilities.set(organizationId, {
+      canRead: results[index * 2] ?? false,
+      canManage: results[index * 2 + 1] ?? false,
+    })
+  })
+
+  return capabilities
+}

--- a/backend/src/utils/portalsDirectoryFlag.ts
+++ b/backend/src/utils/portalsDirectoryFlag.ts
@@ -1,19 +1,31 @@
 /**
- * Portals Directory (backend slice S1) — the `fuzefront.platform.portals-directory`
- * flag: gates the two NEW response fields (`identityMode`, `launchUrl`) that
- * `GET /api/v1/admin/portals` adds to the master-admin portal fleet list.
+ * Portals Directory (backend slices S1 + S5) — the
+ * `fuzefront.platform.portals-directory` flag: gates the NEW response fields
+ * (`identityMode`, `launchUrl`, and — as of S5 — `canManage`/`canOpen`) that
+ * `GET /api/v1/admin/portals` adds to the master-admin portal fleet list,
+ * AND (as of S5) the per-portal read-vs-manage authorization refinement
+ * described below.
  *
  * Type: release. Owner: backend-engineer (platform). Default: OFF — when OFF,
- * `GET /api/v1/admin/portals`'s response is byte-identical to the pre-existing
- * shape (neither new field is emitted). Removal criterion: delete this flag +
- * the OFF-path field-stripping branch in `routes/adminPortals.ts` once the
- * portals directory UI (S3) is rolled out to 100% and the flag-OFF path is no
- * longer exercised in prod.
+ * `GET /api/v1/admin/portals`'s response AND authorization are byte-identical
+ * to the pre-existing (pre-S1) shape/gate (no new fields emitted, blanket
+ * `requireRole(['admin'])`). Removal criterion: delete this flag + the
+ * OFF-path field-stripping/blanket-gate branch in `routes/adminPortals.ts`
+ * once the portals directory UI (S3, S6) is rolled out to 100% and the
+ * flag-OFF path is no longer exercised in prod.
  *
- * NOTE: this flag is rollout convenience only — it gates response SHAPE, not
- * authorization. `GET /api/v1/admin/portals` stays `requireRole(['admin'])`-
- * gated in BOTH flag states; this flag never widens who may call the route or
- * which portals they see.
+ * NOTE (updated for backend slice S5, read-vs-no-access refinement): this
+ * flag ALSO gates authorization now, not just response shape. When OFF,
+ * `GET /api/v1/admin/portals` stays `requireRole(['admin'])`-gated exactly
+ * as before. When ON, the blanket admin-role gate is replaced by a
+ * per-portal Permit `read`/`manage` check on each portal's owning
+ * organization (`utils/portalReadManageCapabilities.ts`) — a caller with
+ * `read` (but not `manage`) authority now gets 200 with read-only rows
+ * instead of a hard 403. Real authorization is still Permit's, never this
+ * flag's: the flag only decides whether the NEW, more granular Permit check
+ * runs at all, and a portal the caller cannot `read` is never returned in
+ * either state (fail-closed, BOLA-safe). See `routes/adminPortals.ts`'s
+ * `GET /` handler for the full flag-branch contract.
  *
  * Read via @fuzefront/feature-flags (OpenFeature) per the `feature-flags`
  * skill — never a hand-wired Unleash/OpenFeature call. Loaded lazily (mirrors

--- a/backend/tests/admin-portals-readonly-authz.test.ts
+++ b/backend/tests/admin-portals-readonly-authz.test.ts
@@ -1,0 +1,297 @@
+/**
+ * Portals Directory read-vs-no-access authorization refinement (backend
+ * slice S5) — real-Postgres integration tests for `GET /api/v1/admin/portals`,
+ * mirroring `tests/admin-portals-directory.test.ts`'s pattern: the shared
+ * jest global setup (tests/setup.ts — real Postgres, full migration chain),
+ * the REAL router (`createAdminPortalRouter`) wired to the REAL
+ * `authenticateToken`/`requireRole(['admin'])` middleware + the REAL
+ * `createAdminPortalStore()`. Permit itself is mocked (no live PDP in this
+ * environment) via `jest.spyOn` on `utils/permit/permission-check`'s
+ * `bulkCheckPermissions` — the SAME "must go through the module namespace
+ * object" pattern the S1 suite already uses for the flag.
+ *
+ * Every test filters the list via `?q=<unique-slug>` so it is immune to
+ * portal rows created by OTHER test files sharing this same Postgres
+ * instance.
+ */
+import request from 'supertest'
+import express from 'express'
+import jwt from 'jsonwebtoken'
+import { v4 as uuidv4 } from 'uuid'
+
+import * as portalsDirectoryFlagModule from '../src/utils/portalsDirectoryFlag'
+import * as permissionCheckModule from '../src/utils/permit/permission-check'
+import { db, initializeDatabaseConnection } from '../src/config/database'
+import { authenticateToken, requireRole } from '../src/middleware/auth'
+import { createAdminPortalRouter } from '../src/routes/adminPortals'
+
+let directoryEnabled = false
+
+/**
+ * Maps `${organizationId}:${action}` -> boolean. Every test sets this up
+ * per-org/action; anything not explicitly granted defaults to `false`
+ * (fail-closed), exercising `resolvePortalReadManageCapabilities`'s `?? false`
+ * defensive default along the way.
+ */
+let permitGrants: Record<string, boolean> = {}
+
+beforeAll(() => {
+  initializeDatabaseConnection()
+  jest
+    .spyOn(portalsDirectoryFlagModule, 'isPortalsDirectoryEnabled')
+    .mockImplementation(async () => directoryEnabled)
+  jest
+    .spyOn(permissionCheckModule, 'bulkCheckPermissions')
+    .mockImplementation(async checks =>
+      checks.map(check => permitGrants[`${check.resource.tenant}:${check.action}`] ?? false)
+    )
+})
+
+beforeEach(() => {
+  directoryEnabled = false
+  permitGrants = {}
+})
+
+const app = express()
+app.use(express.json())
+app.use(
+  '/api/v1/admin/portals',
+  createAdminPortalRouter({
+    authenticate: authenticateToken,
+    authorize: requireRole(['admin']),
+  })
+)
+
+async function createUser(roles: string[] = ['user']): Promise<string> {
+  const id = uuidv4()
+  await db('users').insert({
+    id,
+    email: `admin-portals-readonly-${id.slice(0, 8)}@test.local`,
+    first_name: 'ReadOnly',
+    last_name: 'Test',
+    roles: JSON.stringify(roles),
+    created_at: new Date(),
+    updated_at: new Date(),
+  })
+  return id
+}
+
+async function createPortal(opts: { slug: string; domain?: string }): Promise<{
+  portalId: string
+  organizationId: string
+}> {
+  const ownerId = await createUser(['user'])
+  const orgId = uuidv4()
+  await db('organizations').insert({
+    id: orgId,
+    name: opts.slug,
+    slug: `${opts.slug}-${orgId.slice(0, 6)}`,
+    owner_id: ownerId,
+    type: 'organization',
+    settings: JSON.stringify({}),
+    metadata: JSON.stringify({}),
+    is_active: true,
+    provisioning_state: 'active',
+  })
+  const portalId = `prt_${uuidv4().replace(/-/g, '')}`
+  await db('portals').insert({
+    id: portalId,
+    organization_id: orgId,
+    slug: opts.slug,
+    name: opts.slug,
+    status: 'active',
+    billing_mode: 'free',
+    branding: JSON.stringify({ name: opts.slug }),
+    identity_policy: JSON.stringify({ allowPasswordLogin: true, allowSelfSignup: false }),
+    is_root: false,
+  })
+  if (opts.domain) {
+    await db('portal_domains').insert({
+      portal_id: portalId,
+      domain: opts.domain,
+      kind: 'subdomain',
+      is_primary: true,
+      verification_status: 'verified',
+      tls_status: 'none',
+    })
+  }
+  return { portalId, organizationId: orgId }
+}
+
+function signToken(userId: string): string {
+  return jwt.sign({ userId, sessionId: uuidv4() }, process.env.JWT_SECRET!, { expiresIn: '24h' })
+}
+
+function grantRead(organizationId: string) {
+  permitGrants[`${organizationId}:read`] = true
+}
+function grantManage(organizationId: string) {
+  permitGrants[`${organizationId}:read`] = true
+  permitGrants[`${organizationId}:manage`] = true
+}
+
+describe('GET /api/v1/admin/portals — read-vs-no-access refinement (backend slice S5)', () => {
+  describe('flag ON', () => {
+    it('no-read caller -> 403, no rows leaked', async () => {
+      directoryEnabled = true
+      const userId = await createUser(['user'])
+      const slug = `s5-noread-${uuidv4().slice(0, 8)}`
+      await createPortal({ slug })
+      // Deliberately grant nothing for this org — permitGrants stays empty.
+
+      const response = await request(app)
+        .get(`/api/v1/admin/portals?q=${slug}`)
+        .set('Authorization', `Bearer ${signToken(userId)}`)
+
+      expect(response.status).toBe(403)
+      expect(response.body.items).toBeUndefined()
+    })
+
+    it('read-only caller -> 200, rows present, canManage/canOpen false, launchUrl absent', async () => {
+      directoryEnabled = true
+      const userId = await createUser(['user'])
+      const slug = `s5-readonly-${uuidv4().slice(0, 8)}`
+      const { organizationId } = await createPortal({ slug, domain: `${slug}.example.com` })
+      grantRead(organizationId)
+
+      const response = await request(app)
+        .get(`/api/v1/admin/portals?q=${slug}`)
+        .set('Authorization', `Bearer ${signToken(userId)}`)
+
+      expect(response.status).toBe(200)
+      expect(response.body.items).toHaveLength(1)
+      const item = response.body.items[0]
+      expect(item).toMatchObject({
+        slug,
+        identityMode: 'soft',
+        canManage: false,
+        canOpen: false,
+      })
+      expect(item.launchUrl).toBeUndefined()
+      expect('launchUrl' in item).toBe(false)
+    })
+
+    it('manage caller -> 200, canManage/canOpen true, launchUrl present', async () => {
+      directoryEnabled = true
+      const userId = await createUser(['user'])
+      const slug = `s5-manage-${uuidv4().slice(0, 8)}`
+      const { organizationId } = await createPortal({ slug, domain: `${slug}.example.com` })
+      grantManage(organizationId)
+
+      const response = await request(app)
+        .get(`/api/v1/admin/portals?q=${slug}`)
+        .set('Authorization', `Bearer ${signToken(userId)}`)
+
+      expect(response.status).toBe(200)
+      expect(response.body.items).toHaveLength(1)
+      expect(response.body.items[0]).toMatchObject({
+        slug,
+        identityMode: 'soft',
+        canManage: true,
+        canOpen: true,
+        launchUrl: `https://${slug}.example.com`,
+      })
+    })
+
+    it('mixed case: manages some, reads others, cannot see the rest — per-row capabilities correct, unreadable portal never returned', async () => {
+      directoryEnabled = true
+      const userId = await createUser(['user'])
+      const prefix = `s5-mixed-${uuidv4().slice(0, 8)}`
+
+      const managed = await createPortal({ slug: `${prefix}-managed`, domain: `${prefix}-managed.example.com` })
+      const readable = await createPortal({ slug: `${prefix}-readable` })
+      const denied = await createPortal({ slug: `${prefix}-denied` })
+
+      grantManage(managed.organizationId)
+      grantRead(readable.organizationId)
+      // `denied.organizationId` gets nothing.
+
+      const response = await request(app)
+        .get(`/api/v1/admin/portals?q=${prefix}`)
+        .set('Authorization', `Bearer ${signToken(userId)}`)
+
+      expect(response.status).toBe(200)
+      expect(response.body.items).toHaveLength(2)
+
+      const bySlug = Object.fromEntries(
+        response.body.items.map((item: any) => [item.slug, item])
+      )
+      expect(bySlug[`${prefix}-denied`]).toBeUndefined()
+
+      expect(bySlug[`${prefix}-managed`]).toMatchObject({
+        canManage: true,
+        canOpen: true,
+        launchUrl: `https://${prefix}-managed.example.com`,
+      })
+
+      expect(bySlug[`${prefix}-readable`]).toMatchObject({
+        canManage: false,
+        canOpen: false,
+      })
+      expect('launchUrl' in bySlug[`${prefix}-readable`]).toBe(false)
+    })
+
+    it('fail-closed: a degraded/partial Permit bulk response never grants an unresolved row', async () => {
+      directoryEnabled = true
+      const userId = await createUser(['user'])
+      const slug = `s5-partial-${uuidv4().slice(0, 8)}`
+      await createPortal({ slug })
+
+      // Simulate the degraded-PDP path `permission-check.ts` itself
+      // documents (bulkCheck returning FEWER results than requested, e.g.
+      // OPA 502) by resolving with an EMPTY array. This is exactly what the
+      // real `bulkCheckPermissions` already fails closed to internally on a
+      // genuine Permit error (falls back to per-check `checkPermission`,
+      // which itself catches and returns `false`) — asserting here that
+      // `resolvePortalReadManageCapabilities`'s `?? false` default on a
+      // short/empty result array never mis-reads a missing entry as
+      // granted.
+      jest.spyOn(permissionCheckModule, 'bulkCheckPermissions').mockResolvedValueOnce([])
+
+      const response = await request(app)
+        .get(`/api/v1/admin/portals?q=${slug}`)
+        .set('Authorization', `Bearer ${signToken(userId)}`)
+
+      expect(response.status).toBe(403)
+      expect(response.body.items).toBeUndefined()
+    })
+  })
+
+  describe('flag OFF', () => {
+    it('identical to today: admin-only 403 for a non-admin, no capability fields', async () => {
+      directoryEnabled = false
+      const userId = await createUser(['user'])
+      const slug = `s5-off-nonadmin-${uuidv4().slice(0, 8)}`
+      const { organizationId } = await createPortal({ slug })
+      // Even with FULL Permit manage authority, flag OFF must still 403 a
+      // non-admin — the blanket requireRole(['admin']) gate is untouched.
+      grantManage(organizationId)
+
+      const response = await request(app)
+        .get(`/api/v1/admin/portals?q=${slug}`)
+        .set('Authorization', `Bearer ${signToken(userId)}`)
+
+      expect(response.status).toBe(403)
+      expect(response.body.items).toBeUndefined()
+    })
+
+    it('identical to today: admin caller -> 200, no canManage/canOpen/identityMode/launchUrl keys', async () => {
+      directoryEnabled = false
+      const adminId = await createUser(['admin'])
+      const slug = `s5-off-admin-${uuidv4().slice(0, 8)}`
+      await createPortal({ slug, domain: `${slug}.example.com` })
+
+      const response = await request(app)
+        .get(`/api/v1/admin/portals?q=${slug}`)
+        .set('Authorization', `Bearer ${signToken(adminId)}`)
+
+      expect(response.status).toBe(200)
+      expect(response.body.items).toHaveLength(1)
+      const item = response.body.items[0]
+      expect('canManage' in item).toBe(false)
+      expect('canOpen' in item).toBe(false)
+      expect('identityMode' in item).toBe(false)
+      expect('launchUrl' in item).toBe(false)
+    })
+  })
+})

--- a/frontend/src/services/adminPortalsService.ts
+++ b/frontend/src/services/adminPortalsService.ts
@@ -38,7 +38,7 @@ export interface AdminPortal extends Portal {
    * Server-authoritative — the client renders it directly as the launch
    * anchor's `href` and never composes a host from client-held data.
    */
-  launchUrl?: string | null
+  launchUrl?: string
 }
 
 export interface AdminPortalsPage {

--- a/portal-client/src/schema.ts
+++ b/portal-client/src/schema.ts
@@ -53,7 +53,9 @@ export interface paths {
         };
         /**
          * List portals (master-admin fleet view)
-         * @description Returns a cursor-paginated page of portals for the master-admin fleet list. Permit **platform-admin** only — a non-admin caller is denied fail-closed with 403 `FORBIDDEN`. A fresh install returns exactly one portal (the seeded root portal, slug `fuzefront`).
+         * @description Returns a cursor-paginated page of portals for the master-admin fleet list. A fresh install returns exactly one portal (the seeded root portal, slug `fuzefront`).
+         *     When `fuzefront.platform.portals-directory` is OFF, this stays Permit **platform-admin** only — a non-admin caller is denied fail-closed with 403 `FORBIDDEN`, byte-identical to the pre-1.3.0 contract.
+         *     When the flag is ON (backend slice S5), the blanket admin-only gate is replaced by a per-portal Permit `read`/`manage` check on each portal's owning organization (`Organization:read` / `Organization:manage`, including the parent-org `org-admin` derivation for platform/master admins): a caller with `manage` on a portal's org sees it with `canManage: true, canOpen: true` and a `launchUrl`; a caller with only `read` sees it read-only (`canManage: false, canOpen: false`, no `launchUrl`); a portal the caller cannot even `read` is never returned (BOLA-safe filtering, never after-the-fact leakage). A caller with `read` authority over NONE of the portals this query would otherwise return still gets the fail-closed 403 `FORBIDDEN` no-access response — the read-vs-manage refinement only ever WIDENS who sees a 200 relative to the pre-flag blanket gate, never who is denied.
          */
         get: operations["listPortals"];
         put?: never;
@@ -368,13 +370,17 @@ export interface components {
             domains: components["schemas"]["PortalDomain"][];
             /** @description Convenience: the primary domain string, or null if none yet. */
             primaryDomain?: string | null;
-            /** @description OPTIONAL — only present on `GET /api/v1/admin/portals` (list) responses, and only when `fuzefront.platform.portals-directory` is enabled for the caller. See `IdentityMode` for the field's own description. Absent (not `null`) on every other portal response. */
+            /** @description OPTIONAL — only present on `GET /api/v1/admin/portals` (list) responses, and only when `fuzefront.platform.portals-directory` is enabled for the caller. See `IdentityMode` for the field's own description. Absent (not `null`) on every other portal response. Present on EVERY row the caller may see (read-only or manage — see `canManage`/`canOpen` below). */
             identityMode?: components["schemas"]["IdentityMode"];
+            /** @description OPTIONAL (backend slice S5, read-vs-no-access refinement) — only present on `GET /api/v1/admin/portals` (list) responses when `fuzefront.platform.portals-directory` is enabled. Whether the caller holds Permit `manage` authority (not just `read`) on this portal's owning organization — derived via the existing `Organization` resource's `read`/`manage` actions and the parent-org `org-admin` ReBAC derivation (platform/master admins included). `false` renders the row read-only in the directory UI (no manage/launch affordance). Absent (not present at all) when the flag is OFF. */
+            canManage?: boolean;
+            /** @description OPTIONAL — same gating as `canManage` above. The authority to LAUNCH the portal. There is no separate Permit `open`/`launch` action on `Organization` today, so this intentionally mirrors `canManage` — a caller who can manage a portal can also launch it, and a read-only viewer can neither. If a distinct launch authority is ever introduced this field decouples from `canManage` without a contract break (it is already its own field). Absent when the flag is OFF. */
+            canOpen?: boolean;
             /**
              * Format: uri
-             * @description OPTIONAL — same gating as `identityMode` above. `https://<primary domain>` when the portal has a primary `portal_domains` row, else the platform-owned default subdomain (`https://<slug>.fuzefront.com`) `default_domain_create` provisions for every portal.
+             * @description OPTIONAL — present on `GET /api/v1/admin/portals` (list) responses only when `fuzefront.platform.portals-directory` is enabled AND `canOpen` is `true` for this row. Absent (not `null`, not present at all) for a read-only row (`canOpen: false`) — a caller without launch authority must never receive the launch host. `https://<primary domain>` when the portal has a primary `portal_domains` row, else the platform-owned default subdomain (`https://<slug>.fuzefront.com`) `default_domain_create` provisions for every portal.
              */
-            launchUrl?: string | null;
+            launchUrl?: string;
             /** Format: date-time */
             createdAt: string;
             /** Format: date-time */

--- a/services/portal-service/CHANGELOG.md
+++ b/services/portal-service/CHANGELOG.md
@@ -5,6 +5,40 @@ bumps `info.version` here first, then the client (`@fuzefront/portal-client`) is
 regenerated (`openapi-typescript`) and re-linted (Spectral). Any later change
 re-enters through `contract-designer` — never around it.
 
+## 1.3.0 — 2026-08-11 (Portals Directory read-vs-no-access refinement, backend slice S5)
+
+Additive only — no existing field/response shape changes when
+`fuzefront.platform.portals-directory` is OFF.
+
+### Added — `Portal.canManage` / `Portal.canOpen` (both OPTIONAL)
+- Only populated by `GET /api/v1/admin/portals` (the master-admin fleet
+  list), same gating as `identityMode`/`launchUrl` (the release flag
+  `fuzefront.platform.portals-directory`, default OFF).
+- `canManage`: whether the caller holds Permit `manage` (not just `read`)
+  authority on the portal's owning organization.
+- `canOpen`: the authority to launch the portal. Intentionally mirrors
+  `canManage` today (no separate Permit `open`/`launch` action exists yet);
+  kept as its own field so a future distinct launch authority is not a
+  breaking change.
+
+### Changed — `Portal.launchUrl` is now optional-per-row (non-breaking)
+- Was `[string, 'null']` (always present, occasionally `null`); now `string`
+  and OMITTED entirely on a row where `canOpen` is `false`. A read-only
+  caller must never receive the launch host for a portal they cannot open.
+  Still gated identically to `identityMode`/`canManage`/`canOpen` — absent
+  altogether when the flag is OFF.
+
+### Changed — `GET /api/v1/admin/portals` authorization (flag ON only)
+- The blanket Permit platform-admin (`requireRole(['admin'])`) gate is
+  replaced by a per-portal `read`-vs-`manage` check on each portal's owning
+  organization when `fuzefront.platform.portals-directory` is ON. A caller
+  with `read` (not `manage`) now gets 200 with read-only rows instead of a
+  hard 403; a caller with `read` authority over NONE of the matching
+  portals still gets 403 `FORBIDDEN` (unchanged no-access banner). A portal
+  the caller cannot `read` is never returned. When the flag is OFF, this
+  route's authorization is byte-identical to 1.2.0 (admin-role gate,
+  non-admin ⇒ 403 regardless of any Permit `read`/`manage` grant).
+
 ## 1.2.0 — 2026-08-11 (Portals Directory, backend slice S1)
 
 Additive only — no existing field/response shape changes.

--- a/services/portal-service/openapi.yaml
+++ b/services/portal-service/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: FuzeFront Portal API
-  version: 1.2.0
+  version: 1.3.0
   description: >-
     REST API for **multi-tenant portals** — the first-class `portals` object that
     lets one shared FuzeFront deployment serve many isolated white-label tenant
@@ -48,6 +48,12 @@ info:
     Directory, backend slice S1) are separately staged behind
     `fuzefront.platform.portals-directory` (default OFF) — when OFF,
     `GET /api/v1/admin/portals` omits both fields entirely (not `null`).
+    Backend slice S5 adds the read-vs-manage refinement on the SAME flag:
+    when ON, the blanket admin-only gate on `GET /api/v1/admin/portals` is
+    replaced by a per-portal Permit `read`/`manage` check (`canManage`,
+    `canOpen` — both OPTIONAL, same gating), and `launchUrl` is only present
+    on rows the caller may launch (`canOpen: true`). When OFF, S5 changes
+    nothing — the route stays admin-role gated exactly as before.
   license:
     name: UNLICENSED
 
@@ -136,9 +142,28 @@ paths:
       summary: List portals (master-admin fleet view)
       description: >-
         Returns a cursor-paginated page of portals for the master-admin fleet
-        list. Permit **platform-admin** only — a non-admin caller is denied
-        fail-closed with 403 `FORBIDDEN`. A fresh install returns exactly one
-        portal (the seeded root portal, slug `fuzefront`).
+        list. A fresh install returns exactly one portal (the seeded root
+        portal, slug `fuzefront`).
+
+        When `fuzefront.platform.portals-directory` is OFF, this stays
+        Permit **platform-admin** only — a non-admin caller is denied
+        fail-closed with 403 `FORBIDDEN`, byte-identical to the pre-1.3.0
+        contract.
+
+        When the flag is ON (backend slice S5), the blanket admin-only gate
+        is replaced by a per-portal Permit `read`/`manage` check on each
+        portal's owning organization (`Organization:read` / `Organization:manage`,
+        including the parent-org `org-admin` derivation for platform/master
+        admins): a caller with `manage` on a portal's org sees it with
+        `canManage: true, canOpen: true` and a `launchUrl`; a caller with
+        only `read` sees it read-only (`canManage: false, canOpen: false`,
+        no `launchUrl`); a portal the caller cannot even `read` is never
+        returned (BOLA-safe filtering, never after-the-fact leakage). A
+        caller with `read` authority over NONE of the portals this query
+        would otherwise return still gets the fail-closed 403 `FORBIDDEN`
+        no-access response — the read-vs-manage refinement only ever WIDENS
+        who sees a 200 relative to the pre-flag blanket gate, never who is
+        denied.
       parameters:
         - name: status
           in: query
@@ -750,13 +775,43 @@ components:
             responses, and only when `fuzefront.platform.portals-directory`
             is enabled for the caller. See `IdentityMode` for the field's own
             description. Absent (not `null`) on every other portal response.
+            Present on EVERY row the caller may see (read-only or manage —
+            see `canManage`/`canOpen` below).
+        canManage:
+          type: boolean
+          description: >-
+            OPTIONAL (backend slice S5, read-vs-no-access refinement) — only
+            present on `GET /api/v1/admin/portals` (list) responses when
+            `fuzefront.platform.portals-directory` is enabled. Whether the
+            caller holds Permit `manage` authority (not just `read`) on this
+            portal's owning organization — derived via the existing
+            `Organization` resource's `read`/`manage` actions and the
+            parent-org `org-admin` ReBAC derivation (platform/master admins
+            included). `false` renders the row read-only in the directory UI
+            (no manage/launch affordance). Absent (not present at all) when
+            the flag is OFF.
+        canOpen:
+          type: boolean
+          description: >-
+            OPTIONAL — same gating as `canManage` above. The authority to
+            LAUNCH the portal. There is no separate Permit `open`/`launch`
+            action on `Organization` today, so this intentionally mirrors
+            `canManage` — a caller who can manage a portal can also launch
+            it, and a read-only viewer can neither. If a distinct launch
+            authority is ever introduced this field decouples from
+            `canManage` without a contract break (it is already its own
+            field). Absent when the flag is OFF.
         launchUrl:
-          type: [string, 'null']
+          type: string
           format: uri
           description: >-
-            OPTIONAL — same gating as `identityMode` above. `https://<primary
-            domain>` when the portal has a primary `portal_domains` row, else
-            the platform-owned default subdomain
+            OPTIONAL — present on `GET /api/v1/admin/portals` (list)
+            responses only when `fuzefront.platform.portals-directory` is
+            enabled AND `canOpen` is `true` for this row. Absent (not `null`,
+            not present at all) for a read-only row (`canOpen: false`) — a
+            caller without launch authority must never receive the launch
+            host. `https://<primary domain>` when the portal has a primary
+            `portal_domains` row, else the platform-owned default subdomain
             (`https://<slug>.fuzefront.com`) `default_domain_create`
             provisions for every portal.
         createdAt: { type: string, format: date-time }


### PR DESCRIPTION
## 📋 Description

Adds the **read-only** permission state to the Portals Directory, alongside the existing **no-access** state — both are declared in the approved frames (`design/frames/portals-directory/02-portals-list-states.html`), but only no-access was shipped (S1/S3). This is the backend half (S5); the frontend rendering + QA un-fixme is the sibling S6.

## 🔄 Type of Change
- [x] ✨ New feature (non-breaking)
- [x] 🧪 Test addition

## 🔧 Implementation Details

`GET /api/v1/admin/portals` (`backend/src/routes/adminPortals.ts`), **gated by `fuzefront.platform.portals-directory` (default OFF)**:

- **Flag OFF** — byte-identical to before: the blanket `requireRole(['admin'])` gate, no capability fields. (`authorize` is invoked manually on this branch rather than as route middleware, so the ON branch can admit non-admins with real `read` authority.)
- **Flag ON** — the blanket gate is replaced with a **per-portal Permit `read`/`manage`** check (`backend/src/utils/portalReadManageCapabilities.ts`, using the existing `Organization` `read`/`manage` actions + parent-org derivation):
  - `read` but not `manage` → **200**, rows flagged `canManage:false`/`canOpen:false`, **`launchUrl` withheld** (read-only projection).
  - `manage` → **200**, `canManage:true`/`canOpen:true`, `launchUrl` present.
  - `read` over **none** of the queryable portals → **403** (the same no-access response the blanket gate produced).
  - **BOLA-safe**: a portal the caller can't `read` is never returned (filtered, not leaked). Fail-closed on Permit errors.
- `canOpen` mirrors `canManage` today (no distinct Permit launch action on `Organization`); kept as its own field so a future distinct launch authority is additive, not a contract break.

**Contract:** `services/portal-service/openapi.yaml` + `@fuzefront/portal-client` gain `canManage`/`canOpen` (booleans); `launchUrl` is now optional-per-row.

## 🧪 Testing
`backend/tests/admin-portals-readonly-authz.test.ts` — flag ON: no-read → 403; read-only → 200 with `canManage:false` + no `launchUrl`; manage → 200 with `launchUrl`; mixed per-row capabilities; flag OFF → identical to today; Permit-error fail-closed.

## 🚨 Breaking Changes
None. All new behavior is behind the default-OFF flag; response fields are additive.

## 📝 Notes
Sibling **S6** (frontend renders the read-only projection + QA flips the `d6b` `test.fixme` to a passing test) consumes `canManage`/`canOpen`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0127R9Zcw92tmBkxUUuLEB79)_