### PR TITLE
feat(feature-flags): web-expose the FF-EPIC-17 identity UI flags

### DIFF
--- a/packages/feature-flags/src/catalog.ts
+++ b/packages/feature-flags/src/catalog.ts
@@ -58,6 +58,30 @@ export const FLAG_KEYS = {
    * 100% of admins.
    */
   PORTALS_DIRECTORY: 'fuzefront.platform.portals-directory',
+  /**
+   * FF-EPIC-17 / S4 (#656) — personal-context switcher + my-orgs routes.
+   * Read in the browser via `useFlag()` in App.tsx / UserMenu /
+   * OrganizationDetailPage. Default OFF. Release flag.
+   * Owner: frontend-engineer (identity).
+   * Removal criterion: reconciled switcher GA at 100% of users.
+   */
+  IDENTITY_PERSONAL_CONTEXT: 'fuzefront.identity.personal-context',
+  /**
+   * FF-EPIC-17 / S5 (#671 backend, #672 UI) — root/portal member directory.
+   * Read in the browser via `useFlag()` in OrganizationDetailPage
+   * (`/organizations/:id/directory` route). Default OFF. Release flag.
+   * Owner: backend-engineer (identity).
+   * Removal criterion: 100% rollout; flag-OFF path unexercised.
+   */
+  IDENTITY_MEMBER_DIRECTORY: 'fuzefront.identity.member-directory',
+  /**
+   * FF-EPIC-17 / S8 (#655) + S9 (#673) — Employee cross-org console.
+   * Read in the browser via `useFlag()` in SidePanel / EmployeeConsolePage
+   * (`/staff` routes), gated additionally on `isEmployee`. Default OFF.
+   * Release flag. Owner: backend-engineer (identity).
+   * Removal criterion: 100% rollout; flag-OFF path unexercised.
+   */
+  IDENTITY_EMPLOYEE_CONSOLE: 'fuzefront.identity.employee-console',
 } as const;
 
 export const WEB_EXPOSED_FLAGS: readonly FlagDescriptor[] = [
@@ -69,4 +93,12 @@ export const WEB_EXPOSED_FLAGS: readonly FlagDescriptor[] = [
     default: false,
   },
   { key: FLAG_KEYS.PORTALS_DIRECTORY, type: 'release', default: false },
+  // FF-EPIC-17 identity UI flags — read in the browser via `useFlag()`. Without
+  // these entries the backend `GET /api/flags` never discloses them, so flipping
+  // them ON in Unleash would move server-side evaluation but leave the UI dark.
+  // (`fuzefront.identity.root-membership` is deliberately NOT here — it is
+  // server-only, read directly by the security service's provisioning path.)
+  { key: FLAG_KEYS.IDENTITY_PERSONAL_CONTEXT, type: 'release', default: false },
+  { key: FLAG_KEYS.IDENTITY_MEMBER_DIRECTORY, type: 'release', default: false },
+  { key: FLAG_KEYS.IDENTITY_EMPLOYEE_CONSOLE, type: 'release', default: false },
 ] as const;

--- a/packages/feature-flags/tests/get-client.test.ts
+++ b/packages/feature-flags/tests/get-client.test.ts
@@ -85,6 +85,14 @@ describe('WEB_EXPOSED_FLAGS catalog', () => {
     const keys = WEB_EXPOSED_FLAGS.map(f => f.key);
     expect(keys).toContain('fuzefront.account-security.hub');
     expect(keys).toContain('fuzefront.billing.invoice-history');
+    // FF-EPIC-17 identity UI flags must be web-exposed, or flipping them in
+    // Unleash leaves the browser UI dark (GET /api/flags never discloses them).
+    expect(keys).toContain('fuzefront.identity.personal-context');
+    expect(keys).toContain('fuzefront.identity.member-directory');
+    expect(keys).toContain('fuzefront.identity.employee-console');
+    // root-membership is server-only (security-service provisioning) — the
+    // browser must never see it.
+    expect(keys).not.toContain('fuzefront.identity.root-membership');
     // Server-only app-registry flags must not be disclosed to the browser.
     expect(keys).not.toContain('fuzefront.app-registry.v1-registry-write');
     expect(keys).not.toContain('fuzefront.app-registry.kafka-events-kill-switch');


### PR DESCRIPTION
## Description

Closes the pre-flight blocker surfaced by the FF-EPIC-17 flag-enablement work (#696): the three identity **UI** flags are read in the browser via `useFlag()` but were never listed in `packages/feature-flags/src/catalog.ts`'s `WEB_EXPOSED_FLAGS`. The browser only receives flags the backend `GET /api/flags` route discloses from that list — so flipping these ON in Unleash would move **server-side** evaluation while leaving the **UI dark**.

Without this, "turn all the flags ON" does not actually surface the personal-context switcher, the member directory, or the Employee console.

## Changes

- `packages/feature-flags/src/catalog.ts` — add to `FLAG_KEYS` + `WEB_EXPOSED_FLAGS` (all `release`, fail-safe `default: false`, matching the in-code fallback):
  - `fuzefront.identity.personal-context` (S4 · #656)
  - `fuzefront.identity.member-directory` (S5 · #671/#672)
  - `fuzefront.identity.employee-console` (S8/S9 · #655/#673)
- `fuzefront.identity.root-membership` is deliberately **not** web-exposed — it is server-only (read directly by the security service's provisioning path), so the browser must never see it.
- `packages/feature-flags/tests/get-client.test.ts` — extend the catalog test to pin the three new keys present and `root-membership` absent.

## Verification

- `npm run -w @fuzefront/feature-flags type-check` — clean
- `npm run -w @fuzefront/feature-flags build` (tsup) — clean
- `tests/get-client.test.ts` — 7/7 pass (including the extended `WEB_EXPOSED_FLAGS` assertions)
- LF line endings on both files

## Out of scope

- The live Unleash toggle (operator with admin access — see `docs/runbooks/unleash-enable-ff-epic-17-flags.md` in #696).
- The feature logic/UI the flags gate — already merged (#615, #656, #671/#672, #655/#673).

---
_Generated by [Claude Code](https://claude.ai/code/session_017zdYnxKQVVhFyRubDa1BmK)_