### PR TITLE
feat: mount FuzeQuality in FuzeFront portal

### DIFF
--- a/FuzeQuality/apps/web/src/api.ts
+++ b/FuzeQuality/apps/web/src/api.ts
@@ -8,6 +8,7 @@ import type {
 export type OrganizationRole = 'owner' | 'admin' | 'member' | 'viewer'
 export type OrganizationMember = { id: string; email?: string; name?: string; displayName?: string; userId?: string; user_id?: string; role: OrganizationRole; status?: string }
 
+
 // The standalone dashboard uses same-origin API calls. When mounted as a
 // FuzeFront federated remote, the browser origin is app.fuzefront.com, so the
 // API origin is injected at build time and remains independent of the host.


### PR DESCRIPTION
Expose FuzeQuality as a Module Federation remote and provision it as a built-in portal app at /app/fuzequality. The remote uses the quality production API origin and allows the portal origin to load federation assets.