### PR TITLE
fix(authentik): admin group was assigned to a username that never logs in

### DIFF
--- a/deploy/helm/fuzefront/authentik/blueprints/groups-fuzeinfra-admins.yaml
+++ b/deploy/helm/fuzefront/authentik/blueprints/groups-fuzeinfra-admins.yaml
@@ -38,12 +38,30 @@ entries:
       # makes this account able to administer the IdP, not just consume it.
       is_superuser: true
 
+  # The username here MUST match the account Google actually authenticates into,
+  # because Authentik matches this entry by `username`, not by email.
+  #
+  # It used to be `izzy`, which was a guess and never matched anything. The real
+  # account is created with username == email: FuzeFront's brokered Google path
+  # provisions via the Admin API with `username: email` (see accountApi.ts
+  # findOrCreateUserPk), and the Authentik Google source links to it by email.
+  # Verified against prod — /api/v3/core/users/me/ after a Google login returns:
+  #   {"pk":12,"username":"izzy.weinberg@gmail.com","groups":[],...}
+  #
+  # So this blueprint was assigning the admin group to a phantom `izzy` row while
+  # the account being logged into had no groups at all. Symptom: Google login
+  # succeeds, then Authentik denies at the application authorization step, and
+  # Grafana would have silently landed on the non-admin branch of
+  # roleAttributePath while ArgoCD's policy.csv matched nothing.
+  #
+  # If the login username ever changes, this must change with it. A durable fix
+  # is to derive group membership from the email claim instead of pinning a
+  # username; that is a larger change and is tracked separately.
   - model: authentik_core.user
     state: present
     identifiers:
-      username: izzy
+      username: izzy.weinberg@gmail.com
     attrs:
-      username: izzy
       name: Izzy Weinberg
       email: izzy.weinberg@gmail.com
       is_active: true


### PR DESCRIPTION
Hotfix. Google login now succeeds, then Authentik denies at the application authorization step.

## The gate is right; the membership behind it was wrong

Verified against prod immediately after a completed Google login:

```
GET /api/v3/core/users/me/
{"pk":12,"username":"izzy.weinberg@gmail.com","is_superuser":false,"groups":[]}
```

The account being logged into has **no groups**, so `ak_is_group_member(request.user, name="fuzeinfra-admins")` correctly denies.

This blueprint assigned the group to `username: izzy` — a guess that matches nothing. Authentik matches a user entry by its **identifiers**, and `username` was the identifier, so the email never entered into it.

The real account is created with **username == email**: FuzeFront's brokered Google path provisions through the Admin API with `username: email` (`accountApi.ts` `findOrCreateUserPk`), and the Authentik Google source links to that row by email.

## Fix

Retarget the identifier to the actual username. `username` is deliberately **no longer in `attrs`**, only in `identifiers`, so this attaches the group to the existing row without renaming it.

## Why this was invisible until now

It has been latent since the group was introduced. Nothing had ever completed a login against these providers — they rejected every authorize request for missing `grant_types` until #739. Two bugs in series; the second only became observable once the first was fixed.

Worth noting what this same defect would have caused even without the explicit deny: **Grafana** tests for `fuzeinfra-admins` in the groups claim and would have taken the non-admin branch; **ArgoCD**'s `policy.csv` maps the same group and would have matched nothing. The group name is a cross-repo contract — an account outside it is invisible to all three consumers at once.

## Known brittleness

Pinning a username is fragile: if the login username ever changes, this breaks again in exactly the same silent way. Deriving membership from the **email claim** would be durable. That is a larger change and prod is currently locked out, so it is noted rather than done.

## Verified

Blueprint parses; identifier is the real username; `attrs` no longer rename the row; `helm lint` clean.

**Not verified:** that the group actually attaches and the login completes. Checking against prod once the blueprint applies — `/api/v3/core/users/me/` should show `groups: ["fuzeinfra-admins"]`.

Follows izzywdev/FuzeFront#739 (grant_types) and #738 (forwarded-proto).
