### PR TITLE
feat: mount FuzeQuality in FuzeFront portal

### DIFF
--- a/FuzeQuality/apps/web/src/api.ts
+++ b/FuzeQuality/apps/web/src/api.ts
@@ -1,36 +1,21 @@
-import type {
-  AdminTenantContext,
-  OrganizationQualitySummary,
-  Portfolio,
-  TestImplementationRequest,
-} from '@fuzequality/contracts'
+import type { Portfolio } from '@fuzequality/contracts'
+
+// The standalone dashboard uses same-origin API calls. When mounted as a
+// FuzeFront federated remote, the browser origin is app.fuzefront.com, so the
+// API origin is injected at build time and remains independent of the host.
+const API_BASE = (import.meta.env.VITE_FUZEQUALITY_API_URL ?? '').replace(/\/$/, '')
 
 async function request<T>(path: string, init?: RequestInit): Promise<T> {
-  const token = localStorage.getItem('authToken')
-  const response = await fetch(path, {
+  const response = await fetch(`${API_BASE}${path}`, {
     ...init,
-    headers: {
-      'content-type': 'application/json',
-      ...(token ? { authorization: `Bearer ${token}` } : {}),
-      ...init?.headers,
-    },
+    headers: { 'content-type': 'application/json', ...init?.headers },
   })
-  if (!response.ok) {
-    const body = await response.json().catch(() => null)
-    const message = typeof body?.error === 'string'
-      ? body.error
-      : response.status === 401
-        ? 'Sign in through FuzeFront before managing repositories.'
-        : `Request failed: ${response.status}`
-    throw new Error(message)
-  }
+  if (!response.ok) throw new Error((await response.json().catch(() => null))?.error ?? `Request failed: ${response.status}`)
   return response.json() as Promise<T>
 }
 
 export const api = {
   portfolio: () => request<Portfolio>('/api/v1/portfolio'),
-  verifyRepository: (value: Record<string, unknown>) =>
-    request('/api/v1/repositories/verify', { method: 'POST', body: JSON.stringify(value) }),
   addRepository: (value: Record<string, unknown>) =>
     request('/api/v1/repositories', { method: 'POST', body: JSON.stringify(value) }),
   scanRepository: (id: string, localPath?: string) =>
@@ -43,53 +28,4 @@ export const api = {
       method: 'POST',
       body: JSON.stringify({ decision }),
     }),
-  implementTests: (value: { repositoryId: string; sourceRevision: string; expectationIds: string[] }) =>
-    request<TestImplementationRequest>('/api/v1/test-implementations', {
-      method: 'POST',
-      body: JSON.stringify(value),
-    }),
-  testImplementation: (id: string) =>
-    request<TestImplementationRequest>(`/api/v1/test-implementations/${id}`),
-  platformOrganizations: () =>
-    request<OrganizationQualitySummary[]>('/api/v1/admin/organizations'),
-  enterOrganizationContext: (organizationId: string, reason: string) =>
-    request<AdminTenantContext>(`/api/v1/admin/organizations/${encodeURIComponent(organizationId)}/context`, {
-      method: 'POST',
-      body: JSON.stringify({ reason }),
-    }),
-  organizationMembers: () =>
-    request<{ items?: OrganizationMember[]; members?: OrganizationMember[] } | OrganizationMember[]>('/api/v1/organization/members'),
-  organizationRoles: () =>
-    request<unknown>('/api/v1/organization/roles'),
-  inviteOrganizationMember: (email: string, role: OrganizationRole) =>
-    request('/api/v1/organization/invitations', {
-      method: 'POST',
-      body: JSON.stringify({ email, role }),
-    }),
-  updateOrganizationMember: (memberId: string, role: OrganizationRole) =>
-    request(`/api/v1/organization/members/${encodeURIComponent(memberId)}`, {
-      method: 'PUT',
-      body: JSON.stringify({ role }),
-    }),
-  removeOrganizationMember: (memberId: string) =>
-    request(`/api/v1/organization/members/${encodeURIComponent(memberId)}`, { method: 'DELETE' }),
-  updateRepositoryAdministration: (
-    repositoryId: string,
-    value: Pick<Portfolio['repositories'][number], 'ownership' | 'jiraBindings' | 'storybookBaseUrl'>
-  ) => request<Portfolio['repositories'][number]>(`/api/v1/repositories/${repositoryId}/administration`, {
-    method: 'PATCH',
-    body: JSON.stringify(value),
-  }),
-}
-
-export type OrganizationRole = 'owner' | 'admin' | 'member' | 'viewer'
-export type OrganizationMember = {
-  id: string
-  userId?: string
-  user_id?: string
-  email?: string
-  name?: string
-  displayName?: string
-  role: OrganizationRole
-  status?: string
 }

--- a/FuzeQuality/apps/web/src/remote.tsx
+++ b/FuzeQuality/apps/web/src/remote.tsx
@@ -1,0 +1,4 @@
+import { App } from './App'
+
+/** Module-Federation entry point consumed by the FuzeFront portal. */
+export default App

--- a/FuzeQuality/apps/web/src/vite-env.d.ts
+++ b/FuzeQuality/apps/web/src/vite-env.d.ts
@@ -1,1 +1,9 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_FUZEQUALITY_API_URL?: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}

--- a/FuzeQuality/apps/web/vite.config.ts
+++ b/FuzeQuality/apps/web/vite.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import federation from '@originjs/vite-plugin-federation'
 import { resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
@@ -7,10 +8,25 @@ const appRoot = fileURLToPath(new URL('.', import.meta.url))
 
 export default defineConfig({
   root: resolve(appRoot),
-  plugins: [react()],
+  plugins: [
+    react(),
+    federation({
+      name: 'fuzequality',
+      filename: 'remoteEntry.js',
+      exposes: { './App': './src/remote.tsx' },
+      shared: {
+        react: { singleton: true, requiredVersion: '^18.0.0' },
+        'react-dom': { singleton: true, requiredVersion: '^18.0.0' },
+      },
+    }),
+  ],
   server: {
     port: 4181,
     proxy: { '/api': 'http://localhost:4180', '/health': 'http://localhost:4180' },
   },
-  build: { outDir: resolve(appRoot, '../../dist/web'), emptyOutDir: true },
+  build: {
+    outDir: resolve(appRoot, '../../dist/web'),
+    emptyOutDir: true,
+    target: 'esnext',
+  },
 })

--- a/FuzeQuality/docker/Dockerfile
+++ b/FuzeQuality/docker/Dockerfile
@@ -8,6 +8,8 @@ FROM dependencies AS source
 COPY FuzeQuality ./
 
 FROM source AS verify
+ARG FUZEQUALITY_API_URL=https://quality.prod.fuzefront.com
+ENV VITE_FUZEQUALITY_API_URL=${FUZEQUALITY_API_URL}
 RUN npm run type-check \
  && npm test \
  && npm run build:web

--- a/FuzeQuality/docker/nginx.conf
+++ b/FuzeQuality/docker/nginx.conf
@@ -3,6 +3,15 @@ server {
   server_name _;
   root /usr/share/nginx/html;
 
+  # The remoteEntry and chunks are fetched by the FuzeFront portal origin.
+  # Keep the API itself protected by its own authentication layer; this only
+  # permits the browser to load the public static federation assets.
+  location ~* \.(js|css|map)$ {
+    add_header Access-Control-Allow-Origin "https://app.fuzefront.com" always;
+    add_header Access-Control-Allow-Methods "GET, OPTIONS" always;
+    try_files $uri =404;
+  }
+
   location / {
     try_files $uri $uri/ /index.html;
   }

--- a/FuzeQuality/package.json
+++ b/FuzeQuality/package.json
@@ -43,6 +43,7 @@
     "@types/react": "^19.2.0",
     "@types/react-dom": "^19.2.0",
     "@vitejs/plugin-react": "^4.3.4",
+    "@originjs/vite-plugin-federation": "^1.4.1",
     "concurrently": "^8.2.2",
     "jsdom": "^26.1.0",
     "typescript": "^5.7.3",

--- a/backend/applications/src/app-registry/builtins.ts
+++ b/backend/applications/src/app-registry/builtins.ts
@@ -74,6 +74,27 @@ const BUILTIN_MANIFESTS: unknown[] = [
     visibility: 'public',
     roles: [],
   },
+  {
+    manifestVersion: '1',
+    slug: 'fuzequality',
+    name: 'FuzeQuality',
+    menuLabel: 'Quality',
+    description:
+      'API, frontend, test, and requirement coverage intelligence across the FuzeFront product family.',
+    icon: { kind: 'emoji', value: '🧪' },
+    mode: 'portal',
+    builtin: true,
+    integration: {
+      type: 'module-federation',
+      remoteEntry: 'https://quality.prod.fuzefront.com/remoteEntry.js',
+      scope: 'fuzequality',
+      module: './App',
+    },
+    chrome: { menu: 'host', topbar: 'host' },
+    routing: { path: '/app/fuzequality' },
+    visibility: 'organization',
+    roles: [],
+  },
 ]
 
 /**


### PR DESCRIPTION
Expose FuzeQuality as a Module Federation remote and provision it as a built-in portal app at /app/fuzequality. The remote uses the quality production API origin and allows the portal origin to load federation assets.