### PR TITLE
feat(identity): portal TypeID backfill — migration 024 + serializer fix (FFRNT-185 step 5)

### DIFF
--- a/backend/src/identity/serializer.ts
+++ b/backend/src/identity/serializer.ts
@@ -22,6 +22,23 @@
 import { EntityType, fromUuid } from '@izzywdev/fuzefront-identity'
 
 /**
+ * `generatePortalId()` in portalRepository.ts used to produce
+ * `prt_<hex32>` — a UUID v4 with dashes stripped, not standard TypeID.
+ * This pattern lets `toWireId` detect that legacy form and re-insert the
+ * dashes before handing it to `fromUuid`, which expects a bare UUID.
+ * Matched only when `type === 'portal'` so the overhead is negligible.
+ * Remove once migration 024 has converted all stored rows to bare UUIDs.
+ */
+const LEGACY_PORTAL_HEX_RE = /^prt_([0-9a-f]{32})$/
+
+function legacyPortalIdToUuid(id: string): string | null {
+  const m = LEGACY_PORTAL_HEX_RE.exec(id)
+  if (!m) return null
+  const hex = m[1]
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`
+}
+
+/**
  * Converts a storage-form entity id (bare UUID from the DB column) to the
  * appropriate API wire form:
  *
@@ -34,6 +51,14 @@ import { EntityType, fromUuid } from '@izzywdev/fuzefront-identity'
 export function toWireId(type: EntityType, uuid: string, prefixed: boolean): string {
   if (!prefixed) return uuid
   try {
+    // Special case: portals stored before migration 024 use the legacy
+    // prt_<hex32> form rather than a bare UUID. Detect and normalise.
+    if (type === 'portal') {
+      const bareUuid = legacyPortalIdToUuid(uuid)
+      if (bareUuid !== null) {
+        return fromUuid(type, bareUuid)
+      }
+    }
     return fromUuid(type, uuid)
   } catch {
     // Malformed UUID in the DB — return bare form rather than 500.

--- a/backend/src/migrations/024_portal_typeid_backfill.ts
+++ b/backend/src/migrations/024_portal_typeid_backfill.ts
@@ -1,0 +1,141 @@
+import { Knex } from 'knex'
+
+/**
+ * FFRNT-185 step 5 — portal storage-form backfill.
+ *
+ * WHEN TO RUN: after the `fuzefront.identity.prefixed-ids` release flag has
+ * been flipped ON for 100 % of the fleet and all clients are receiving and
+ * forwarding the TypeID wire form (`prt_01h…`). Running this migration while
+ * the flag is still OFF turns every existing portal id from the legacy hex form
+ * (`prt_3b1c…`) into a bare UUID on the wire — a breaking change clients do
+ * not expect. Once the flag is ON and clients are on TypeID, the switch to bare
+ * UUID storage is invisible because the serializer always re-emits TypeID.
+ *
+ * WHAT IT DOES: converts the legacy portal id storage format to a bare UUID so
+ * the `portals` table aligns with every other entity type:
+ *
+ *   storage before: `prt_3b1c2a7f5e9d4b0a8c6f1e3d2a7b5c9e`  (32 hex chars)
+ *   storage after:  `3b1c2a7f-5e9d-4b0a-8c6f-1e3d2a7b5c9e`  (bare UUID)
+ *   wire (flag ON): `prt_01h455vb4pex5vsknk084sn02q`          (TypeID base32)
+ *
+ * The legacy format was produced by `generatePortalId()` in
+ * `backend/src/repositories/portalRepository.ts`:
+ *   `prt_${uuidv4().replace(/-/g, '')}` — UUID v4, dashes stripped.
+ * Converting back to a bare UUID is therefore lossless: re-insert the dashes.
+ *
+ * SPECIAL IDs (`prt_fuzefront`, `prt_bootstrap`) do NOT match the 32-hex-char
+ * pattern and are left unchanged.
+ *
+ * TABLES UPDATED (all in the same `fuzefront_platform` database):
+ *   portals.id                               (PK — the primary conversion)
+ *   portal_domains.portal_id                 FK → portals.id, ON DELETE CASCADE
+ *   portal_provisioning.portal_id            FK → portals.id, ON DELETE CASCADE
+ *   portal_apps.portal_id                    FK → portals.id, ON DELETE CASCADE
+ *   users.home_portal_id                     FK → portals.id, ON DELETE SET NULL
+ *   organization_invitations.portal_id       FK → portals.id, ON DELETE SET NULL
+ *
+ * FK HANDLING: PostgreSQL FK constraints are `NOT DEFERRABLE` by default, so
+ * updating the PK in `portals` while children still hold the old value would
+ * violate the FK at statement boundary. We temporarily disable FK-check
+ * triggers on all affected tables for the duration of the update block (inside
+ * a single transaction so the disable/enable pair is atomic with the data
+ * change). `DISABLE TRIGGER ALL` requires table ownership or superuser; the
+ * migrations run as the DB owner, so this is safe.
+ *
+ * IDEMPOTENT: a second run of `up()` finds zero rows matching
+ * `^prt_[0-9a-f]{32}$` and exits early.
+ */
+
+/** Matches the legacy generatePortalId() output: `prt_` + exactly 32 lowercase hex chars. */
+const LEGACY_HEX_RE = /^prt_([0-9a-f]{32})$/
+
+/** Converts 32 bare hex chars back to a dashed UUID string. */
+function hexToUuid(hex: string): string {
+  return (
+    `${hex.slice(0, 8)}-` +
+    `${hex.slice(8, 12)}-` +
+    `${hex.slice(12, 16)}-` +
+    `${hex.slice(16, 20)}-` +
+    `${hex.slice(20)}`
+  )
+}
+
+// child tables that hold a FK → portals.id (all in the same DB)
+const FK_TABLES: Array<{ table: string; col: string }> = [
+  { table: 'portal_domains', col: 'portal_id' },
+  { table: 'portal_provisioning', col: 'portal_id' },
+  { table: 'portal_apps', col: 'portal_id' },
+  { table: 'users', col: 'home_portal_id' },
+  { table: 'organization_invitations', col: 'portal_id' },
+]
+
+export async function up(knex: Knex): Promise<void> {
+  // Collect legacy-format portal ids
+  const rows: Array<{ id: string }> = await knex('portals')
+    .select('id')
+    .where(knex.raw("id ~ '^prt_[0-9a-f]{32}$'"))
+
+  if (rows.length === 0) {
+    console.log('[024] No legacy portal IDs found — nothing to migrate.')
+    return
+  }
+
+  const idMap: Array<{ oldId: string; newId: string }> = rows.map(({ id }) => {
+    const m = LEGACY_HEX_RE.exec(id)!
+    return { oldId: id, newId: hexToUuid(m[1]) }
+  })
+
+  console.log(
+    `[024] Converting ${idMap.length} portal IDs from legacy prt_<hex32> → bare UUID...`
+  )
+
+  // Determine which FK child tables actually exist (guard against partial installs
+  // or a very early schema state where some tables haven't been created yet).
+  const activeFkTables = await Promise.all(
+    FK_TABLES.map(async ({ table, col }) => ({
+      table,
+      col,
+      exists: (await knex.schema.hasTable(table)) && (await knex.schema.hasColumn(table, col)),
+    }))
+  ).then(results => results.filter(r => r.exists))
+
+  const allTables = ['portals', ...activeFkTables.map(r => r.table)]
+
+  await knex.transaction(async trx => {
+    // Disable FK-check triggers on every affected table.
+    for (const table of allTables) {
+      await trx.raw('ALTER TABLE ?? DISABLE TRIGGER ALL', [table])
+    }
+
+    for (const { oldId, newId } of idMap) {
+      // 1. Rename the PK row itself.
+      await trx('portals').where('id', oldId).update({ id: newId })
+
+      // 2. Repoint all FK child columns.
+      for (const { table, col } of activeFkTables) {
+        await trx(table).where(col, oldId).update({ [col]: newId })
+      }
+    }
+
+    // Re-enable FK-check triggers. The data is now consistent so the check
+    // passes immediately when the transaction commits.
+    for (const table of allTables) {
+      await trx.raw('ALTER TABLE ?? ENABLE TRIGGER ALL', [table])
+    }
+  })
+
+  console.log(`[024] Done. Converted ${idMap.length} portal IDs.`)
+}
+
+export async function down(knex: Knex): Promise<void> {
+  // Intentionally not reversible: this migration converts legacy prt_<hex32>
+  // to bare UUIDs. The reverse would require knowing WHICH bare UUIDs were
+  // originally prt_<hex32> vs. minted as bare UUIDs by post-migration code
+  // (generatePortalId() is updated alongside this migration to emit bare UUIDs
+  // directly). Attempting a down migration on a live system would be unsafe.
+  //
+  // To roll back in an emergency: restore from a pre-migration DB snapshot.
+  console.warn(
+    '[024] down() is a no-op — portal TypeID backfill is not reversible via migration.'
+  )
+}

--- a/backend/src/repositories/portalRepository.ts
+++ b/backend/src/repositories/portalRepository.ts
@@ -171,9 +171,18 @@ export function getPortalIdentityPolicy(row: { identity_policy?: unknown }): Por
   return parseJsonColumnWithDefaults(row.identity_policy, DEFAULT_IDENTITY_POLICY)
 }
 
-/** Generates a server-issued portal id matching `^prt_[A-Za-z0-9]{1,40}$`. */
+/**
+ * Generates a storage-form portal id (bare UUID v4 with dashes).
+ *
+ * Previously returned `prt_<hex32>` (UUID with dashes stripped). That legacy
+ * format is converted to bare UUID by migration 024_portal_typeid_backfill.
+ * New portals minted from this point forward store a bare UUID directly —
+ * consistent with the identifier standard (governance/identifier-standard.md
+ * §2) and with every other entity type. The `prt_` prefix appears only on the
+ * wire via `toWireId` when `fuzefront.identity.prefixed-ids` is ON.
+ */
 export function generatePortalId(): string {
-  return `prt_${uuidv4().replace(/-/g, '')}`
+  return uuidv4()
 }
 
 /**


### PR DESCRIPTION
## Summary

FFRNT-185 step 5 — normalises portal ID storage to bare UUID and fixes the serializer for the pre-migration transition window.

Three coordinated changes:

- **`backend/src/migrations/024_portal_typeid_backfill.ts`** — new one-way migration that converts all `portals.id` values from the legacy `prt_<hex32>` format (UUID with dashes stripped) to bare UUID (`xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`). Updates the PK and all five FK referencing columns in the same `fuzefront_platform` database: `portal_domains.portal_id`, `portal_provisioning.portal_id`, `portal_apps.portal_id`, `users.home_portal_id`, `organization_invitations.portal_id`. Uses `DISABLE/ENABLE TRIGGER ALL` inside a single transaction to avoid FK violations during the PK rename. Idempotent — a second run exits early. **Must be run after `fuzefront.identity.prefixed-ids` is ON for 100% of the fleet** (see migration doc-comment for details).

- **`backend/src/identity/serializer.ts`** — fixes `toWireId()` for portals when the flag is ON but the DB still holds the legacy `prt_<hex32>` format. Previously `fromUuid()` would throw on that input and the catch returned it as-is, giving clients `prt_<hex32>` instead of the correct TypeID base32 form. Now detects the legacy pattern, re-inserts the UUID dashes, and passes the normalised value to `fromUuid()`.

- **`backend/src/repositories/portalRepository.ts`** — updates `generatePortalId()` to return `uuidv4()` directly (bare UUID with dashes) instead of `prt_${uuidv4().replace(/-/g, '')}`. New portals created after migration 024 go directly to bare-UUID storage rather than creating fresh `prt_<hex32>` rows that would need re-migrating.

## Test plan

- [ ] `npx tsc -p backend/tsconfig.json --noEmit` — passes (verified locally)
- [ ] `python scripts/gate_identifier.py . --source` — passes (verified locally)
- [ ] Migration idempotency: run `up()` twice on a DB with legacy portal rows — second run emits "nothing to migrate" and exits
- [ ] Migration correctness: verify `portals.id`, `users.home_portal_id`, `portal_domains.portal_id` all updated to UUID-with-dashes form; special IDs (`prt_fuzefront`, `prt_bootstrap`) unchanged
- [ ] Serializer: with `fuzefront.identity.prefixed-ids` ON and a legacy `prt_<hex32>` row, API response carries the correct TypeID `prt_01h…` form
- [ ] Serializer: special IDs (`prt_fuzefront`) returned as-is from the catch block (no regression)
- [ ] `generatePortalId()` now returns a bare UUID — confirm new provisioning creates portal rows with UUID format

---
_Generated by [Claude Code](https://claude.ai/code/session_01GLocxJ1aNrFWeAo51iHuFa)_