### PR TITLE
fix(FQ): use canonical production remote host

### DIFF
--- a/FuzeQuality/docker/Dockerfile
+++ b/FuzeQuality/docker/Dockerfile
@@ -8,7 +8,7 @@ FROM dependencies AS source
 COPY FuzeQuality ./
 
 FROM source AS verify
-ARG FUZEQUALITY_API_URL=https://quality.prod.fuzefront.com
+ARG FUZEQUALITY_API_URL=https://fuzequality.prod.fuzefront.com
 ENV VITE_FUZEQUALITY_API_URL=${FUZEQUALITY_API_URL}
 RUN npm run type-check \
  && npm test \

--- a/backend/applications/src/app-registry/builtins.ts
+++ b/backend/applications/src/app-registry/builtins.ts
@@ -86,7 +86,7 @@ const BUILTIN_MANIFESTS: unknown[] = [
     builtin: true,
     integration: {
       type: 'module-federation',
-      remoteEntry: 'https://quality.prod.fuzefront.com/remoteEntry.js',
+           remoteEntry: 'https://fuzequality.prod.fuzefront.com/remoteEntry.js',
       scope: 'fuzequality',
       module: './App',
     },


### PR DESCRIPTION
Point the portal federation manifest and frontend API origin at the deployed fuzequality.prod.fuzefront.com host.