### PR TITLE
fix: post-prod Playwright smoke — prod-post-deploy.yml chronic failure

### DIFF
--- a/.github/workflows/post-prod-e2e.yml
+++ b/.github/workflows/post-prod-e2e.yml
@@ -39,6 +39,8 @@ on:
         required: false
       POST_PROD_PASSWORD:
         required: false
+      AUTHENTIK_ADMIN_TOKEN:
+        required: false
 
 permissions:
   contents: read
@@ -73,6 +75,14 @@ jobs:
           # Falls back to the seeded admin creds inside the spec when unset.
           POST_PROD_EMAIL: ${{ secrets.POST_PROD_EMAIL }}
           POST_PROD_PASSWORD: ${{ secrets.POST_PROD_PASSWORD }}
+          # Authentik admin token — required only for the credential-drift self-heal
+          # path in test 7. When POST_PROD_PASSWORD no longer matches the Authentik
+          # account (e.g. the secret was rotated), the spec calls
+          # GET /api/v3/core/users/?email=<EMAIL> then
+          # POST /api/v3/core/users/{pk}/set_password/ to reset it, then retries.
+          # Without this token the spec fails with a clear diagnostic instead of
+          # silently looping on 401.
+          AUTHENTIK_ADMIN_TOKEN: ${{ secrets.AUTHENTIK_ADMIN_TOKEN }}
         run: cd frontend && npx playwright test --config playwright.post-prod.config.ts --grep-invert "@authn-pending-deploy" --reporter=list,html
 
       # AuthN provider-boundary smoke (contract PR #243). Runs only when

--- a/.github/workflows/prod-post-deploy.yml
+++ b/.github/workflows/prod-post-deploy.yml
@@ -117,3 +117,4 @@ jobs:
     secrets:
       POST_PROD_EMAIL: ${{ secrets.POST_PROD_EMAIL }}
       POST_PROD_PASSWORD: ${{ secrets.POST_PROD_PASSWORD }}
+      AUTHENTIK_ADMIN_TOKEN: ${{ secrets.AUTHENTIK_ADMIN_TOKEN }}

--- a/frontend/e2e/post-prod/live-smoke.spec.ts
+++ b/frontend/e2e/post-prod/live-smoke.spec.ts
@@ -241,13 +241,79 @@ test.describe('FuzeFront live post-prod smoke', () => {
       const loginResp = await request.post('/api/v1/security/session', {
         data: { email: EMAIL, password: PASSWORD },
       })
-      expect(
-        loginResp.status(),
-        `POST /api/v1/security/session -> ${loginResp.status()} — ${EMAIL} EXISTS but its ` +
-          'credentials were rejected, so POST_PROD_PASSWORD does not match the account. Reset it in ' +
-          'prod and update the secret; do NOT hard-code a password here (public repo). 5xx = backend error.'
-      ).toBe(200)
-      loginBody = await loginResp.json()
+
+      if (loginResp.status() === 401) {
+        // Self-heal: credential drift — the account exists but POST_PROD_PASSWORD
+        // no longer matches what Authentik has stored (e.g. the secret was rotated
+        // without resetting the Authentik user). Use the Authentik admin API to
+        // reset the password, then retry sign-in. Mirrors the pattern in
+        // backend/security/src/providers/authentik/accountApi.ts (findUserPk /
+        // setUserPassword). This runs only when AUTHENTIK_ADMIN_TOKEN is set; if
+        // it is not, fail with a diagnostic that names the secret to add.
+        const authentikAdminToken = process.env.AUTHENTIK_ADMIN_TOKEN
+        const authOrigin = process.env.POST_PROD_AUTH_ORIGIN || 'https://auth.fuzefront.com'
+        expect(
+          authentikAdminToken,
+          `POST /api/v1/security/session -> 401: ${EMAIL} exists but credentials were rejected. ` +
+            `Credential drift: POST_PROD_PASSWORD was likely rotated without resetting the Authentik account. ` +
+            `Set the AUTHENTIK_ADMIN_TOKEN workflow secret to enable automatic self-heal. ` +
+            `Without it, manually reset the Authentik password in prod and update POST_PROD_PASSWORD.`
+        ).toBeTruthy()
+
+        // Find the Authentik user's numeric pk via exact email match.
+        const findResp = await request.get(`${authOrigin}/api/v3/core/users/`, {
+          params: { email: EMAIL },
+          headers: { Authorization: `Bearer ${authentikAdminToken}`, Accept: 'application/json' },
+        })
+        expect(
+          findResp.status(),
+          `Self-heal: Authentik admin user lookup -> ${findResp.status()} (401/403 = admin token invalid or lacks User Manager permission)`
+        ).toBe(200)
+        const findData = await findResp.json()
+        const hits: Array<{ pk: number; email: string }> = findData?.results ?? []
+        const userPk = hits.find(u => u.email?.toLowerCase() === EMAIL.toLowerCase())?.pk
+        expect(
+          userPk,
+          `Self-heal: Authentik user not found for ${EMAIL} — was the account deleted outside the smoke?`
+        ).toBeTruthy()
+
+        // Reset the Authentik password to match the current POST_PROD_PASSWORD.
+        const resetResp = await request.post(
+          `${authOrigin}/api/v3/core/users/${userPk}/set_password/`,
+          {
+            data: { password: PASSWORD },
+            headers: { Authorization: `Bearer ${authentikAdminToken}` },
+          }
+        )
+        expect(
+          resetResp.status(),
+          `Self-heal: Authentik set_password -> ${resetResp.status()} ` +
+            `(400 = password rejected by Authentik policy; 403 = admin token lacks write permission)`
+        ).toBeLessThan(300)
+
+        // Retry sign-in — must succeed with the reset password.
+        const retryResp = await request.post('/api/v1/security/session', {
+          data: { email: EMAIL, password: PASSWORD },
+        })
+        expect(
+          retryResp.status(),
+          `Sign-in retry after self-heal (Authentik set_password) -> ${retryResp.status()}: ` +
+            `password was reset in Authentik but sign-in still failed`
+        ).toBe(200)
+        loginBody = await retryResp.json()
+        testInfo.annotations.push({
+          type: 'self-healed',
+          description:
+            `Stale Authentik password for ${EMAIL} was reset via admin API and sign-in retried successfully`,
+        })
+      } else {
+        expect(
+          loginResp.status(),
+          `POST /api/v1/security/session -> ${loginResp.status()} — ${EMAIL} EXISTS but its ` +
+            'credentials were rejected. 5xx = backend error.'
+        ).toBe(200)
+        loginBody = await loginResp.json()
+      }
     }
     expect(
       loginBody.status,


### PR DESCRIPTION
## Root cause

The `postprod-smoke@fuzefront.com` synthetic account was self-provisioned on an earlier CI run. Since then, `POST_PROD_PASSWORD` and the Authentik-stored password drifted — they no longer match. Every run from #76–#92 hit the `else` branch of test 7 (account exists → sign-in), received a 401 from `POST /api/v1/security/session`, and hard-failed across all 3 Playwright retries. Tests 1–6 and 8 all pass because they require no authentication.

## Fix

**`frontend/e2e/post-prod/live-smoke.spec.ts`** — When `POST /api/v1/security/session` returns 401 in the steady-state sign-in branch, the spec now self-heals using the Authentik admin API (the same pattern already used by `backend/security/src/providers/authentik/accountApi.ts`):

1. `GET https://auth.fuzefront.com/api/v3/core/users/?email=<EMAIL>` — find the user's numeric `pk` by exact email match.
2. `POST .../api/v3/core/users/{pk}/set_password/` — reset the Authentik password to match the current `POST_PROD_PASSWORD`.
3. Retry `POST /api/v1/security/session` — now succeeds.
4. Annotate the test result with `type: 'self-healed'` so the self-heal is visible in the Playwright report.

Without `AUTHENTIK_ADMIN_TOKEN` the spec fails immediately with a diagnostic message that names the missing secret and explains the manual recovery path — it never loops silently on 401.

**`.github/workflows/post-prod-e2e.yml`** — Add `AUTHENTIK_ADMIN_TOKEN` to the `workflow_call` secrets block (as `required: false`) and to the "Run post-prod smoke" step `env`, with an inline comment explaining when it is used.

**`.github/workflows/prod-post-deploy.yml`** — Pass `AUTHENTIK_ADMIN_TOKEN: ${{ secrets.AUTHENTIK_ADMIN_TOKEN }}` through the `e2e` job's `secrets` block so the reusable workflow receives it.

## What was NOT changed

- No test was disabled, skipped, or quarantined.
- The `AUTHENTIK_ADMIN_TOKEN` secret itself is not committed anywhere; it must be set as a GitHub Actions secret (`Settings → Secrets → Actions`).
- Playwright config (`playwright.post-prod.config.ts`) is unchanged.
- All 8 test bodies are structurally the same; only the 401-handling branch of test 7's `else` block is new.

## Test plan

- [ ] Confirm `AUTHENTIK_ADMIN_TOKEN` is set as a GitHub Actions secret with an Authentik token that has **User Manager** permission.
- [ ] Dispatch `prod-post-deploy.yml` manually — all 8 tests should pass; the Playwright report for test 7 should show a `self-healed` annotation on the first run where drift was present.
- [ ] On subsequent runs (password now matches) the self-heal branch is not entered — test 7 signs in directly on first attempt.
- [ ] If `AUTHENTIK_ADMIN_TOKEN` is absent and 401 occurs, test 7 fails with a message naming the missing secret (not a silent retry loop).

---
_Generated by [Claude Code](https://claude.ai/code/session_01VDvprmS9SwG7vcVZum7RDM)_