### PR TITLE
fix(fuzequality): type the 4 untyped api.ts calls so the frontend image can build again

### DIFF
--- a/FuzeQuality/apps/web/src/api.ts
+++ b/FuzeQuality/apps/web/src/api.ts
@@ -1,4 +1,9 @@
-import type { Portfolio } from '@fuzequality/contracts'
+import type {
+  AdminTenantContext,
+  OrganizationQualitySummary,
+  Portfolio,
+  TestImplementationRequest,
+} from '@fuzequality/contracts'
 
 export type OrganizationRole = 'owner' | 'admin' | 'member' | 'viewer'
 export type OrganizationMember = { id: string; email?: string; name?: string; displayName?: string; userId?: string; user_id?: string; role: OrganizationRole; status?: string }
@@ -36,8 +41,9 @@ export const api = {
   updateRepositoryAdministration: (id: string, value: Record<string, unknown>) =>
     request(`/api/v1/repositories/${id}/administration`, { method: 'PATCH', body: JSON.stringify(value) }),
   implementTests: (value: Record<string, unknown>) =>
-    request('/api/v1/test-implementations', { method: 'POST', body: JSON.stringify(value) }),
-  testImplementation: (id: string) => request(`/api/v1/test-implementations/${id}`),
+    request<TestImplementationRequest>('/api/v1/test-implementations', { method: 'POST', body: JSON.stringify(value) }),
+  testImplementation: (id: string) =>
+    request<TestImplementationRequest>(`/api/v1/test-implementations/${id}`),
   organizationMembers: () => request<{ items?: OrganizationMember[]; members?: OrganizationMember[] } | OrganizationMember[]>('/api/v1/organization/members'),
   inviteOrganizationMember: (email: string, role: OrganizationRole) =>
     request('/api/v1/organization/invitations', { method: 'POST', body: JSON.stringify({ email, role }) }),
@@ -45,7 +51,7 @@ export const api = {
     request(`/api/v1/organization/members/${id}`, { method: 'PUT', body: JSON.stringify({ role }) }),
   removeOrganizationMember: (id: string) =>
     request(`/api/v1/organization/members/${id}`, { method: 'DELETE' }),
-  platformOrganizations: () => request('/api/v1/admin/organizations'),
+  platformOrganizations: () => request<OrganizationQualitySummary[]>('/api/v1/admin/organizations'),
   enterOrganizationContext: (organizationId: string, reason: string) =>
-    request(`/api/v1/admin/organizations/${encodeURIComponent(organizationId)}/context`, { method: 'POST', body: JSON.stringify({ reason }) }),
+    request<AdminTenantContext>(`/api/v1/admin/organizations/${encodeURIComponent(organizationId)}/context`, { method: 'POST', body: JSON.stringify({ reason }) }),
 }


### PR DESCRIPTION
## Why

`fuzequality-release.yml` has failed **every run since 06:47 today**, including on the merge of #701, at `npm run type-check` inside the frontend image build:

```
apps/web/src/App.tsx(128,31): TS2345 unknown -> TestImplementationRequest
apps/web/src/App.tsx(137,25): TS2345 unknown -> TestImplementationRequest
apps/web/src/App.tsx(537,18): TS2345 unknown -> AdminTenantContext
apps/web/src/App.tsx(593,30): TS2345 unknown -> OrganizationQualitySummary[]
```

`request<T>` in `apps/web/src/api.ts` falls back to `unknown` when called without a type argument, and four api methods omitted theirs — so their results could not be assigned to the matching `useState` setters.

## Fix

Supplied the four type arguments. The types already exist in `@fuzequality/contracts` and are now imported alongside `Portfolio`. **Types only — no behaviour change.**

## Why it is urgent

This **blocks #701** (already merged). That PR routes `app.fuzefront.com/apps/fuzequality/*` to this app's in-cluster Service, but the routing is inert until the image is rebuilt with the new Vite `base: /apps/fuzequality/`. While type-check fails the image cannot be rebuilt, so the Quality tile stays broken and the `values-prod` tag stays pinned at the pre-change image.

## Verification

Ran `tsc --noEmit` locally: **App.tsx now reports zero errors** (all four gone). Remaining local errors are cascading "cannot find module" noise from an incomplete dependency install (`zod`, `vite`, `react` absent locally) and are unrelated — CI is the authoritative check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
