### PR TITLE
fix(authentik): admin OIDC providers had no grant_types, so no login could work

### DIFF
--- a/deploy/helm/fuzefront/authentik/blueprints/provider-oidc-fuzeinfra-admin.yaml
+++ b/deploy/helm/fuzefront/authentik/blueprints/provider-oidc-fuzeinfra-admin.yaml
@@ -59,7 +59,12 @@ entries:
       slug: fuzeinfra-admin-authorization-implicit-consent
       designation: authorization
       title: FuzeInfra Admin Sign In
-      authentication: require_authenticated
+      # MUST be `none`, not require_authenticated. Authentik's OAuth2 provider
+      # view handles the auth redirect itself — it sends an unauthenticated user
+      # to the login flow and back. require_authenticated makes Authentik reject
+      # the request outright instead of redirecting to login. Same rationale as
+      # fuzefront-authorization-implicit-consent in provider-oidc.yaml.
+      authentication: none
       policy_engine_mode: all
 
   # ── Shared scope mappings ────────────────────────────────────────────────────
@@ -143,6 +148,16 @@ entries:
       include_claims_in_id_token: true
       authorization_flow: !Find [authentik_flows.flow, [slug, fuzeinfra-admin-authorization-implicit-consent]]
       invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+      # REQUIRED on Authentik 2026.x (prod runs server:2026.5.5). A provider
+      # created without grant_types has an EMPTY allow-list and rejects every
+      # authorize request — the browser is bounced straight back to the client's
+      # redirect_uri with error=invalid_request ("The request is otherwise
+      # malformed"), which reads like a client bug rather than a provider one.
+      # provider-oidc.yaml and provider-oidc-mendys-datasets.yaml already set it;
+      # these four did not, so none of them could ever complete a login.
+      grant_types:
+        - authorization_code
+        - refresh_token
 
   - model: authentik_core.application
     state: present
@@ -178,6 +193,16 @@ entries:
       include_claims_in_id_token: true
       authorization_flow: !Find [authentik_flows.flow, [slug, fuzeinfra-admin-authorization-implicit-consent]]
       invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+      # REQUIRED on Authentik 2026.x (prod runs server:2026.5.5). A provider
+      # created without grant_types has an EMPTY allow-list and rejects every
+      # authorize request — the browser is bounced straight back to the client's
+      # redirect_uri with error=invalid_request ("The request is otherwise
+      # malformed"), which reads like a client bug rather than a provider one.
+      # provider-oidc.yaml and provider-oidc-mendys-datasets.yaml already set it;
+      # these four did not, so none of them could ever complete a login.
+      grant_types:
+        - authorization_code
+        - refresh_token
 
   # Application slug is load-bearing: it forms the issuer URL
   # https://auth.fuzefront.com/application/o/grafana/ that FuzeInfra's
@@ -220,6 +245,16 @@ entries:
       include_claims_in_id_token: true
       authorization_flow: !Find [authentik_flows.flow, [slug, fuzeinfra-admin-authorization-implicit-consent]]
       invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+      # REQUIRED on Authentik 2026.x (prod runs server:2026.5.5). A provider
+      # created without grant_types has an EMPTY allow-list and rejects every
+      # authorize request — the browser is bounced straight back to the client's
+      # redirect_uri with error=invalid_request ("The request is otherwise
+      # malformed"), which reads like a client bug rather than a provider one.
+      # provider-oidc.yaml and provider-oidc-mendys-datasets.yaml already set it;
+      # these four did not, so none of them could ever complete a login.
+      grant_types:
+        - authorization_code
+        - refresh_token
 
   - model: authentik_core.application
     state: present
@@ -263,6 +298,16 @@ entries:
       include_claims_in_id_token: true
       authorization_flow: !Find [authentik_flows.flow, [slug, fuzeinfra-admin-authorization-implicit-consent]]
       invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+      # REQUIRED on Authentik 2026.x (prod runs server:2026.5.5). A provider
+      # created without grant_types has an EMPTY allow-list and rejects every
+      # authorize request — the browser is bounced straight back to the client's
+      # redirect_uri with error=invalid_request ("The request is otherwise
+      # malformed"), which reads like a client bug rather than a provider one.
+      # provider-oidc.yaml and provider-oidc-mendys-datasets.yaml already set it;
+      # these four did not, so none of them could ever complete a login.
+      grant_types:
+        - authorization_code
+        - refresh_token
 
   - model: authentik_core.application
     state: present


### PR DESCRIPTION
Hotfix. Kafka UI, ArgoCD and Grafana SSO cannot complete a login — and, on the evidence, never could.

## Reproduction

Hand-built authorize request against prod:

```
/application/o/authorize/?client_id=kafka-ui&redirect_uri=...&response_type=code&scope=openid+email+profile
-> 302 .../login/oauth2/code/authentik?error=invalid_request
      &error_description=The%20request%20is%20otherwise%20malformed
```

Bisected rather than guessed:

| provider | blueprint | unauthenticated authorize |
|---|---|---|
| `kafka-ui` | admin | `error=invalid_request` |
| `grafana` | admin | `error=invalid_request` |
| `argocd` | admin | `error=invalid_request` |
| `cloudflare-access` | admin | `error=invalid_request` |
| **`fuzefront`** (control) | `provider-oidc.yaml` | ✅ `/if/flow/default-authentication-flow` |

Identical on all three Authentik hosts (`auth.`, `app.`, `authentik.prod.`), so this is **provider config — not ingress, not proxy headers, not the recent path narrowing.**

## Two defects, both original

**1. No `grant_types`.** Required on Authentik 2026.x (prod runs `server:2026.5.5`). A provider created without it has an *empty* allow-list and rejects every authorize request. `provider-oidc.yaml` documents this precisely — *"fresh providers default to NO allowed grant types and reject every authorize request"* — and sets it. So does `provider-oidc-mendys-datasets.yaml`. These four did not.

**2. `authentication: require_authenticated` on the shared authorization flow.** Authentik's OAuth2 provider view performs the auth redirect itself; `require_authenticated` makes it reject instead of redirecting to login. `provider-oidc.yaml` documents this too and uses `none`.

Both fixes copy the sibling blueprint that demonstrably works in this same instance.

## Why earlier verification missed it

I verified each provider's discovery document returned 200 with correct `https` endpoints and the right scopes. All true — and all irrelevant. **Discovery says nothing about whether the provider will accept an authorize request.** The check that catches this is an actual authorize call, which is now the thing to run against any new provider.

These providers have never completed a login. The recent ingress and forwarded-proto work was necessary but not sufficient; this is the remaining cause.

## Verified

Blueprint parses; all four providers carry `grant_types: [authorization_code, refresh_token]`; flow `authentication: none`; `helm lint` clean.

**Not verified:** a completed browser login. Checking against prod after Argo syncs and the Authentik pods roll on the `checksum/blueprints` annotation.

Related: izzywdev/FuzeFront#738 (forwarded-proto), izzywdev/FuzeInfra#562.
