### PR TITLE
feat(portals): read-only vs no-access directory UI (Portals Directory S6)

### DIFF
--- a/frontend/src/components/portalsDirectory/PortalsList.tsx
+++ b/frontend/src/components/portalsDirectory/PortalsList.tsx
@@ -1,4 +1,4 @@
-import type { AdminPortal } from '../../services/adminPortalsService'
+import { pageIsReadOnly, type AdminPortal } from '../../services/adminPortalsService'
 import { PortalRow } from './PortalRow'
 
 /**
@@ -7,12 +7,28 @@ import { PortalRow } from './PortalRow'
  * Loading/empty/error/forbidden are separate sibling states the orchestrator
  * swaps in instead of this component; by the time `PortalsList` renders,
  * `portals` is a real, non-empty page.
+ *
+ * Per-row launch authority (S5) comes straight off each portal's own
+ * `canOpen` — a page can legitimately mix manageable and read-only rows.
+ * `data-readonly="true"` is set on the wrapper only when EVERY row in this
+ * page is read-only (`pageIsReadOnly`), matching
+ * design/frames/portals-directory/02-portals-list-states.html d6b — a caller
+ * with `read` but not `manage`/`open` authority still SEES the directory
+ * (name / domain / tier / status), just with zero launch affordances,
+ * distinct from the fail-closed 403 no-access state (`PermissionDeniedNotice`,
+ * no rows at all).
  */
 export function PortalsList({ portals }: { portals: AdminPortal[] }) {
+  const readOnly = pageIsReadOnly(portals)
   return (
-    <div className="pd-dir" data-list="portals" role="list">
+    <div
+      className="pd-dir"
+      data-list="portals"
+      role="list"
+      {...(readOnly ? { 'data-readonly': 'true' } : {})}
+    >
       {portals.map(portal => (
-        <PortalRow key={portal.id} portal={portal} canOpen />
+        <PortalRow key={portal.id} portal={portal} canOpen={portal.canOpen ?? true} />
       ))}
     </div>
   )

--- a/frontend/src/pages/PortalsDirectory.tsx
+++ b/frontend/src/pages/PortalsDirectory.tsx
@@ -13,6 +13,7 @@ import {
 import {
   listAdminPortals,
   pageHasMore,
+  pageIsReadOnly,
   type AdminPortal,
 } from '../services/adminPortalsService'
 import { useFlag } from '../platform/featureFlags'
@@ -140,9 +141,17 @@ export function PortalsDirectoryContent() {
   }
 
   const activeCount = portals.filter(p => p.status === 'active').length
+  // S5: a 200 whose every row came back `canOpen: false` is the read-only
+  // projection (caller has `read` but not `manage`/`open` authority over any
+  // returned portal) — distinct from the fail-closed 403 no-access state
+  // (`state === 'forbidden'`, no rows at all). Both get "Read-only" header
+  // copy; only the 403 case renders zero rows.
+  const readOnlyPage = state === 'ready' && pageIsReadOnly(portals)
   const subtitle =
     state === 'ready'
-      ? `${total ?? portals.length} portal${portals.length === 1 ? '' : 's'} · ${activeCount} active`
+      ? readOnlyPage
+        ? 'Read-only'
+        : `${total ?? portals.length} portal${portals.length === 1 ? '' : 's'} · ${activeCount} active`
       : undefined
 
   return (
@@ -157,7 +166,7 @@ export function PortalsDirectoryContent() {
       </div>
 
       <PortalsDirectoryShell
-        title={state === 'forbidden' ? 'Portals' : 'Portals you manage'}
+        title={state === 'forbidden' || readOnlyPage ? 'Portals' : 'Portals you manage'}
         subtitle={state === 'forbidden' ? 'Read-only' : subtitle}
         showSearch={state !== 'forbidden' && state !== 'error'}
         searchValue={searchInput}

--- a/frontend/src/services/adminPortalsService.ts
+++ b/frontend/src/services/adminPortalsService.ts
@@ -37,8 +37,39 @@ export interface AdminPortal extends Portal {
    * root host's `/p/{slug}` path route when it has no custom domain).
    * Server-authoritative — the client renders it directly as the launch
    * anchor's `href` and never composes a host from client-held data.
+   * Only present when `canOpen: true` (S5) — a read-only viewer must never
+   * receive the launch host.
    */
   launchUrl?: string
+  /**
+   * S5 read-vs-manage refinement (`backend/src/routes/adminPortals.ts`).
+   * Authority to MANAGE this portal (Permit ReBAC over its owning
+   * organization). Undefined on an older/flag-OFF server response — callers
+   * treat `undefined` as `true` (the pre-S5 contract: reaching a 200 at all
+   * already implied blanket admin authority).
+   */
+  canManage?: boolean
+  /**
+   * Authority to LAUNCH (open) this portal. `false` on a row the caller may
+   * only `read` — that row carries no `launchUrl` and the UI renders
+   * `[data-action-absent="open-portal"]` instead of a launch anchor/button.
+   * Undefined on an older/flag-OFF server response — treated as `true`.
+   */
+  canOpen?: boolean
+}
+
+/**
+ * A response page is a READ-ONLY projection when every row in it came back
+ * `canOpen: false` — the caller has `read` but not `manage`/`open` authority
+ * over any portal this query returned (S5). Drives the
+ * `[data-list="portals"][data-readonly="true"]` wrapper hook
+ * (design/frames/portals-directory/02-portals-list-states.html, d6b) and the
+ * directory header copy. An EMPTY page, or a page mixing manageable and
+ * read-only rows, is not "read-only" as a whole — only a page where nothing
+ * is openable is.
+ */
+export function pageIsReadOnly(items: AdminPortal[]): boolean {
+  return items.length > 0 && items.every(item => item.canOpen === false)
 }
 
 export interface AdminPortalsPage {

--- a/frontend/tests/portals-directory.frontend.spec.ts
+++ b/frontend/tests/portals-directory.frontend.spec.ts
@@ -261,6 +261,19 @@ function suspendedPortal() {
   }
 }
 
+// S5 read-only rows: `canOpen:false` and NO `launchUrl` — a caller with
+// `read` but not `manage`/`open` authority over this portal's owning org
+// (backend/src/routes/adminPortals.ts, `resolvePortalReadManageCapabilities`).
+function readOnlyPortal(overrides: Partial<ReturnType<typeof softPortal>> = {}) {
+  const { launchUrl: _launchUrl, ...base } = softPortal()
+  return { ...base, canManage: false, canOpen: false, ...overrides }
+}
+
+function readOnlyHardPortal() {
+  const { launchUrl: _launchUrl, ...base } = hardPortal()
+  return { ...base, canManage: false, canOpen: false }
+}
+
 test.describe('Portals Directory — built UI (mocked contract surface)', () => {
   test.beforeEach(async ({ page }) => {
     await seedAuth(page)
@@ -545,35 +558,110 @@ test.describe('Portals Directory — built UI (mocked contract surface)', () => 
       assertCleanRuntime(consoleState)
     })
 
-    // FRAME/BUILD MISMATCH (reported — pending a design decision, NOT silently
-    // passed). The approved frame's d6
-    // (`design/frames/portals-directory/02-portals-list-states.html`) depicts a
-    // READ-ONLY PROJECTION on 403: rows stay visible (name/domain/tier) inside a
-    // `[data-list="portals"][data-readonly="true"]` wrapper with per-row
-    // `[data-action-absent="open-portal"]` "— no access —" spans. The BUILT app
-    // renders NO rows on 403 (banner only) because `GET /api/v1/admin/portals`
-    // denies the whole request (`requireRole(['admin'])`,
-    // `backend/src/routes/adminPortals.ts`) — the security-correct, no-leak
-    // behavior. Resolution is a design call: amend the frame to banner-only
-    // (recommended — no row leak to a denied caller), or introduce a distinct
-    // authorized-view-only state backed by a row-scoped 200. Marked fixme so the
-    // gap stays visible in the report without blocking CI or asserting a verdict.
-    test.fixme(
-      'd6b FRAME/BUILD MISMATCH: frame depicts read-only rows on 403; build renders banner-only',
-      async ({ page }) => {
-        await page.route(PORTALS_PATH, route =>
-          route.fulfill({
-            status: 403,
-            contentType: 'application/json',
-            body: JSON.stringify({ error: 'FORBIDDEN' }),
-          })
-        )
-        await page.goto('/portals')
-        await expect(
-          page.locator('[data-list="portals"][data-readonly="true"]')
-        ).toBeVisible()
-      }
-    )
+    // d6b · RESOLVED (Portals Directory S5/S6). The original FRAME/BUILD
+    // MISMATCH note here recorded that the frame's read-only projection was
+    // (mis)modeled as a variant of the 403 response, while the security-
+    // correct build denied the WHOLE request on 403 (banner-only, no rows —
+    // still asserted immediately above by `d6`). S5
+    // (`backend/src/routes/adminPortals.ts`,
+    // `resolvePortalReadManageCapabilities`) resolved the design call
+    // decisively: the fail-closed 403 stays banner-only/zero-rows (a caller
+    // with NO readable portals in this query) — `d6` above is unchanged —
+    // and the read-only projection is instead a distinct, ADDITIVE 200: rows
+    // whose owning-org Permit authority is `read` but not `manage`/`open`
+    // come back with `canOpen:false` and no `launchUrl`, still inside the
+    // SAME `[data-list="portals"]` wrapper, now carrying
+    // `data-readonly="true"` (`PortalsList`/`pageIsReadOnly`,
+    // frontend/src/services/adminPortalsService.ts). Per-row
+    // `[data-action-absent="open-portal"]` "— no access —" replaces the
+    // launch anchor for a `canOpen:false` row; a `canOpen:true` row on the
+    // SAME page still renders the real `OpenPortalLink` — the wrapper only
+    // reads `data-readonly="true"` when EVERY row on the page is read-only.
+    test('d6b read-only projection: a 200 with canOpen:false rows lists them read-only, zero launch anchors/buttons', async ({
+      page,
+    }) => {
+      const consoleState = trackConsole(page)
+      await page.route(PORTALS_PATH, route =>
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            items: [readOnlyPortal(), readOnlyHardPortal()],
+            page: { nextCursor: null, hasMore: false, total: 2 },
+          }),
+        })
+      )
+      await page.goto('/portals')
+
+      const list = page.locator('[data-list="portals"]')
+      await expect(list).toBeVisible()
+      await expect(list).toHaveAttribute('data-readonly', 'true')
+
+      // Rows are visible — name / primary domain / tier badge / status —
+      // this is NOT the fail-closed 403 (no permission-denied panel).
+      await expect(page.locator('[data-panel="permission-denied"]')).toHaveCount(0)
+      const northwind = page.locator('[data-portal="prt_northwind"]')
+      await expect(northwind).toBeVisible()
+      await expect(northwind).toHaveAttribute('data-can-open', 'false')
+      await expect(northwind.locator('[data-domain="primary"]')).toHaveText(
+        'portal.northwind.example'
+      )
+      await expect(northwind.locator('[data-tier="soft"]')).toBeVisible()
+      await expect(northwind.locator('[data-action-absent="open-portal"]')).toHaveText(
+        '— no access —'
+      )
+
+      const mendys = page.locator('[data-portal="prt_mendys"]')
+      await expect(mendys).toHaveAttribute('data-can-open', 'false')
+      await expect(mendys.locator('[data-action-absent="open-portal"]')).toBeVisible()
+
+      // ZERO launch anchors/buttons ANYWHERE — same load-bearing assertion
+      // as `d6`, now proven against a 200 with rows rather than a 403.
+      await expect(page.locator('a[data-action="open-portal"]')).toHaveCount(0)
+      await expect(page.locator('button[data-action="open-portal"]')).toHaveCount(0)
+      await expect(page.getByRole('link', { name: /open portal/i })).toHaveCount(0)
+      await expect(page.getByRole('button', { name: /open portal/i })).toHaveCount(0)
+
+      assertCleanRuntime(consoleState)
+    })
+
+    test('d6b mixed page: a canOpen:true row keeps its real launch anchor beside read-only rows; wrapper is not marked readonly', async ({
+      page,
+    }) => {
+      const consoleState = trackConsole(page)
+      await page.route(PORTALS_PATH, route =>
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            items: [{ ...softPortal(), canManage: true, canOpen: true }, readOnlyHardPortal()],
+            page: { nextCursor: null, hasMore: false, total: 2 },
+          }),
+        })
+      )
+      await page.goto('/portals')
+
+      // Not every row is read-only -> the wrapper does not carry
+      // data-readonly="true" (matches design/frames 01-portals-list, which
+      // has no data-readonly attribute at all).
+      const list = page.locator('[data-list="portals"]')
+      await expect(list).toBeVisible()
+      await expect(list).not.toHaveAttribute('data-readonly', 'true')
+
+      const northwind = page.locator('[data-portal="prt_northwind"]')
+      await expect(northwind).toHaveAttribute('data-can-open', 'true')
+      await expect(northwind.locator('a[data-action="open-portal"]')).toHaveAttribute(
+        'href',
+        'https://portal.northwind.example/'
+      )
+
+      const mendys = page.locator('[data-portal="prt_mendys"]')
+      await expect(mendys).toHaveAttribute('data-can-open', 'false')
+      await expect(mendys.locator('[data-action-absent="open-portal"]')).toBeVisible()
+      await expect(mendys.locator('a[data-action="open-portal"]')).toHaveCount(0)
+
+      assertCleanRuntime(consoleState)
+    })
 
     test('401: no error/forbidden banner — the global interceptor re-authenticates (redirects to /login)', async ({
       page,


### PR DESCRIPTION
## Description

Frontend slice (S6) of the Portals Directory "read-only vs no-access" states, on top of the merged S5 backend (#645) which extended `GET /api/v1/admin/portals` with per-portal `canManage`/`canOpen` and withholds `launchUrl` unless `canOpen:true`.

Previously the built UI only rendered the fail-closed 403 no-access state (banner, zero rows). The approved frame (`design/frames/portals-directory/02-portals-list-states.html`, d6b) also defines a distinct **read-only** state — a 200 where the caller can `read` but not `manage`/`open` a portal — which was not built. This PR closes that gap.

## Type of Change

- [x] ✨ New feature (non-breaking)
- [x] 🧪 Test addition or improvement

## Changes Made

- `frontend/src/services/adminPortalsService.ts` — `AdminPortal` now carries `canManage`/`canOpen` (optional; `undefined` is treated as `true` for back-compat with a flag-OFF/older server response, matching the pre-S5 contract). Added `pageIsReadOnly(items)`: a page is read-only when every row in it has `canOpen:false`.
- `frontend/src/components/portalsDirectory/PortalsList.tsx` — per-row launch authority now comes from each portal's own `canOpen` (was hard-coded `true` for every row). The `[data-list="portals"]` wrapper gets `data-readonly="true"` only when the whole page is read-only (a page can legitimately mix manageable and read-only rows — a mixed page renders each row correctly but is not marked `data-readonly`). `PortalRow`/`PortalCard` already supported `canOpen={false}` (renders `[data-action-absent="open-portal"]` "— no access —", no anchor/button) from S3 — no changes needed there.
- `frontend/src/pages/PortalsDirectory.tsx` — directory header shows "Portals / Read-only" for an all-read-only 200 page, matching the frame's copy for the fail-closed 403 case while keeping the two states behaviorally distinct (read-only still renders rows; 403 renders none).
- `frontend/tests/portals-directory.frontend.spec.ts` — un-`fixme`'d `d6b`: replaced the FRAME/BUILD-MISMATCH placeholder with two real, passing tests — a uniform read-only page (`data-readonly="true"`, per-row "no access", zero launch anchors/buttons anywhere) and a mixed page (one `canOpen:true` row keeps its real `OpenPortalLink`, wrapper is *not* marked read-only). The existing `d6` 403 no-access test (banner, zero rows) is untouched.

Both the no-access (403, zero rows) and read-only (200, rows with per-row `canOpen`) states now exist side by side. Everything stays behind `fuzefront.platform.portals-directory` (default OFF, unchanged).

## Testing

- [x] Component/contract-level reasoning verified by reading `PortalCard`/`PortalRow` (already S3-built to support `canOpen={false}`)
- [x] Playwright (built-UI acceptance suite) — `frontend/tests/portals-directory.frontend.spec.ts`, including the two un-fixme'd `d6b` tests
- [ ] E2E against a live backend — out of scope for this slice (frontend-test-engineer / live deploy)

### Test Instructions

```bash
npm ci --workspaces --include-workspace-root
cd frontend
npx tsc --noEmit -p tsconfig.json
npx playwright test tests/portals-directory.frontend.spec.ts
```

## Checklist

- [x] Design-system-first — reuses existing S3 DS-composed primitives (`Badge`, `Button`, `ExternalLink`, `Alert`, `SearchField`); zero new hard-coded colors/spacing/type; no DS primitive forked or shadowed.
- [x] Matches the approved frame (`design/frames/portals-directory/02-portals-list-states.html`, d6b) — `data-readonly`, `data-can-open`, `data-action-absent="open-portal"` test hooks wired exactly as declared.
- [x] Feature flag unchanged: `fuzefront.platform.portals-directory`, default OFF.
- [x] Cursor-paginated list unaffected (S3) — read-only rows and "Load more" coexist normally.

## Out of scope (sibling layers, not this PR)

- Backend (`adminPortals` S5 authorization/capability fields) — already merged in #645.
- Independent Playwright QA sign-off / live-app post-deploy verification — `frontend-test-engineer`.
- Helm/Argo/CI/CD — `devops-engineer`.
- Consumer docs — `docs-maintainer`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0127R9Zcw92tmBkxUUuLEB79

---
_Generated by [Claude Code](https://claude.ai/code/session_0127R9Zcw92tmBkxUUuLEB79)_