### PR TITLE
chore(ci): cut artifact retention to stop storage quota failures

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -172,7 +172,7 @@ jobs:
           path: |
             backend/coverage/
             backend/test-results/
-          retention-days: 30
+          retention-days: 7
 
   # Permit.io integration tests run in a separate non-matrix job so the
   # permit-pdp service container (which needs secrets.PERMIT_API_KEY in its

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,6 +235,10 @@ jobs:
         run: cd sdk && npm run build
 
       - name: Upload build artifacts
+        # Only upload on release events — 1,928 copies at 6.36 GB was the dominant
+        # storage consumer. integration-tests below rebuilds from source so the
+        # artifact is not needed on every PR/push run.
+        if: github.event_name == 'release'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: build-artifacts
@@ -242,6 +246,7 @@ jobs:
             backend/dist/
             frontend/dist/
             sdk/dist/
+          retention-days: 7
 
   chat-service-tests:
     name: Chat service (unit)
@@ -401,11 +406,6 @@ jobs:
         with:
           node-version: '24.x'
           cache: 'npm'
-
-      - name: Download build artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: build-artifacts
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Why

The \`izzywdev\` GitHub Actions artifact storage quota was exhausted on 2026-08-19, causing \`gate-secret-scan\` to fail with \`Artifact storage quota has been hit\` after gitleaks reported no leaks. Root cause: FuzeFront alone held **12,593 live artifacts / 8.99 GB**.

A one-time cleanup deleted 2,851 artifacts (6.18 GB freed, 8.99 → 2.81 GB). This PR prevents the quota refilling.

## Changes

### ci.yml — build-artifacts (was 1,928 copies / 6.36 GB)

- **Made conditional on release events only.** Every PR/master push was uploading ~3.3 MB that was never inspected.
- Added retention-days: 7 as belt-and-suspenders.
- **Removed download-artifact from integration-tests** — that job runs \`cd backend && npm run test:integration\` via ts-jest which compiles from source; the pre-built backend/dist/ was never used by the test runner.

### backend-tests.yml — test-results-* (was 1,204 artifacts / 870 MB combined)

Lowered retention-days from 30 to 7. Covers test-results-24.x and test-results-22.x. 7 days is enough to inspect a recent failure.

## What was NOT changed

- sbom-files (historical record) — left at 30 days
- Playwright reports — left at current 14-day retention
- Android APK uploads — already conditional and rare

## Merge note

FuzeFront is deployOnPush: true on master. Merge only during a deploy window.