### PR TITLE
fix(fuzequality): cast the MF shared config so the frontend image type-checks

### DIFF
--- a/FuzeQuality/apps/web/vite.config.ts
+++ b/FuzeQuality/apps/web/vite.config.ts
@@ -26,9 +26,15 @@ export default defineConfig({
       // `singleton: true`, or on a different major range, this remote loads its
       // own React copy across the federation boundary and dies at runtime on
       // "Invalid hook call" — in the browser, with nothing in CI to catch it.
+      //
+      // The `as any` casts mirror the host verbatim: @originjs/vite-plugin-
+      // federation@1.4.1 types `shared` as `Shared`, which does not admit this
+      // per-package object form even though the plugin consumes it at runtime.
+      // Dropping the casts fails `tsc --noEmit` with TS2322 and takes the whole
+      // image build down at the Dockerfile's type-check step.
       shared: {
-        react: { singleton: true, requiredVersion: '^19.0.0' },
-        'react-dom': { singleton: true, requiredVersion: '^19.0.0' },
+        react: { singleton: true, requiredVersion: '^19.0.0' } as any,
+        'react-dom': { singleton: true, requiredVersion: '^19.0.0' } as any,
       },
     }),
   ],


### PR DESCRIPTION
## Regression from #701 — my bug

Adding `singleton: true` to FuzeQuality's Module-Federation `shared` config broke the frontend image build:

```
apps/web/vite.config.ts(30,18): error TS2322: Type '{ react: { singleton: true;
requiredVersion: string; }; ... }' is not assignable to type 'Shared | undefined'.
```

## Root cause

Confirmed against the installed types, not guessed. In `@originjs/vite-plugin-federation@1.4.1`, `SharedConfig.singleton` is **commented out** of `types/index.d.ts`:

```ts
declare interface SharedConfig {
  requiredVersion?: string | false
  // singleton?: boolean      <-- declared only in a comment
}
```

So the object literal fails excess-property checking. The plugin honours `singleton` at **runtime**; only its type declaration omits it.

## Fix

Mirror the host verbatim — `frontend/vite.config.ts:187-188` already carries the identical `as any` cast for the identical reason, on the identical plugin version. Keeping the two byte-compatible is the entire point of that block: a mismatch lets the remote load its own React and die on "Invalid hook call" in the browser.

## Verification

Compiled both forms against the real 1.4.1 type definitions:

| form | result |
|---|---|
| without cast | `TS2353: 'singleton' does not exist in type 'SharedConfig'` — on both entries |
| with cast | clean |

## Why it matters

`fuzequality-release.yml` is still failing, so the FuzeQuality image has **never** been rebuilt with `base: /apps/fuzequality/`, and `values-prod` remains pinned at `6da67c73185a`. Prod is half-migrated: #701 switched the route to `/apps/fuzequality/*`, but the image behind it is still built with `base: '/'`, so its chunks resolve against the host shell's bundle. This unblocks the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
