### PR TITLE
test(frontend): verify portal-scoped app menu end-to-end (FF-EPIC-12-S4)

### DIFF
--- a/frontend/src/components/__tests__/SidePanel.portalScopedApps.test.tsx
+++ b/frontend/src/components/__tests__/SidePanel.portalScopedApps.test.tsx
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import SidePanel from '../SidePanel'
+
+/**
+ * FF-EPIC-12-S4 — the "Apps" menu section renders exactly whatever
+ * `useRegisteredApps()` hands it. The scoping decision (curated
+ * tenant-portal catalog vs. the full root catalog vs. flag-off/pre-epic
+ * global list vs. a fail-closed empty set) is made entirely server-side —
+ * see `appRegistry.portalScoping.test.tsx` for that contract. This suite
+ * proves the MENU itself degrades correctly for each shape of that response:
+ * only the given apps are shown, nothing extra leaks in, and an empty list
+ * never breaks or hangs the menu.
+ */
+
+let mockApps: Array<{ slug: string; manifest: { icon?: unknown; menuLabel: string } }> = []
+
+vi.mock('../../lib/shared', () => ({
+  useCurrentUser: () => ({ user: { roles: ['admin'] } }),
+  useAppContext: () => ({ state: { menuItems: [] } }),
+}))
+vi.mock('../../platform/appRegistry', () => ({
+  useRegisteredApps: () => ({ apps: mockApps }),
+}))
+vi.mock('../../platform/useActiveApp', () => ({
+  useActiveApp: () => null,
+}))
+vi.mock('@fuzefront/i18n', () => ({
+  useT: () => ({
+    t: (_key: string, opts?: { defaultValue?: string }) => opts?.defaultValue ?? _key,
+  }),
+}))
+vi.mock('../../platform/featureFlags', () => ({
+  useFlag: (_key: string, fallback: boolean) => fallback,
+}))
+
+function renderSidePanel() {
+  return render(
+    <MemoryRouter>
+      <SidePanel />
+    </MemoryRouter>,
+  )
+}
+
+const tenantApp = { slug: 'tenant-crm', manifest: { menuLabel: 'CRM' } }
+const rootApps = [
+  { slug: 'clock', manifest: { menuLabel: 'Clock' } },
+  { slug: 'market', manifest: { menuLabel: 'Market' } },
+  // NOT "Billing" — the portal menu's own static section also renders a
+  // "Billing" item (see SidePanel.tsx), so reusing that label here would
+  // make the assertion ambiguous between the two, unrelated sections.
+  { slug: 'timesheets', manifest: { menuLabel: 'Timesheets' } },
+]
+const globalApp = { slug: 'public-directory', manifest: { menuLabel: 'Directory' } }
+
+describe('<SidePanel /> — portal-scoped Apps section (FF-EPIC-12-S4)', () => {
+  afterEach(() => {
+    mockApps = []
+  })
+
+  it('tenant-portal session (scoped): shows ONLY the curated app(s), nothing else', () => {
+    mockApps = [tenantApp]
+    renderSidePanel()
+
+    expect(screen.getByText('Apps')).toBeInTheDocument()
+    expect(screen.getByText('CRM')).toBeInTheDocument()
+    expect(screen.queryByText('Clock')).not.toBeInTheDocument()
+    expect(screen.queryByText('Directory')).not.toBeInTheDocument()
+  })
+
+  it('root-portal session: shows the FULL catalog', () => {
+    mockApps = rootApps
+    renderSidePanel()
+
+    expect(screen.getByText('Apps')).toBeInTheDocument()
+    expect(screen.getByText('Clock')).toBeInTheDocument()
+    expect(screen.getByText('Market')).toBeInTheDocument()
+    expect(screen.getByText('Timesheets')).toBeInTheDocument()
+  })
+
+  it('flag OFF / pre-epic session: unchanged — the global list renders exactly as before', () => {
+    mockApps = [globalApp]
+    renderSidePanel()
+
+    expect(screen.getByText('Apps')).toBeInTheDocument()
+    expect(screen.getByText('Directory')).toBeInTheDocument()
+  })
+
+  it('empty / denied scoped list: the Apps section is gracefully omitted — no crash, no console error, the rest of the menu still renders', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    mockApps = []
+
+    renderSidePanel()
+
+    // No "Apps" heading at all — a clean empty affordance, not a broken/hung
+    // section with a header and no rows.
+    expect(screen.queryByText('Apps')).not.toBeInTheDocument()
+    // The rest of the portal menu is unaffected.
+    expect(screen.getByText('Applications')).toBeInTheDocument()
+    expect(errorSpy).not.toHaveBeenCalled()
+
+    errorSpy.mockRestore()
+  })
+})

--- a/frontend/src/platform/__tests__/appRegistry.portalScoping.test.tsx
+++ b/frontend/src/platform/__tests__/appRegistry.portalScoping.test.tsx
@@ -62,7 +62,7 @@ describe('AppRegistryProvider — portal-scoped catalog (FF-EPIC-12-S4)', () => 
   })
 
   it('tenant-portal session, flag ON (mode "scoped"): shows ONLY the curated apps the backend returned', async () => {
-    ;(AppRegistryClient as unknown as ReturnType<typeof vi.fn>).mockImplementation(() => ({
+    (AppRegistryClient as unknown as ReturnType<typeof vi.fn>).mockImplementation(() => ({
       listApps: vi.fn().mockResolvedValue({ apps: [tenantApp], nextCursor: null }),
     }))
 
@@ -78,7 +78,7 @@ describe('AppRegistryProvider — portal-scoped catalog (FF-EPIC-12-S4)', () => 
   })
 
   it('root-portal session, flag ON (mode "root"): shows the FULL catalog, unfiltered', async () => {
-    ;(AppRegistryClient as unknown as ReturnType<typeof vi.fn>).mockImplementation(() => ({
+    (AppRegistryClient as unknown as ReturnType<typeof vi.fn>).mockImplementation(() => ({
       listApps: vi.fn().mockResolvedValue({
         apps: [rootApp1, rootApp2, rootApp3],
         nextCursor: null,
@@ -96,7 +96,7 @@ describe('AppRegistryProvider — portal-scoped catalog (FF-EPIC-12-S4)', () => 
   })
 
   it('flag OFF (mode "off"): unchanged pre-epic contract — one call, whatever the backend returns is passed through as-is', async () => {
-    ;(AppRegistryClient as unknown as ReturnType<typeof vi.fn>).mockImplementation(() => ({
+    (AppRegistryClient as unknown as ReturnType<typeof vi.fn>).mockImplementation(() => ({
       listApps: vi.fn().mockResolvedValue({ apps: [globalApp], nextCursor: null }),
     }))
 
@@ -115,7 +115,7 @@ describe('AppRegistryProvider — portal-scoped catalog (FF-EPIC-12-S4)', () => 
 
   it('denied / empty scoped list (flag ON, missing or malformed portal context): degrades to an empty, error-free apps list — no crash, no console error', async () => {
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
-    ;(AppRegistryClient as unknown as ReturnType<typeof vi.fn>).mockImplementation(() => ({
+    (AppRegistryClient as unknown as ReturnType<typeof vi.fn>).mockImplementation(() => ({
       // The backend's fail-closed contract (S2 AC4) returns a normal 200
       // with an empty set — never an HTTP error — so this must resolve
       // cleanly, not throw.

--- a/frontend/src/platform/__tests__/appRegistry.portalScoping.test.tsx
+++ b/frontend/src/platform/__tests__/appRegistry.portalScoping.test.tsx
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, waitFor } from '@testing-library/react'
+import { AppRegistryClient } from '@fuzefront/app-registry-client'
+import { AppRegistryProvider, useAppRegistry } from '../appRegistry'
+
+/**
+ * FF-EPIC-12-S4 — frontend coverage for the portal-scoped app menu.
+ *
+ * The scoping decision itself is made ENTIRELY server-side (see
+ * `backend/applications/src/app-registry/portalContext.ts` +
+ * `service.ts`'s `list()`, exercised end-to-end against a real Postgres in
+ * `backend/applications/tests/portal-catalog.integration.test.ts`): the
+ * `fuzefront.apps.portal-catalog` flag and the JWT's `portalId` claim are
+ * resolved by the applications-service before it ever answers
+ * `GET /api/v1/app-registry`. This provider makes exactly ONE unconditional
+ * `listApps({ status: 'activated' })` call and trusts the response as
+ * already-scoped — there is no client-side flag branch to get wrong, and no
+ * second request that could race a first "unscoped" one. These tests mock
+ * that single response for each of the four contract states (tenant-scoped,
+ * root/full, flag-off/pre-epic, denied-empty) and prove the provider passes
+ * each through untouched, without ever surfacing a console error for the
+ * cases that are 200s (not failures).
+ */
+
+vi.mock('@fuzefront/app-registry-client', () => {
+  const listApps = vi.fn()
+  return {
+    AppRegistryClient: vi.fn().mockImplementation(() => ({ listApps })),
+  }
+})
+
+function getMockedListApps() {
+  const results = (AppRegistryClient as unknown as ReturnType<typeof vi.fn>).mock.results
+  const instance = results[results.length - 1]?.value
+  return instance.listApps as ReturnType<typeof vi.fn>
+}
+
+function Probe() {
+  const { apps, loading, error } = useAppRegistry()
+  return (
+    <div>
+      <span data-testid="loading">{String(loading)}</span>
+      <span data-testid="error">{error ?? ''}</span>
+      <ul data-testid="apps">
+        {apps.map(a => (
+          <li key={a.slug}>{a.slug}</li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+
+const tenantApp = { slug: 'tenant-crm', manifest: { menuLabel: 'CRM' } } as any
+const rootApp1 = { slug: 'clock', manifest: { menuLabel: 'Clock' } } as any
+const rootApp2 = { slug: 'market', manifest: { menuLabel: 'Market' } } as any
+const rootApp3 = { slug: 'billing', manifest: { menuLabel: 'Billing' } } as any
+const globalApp = { slug: 'public-directory', manifest: { menuLabel: 'Directory' } } as any
+
+describe('AppRegistryProvider — portal-scoped catalog (FF-EPIC-12-S4)', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('tenant-portal session, flag ON (mode "scoped"): shows ONLY the curated apps the backend returned', async () => {
+    ;(AppRegistryClient as unknown as ReturnType<typeof vi.fn>).mockImplementation(() => ({
+      listApps: vi.fn().mockResolvedValue({ apps: [tenantApp], nextCursor: null }),
+    }))
+
+    const { getByTestId } = render(
+      <AppRegistryProvider>
+        <Probe />
+      </AppRegistryProvider>,
+    )
+
+    await waitFor(() => expect(getByTestId('loading').textContent).toBe('false'))
+    expect(getByTestId('apps').textContent).toBe('tenant-crm')
+    expect(getByTestId('error').textContent).toBe('')
+  })
+
+  it('root-portal session, flag ON (mode "root"): shows the FULL catalog, unfiltered', async () => {
+    ;(AppRegistryClient as unknown as ReturnType<typeof vi.fn>).mockImplementation(() => ({
+      listApps: vi.fn().mockResolvedValue({
+        apps: [rootApp1, rootApp2, rootApp3],
+        nextCursor: null,
+      }),
+    }))
+
+    const { getByTestId } = render(
+      <AppRegistryProvider>
+        <Probe />
+      </AppRegistryProvider>,
+    )
+
+    await waitFor(() => expect(getByTestId('loading').textContent).toBe('false'))
+    expect(getByTestId('apps').textContent).toBe('clockmarketbilling')
+  })
+
+  it('flag OFF (mode "off"): unchanged pre-epic contract — one call, whatever the backend returns is passed through as-is', async () => {
+    ;(AppRegistryClient as unknown as ReturnType<typeof vi.fn>).mockImplementation(() => ({
+      listApps: vi.fn().mockResolvedValue({ apps: [globalApp], nextCursor: null }),
+    }))
+
+    const { getByTestId } = render(
+      <AppRegistryProvider>
+        <Probe />
+      </AppRegistryProvider>,
+    )
+
+    await waitFor(() => {
+      expect(getMockedListApps()).toHaveBeenCalledWith({ status: 'activated' })
+      expect(getMockedListApps()).toHaveBeenCalledTimes(1)
+    })
+    expect(getByTestId('apps').textContent).toBe('public-directory')
+  })
+
+  it('denied / empty scoped list (flag ON, missing or malformed portal context): degrades to an empty, error-free apps list — no crash, no console error', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    ;(AppRegistryClient as unknown as ReturnType<typeof vi.fn>).mockImplementation(() => ({
+      // The backend's fail-closed contract (S2 AC4) returns a normal 200
+      // with an empty set — never an HTTP error — so this must resolve
+      // cleanly, not throw.
+      listApps: vi.fn().mockResolvedValue({ apps: [], nextCursor: null }),
+    }))
+
+    const { getByTestId } = render(
+      <AppRegistryProvider>
+        <Probe />
+      </AppRegistryProvider>,
+    )
+
+    await waitFor(() => expect(getByTestId('loading').textContent).toBe('false'))
+    expect(getByTestId('apps').textContent).toBe('')
+    expect(getByTestId('error').textContent).toBe('')
+    expect(errorSpy).not.toHaveBeenCalled()
+
+    errorSpy.mockRestore()
+  })
+})

--- a/frontend/src/platform/__tests__/appRegistry.portalScoping.test.tsx
+++ b/frontend/src/platform/__tests__/appRegistry.portalScoping.test.tsx
@@ -115,7 +115,8 @@ describe('AppRegistryProvider — portal-scoped catalog (FF-EPIC-12-S4)', () => 
 
   it('denied / empty scoped list (flag ON, missing or malformed portal context): degrades to an empty, error-free apps list — no crash, no console error', async () => {
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
-    (AppRegistryClient as unknown as ReturnType<typeof vi.fn>).mockImplementation(() => ({
+    const MockedClient = AppRegistryClient as unknown as ReturnType<typeof vi.fn>
+    MockedClient.mockImplementation(() => ({
       // The backend's fail-closed contract (S2 AC4) returns a normal 200
       // with an empty set — never an HTTP error — so this must resolve
       // cleanly, not throw.


### PR DESCRIPTION
## 📋 Description

FF-EPIC-12-S4 — frontend portal-scoped app menu. Per the ticket's own "VERIFY BEFORE BUILDING" instruction, this PR is the result of verifying the existing implementation against `origin/master` rather than rebuilding it: **the scoping is already fully implemented and exhaustively tested end-to-end on the backend** (S2/S5). The genuine remaining gap was frontend-side proof and empty/denied-state confirmation, which is what this PR adds.

### What was already done (verified, not rebuilt)
- `frontend/src/components/FederatedAppLoader.tsx` already resolves `tenantId` from `usePortalContext()` (`portal.id` / `'default-tenant'` fallback) — #425/EPIC-10, unchanged.
- The applications-service (`backend/applications/src/app-registry/portalContext.ts` + `service.ts`'s `list()`) independently re-verifies the bearer JWT's `portalId` claim and scopes the catalog in SQL, gated by `fuzefront.apps.portal-catalog` (default OFF). The host-backend proxy (`backend/src/routes/app-registry.ts`) forwards only the `Authorization` header — confirmed by reading the proxy source.
- The fail-closed contract (`mode: 'denied'` → `whereRaw('1 = 0')`, a normal 200 with an empty set, never an HTTP error) is real and already exercised by `backend/applications/tests/portal-catalog.integration.test.ts` against a real Postgres, covering flag off/on × root/scoped/denied, no-leak, and the admin surface.
- `frontend/src/platform/appRegistry.tsx`'s `AppRegistryProvider` makes exactly ONE unconditional `listApps({ status: 'activated' })` call and trusts the response — there is no client-side flag branch, so there is no "unscoped-then-scoped" race to fix (item 3 in the ticket): the scoping decision is made entirely server-side, atomically, before the response is ever sent.
- `SidePanel.tsx`'s Apps section is already gated by `{apps.length > 0 && (...)}`, so an empty/denied response already degrades gracefully — no crash, no hang, no dangling header with zero rows.

**Conclusion: no production code needed to change.** Per the ticket's own item 4, the deliverable is tests + verification + an honest report.

### What this PR adds
- `frontend/src/platform/__tests__/appRegistry.portalScoping.test.tsx` — proves `AppRegistryProvider` passes each of the four backend response shapes through untouched: tenant-scoped, root/full, flag-off/pre-epic, and a denied/empty 200 (asserting no error state and no `console.error`).
- `frontend/src/components/__tests__/SidePanel.portalScopedApps.test.tsx` — proves the "Apps" menu section renders exactly the given apps for scoped/root/flag-off, and is cleanly omitted (no crash, no console error, rest of the menu intact) when empty/denied.

## 🔄 Type of Change

- [x] 🧪 Test addition or improvement

## 🧪 Testing

- [x] Unit tests
- [x] Manual testing (real-Chromium render, see below)

```
cd frontend && npx vitest run --config vitest.config.ts \
  src/platform/__tests__/appRegistry.portalScoping.test.tsx \
  src/components/__tests__/SidePanel.portalScopedApps.test.tsx
# Test Files  2 passed (2) — Tests  8 passed (8)
```

Also ran the full existing frontend suite (139 tests) — all pass; the only 3 failing suites (`App.authed-login-redirect`, `App.portal-shell-flag`, `BillingPage`) fail to *resolve* on missing `@tanstack/react-table` / `@stripe/react-stripe-js` types in unrelated sibling workspace packages whose own `node_modules` aren't populated in this sandbox (only `frontend/`'s own deps were installed) — confirmed pre-existing and unrelated by `git status` showing no changes to any file in those import chains.

### ui-runtime-validation (console-clean gate)

No Chrome DevTools MCP plugin was installed in this session, so per the skill's fallback I used the sandbox's `/opt/pw-browsers` Chromium directly via Playwright. Since this is a data-scoping change to already-shipped UI (no new visual surface) and no live backend/cluster is available in this sandbox, I built a temporary (uncommitted, deleted before push) harness that mounts the **real, unmodified** `SidePanel` + `AppRegistryProvider` + `FeatureFlagProvider` + `I18nProvider` production wiring via the real Vite dev server, intercepting only the network boundary (`/api/v1/app-registry`, `/api/flags`) to feed each of the four backend response shapes.

Rendered desktop (1280×800) for all four states + one small-screen pass (390×844, tenant-scoped):
- **0 real console errors**, 0 uncaught exceptions, 0 CSP/mixed-content violations, 0 real failed/4xx-5xx requests in every state.
- The only network noise is a `net::ERR_CONNECTION_RESET` on the `fonts.googleapis.com` CSS import in `frontend/src/index.css` (pre-existing, unrelated — this sandbox has no external network egress), matching the ticket's own named "known env noise" category.
- Visually confirmed: tenant-scoped shows only "CRM" under "Apps"; the empty/denied state shows no "Apps" heading at all, with the rest of the Portal menu (Applications/Organizations/Profile/Billing/Admin/Help/Status) fully intact and unaffected.

## 🔧 Implementation Details

### Changes Made

- **Frontend Changes:** two new test files only — no production code changed.

## 📋 Checklist

### Pre-submission

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove the feature works
- [x] New and existing unit tests pass locally with my changes

### Code Quality

- [x] TypeScript strict mode passes (`tsc --noEmit` clean for both new files; pre-existing unrelated errors in other files confirmed via `git status`)
- [x] No security vulnerabilities introduced

## Gates

- **gate-frames-first**: ran `node scripts/check-frames-first.mjs --files <the two new test files>` locally → `OK`. Both files match `**/__tests__/**` / `**/*.test.tsx` in `governance/frames-first-policy.json`'s `nonFeaturePaths` (structural test-file exclusion), so no frame coverage is required. No production UI paths changed. The existing `design/frames/federated-apps/01-app-menu.html` frame already covers the Apps-menu happy path this PR verifies against; no new frames were fabricated.
- **design-system-conformance**: N/A — test files only, no styling.
- **ui-runtime-validation**: see above.

## 🎯 Reviewers

Please request review from the epic owner.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0127R9Zcw92tmBkxUUuLEB79


---
_Generated by [Claude Code](https://claude.ai/code/session_0127R9Zcw92tmBkxUUuLEB79)_