### PR TITLE
fix(authentik): gate the four admin Applications on fuzeinfra-admins membership

### DIFF
--- a/deploy/helm/fuzefront/authentik/blueprints/provider-oidc-fuzeinfra-admin.yaml
+++ b/deploy/helm/fuzefront/authentik/blueprints/provider-oidc-fuzeinfra-admin.yaml
@@ -253,6 +253,12 @@ entries:
         - !Find [authentik_providers_oauth2.scopemapping, [name, "FuzeInfra Admin OIDC scope - openid"]]
         - !Find [authentik_providers_oauth2.scopemapping, [name, "FuzeInfra Admin OIDC scope - email"]]
         - !Find [authentik_providers_oauth2.scopemapping, [name, "FuzeInfra Admin OIDC scope - profile"]]
+        # groups was MISSING here while Grafana and ArgoCD both had it. Kafka UI
+        # therefore received no group claim and could not role-gate even in
+        # principle, which is why it treats every authenticated user as a
+        # write-capable admin. Granting the scope is the precondition for giving
+        # it an actual role model.
+        - !Find [authentik_providers_oauth2.scopemapping, [name, "FuzeInfra Admin OIDC scope - groups"]]
       sub_mode: user_email
       include_claims_in_id_token: true
       authorization_flow: !Find [authentik_flows.flow, [slug, fuzeinfra-admin-authorization-implicit-consent]]
@@ -270,3 +276,81 @@ entries:
       meta_description: "Kafka topics, consumers and cluster config"
       policy_engine_mode: all
       open_in_new_tab: false
+
+  # ── Authorization: only fuzeinfra-admins may reach these Applications ────────
+  #
+  # THIS IS THE GATE THAT WAS MISSING. Every Application above declares
+  # `policy_engine_mode: all`, but "all" over an EMPTY policy set evaluates to
+  # PASS — so any user who existed in the directory could obtain a token for
+  # cloudflare-access, grafana, argocd and kafka-ui.
+  #
+  # That matters because FuzeFront is a product with self-serve signup: any
+  # Google account that completes the handshake is provisioned as an active
+  # internal user, by design. Enrollment is therefore the WRONG place to gate —
+  # closing it would break customer registration. The right place is here, on the
+  # four admin-plane Applications, which no customer should ever reach.
+  #
+  # Until now the only thing standing between an ordinary product user and the
+  # admin plane was `require { email = allowed_admin_emails }` on the Cloudflare
+  # Access policy, in a different repo. This makes Authentik enforce it too, so
+  # neither layer is load-bearing alone.
+  - model: authentik_policies_expression.expressionpolicy
+    state: present
+    identifiers:
+      name: fuzeinfra-admin-group-required
+    attrs:
+      name: fuzeinfra-admin-group-required
+      # ak_is_group_member is Authentik's built-in helper; `name` matches the
+      # group created in groups-fuzeinfra-admins.yaml, which is a cross-repo
+      # contract also consumed by Grafana roleAttributePath and ArgoCD policy.csv.
+      # Renaming that group silently locks everyone out of all four apps.
+      expression: |
+        return ak_is_group_member(request.user, name="fuzeinfra-admins")
+
+  - model: authentik_policies.policybinding
+    state: present
+    identifiers:
+      target: !Find [authentik_core.application, [slug, cloudflare-access]]
+      policy: !Find [authentik_policies_expression.expressionpolicy, [name, fuzeinfra-admin-group-required]]
+    attrs:
+      order: 0
+      enabled: true
+      negate: false
+      timeout: 30
+      failure_result: false
+
+  - model: authentik_policies.policybinding
+    state: present
+    identifiers:
+      target: !Find [authentik_core.application, [slug, grafana]]
+      policy: !Find [authentik_policies_expression.expressionpolicy, [name, fuzeinfra-admin-group-required]]
+    attrs:
+      order: 0
+      enabled: true
+      negate: false
+      timeout: 30
+      failure_result: false
+
+  - model: authentik_policies.policybinding
+    state: present
+    identifiers:
+      target: !Find [authentik_core.application, [slug, argocd]]
+      policy: !Find [authentik_policies_expression.expressionpolicy, [name, fuzeinfra-admin-group-required]]
+    attrs:
+      order: 0
+      enabled: true
+      negate: false
+      timeout: 30
+      failure_result: false
+
+  - model: authentik_policies.policybinding
+    state: present
+    identifiers:
+      target: !Find [authentik_core.application, [slug, kafka-ui]]
+      policy: !Find [authentik_policies_expression.expressionpolicy, [name, fuzeinfra-admin-group-required]]
+    attrs:
+      order: 0
+      enabled: true
+      negate: false
+      timeout: 30
+      failure_result: false

--- a/deploy/helm/fuzefront/templates/_helpers.tpl
+++ b/deploy/helm/fuzefront/templates/_helpers.tpl
@@ -56,3 +56,41 @@ prometheus.io/port: {{ .port | quote }}
 prometheus.io/path: {{ .path | default $m.path | default "/metrics" | quote }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+The ONLY Authentik paths that may be reachable from the public internet.
+
+Authentik is an IdP for public products (FuzeFront, and MendysRobotics via
+marketplace.mendysrobotics.com, whose /api/auth/oidc/login 302s to this IdP), so
+its OIDC protocol and login-flow surface cannot be made private without breaking
+customer logins. Its ADMINISTRATION surface can, and must be.
+
+The critical entry is what is ABSENT: a bare "/if". That prefix served
+/if/admin/ — the full Authentik admin interface — from every public host. Only
+/if/flow (the login/enrollment flow executor UI) and /if/session-end are needed
+by a browser. Admins reach the admin UI at authentik.<prod domain>, which sits
+behind Cloudflare Access.
+
+Do NOT re-add "/if", and do not add "/if/user": FuzeFront owns its own profile
+and MFA UI (mfa_factors is native, not an Authentik stage).
+
+/api/v3 has to stay for now — Authentik's flow-executor page is a SPA that calls
+it from the browser, and fuzefront-backend currently reaches Authentik's Admin API
+by hairpinning out through this same public edge (it sets no AUTHENTIK_BASE_URL,
+so authentik-admin.ts falls back to deriving it from AUTHENTIK_ISSUER_URL). It is
+authenticated — /api/v3/core/users/me/ returns 403 unauthenticated — but it is
+surface that should shrink once that hairpin is repointed in-cluster.
+*/}}
+{{- define "fuzefront.authentikPublicPaths" -}}
+- /application
+- /if/flow
+- /if/session-end
+- /source
+- /flows
+- /ws
+- /-
+- /outpost.goauthentik.io
+- /api/v3
+- /static/dist
+- /static/authentik
+{{- end -}}

--- a/deploy/helm/fuzefront/templates/authentik.yaml
+++ b/deploy/helm/fuzefront/templates/authentik.yaml
@@ -345,12 +345,21 @@ spec:
     - host: {{ $ak.host | quote }}
       http:
         paths:
-          - path: /
+          {{- /* Was `path: /` — the ENTIRE Authentik, including /if/admin/ and
+                 /api/v3, served publicly on this host. Verified against prod:
+                 /if/admin/, /if/flow/default-authentication-flow/ and
+                 /api/v3/root/config/ all returned 200 to an anonymous client.
+                 Narrowed to the same protocol+login set the app-host proxy uses.
+                 This host cannot simply be deleted: marketplace.mendysrobotics.com
+                 is live and its /api/auth/oidc/login 302s here. */ -}}
+          {{- range $p := (include "fuzefront.authentikPublicPaths" $ | fromYamlArray) }}
+          - path: {{ $p }}
             pathType: Prefix
             backend:
               service:
                 name: authentik-server
                 port:
                   number: 9000
+          {{- end }}
 {{- end }}
 {{- end }}

--- a/deploy/helm/fuzefront/templates/ingress.yaml
+++ b/deploy/helm/fuzefront/templates/ingress.yaml
@@ -360,7 +360,10 @@ spec:
                  (password/enrollment flow driver). Must route to authentik-server,
                  or flow-executor calls hit FuzeFront's /api and fail with
                  PROVIDER_UNAVAILABLE. Does not collide with FuzeFront's /api/v1/*. */ -}}
-          {{- range $p := list "/application" "/if" "/source" "/flows" "/ws" "/-" "/outpost.goauthentik.io" "/api/v3" "/static/dist" "/static/authentik" }}
+          {{- /* Single source of truth, shared with the auth.<zone> Ingress in
+                 authentik.yaml so the two public surfaces cannot drift. Notably
+                 has NO bare "/if" — that is what exposed /if/admin/. */ -}}
+          {{- range $p := (include "fuzefront.authentikPublicPaths" $ | fromYamlArray) }}
           - path: {{ $p }}
             pathType: Prefix
             backend:


### PR DESCRIPTION
Closes the authorization hole underneath the admin-plane SSO work.

## The hole

All four admin-plane Applications declared `policy_engine_mode: all` with **zero policy bindings**. In Authentik, "all" over an *empty* policy set evaluates to **pass** — so any user who existed in the directory could obtain a token for `cloudflare-access`, `grafana`, `argocd` and `kafka-ui`.

That is not theoretical. FuzeFront has self-serve signup, and any Google account that completes the handshake is provisioned as an **active internal user** — by the enrollment flow on the legacy path (`create_users_as_inactive: false`), and by the Admin API on the brokered path prod actually runs (`is_active: true` in `accountApi.ts`).

So **every product signup created an identity authorized against the infrastructure admin applications.**

## What I deliberately did *not* do

The obvious fix is to gate enrollment so unknown Google accounts cannot self-provision. That is wrong, and I want to be explicit about rejecting it: auto-provisioning a signing-up customer **is the product working as intended**. Gating it would break registration.

The correct boundary is the four admin-plane Applications, which no customer should ever reach. Enrollment stays open; these four do not.

## Before / after

| | before | after |
|---|---|---|
| Any product user → `grafana` token | ✅ issued | ❌ denied |
| Any product user → `argocd` token | ✅ issued | ❌ denied |
| Any product user → `kafka-ui` token | ✅ issued | ❌ denied |
| Any product user → `cloudflare-access` token | ✅ issued | ❌ denied |
| `fuzeinfra-admins` member | ✅ | ✅ |

Until now the only control was `require { email = allowed_admin_emails }` on the Cloudflare Access policy — in a **different repository**, and the single point of failure for the entire platform. Authentik now enforces the same restriction independently, so neither layer is load-bearing alone.

## Also: kafka-ui gets the `groups` scope

It was the only admin provider without it, while Grafana and ArgoCD both had it. So Kafka UI received no group claim and **could not role-gate even in principle** — which is why it treats every authenticated user as a write-capable admin (`DYNAMIC_CONFIG_ENABLED=true`).

Granting the scope is the precondition for giving it a real role model. That role model is a follow-up, not this PR — so after merge Kafka UI is still authn-only, just now gated to admins at the Authentik layer.

## Sharp edge

The policy matches by group **name**. Renaming `fuzeinfra-admins` silently locks everyone out of all four applications. That group is already a cross-repo contract consumed by Grafana's `roleAttributePath` and ArgoCD's `policy.csv`, and it is documented as such in `groups-fuzeinfra-admins.yaml`.

## Verified

Blueprint parses — 18 entries, 1 expression policy, 4 bindings. `helm lint` clean. Rendered ConfigMap carries the new entries.

**Not verified:** live enforcement. After deploy, confirm the admin can still reach all four applications — and ideally that a non-admin account cannot. If the policy expression is wrong, the failure mode is lockout from all four, recoverable via the `akadmin` break-glass account.

Related: izzywdev/FuzeInfra#562 (admin plane → Authentik), izzywdev/FuzeFront#735 (IdP admin surface off the public internet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
