### PR TITLE
fix(config-clients): correct the Python default port and actually publish the Node client

### DIFF
--- a/backend/applications/Dockerfile
+++ b/backend/applications/Dockerfile
@@ -28,6 +28,7 @@ COPY backend/applications/package.json ./backend/applications/
 COPY shared/package.json ./shared/
 COPY packages/identity/package.json ./packages/identity/
 COPY billing-client/package.json ./billing-client/
+COPY config-client/package.json ./config-client/
 COPY custom-hostname-client/package.json ./custom-hostname-client/
 COPY packages/billing-ui/package.json ./packages/billing-ui/
 COPY packages/chat-client/package.json ./packages/chat-client/

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "shared",
         "packages/identity",
         "billing-client",
+        "config-client",
         "custom-hostname-client",
         "packages/billing-ui",
         "packages/chat-client",
@@ -720,6 +721,76 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "config-client": {
+      "name": "@fuzefront/config-client",
+      "version": "1.0.0",
+      "license": "UNLICENSED",
+      "devDependencies": {
+        "@stoplight/spectral-cli": "^6.11.0",
+        "@types/node": "^24.13.3",
+        "rimraf": "^5.0.1",
+        "tsup": "^8.0.2",
+        "typescript": "^5.9.0"
+      },
+      "engines": {
+        "node": ">=24.0.0",
+        "npm": ">=10.0.0"
+      }
+    },
+    "config-client/node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "config-client/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "config-client/node_modules/rimraf": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
+      "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^10.3.7"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "custom-hostname-client": {
@@ -3610,6 +3681,10 @@
     },
     "node_modules/@fuzefront/chat-ui": {
       "resolved": "packages/chat-ui",
+      "link": true
+    },
+    "node_modules/@fuzefront/config-client": {
+      "resolved": "config-client",
       "link": true
     },
     "node_modules/@fuzefront/core": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "shared",
     "packages/identity",
     "billing-client",
+    "config-client",
     "custom-hostname-client",
     "packages/billing-ui",
     "packages/chat-client",

--- a/packages/config-client-py/README.md
+++ b/packages/config-client-py/README.md
@@ -35,7 +35,7 @@ pip install https://github.com/izzywdev/FuzeFront/releases/download/config-clien
 from fuzefront_config_client import ConfigClient, Scope, ScopeType, is_not_modified
 
 client = ConfigClient(
-    base_url="http://fuzefront-config-service:3013",  # Kubernetes Service DNS
+    base_url="http://fuzefront-config-service:3011",  # Kubernetes Service DNS
     token=lambda: session.access_token,
 )
 

--- a/packages/config-client-py/src/fuzefront_config_client/__init__.py
+++ b/packages/config-client-py/src/fuzefront_config_client/__init__.py
@@ -16,7 +16,7 @@ Quick start::
     from fuzefront_config_client import ConfigClient, Scope, ScopeType, is_not_modified
 
     client = ConfigClient(
-        base_url="http://fuzefront-config-service:3013",
+        base_url="http://fuzefront-config-service:3011",
         token="<bearer-token>",
     )
     resolved = client.get_effective_config(

--- a/packages/config-client-py/src/fuzefront_config_client/client.py
+++ b/packages/config-client-py/src/fuzefront_config_client/client.py
@@ -14,7 +14,7 @@ Usage::
     from fuzefront_config_client import ConfigClient, Scope, ScopeType
 
     client = ConfigClient(
-        base_url="http://fuzefront-config-service:3013",
+        base_url="http://fuzefront-config-service:3011",
         token="<your-bearer-token>",
     )
     resolved = client.get_effective_config(
@@ -97,7 +97,7 @@ class ConfigClient:
     Typed client for the FuzeFront config-service.
 
     :param base_url:
-        Base URL of the service, e.g. ``http://fuzefront-config-service:3013``
+        Base URL of the service, e.g. ``http://fuzefront-config-service:3011``
         (Kubernetes Service DNS) or an ingress host. Only ``http``/``https``
         are accepted. Trailing slashes are stripped.
 

--- a/services/chat-service/Dockerfile
+++ b/services/chat-service/Dockerfile
@@ -23,6 +23,7 @@ COPY backend/applications/package.json ./backend/applications/
 COPY shared/package.json ./shared/
 COPY packages/identity/package.json ./packages/identity/
 COPY billing-client/package.json ./billing-client/
+COPY config-client/package.json ./config-client/
 COPY custom-hostname-client/package.json ./custom-hostname-client/
 COPY packages/billing-ui/package.json ./packages/billing-ui/
 COPY packages/chat-client/package.json ./packages/chat-client/
@@ -56,6 +57,7 @@ COPY backend/applications/package.json ./backend/applications/
 COPY shared/package.json ./shared/
 COPY packages/identity/package.json ./packages/identity/
 COPY billing-client/package.json ./billing-client/
+COPY config-client/package.json ./config-client/
 COPY custom-hostname-client/package.json ./custom-hostname-client/
 COPY packages/billing-ui/package.json ./packages/billing-ui/
 COPY packages/chat-client/package.json ./packages/chat-client/

--- a/services/notification-service/Dockerfile
+++ b/services/notification-service/Dockerfile
@@ -23,6 +23,7 @@ COPY backend/applications/package.json ./backend/applications/
 COPY shared/package.json ./shared/
 COPY packages/identity/package.json ./packages/identity/
 COPY billing-client/package.json ./billing-client/
+COPY config-client/package.json ./config-client/
 COPY custom-hostname-client/package.json ./custom-hostname-client/
 COPY packages/billing-ui/package.json ./packages/billing-ui/
 COPY packages/chat-client/package.json ./packages/chat-client/
@@ -55,6 +56,7 @@ COPY backend/applications/package.json ./backend/applications/
 COPY shared/package.json ./shared/
 COPY packages/identity/package.json ./packages/identity/
 COPY billing-client/package.json ./billing-client/
+COPY config-client/package.json ./config-client/
 COPY custom-hostname-client/package.json ./custom-hostname-client/
 COPY packages/billing-ui/package.json ./packages/billing-ui/
 COPY packages/chat-client/package.json ./packages/chat-client/

--- a/services/selection-list-service/Dockerfile
+++ b/services/selection-list-service/Dockerfile
@@ -24,6 +24,7 @@ COPY backend/applications/package.json ./backend/applications/
 COPY shared/package.json ./shared/
 COPY packages/identity/package.json ./packages/identity/
 COPY billing-client/package.json ./billing-client/
+COPY config-client/package.json ./config-client/
 COPY custom-hostname-client/package.json ./custom-hostname-client/
 COPY packages/billing-ui/package.json ./packages/billing-ui/
 COPY packages/chat-client/package.json ./packages/chat-client/
@@ -57,6 +58,7 @@ COPY backend/applications/package.json ./backend/applications/
 COPY shared/package.json ./shared/
 COPY packages/identity/package.json ./packages/identity/
 COPY billing-client/package.json ./billing-client/
+COPY config-client/package.json ./config-client/
 COPY custom-hostname-client/package.json ./custom-hostname-client/
 COPY packages/billing-ui/package.json ./packages/billing-ui/
 COPY packages/chat-client/package.json ./packages/chat-client/


### PR DESCRIPTION
## 📋 Description

Two defects found while writing the FFRNT-260 consumer guide. Both are in **already-merged** code, and each defeats something the clients exist to do.

## 1. The Python client's default port matched nothing

`packages/config-client-py` defaulted to `http://fuzefront-config-service:3013`. Checked against every source of truth:

| Source | Port |
|---|---|
| `openapi.yaml` `servers:` | *(none — `url: /api/config`, same-origin by design)* |
| Helm Service `port` / `targetPort` | **3011** |
| Helm Deployment `PORT` env + `containerPort` | **3011** |
| Dockerfile / `src/config.ts` in-image default | 3009 *(chart always overrides)* |
| **Python client default** | **3013 — matches nothing** |

`values.yaml` documents the allocation deliberately (3001 backend, 3002 security, … 3010 payment) and notes 3011 was chosen to avoid a collision, with the chart always passing `PORT` explicitly. So **3011 is authoritative in-cluster**, 3009 is a harmless in-image default, and **3013 was invented** — a Python consumer taking the default got connection-refused.

Fixed across all four sites (`client.py` ×2, `__init__.py`, `README.md`).

## 2. `@fuzefront/config-client` was never published

The package is publishable — no `private`, `publishConfig` → `https://npm.pkg.github.com` — but `scripts/publish-packages.mjs` builds its list from the root `workspaces` array:

```js
workspaces().filter((dir) => existsSync(`${root}/${dir}/package.json`))
            .filter(({ pkg }) => !pkg.private && pkg.name)
```

`config-client` was not in that array, so it was silently excluded from the publish set. **A client nobody can `npm install` is not a client** — and shipping one was an explicit requirement of this epic.

`billing-client` is the precedent: in `workspaces`, published. Added `config-client` alongside it.

No nested `package-lock.json` was added — it was deliberately gitignored in #608, and workspace members resolve from the root lockfile.

## 🧪 Testing

Verified against the committed tree (`git status` clean):

| Check | Result |
|---|---|
| `node scripts/publish-packages.mjs --dry-run` | 18 → **19** packages, and it now **names** `@fuzefront/config-client -> @izzywdev/fuzefront-config-client@1.0.0` |
| `node scripts/check-workspace-deps.mjs` | passed — 47 in-repo packages, 47 manifests |
| `pytest -q` (`PYTHONPATH=src`) | **35 passed** |

The dry-run was checked for the package *name*, not just the count — a count going up proves nothing about which package was added.

## 📝 Notes

**`selection-list-client` has the identical non-workspace shape** and is presumably also unpublished. Flagged rather than fixed — that's a separate call, and bundling it here would widen an otherwise narrow fix.

**Still true after this PR:** the Python wheel has no release tag pushed, so a real `pip install` from GitHub Releases remains unproven. This PR makes the npm side publishable; it does not prove either install path end to end.

---
_Generated by [Claude Code](https://claude.ai/code/session_0183JMAkioT5pGt8aVmddPtc)_