### PR TITLE
fix(design-approval): recover approvals when the prefill label is dropped (issues:labeled)

### DIFF
--- a/.github/workflows/design-approval.yml
+++ b/.github/workflows/design-approval.yml
@@ -24,13 +24,22 @@ name: design-approval
 # (scripts/stamp-frames.mjs), so flipping a flow to approved does not change the
 # stamp — sibling flows keep the same valid stamp and per-flow approval works.
 #
-# on: issues:[opened] ONLY — edits can't re-fire (avoids double-trigger). Every
-# expectation is DERIVED from a source of truth (stamp from files, flip target from
-# the parsed issue, authorization from CODEOWNERS); nothing is hand-mirrored.
+# on: issues:[opened, labeled]. `opened` is the happy path (the in-frame Approve
+# link opens a prefilled issue already carrying the `design-approval` label). But
+# some GitHub clients (notably the mobile app / mobile web) SILENTLY DROP the
+# `labels=` query param when submitting that prefilled form, so the issue opens
+# WITHOUT the label and the `if:` guard below skips the job — the approval is lost
+# with no signal. `labeled` recovers exactly that case: a maintainer (or an agent)
+# adds the `design-approval` label to the already-open issue and the job re-fires,
+# now that the guard passes. Re-firing is safe: the idempotency check (step 3)
+# treats an already-approved-at-this-stamp flow as a no-op, so an issue that opened
+# WITH the label (both events fire) is not double-approved. Every expectation is
+# DERIVED from a source of truth (stamp from files, flip target from the parsed
+# issue, authorization from CODEOWNERS); nothing is hand-mirrored.
 
 on:
   issues:
-    types: [opened]
+    types: [opened, labeled]
 
 permissions:
   contents: write   # flip the manifest on master via Contents API


### PR DESCRIPTION
## Description

The design-approval flow silently loses approvals when the in-frame Approve link is submitted from a GitHub client that drops the prefilled `labels=` query param (notably the **mobile app / mobile web**). The issue opens with the correct feature/flow/stamp but **no `design-approval` label**, so `design-approval.yml`'s `if: contains(labels, 'design-approval')` guard skips the job — the approval is lost with no signal.

Observed live on the FF-EPIC-17 `portal-admin-consoles` approvals: issues **#725–#731** all opened unlabeled and never recorded, even after the frames stamp was corrected (`c295cdea…`). Earlier desktop-submitted approvals (`api-tokens`, `selection-lists`) carried the label fine — the difference is the client, not the repo.

## Change

`design-approval.yml` trigger: `types: [opened]` → **`types: [opened, labeled]`**.

Now a maintainer (or an agent) can apply the `design-approval` label to an already-open approval issue and the workflow re-fires — the guard passes, and every expectation is still derived from source-of-truth (stamp recomputed from files, flip target parsed from the issue, authorization from CODEOWNERS).

## Safety

- **Idempotent.** The existing step-3 check (already-approved-at-this-stamp → no-op, close) makes the extra event harmless when a desktop submission fires both `opened` and `labeled`.
- **No authorization change.** Author is still checked against CODEOWNERS; a non-owner labeling the issue still can't approve.
- **No new stamp path.** Staleness is still recomputed and compared exactly.
- Only `.github/workflows/design-approval.yml` changes; no app code, UI, or migration — no feature-UI gate implicated.

## Type of Change

- [x] 🐛 Bug fix (workflow reliability)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017zdYnxKQVVhFyRubDa1BmK)_