### PR TITLE
fix(gate-toolchain): reject the bare-array shared form and require singleton: true

### DIFF
--- a/scripts/gate-toolchain.mjs
+++ b/scripts/gate-toolchain.mjs
@@ -13,8 +13,10 @@
 //   - @types/react / @types/react-dom >=19.2.0 where declared
 //   - peerDependencies react/react-dom >=19.0.0 (and does not admit 18) where
 //     a package already declares a React peer
-//   - Module-Federation `shared.react(-dom).requiredVersion` — every
-//     federation config found must read '^19.0.0', AND the host
+//   - Module-Federation `shared.react(-dom)` — every federation config found
+//     must use the explicit object form (the bare-array shorthand is rejected:
+//     it requests no singleton semantics), must carry `singleton: true`, must
+//     read requiredVersion '^19.0.0', AND the host
 //     (frontend/vite.config.ts) must match every remote found in-repo. A
 //     silent mismatch here is the dangerous half of this gate: the remote
 //     loads its own React copy and dies on "Invalid hook call" at runtime,
@@ -194,6 +196,27 @@ for (const f of federationConfigs) {
   if (!/@originjs\/vite-plugin-federation|ModuleFederationPlugin/.test(text)) continue
   if (!/shared\s*:/.test(text)) continue
 
+  // The BARE-ARRAY shorthand — `shared: ['react', 'react-dom']` — requests no
+  // singleton semantics at all, so version agreement is not even the question:
+  // the remote can load its own React copy regardless of what any version
+  // string says. It has to be caught structurally, because it presents as an
+  // ABSENCE (no requiredVersion to compare) rather than as a wrong value — the
+  // requiredVersion scan below finds nothing and would otherwise skip the file
+  // as "not part of this repo's MF contract". See #658 Group B, where four
+  // sibling repos adopted this form after a real constraint (never list
+  // `@fuzefront/*` in `shared`, it hits ENOTDIR on source-aliased paths) was
+  // over-generalised into "shared must be a bare array". The object form is
+  // compatible with that constraint; the host proves it.
+  const bareArrayShared = text.match(/shared\s*:\s*\[([^\]]*)\]/)
+  if (bareArrayShared && /['"]react(-dom)?['"]/.test(bareArrayShared[1])) {
+    violations.push(
+      `${f}: shared uses the bare-array shorthand (shared: [${bareArrayShared[1].trim()}]) — it never requests ` +
+        `singleton semantics, so the remote may load its own React copy and die on "Invalid hook call" at runtime. ` +
+        `Use the explicit object form: { react: { singleton: true, requiredVersion: '^19.0.0' }, ... }`
+    )
+    continue
+  }
+
   // Find requiredVersion for the react and react-dom entries specifically —
   // scan each shared-block entry's local text window rather than a single
   // global regex, since react and react-dom are separate keys.
@@ -210,6 +233,25 @@ for (const f of federationConfigs) {
       violations.push(`${f}: shared.${label} declared but has no requiredVersion`)
     } else if (spec !== '^19.0.0') {
       violations.push(`${f}: shared.${label}.requiredVersion is "${spec}", expected "^19.0.0"`)
+    }
+  }
+
+  // `singleton: true` is the half that actually forces one React instance —
+  // a matching requiredVersion without it still permits a second copy. Checked
+  // separately from the version so a config that drops ONLY the singleton flag
+  // cannot pass: that exact regression reached master during #647, where a
+  // remote's shared block briefly lost `singleton: true` alongside its version
+  // revert, and only the version half was detectable at the time.
+  for (const [label, pattern] of [
+    ['react', /(['"]?)react\1\s*:\s*\{[^}]*singleton:\s*true/],
+    ['react-dom', /(['"]?)react-dom\1\s*:\s*\{[^}]*singleton:\s*true/],
+  ]) {
+    const declared = label === 'react' ? reactMatch : reactDomMatch
+    if (declared && !pattern.test(text)) {
+      violations.push(
+        `${f}: shared.${label} is missing "singleton: true" — requiredVersion alone does not force a single ` +
+          `React instance across the federation boundary; the remote can still load its own copy`
+      )
     }
   }
 }


### PR DESCRIPTION
## 📋 Description

Implements the FuzeFront-side half of #658 — the part the issue calls *"the single highest-value check in the whole #646 family, and the cheapest to write"*.

`gate-toolchain` already compared Module-Federation `requiredVersion` across in-repo configs, but it had two blind spots — and both are the half with the actual runtime consequence.

Refs #658.

## 🔄 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## 🔧 Implementation Details

### Blind spot 1 — the bare-array shorthand was skipped entirely

```js
if (!reactMatch && !reactDomMatch) continue // ← shared: ['react','react-dom'] lands here
```

`shared: ['react', 'react-dom']` presents as an **absence**: there is no `requiredVersion` to compare, so the scan matched nothing and `continue`d, treating the file as "not part of this repo's MF contract". It therefore had to be caught *structurally* rather than by value.

Per the host's own comment, the bare array is not equivalent to an explicit singleton — it never requests singleton semantics, so version agreement isn't even the question; the remote can take its own React copy regardless.

#658 Group B documents how this spread: a genuine constraint (never list `@fuzefront/*` in `shared` — it hits `ENOTDIR` on source-aliased paths) was over-generalised into "shared must be a bare array". The object form satisfies that constraint; the host proves it.

### Blind spot 2 — `singleton: true` was never checked at all

A matching `requiredVersion` without `singleton: true` still permits a second React instance. Checked separately from the version so a config that drops *only* the flag cannot pass.

**This is not hypothetical.** During #647 a remote's `shared` block reached master having lost `singleton: true` alongside a version revert to `^18.0.0`. The gate caught the version half; the singleton half was undetectable at the time.

## 🧪 Testing

- [x] Real repo still passes — `✓ gate-toolchain passed (50 package.json, 19 Dockerfile(s), 60 workflow(s), 11 federation config(s) scanned)`
- [x] Bare-array fixture (FuzeContact/FuzeAgent shape) → correctly rejected
- [x] `requiredVersion`-without-`singleton` fixture → correctly flags both `react` and `react-dom`
- [x] Correct object-form fixture → passes (no false positive)
- [x] `node scripts/check-workspace-deps.mjs` — passes
- [x] `node scripts/check-dockerfile-lockfile.mjs` — passes

Both checks are **forward-looking**: all three in-repo federation configs (`frontend`, `clock-app`, `FuzeQuality/apps/web`) already use the correct object form, so this adds zero violations today while guarding against a regression shape that has already occurred once.

### Code Quality

- [x] Self-review of code completed
- [x] Code follows conventional commit format

## ⚠️ Scope — this does NOT close #658

#658 spans **nine sibling repos** and this PR only covers what lives in FuzeFront. Still outstanding, and outside this repo:

| Group | Repos | Fix |
|---|---|---|
| **A** — declare `^18.0.0` | FuzeKeys, FuzeMarket, FuzePlan, FuzePicker | bump to `^19.0.0` **together with** each repo's own `react`/`react-dom` → `^19.2.0` |
| **B** — bare array | FuzeAgent, FuzeContact, FuzeSales, FuzeService | switch to the explicit object form |
| **C** — MF declared, no federation build | FuzeSocial | decide the real `integration.type` or build the remote |

Two caveats from the issue worth preserving:

- **Coordination**: the host and remotes must land in one window. A remote bumped ahead of the host is as broken as one left behind.
- **Unverified**: whether these remotes fail in prod *today* is still not established. #658 asks for a real-Chromium click-through of the registered MF tiles (per `ui-runtime-validation`) before deciding urgency. This gate does not answer that.

This gate cannot see those repos — it only scans in-repo configs — so cross-repo enforcement would need this check propagated via FuzeSDLC.

---
_Generated by [Claude Code](https://claude.ai/code/session_013tMciHkPE8To7V67CsgKKc)_