### PR TITLE
fix(authentik): take the IdP admin interface off the public internet

### DIFF
--- a/deploy/helm/fuzefront/templates/_helpers.tpl
+++ b/deploy/helm/fuzefront/templates/_helpers.tpl
@@ -56,3 +56,41 @@ prometheus.io/port: {{ .port | quote }}
 prometheus.io/path: {{ .path | default $m.path | default "/metrics" | quote }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+The ONLY Authentik paths that may be reachable from the public internet.
+
+Authentik is an IdP for public products (FuzeFront, and MendysRobotics via
+marketplace.mendysrobotics.com, whose /api/auth/oidc/login 302s to this IdP), so
+its OIDC protocol and login-flow surface cannot be made private without breaking
+customer logins. Its ADMINISTRATION surface can, and must be.
+
+The critical entry is what is ABSENT: a bare "/if". That prefix served
+/if/admin/ — the full Authentik admin interface — from every public host. Only
+/if/flow (the login/enrollment flow executor UI) and /if/session-end are needed
+by a browser. Admins reach the admin UI at authentik.<prod domain>, which sits
+behind Cloudflare Access.
+
+Do NOT re-add "/if", and do not add "/if/user": FuzeFront owns its own profile
+and MFA UI (mfa_factors is native, not an Authentik stage).
+
+/api/v3 has to stay for now — Authentik's flow-executor page is a SPA that calls
+it from the browser, and fuzefront-backend currently reaches Authentik's Admin API
+by hairpinning out through this same public edge (it sets no AUTHENTIK_BASE_URL,
+so authentik-admin.ts falls back to deriving it from AUTHENTIK_ISSUER_URL). It is
+authenticated — /api/v3/core/users/me/ returns 403 unauthenticated — but it is
+surface that should shrink once that hairpin is repointed in-cluster.
+*/}}
+{{- define "fuzefront.authentikPublicPaths" -}}
+- /application
+- /if/flow
+- /if/session-end
+- /source
+- /flows
+- /ws
+- /-
+- /outpost.goauthentik.io
+- /api/v3
+- /static/dist
+- /static/authentik
+{{- end -}}

--- a/deploy/helm/fuzefront/templates/authentik.yaml
+++ b/deploy/helm/fuzefront/templates/authentik.yaml
@@ -345,12 +345,21 @@ spec:
     - host: {{ $ak.host | quote }}
       http:
         paths:
-          - path: /
+          {{- /* Was `path: /` — the ENTIRE Authentik, including /if/admin/ and
+                 /api/v3, served publicly on this host. Verified against prod:
+                 /if/admin/, /if/flow/default-authentication-flow/ and
+                 /api/v3/root/config/ all returned 200 to an anonymous client.
+                 Narrowed to the same protocol+login set the app-host proxy uses.
+                 This host cannot simply be deleted: marketplace.mendysrobotics.com
+                 is live and its /api/auth/oidc/login 302s here. */ -}}
+          {{- range $p := (include "fuzefront.authentikPublicPaths" $ | fromYamlArray) }}
+          - path: {{ $p }}
             pathType: Prefix
             backend:
               service:
                 name: authentik-server
                 port:
                   number: 9000
+          {{- end }}
 {{- end }}
 {{- end }}

--- a/deploy/helm/fuzefront/templates/ingress.yaml
+++ b/deploy/helm/fuzefront/templates/ingress.yaml
@@ -360,7 +360,10 @@ spec:
                  (password/enrollment flow driver). Must route to authentik-server,
                  or flow-executor calls hit FuzeFront's /api and fail with
                  PROVIDER_UNAVAILABLE. Does not collide with FuzeFront's /api/v1/*. */ -}}
-          {{- range $p := list "/application" "/if" "/source" "/flows" "/ws" "/-" "/outpost.goauthentik.io" "/api/v3" "/static/dist" "/static/authentik" }}
+          {{- /* Single source of truth, shared with the auth.<zone> Ingress in
+                 authentik.yaml so the two public surfaces cannot drift. Notably
+                 has NO bare "/if" — that is what exposed /if/admin/. */ -}}
+          {{- range $p := (include "fuzefront.authentikPublicPaths" $ | fromYamlArray) }}
           - path: {{ $p }}
             pathType: Prefix
             backend:


### PR DESCRIPTION
Closes public access to Authentik's administration surface. Draft — please read the MendysRobotics section before merging.

## What was exposed

Verified against prod as an anonymous client:

| URL | before |
|---|---|
| `app.fuzefront.com/if/admin/` | **200** |
| `auth.fuzefront.com/if/admin/` | **200** |
| `auth.fuzefront.com/api/v3/root/config/` | **200** |
| `auth.fuzefront.com/if/flow/default-authentication-flow/` | **200** |

Two independent causes:

1. The app-host IdP proxy proxied a bare **`/if`**. `/if/flow` is the login UI; `/if/admin` under the same prefix is the entire administration interface.
2. `templates/authentik.yaml` renders an Ingress for `auth.<zone>` with **`path: /`** — all of Authentik, publicly. Gated only on `authentik.enabled && ingress.enabled`, both true in prod.

That second one contradicts `values-prod.yaml:473` (*"no public Ingress binds this"*) and the S4 assertion in `authn-boundary-smoke.spec.ts`. **Both were wrong** — the Ingress renders, and I confirmed it serves.

To be accurate about severity: this is the SPA shell, not an unauthenticated breach. `/api/v3/core/users/me/` returns 403 without a session. But the admin interface had no business being on the internet.

## The fix

Both public hosts now render one shared path list (`fuzefront.authentikPublicPaths`) so they cannot drift. The load-bearing part is what is **absent** — no bare `/if`, no catch-all `/`:

```
/application  /if/flow  /if/session-end  /source  /flows
/ws  /-  /outpost.goauthentik.io  /api/v3  /static/dist  /static/authentik
```

Admins reach the admin UI at `authentik.prod.fuzefront.com`, behind Cloudflare Access. **That** Ingress deliberately keeps `path: /`.

## Why the host is not simply deleted

My first instinct was to delete `auth.fuzefront.com` outright. That would have broken a live product.

**`marketplace.mendysrobotics.com` is live (200), and both `/api/auth/oidc/login` and `/api/dsm/auth/oidc/login` 302 to this IdP.** Closing the host outright breaks MendysRobotics customer logins.

An IdP serving public products cannot have a fully private *protocol* surface — Google's and Okta's authorize endpoints are public too. What it can and must have is a private *admin* surface. That is what this does.

## FuzeFront logins are unaffected

Prod runs `securityService.googleBrokered: "true"`, so the browser only ever sees `app.fuzefront.com` and `accounts.google.com`. Password and enrollment are driven server-side against `http://authentik-server:9000`. The SPA contains no Authentik URL — grepping `frontend/src` for `application/o`, `if/flow`, `authorize` returns only two test files asserting the Authentik button is *absent*.

## Known remaining surface — deliberately not closed here

- **`/api/v3` must stay for now.** Authentik's flow-executor page is a browser SPA that calls it, *and* `fuzefront-backend` hairpins to Authentik's Admin API through this public edge because it sets no `AUTHENTIK_BASE_URL` (`authentik-admin.ts` derives the base from `AUTHENTIK_ISSUER_URL`). `issueM2MToken()` does the same for `/application/o/token/`. Repoint those in-cluster, then this can shrink. Blocking it now would break custom-domain provisioning, portal brands, and M2M/A2A provisioning.
- **Contradictory tests.** `post-prod-e2e` live-smoke test 8 asserts `auth.fuzefront.com/api/v3/flows/...` returns 200; `authn-boundary-smoke` S4 asserts the same host must be unreachable. That pair needs resolving — this PR keeps test 8 passing.
- The `googleBrokered=false` rollback still needs `/source` and `/application`, both kept.

## Verified

`helm lint` clean; rendered `values-prod.yaml` and asserted both public hosts carry the identical narrowed list with no bare `/if` and no `/`.

**Not verified:** live behaviour post-deploy. After merge, `/if/admin/` on both public hosts should stop returning 200 while `marketplace.mendysrobotics.com` login still completes — worth checking both.

Related: izzywdev/FuzeInfra#562 moves the admin plane's OIDC to the Access-gated host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
