### PR TITLE
fix(authentik): admin Ingress was missing X-Forwarded-Proto, breaking OIDC logins

### DIFF
--- a/deploy/helm/fuzefront/templates/ingress.yaml
+++ b/deploy/helm/fuzefront/templates/ingress.yaml
@@ -403,10 +403,28 @@ metadata:
   labels:
     {{- include "fuzefront.labels" . | nindent 4 }}
     app.kubernetes.io/component: authentik-admin
-  {{- with .Values.authentik.adminIngress.annotations }}
   annotations:
+    # NOT OPTIONAL. Authentik derives every URL it advertises — issuer,
+    # authorization_endpoint, token_endpoint, jwks_uri — from the incoming
+    # request, so without X-Forwarded-Proto it builds them as http:// even though
+    # the client arrived over TLS.
+    #
+    # This Ingress was the only one of the three Authentik ingresses missing it.
+    # That went unnoticed while the host served just the admin UI, and broke the
+    # moment FuzeInfra pointed OIDC consumers here: discovery returned
+    #   "issuer": "http://authentik.prod.fuzefront.com/application/o/kafka-ui/"
+    # and every client that validates the iss claim against its configured https
+    # issuer rejected the login. Kafka UI and ArgoCD self-discover and both
+    # failed with a bare /login?error; Grafana uses explicit URLs so it degraded
+    # more quietly.
+    #
+    # Keep this in sync with the other two: templates/ingress.yaml
+    # (fuzefront-authentik-idp) and templates/authentik.yaml (the auth.<zone>
+    # Ingress) both set the same middleware.
+    traefik.ingress.kubernetes.io/router.middlewares: {{ .Release.Namespace }}-authentik-forwarded-proto@kubernetescrd
+    {{- with .Values.authentik.adminIngress.annotations }}
     {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- end }}
 spec:
   ingressClassName: {{ .Values.authentik.adminIngress.className | default .Values.ingress.className }}
   rules:


### PR DESCRIPTION
Hotfix. Kafka UI and ArgoCD SSO are failing in production with a bare `/login?error`.

## Root cause

Authentik derives every URL it advertises — `issuer`, `authorization_endpoint`, `token_endpoint`, `jwks_uri` — from the **incoming request**. Without `X-Forwarded-Proto` it builds them as `http://` even when the client arrived over TLS.

Measured against prod. Same Authentik, three Ingresses:

| host | advertised issuer | has `authentik-forwarded-proto` |
|---|---|---|
| `auth.fuzefront.com` | `https://...` | yes |
| `app.fuzefront.com` | `https://...` | yes |
| `authentik.prod.fuzefront.com` | **`http://...`** | **no** |

`fuzefront-authentik-admin` only emitted an `annotations:` block at all if `authentik.adminIngress.annotations` was set — and it is not set in prod. So the middleware the other two carry was silently absent.

That was harmless while the host served only the admin UI. It broke the moment izzywdev/FuzeInfra#562 pointed OIDC consumers at it:

```
"issuer": "http://authentik.prod.fuzefront.com/application/o/kafka-ui/"
```

Any client that validates the `iss` claim against its configured `https` issuer rejects the login. **Kafka UI and ArgoCD self-discover from the issuer and both break outright. Grafana is configured with explicit https endpoints, so it degrades more quietly** rather than failing — worth re-checking its role mapping after this lands.

## Fix

Make the annotation unconditional on that Ingress, with user-supplied annotations merged after it so they can still override deliberately.

## Verified

`helm lint` clean; rendered `values-prod.yaml` confirms every Authentik Ingress now carries the middleware.

**Not verified:** that the advertised issuer actually flips to `https://` — that needs Traefik to pick up the changed annotation post-deploy. I'll confirm against prod after Argo syncs, and re-test the Kafka UI login.

## My error

This is a defect in #562's design, not a pre-existing bug someone else left. I moved the consumers onto the one Ingress of three that lacked the proxy headers, and did not check that the destination host advertised the same scheme as the source. The discovery-document comparison above is the check I should have run before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
