### PR TITLE
feat(provisioning): react to org updated + deleted (FFRNT-174 slice 2)

### DIFF
--- a/backend/security/src/routes/internal.ts
+++ b/backend/security/src/routes/internal.ts
@@ -1,8 +1,28 @@
 import crypto from 'crypto'
 import express from 'express'
-import { runInternalProvision } from '../services/organizationProvisioning'
+import {
+  runInternalProvision,
+  deprovisionOrganization,
+} from '../services/organizationProvisioning'
 
 const router = express.Router()
+
+/**
+ * Constant-time check of the shared `x-internal-secret` header against
+ * INTERNAL_PROVISION_SECRET. Fails closed when the secret is unconfigured.
+ */
+function isAuthorized(req: express.Request): boolean {
+  const expected = process.env.INTERNAL_PROVISION_SECRET
+  const provided = req.header('x-internal-secret')
+  const a = Buffer.from(provided || '')
+  const b = Buffer.from(expected || '')
+  return !(
+    !expected ||
+    !provided ||
+    a.length !== b.length ||
+    !crypto.timingSafeEqual(a, b)
+  )
+}
 
 /**
  * Internal, service-to-service provisioning endpoint.
@@ -25,16 +45,7 @@ const router = express.Router()
  * Idempotent; safe to retry.
  */
 router.post('/provision', async (req, res) => {
-  const expected = process.env.INTERNAL_PROVISION_SECRET
-  const provided = req.header('x-internal-secret')
-
-  // Fail closed: if no secret is configured the endpoint is unusable; use a
-  // constant-time compare (I1) to prevent timing-based secret oracle attacks.
-  const a = Buffer.from(provided || '')
-  const b = Buffer.from(expected || '')
-  const unauthorised =
-    !expected || !provided || a.length !== b.length || !crypto.timingSafeEqual(a, b)
-  if (unauthorised) {
+  if (!isAuthorized(req)) {
     return res.status(401).json({ error: 'Unauthorized' })
   }
 
@@ -51,6 +62,41 @@ router.post('/provision', async (req, res) => {
     return res
       .status(500)
       .json({ error: 'Provisioning failed', detail: String(error?.message ?? error) })
+  }
+})
+
+/**
+ * Internal, service-to-service DE-provisioning endpoint — the teardown mirror of
+ * /provision, called by provisioning-service on `identity.org.deleted`.
+ *
+ *   POST /internal/deprovision
+ *   Headers: x-internal-secret: <INTERNAL_PROVISION_SECRET>
+ *   Body:    { "organizationId": "<uuid>", "cascade": "soft" | "hard" }
+ *   200 { ok: true, organizationId, cascade, rolesRevoked, tenantDeleted }
+ *   400 { error } missing organizationId
+ *   401 { error } bad/missing secret
+ *
+ * Idempotent + best-effort; safe to retry.
+ */
+router.post('/deprovision', async (req, res) => {
+  if (!isAuthorized(req)) {
+    return res.status(401).json({ error: 'Unauthorized' })
+  }
+
+  const { organizationId, cascade } = req.body || {}
+  if (!organizationId || typeof organizationId !== 'string') {
+    return res.status(400).json({ error: 'organizationId is required' })
+  }
+  const mode: 'soft' | 'hard' = cascade === 'hard' ? 'hard' : 'soft'
+
+  try {
+    const result = await deprovisionOrganization(organizationId, mode)
+    return res.status(200).json({ ok: true, ...result })
+  } catch (error: any) {
+    console.error('Internal deprovision failed:', error)
+    return res
+      .status(500)
+      .json({ error: 'Deprovisioning failed', detail: String(error?.message ?? error) })
   }
 })
 

--- a/backend/security/src/services/organizationProvisioning.ts
+++ b/backend/security/src/services/organizationProvisioning.ts
@@ -2,9 +2,16 @@ import { v4 as uuidv4 } from 'uuid'
 import { mintId, toUuid } from '@izzywdev/fuzefront-identity'
 import { db as defaultDb } from '../config/database'
 import { Organization } from '../types/shared'
-import { createTenantInPermit } from '../utils/permit/tenant-management'
+import {
+  createTenantInPermit,
+  deleteTenantFromPermit,
+} from '../utils/permit/tenant-management'
 import { syncUserToPermit } from '../utils/permit/user-sync'
-import { assignOrganizationRole } from '../utils/permit/role-assignment'
+import {
+  assignOrganizationRole,
+  unassignOrganizationRole,
+} from '../utils/permit/role-assignment'
+import { deleteResourceInstance } from '../utils/permit/resource-instances'
 import { isRootMembershipEnabled } from '../utils/rootMembershipFlag'
 import { ROOT_ORG_ID } from '../migrations/014_seed_root_platform_organization'
 import {
@@ -409,6 +416,61 @@ export async function reconcileOrganizationProvisioning(
  * Either way, every org the user OWNS that isn't yet `active` is still
  * reconciled — unaffected by the flag.
  */
+/**
+ * Tear down an organization's Permit access when `identity.org.deleted` fires.
+ *
+ * - `cascade='soft'` (the current org DELETE — `is_active=false`, reversible):
+ *   revoke every active member's Permit role so no one retains access while the
+ *   org is deactivated, but KEEP the Permit tenant + resource instance so a
+ *   later reactivation restores cleanly.
+ * - `cascade='hard'`: additionally delete the `Organization` resource instance
+ *   and the Permit tenant.
+ *
+ * Best-effort + idempotent: Permit failures are logged, not thrown, so a retry
+ * re-runs the same no-op-safe steps. Safe for an org that was never provisioned.
+ */
+export async function deprovisionOrganization(
+  organizationId: string,
+  cascade: 'soft' | 'hard' = 'soft',
+  overrides?: Partial<ProvisioningDeps>
+): Promise<{
+  organizationId: string
+  cascade: 'soft' | 'hard'
+  rolesRevoked: number
+  tenantDeleted: boolean
+}> {
+  const { db } = getDeps(overrides)
+
+  const memberships = await db('organization_memberships')
+    .where({ organization_id: organizationId, status: 'active' })
+    .select('user_id', 'role')
+
+  let rolesRevoked = 0
+  for (const m of memberships) {
+    const ok = await unassignOrganizationRole(
+      m.user_id,
+      organizationId,
+      m.role as 'owner' | 'admin' | 'member' | 'viewer'
+    )
+    if (ok) rolesRevoked++
+  }
+
+  let tenantDeleted = false
+  if (cascade === 'hard') {
+    // Org resource instance key format is `<resource>:<key>` (see
+    // createOrganizationResourceInstance: resource 'Organization', key = org id).
+    await deleteResourceInstance(`Organization:${organizationId}`)
+    tenantDeleted = await deleteTenantFromPermit(organizationId)
+  }
+
+  logger.info(
+    { organizationId, cascade, rolesRevoked, tenantDeleted },
+    'deprovisionOrganization complete'
+  )
+
+  return { organizationId, cascade, rolesRevoked, tenantDeleted }
+}
+
 export async function runInternalProvision(
   userId: string,
   overrides?: Partial<ProvisioningDeps>

--- a/backend/security/src/utils/permit/role-assignment.ts
+++ b/backend/security/src/utils/permit/role-assignment.ts
@@ -166,8 +166,11 @@ export async function unassignOrganizationRole(
       tenant: organizationId,
     })
   } catch (error) {
+    // Constant format string (userId passed as an argument, not interpolated)
+    // to satisfy the log-injection SAST rule.
     console.error(
-      `Error unassigning organization role for user ${userId}:`,
+      'Error unassigning organization role for user',
+      userId,
       error
     )
     return false

--- a/backend/security/src/utils/permit/role-assignment.ts
+++ b/backend/security/src/utils/permit/role-assignment.ts
@@ -140,6 +140,41 @@ export async function assignOrganizationRole(
 }
 
 /**
+ * Unassigns the Permit role that corresponds to a membership role — the mirror
+ * of `assignOrganizationRole` (same role mapping). Best-effort: returns false
+ * rather than throwing.
+ */
+export async function unassignOrganizationRole(
+  userId: string,
+  organizationId: string,
+  membershipRole: 'owner' | 'admin' | 'member' | 'viewer'
+): Promise<boolean> {
+  try {
+    // Same mapping as assignOrganizationRole.
+    const roleMapping: Record<string, string> = {
+      owner: 'admin',
+      admin: 'admin',
+      member: 'editor',
+      viewer: 'viewer',
+    }
+
+    const permitRole = roleMapping[membershipRole] || 'viewer'
+
+    return await unassignRoleInPermit({
+      user: userId,
+      role: permitRole,
+      tenant: organizationId,
+    })
+  } catch (error) {
+    console.error(
+      `Error unassigning organization role for user ${userId}:`,
+      error
+    )
+    return false
+  }
+}
+
+/**
  * Updates user role when membership role changes
  */
 export async function updateOrganizationRole(

--- a/governance/identifier-allowlist.txt
+++ b/governance/identifier-allowlist.txt
@@ -44,11 +44,11 @@
 src backend/core/src/events/outbox.ts:34                    # event_outbox row id
 src backend/src/services/organizationProvisioning.ts:367    # event_outbox row id
 src backend/src/services/portalProvisioning.ts:591          # event_outbox row id
-src backend/security/src/services/organizationProvisioning.ts:287  # event_outbox row id
+src backend/security/src/services/organizationProvisioning.ts:294  # event_outbox row id
 
 # Provisioning workflow step rows: bookkeeping for a saga, not entities.
 src backend/src/services/organizationProvisioning.ts:275    # organization_provisioning step row
-src backend/security/src/services/organizationProvisioning.ts:241  # organization_provisioning step row
+src backend/security/src/services/organizationProvisioning.ts:248  # organization_provisioning step row
 src backend/src/services/portalProvisioning.ts:250          # portal_provisioning step row
 
 # One-shot credential artifacts. Same family as the token/nonce/verifier targets

--- a/services/provisioning-service/src/handler.ts
+++ b/services/provisioning-service/src/handler.ts
@@ -2,8 +2,15 @@ import {
   FuzeEvent,
   IdentityUserCreatedPayloadV1,
   IdentityOrgCreatedPayloadV1,
+  IdentityOrgUpdatedPayloadV1,
+  IdentityOrgDeletedPayloadV1,
 } from '@fuzefront/shared/kafka';
-import { callProvision, HttpClient, nodeFetchClient } from './provision';
+import {
+  callProvision,
+  callDeprovision,
+  HttpClient,
+  nodeFetchClient,
+} from './provision';
 
 export interface HandlerDeps {
   securityServiceUrl: string;
@@ -76,5 +83,68 @@ export async function handleOrgCreated(
 
   console.log(
     `[provisioning-service] Reconciled org ${organizationId} (owner ${ownerId}): reconciled=${result.reconciled}`
+  );
+}
+
+/**
+ * Handles an identity.org.updated event by re-reconciling the org's Permit
+ * wiring — the same idempotent /internal/provision (by owner) re-syncs the
+ * org's current state. Skips ownerless (root/platform) orgs.
+ */
+export async function handleOrgUpdated(
+  event: FuzeEvent<IdentityOrgUpdatedPayloadV1>,
+  deps: HandlerDeps
+): Promise<void> {
+  const { organizationId, ownerId } = event.payload;
+
+  if (!ownerId) {
+    console.log(
+      `[provisioning-service] org ${organizationId} has no owner — skipping re-sync (correlationId=${event.correlationId})`
+    );
+    return;
+  }
+
+  const http = deps.http ?? nodeFetchClient;
+
+  console.log(
+    `[provisioning-service] Re-syncing org ${organizationId} via owner ${ownerId} (correlationId=${event.correlationId})`
+  );
+
+  await callProvision(
+    ownerId,
+    deps.securityServiceUrl,
+    deps.internalProvisionSecret,
+    http
+  );
+}
+
+/**
+ * Handles an identity.org.deleted event by tearing down the org's Permit access
+ * via security /internal/deprovision. `cascade` ('soft'|'hard') is forwarded so
+ * a soft delete revokes access (reversible) and a hard delete removes the
+ * tenant. The TypedConsumer already validated the payload against
+ * identityOrgDeletedSchemaV1.
+ */
+export async function handleOrgDeleted(
+  event: FuzeEvent<IdentityOrgDeletedPayloadV1>,
+  deps: HandlerDeps
+): Promise<void> {
+  const { organizationId, cascade } = event.payload;
+  const http = deps.http ?? nodeFetchClient;
+
+  console.log(
+    `[provisioning-service] Deprovisioning org ${organizationId} (cascade=${cascade}, correlationId=${event.correlationId})`
+  );
+
+  const result = await callDeprovision(
+    organizationId,
+    cascade,
+    deps.securityServiceUrl,
+    deps.internalProvisionSecret,
+    http
+  );
+
+  console.log(
+    `[provisioning-service] Deprovisioned org ${organizationId}: rolesRevoked=${result.rolesRevoked} tenantDeleted=${result.tenantDeleted}`
   );
 }

--- a/services/provisioning-service/src/index.ts
+++ b/services/provisioning-service/src/index.ts
@@ -8,9 +8,19 @@ import {
   identityUserCreatedSchemaV1,
   IdentityOrgCreatedPayloadV1,
   identityOrgCreatedSchemaV1,
+  IdentityOrgUpdatedPayloadV1,
+  identityOrgUpdatedSchemaV1,
+  IdentityOrgDeletedPayloadV1,
+  identityOrgDeletedSchemaV1,
 } from '@fuzefront/shared/kafka';
 import { loadConfig } from './config';
-import { handleUserCreated, handleOrgCreated, HandlerDeps } from './handler';
+import {
+  handleUserCreated,
+  handleOrgCreated,
+  handleOrgUpdated,
+  handleOrgDeleted,
+  HandlerDeps,
+} from './handler';
 import { createApp } from './app';
 
 async function main() {
@@ -85,6 +95,30 @@ async function main() {
     dlqProducer
   );
 
+  // identity.org.updated -> re-reconcile the org's Permit wiring.
+  const orgUpdatedConsumer = new TypedConsumer(kafka, `${config.kafka.groupId}-org-updated`);
+  await orgUpdatedConsumer.connect();
+  await orgUpdatedConsumer.subscribe(TOPICS.IDENTITY_ORG_UPDATED);
+  await orgUpdatedConsumer.run(
+    withDlq<IdentityOrgUpdatedPayloadV1>(TOPICS.IDENTITY_ORG_UPDATED, event =>
+      handleOrgUpdated(event, handlerDeps)
+    ),
+    identityOrgUpdatedSchemaV1,
+    dlqProducer
+  );
+
+  // identity.org.deleted -> tear down the org's Permit access (soft/hard).
+  const orgDeletedConsumer = new TypedConsumer(kafka, `${config.kafka.groupId}-org-deleted`);
+  await orgDeletedConsumer.connect();
+  await orgDeletedConsumer.subscribe(TOPICS.IDENTITY_ORG_DELETED);
+  await orgDeletedConsumer.run(
+    withDlq<IdentityOrgDeletedPayloadV1>(TOPICS.IDENTITY_ORG_DELETED, event =>
+      handleOrgDeleted(event, handlerDeps)
+    ),
+    identityOrgDeletedSchemaV1,
+    dlqProducer
+  );
+
   // --- HTTP health probe ---
   const app = createApp();
   app.listen(config.port, () => {
@@ -96,6 +130,8 @@ async function main() {
     console.log('[provisioning-service] Shutting down...');
     await userConsumer.disconnect();
     await orgConsumer.disconnect();
+    await orgUpdatedConsumer.disconnect();
+    await orgDeletedConsumer.disconnect();
     await dlqProducer.disconnect();
     process.exit(0);
   };

--- a/services/provisioning-service/src/provision.ts
+++ b/services/provisioning-service/src/provision.ts
@@ -72,3 +72,59 @@ export async function callProvision(
 
   throw lastError ?? new Error('callProvision: exhausted retries');
 }
+
+export interface DeprovisionResult {
+  ok: boolean;
+  organizationId: string;
+  cascade: string;
+  rolesRevoked: number;
+  tenantDeleted: boolean;
+}
+
+/**
+ * Calls security-service POST /internal/deprovision to tear down an org's Permit
+ * access. Same retry/backoff + idempotency contract as callProvision.
+ */
+export async function callDeprovision(
+  organizationId: string,
+  cascade: string,
+  securityServiceUrl: string,
+  internalProvisionSecret: string,
+  http: HttpClient = nodeFetchClient
+): Promise<DeprovisionResult> {
+  let lastError: Error | null = null;
+
+  for (let attempt = 0; attempt <= RETRY_COUNT; attempt++) {
+    if (attempt > 0) {
+      const delay = Math.min(RETRY_BASE_MS * Math.pow(RETRY_FACTOR, attempt - 1), RETRY_MAX_MS);
+      await sleep(delay);
+    }
+
+    const response = await http.fetch(`${securityServiceUrl}/internal/deprovision`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-internal-secret': internalProvisionSecret,
+      },
+      body: JSON.stringify({ organizationId, cascade }),
+    });
+
+    if (response.status === 200) {
+      const body = await response.json();
+      return body as DeprovisionResult;
+    }
+
+    if (response.status >= 500) {
+      lastError = new Error(`security-service returned ${response.status} (attempt ${attempt + 1})`);
+      console.warn(`[provisioning-service] Transient error: ${lastError.message}`);
+      continue;
+    }
+
+    const body = await response.json().catch(() => ({}));
+    throw new Error(
+      `security-service returned ${response.status}: ${JSON.stringify(body)}`
+    );
+  }
+
+  throw lastError ?? new Error('callDeprovision: exhausted retries');
+}

--- a/services/provisioning-service/tests/org-updated-deleted-handler.test.ts
+++ b/services/provisioning-service/tests/org-updated-deleted-handler.test.ts
@@ -1,0 +1,121 @@
+import { handleOrgUpdated, handleOrgDeleted } from '../src/handler';
+import {
+  FuzeEvent,
+  TOPICS,
+  IdentityOrgUpdatedPayloadV1,
+  IdentityOrgDeletedPayloadV1,
+} from '@fuzefront/shared/kafka';
+import { HttpClient } from '../src/provision';
+
+const SECRET = 'test-secret';
+const SECURITY_URL = 'http://security:3002';
+const OWNER_ID = '22222222-2222-2222-2222-222222222222';
+const ORG_ID = '33333333-3333-3333-3333-333333333333';
+
+function updatedEvent(
+  overrides: Partial<IdentityOrgUpdatedPayloadV1> = {}
+): FuzeEvent<IdentityOrgUpdatedPayloadV1> {
+  return {
+    version: '1.0',
+    topic: TOPICS.IDENTITY_ORG_UPDATED,
+    correlationId: 'corr-org-upd',
+    occurredAt: new Date().toISOString(),
+    payload: {
+      organizationId: ORG_ID,
+      slug: 'acme',
+      name: 'Acme Inc',
+      type: 'organization',
+      parentId: null,
+      ownerId: OWNER_ID,
+      isActive: true,
+      ...overrides,
+    },
+  };
+}
+
+function deletedEvent(
+  overrides: Partial<IdentityOrgDeletedPayloadV1> = {}
+): FuzeEvent<IdentityOrgDeletedPayloadV1> {
+  return {
+    version: '1.0',
+    topic: TOPICS.IDENTITY_ORG_DELETED,
+    correlationId: 'corr-org-del',
+    occurredAt: new Date().toISOString(),
+    payload: {
+      organizationId: ORG_ID,
+      slug: 'acme',
+      ownerId: OWNER_ID,
+      cascade: 'soft',
+      ...overrides,
+    },
+  };
+}
+
+function makeHttpClient(
+  responses: Array<{ status: number; body?: object }>
+): HttpClient & { calls: any[] } {
+  const calls: any[] = [];
+  let idx = 0;
+  return {
+    calls,
+    fetch: jest.fn(async (url: string, init: RequestInit) => {
+      const resp = responses[idx] ?? responses[responses.length - 1];
+      idx++;
+      calls.push({ url, init, respondedWith: resp });
+      return { status: resp.status, json: async () => resp.body ?? {} };
+    }),
+  };
+}
+
+const deps = (http: HttpClient) => ({
+  securityServiceUrl: SECURITY_URL,
+  internalProvisionSecret: SECRET,
+  http,
+});
+
+describe('handleOrgUpdated', () => {
+  it('re-reconciles via /internal/provision with the owner id', async () => {
+    const http = makeHttpClient([{ status: 200, body: { ok: true, personalOrgId: null, reconciled: true } }]);
+    await handleOrgUpdated(updatedEvent(), deps(http));
+    expect(http.calls).toHaveLength(1);
+    expect(http.calls[0].url).toBe(`${SECURITY_URL}/internal/provision`);
+    expect(JSON.parse(http.calls[0].init.body as string)).toEqual({ userId: OWNER_ID });
+  });
+
+  it('skips when the org has no owner', async () => {
+    const http = makeHttpClient([{ status: 200 }]);
+    await handleOrgUpdated(updatedEvent({ ownerId: null, type: 'platform' }), deps(http));
+    expect(http.calls).toHaveLength(0);
+  });
+});
+
+describe('handleOrgDeleted', () => {
+  it('calls /internal/deprovision with organizationId + cascade', async () => {
+    const http = makeHttpClient([
+      { status: 200, body: { ok: true, organizationId: ORG_ID, cascade: 'soft', rolesRevoked: 2, tenantDeleted: false } },
+    ]);
+    await handleOrgDeleted(deletedEvent(), deps(http));
+    expect(http.calls).toHaveLength(1);
+    expect(http.calls[0].url).toBe(`${SECURITY_URL}/internal/deprovision`);
+    expect(JSON.parse(http.calls[0].init.body as string)).toEqual({
+      organizationId: ORG_ID,
+      cascade: 'soft',
+    });
+  });
+
+  it('forwards a hard cascade', async () => {
+    const http = makeHttpClient([
+      { status: 200, body: { ok: true, organizationId: ORG_ID, cascade: 'hard', rolesRevoked: 0, tenantDeleted: true } },
+    ]);
+    await handleOrgDeleted(deletedEvent({ cascade: 'hard' }), deps(http));
+    expect(JSON.parse(http.calls[0].init.body as string)).toEqual({
+      organizationId: ORG_ID,
+      cascade: 'hard',
+    });
+  });
+
+  it('propagates a non-retryable failure so the caller can dead-letter', async () => {
+    const http = makeHttpClient([{ status: 400, body: { error: 'bad' } }]);
+    await expect(handleOrgDeleted(deletedEvent(), deps(http))).rejects.toThrow(/security-service returned 400/);
+  });
+});


### PR DESCRIPTION
## 📋 Description

FFRNT-174 slice 2 (after #599). provisioning-service now reacts to the **remaining org lifecycle events**, so the full create/update/delete loop is wired:

- **`identity.org.updated`** → re-reconcile via the idempotent `/internal/provision` (by owner), re-syncing the org's current state.
- **`identity.org.deleted`** → tear down the org's Permit access via a **new** security `POST /internal/deprovision`.

## 🔄 Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🧪 Test addition or improvement

## 🧪 Testing

- [x] Unit tests — `services/provisioning-service`: `npx jest` → 16 pass (4 suites), `tsc --noEmit` clean. `backend/security`: `tsc --noEmit` clean.

## 🔧 Implementation Details

**Soft-delete semantics:** org DELETE is a soft delete (`cascade:'soft'`, reversible). On soft, `deprovisionOrganization` **revokes active members' Permit roles** (removes access) but **keeps** the tenant + resource instance so reactivation restores cleanly. `cascade:'hard'` additionally deletes the `Organization` resource instance + Permit tenant.

- **security-service**
  - `utils/permit/role-assignment.ts` — `unassignOrganizationRole()` mirrors `assignOrganizationRole` (same role mapping; wraps existing `unassignRoleInPermit`).
  - `services/organizationProvisioning.ts` — `deprovisionOrganization(orgId, cascade)`: enumerate active `organization_memberships`, unassign each (best-effort, log+continue); `hard` also `deleteResourceInstance` + `deleteTenantFromPermit`. Idempotent; safe for a never-provisioned org.
  - `routes/internal.ts` — `POST /internal/deprovision { organizationId, cascade }`, same `x-internal-secret` guard (extracted `isAuthorized()`; `/provision` now uses it too).
- **provisioning-service**
  - `provision.ts` — `callDeprovision()` mirrors `callProvision` (5xx retry/backoff, throw on 4xx).
  - `handler.ts` — `handleOrgUpdated` (provision-by-owner; skip ownerless) + `handleOrgDeleted` (deprovision with cascade).
  - `index.ts` — two more `TypedConsumer`s via the existing `withDlq` wrapper (`identity.org.updated`, `identity.org.deleted`), groupIds `<group>-org-updated` / `<group>-org-deleted`; all disconnect on shutdown.
  - `tests/org-updated-deleted-handler.test.ts` — provision-by-owner / skip, deprovision soft+hard, error→DLQ.

Topics `identity.org.updated/deleted` + `.dlq` were already provisioned by the `kafka-topics-job` (#520).

## 🔗 Related Issues and PRs

- **FFRNT-174** slice 2. Follows #599; builds on #520, #530. Anchor story **FFRNT-115**.

## 📝 Additional Notes

### Deployment Notes

- [x] No config/schema change — reuses `KAFKA_BROKERS` / `SECURITY_SERVICE_URL` / `INTERNAL_PROVISION_SECRET`; consumes existing topics + DLQs; new internal endpoint is cluster-internal only.

### Future Work (remaining FFRNT-174)

- Cross-service `identity.org.deleted` reactions in **billing** (cancel Stripe subscription) and **portal** (teardown portals); `identity.user.updated|deleted`; `identity.membership.*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HxwMXu8tusGrFcZe6iC9j8)_