### PR TITLE
fix(ci): restore full-severity Trivy filesystem coverage to code scanning

### DIFF
--- a/.github/workflows/harden-gate.yml
+++ b/.github/workflows/harden-gate.yml
@@ -121,7 +121,18 @@ jobs:
           scan-ref: .
           format: sarif
           output: trivy.sarif
-          severity: CRITICAL,HIGH
+          # ALL severities, deliberately and explicitly. When ci.yml's duplicate
+          # filesystem scan stopped uploading to code scanning (it was the same
+          # scan racing this one under a shared SARIF tool identity), this job
+          # became the only filesystem config reaching the Security tab — and it
+          # was CRITICAL,HIGH only, while ci.yml's had no severity filter at all.
+          # Net effect was that LOW and MEDIUM filesystem findings silently
+          # stopped producing alerts: a real coverage regression that arrived as
+          # a side effect of a de-duplication, which is exactly how coverage gets
+          # lost without anyone deciding to lose it. Listed out rather than
+          # omitted so the intent is visible at the call site; omitting `severity`
+          # defaults to the same set but reads like an oversight.
+          severity: UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL
           exit-code: '0'
           ignore-unfixed: true
           trivyignores: '.trivyignore'


### PR DESCRIPTION
## 📋 Description

Restores code-scanning coverage that was lost as a **side effect** of a de-duplication, not by any decision to reduce it.

`harden-gate`'s filesystem Trivy scan was `CRITICAL,HIGH` only. `ci.yml` ran a byte-identical filesystem scan with **no severity filter**, and it was the one carrying LOW/MEDIUM into the Security tab. When `ci.yml`'s duplicate SARIF upload was removed in #647 (it raced this job under a shared SARIF tool identity), LOW and MEDIUM filesystem findings silently stopped producing alerts.

The scan still ran and its SARIF was kept as an artifact — but an artifact nobody opens is not an alert. That is a real coverage regression, and it is exactly how coverage gets lost without anyone choosing to lose it.

## 🔄 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## 🔧 Implementation Details

```diff
-          severity: CRITICAL,HIGH
+          severity: UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL
```

Listed explicitly rather than omitting `severity` — omitting it defaults to the same set, but reads like an oversight rather than a decision. The comment at the call site records why.

`ignore-unfixed: true` and `.trivyignore` are unchanged, so only **actionable** findings are reported.

This does not reintroduce the race #647 fixed: there is still exactly **one** filesystem configuration uploading under the `trivy` category.

## ⚠️ Expect a one-off influx — this is the intended effect

Scanning locally at the exact restored config: **54 findings return** (46 MEDIUM + 8 LOW). They are **pre-existing, not introduced here** — they were being scanned all along and simply stopped being surfaced.

Triaged in full in **#747**, with a per-package worklist. Headline: it is concentrated, not scattered — **`axios` 1.11.0 → 1.18.0 alone clears 17 of the 54**, and `tar` → 7.5.21 clears 4 more *plus* both outstanding CRITICALs.

Two entries (`react-router` 6→7, `uuid` 9→11) are **major** bumps flagged in #747 as needing their own PRs, not batching.

## 🧪 Testing

- [x] YAML parses
- [x] `node scripts/gate-toolchain.mjs` — passes
- [x] `node scripts/check-workspace-deps.mjs` — passes
- [x] `node scripts/check-dockerfile-lockfile.mjs` — passes
- [x] Local scan at the restored config to quantify the incoming backlog (see #747)

### Code Quality

- [x] Self-review of code completed
- [x] Code follows conventional commit format

## Caveats

- The local triage used a **cached vulnerability DB dated 2026-08-16** (live DB pull returned `ghcr.io: DENIED` in the sandbox). CI runs a fresh DB, so its exact counts may differ — the shape and the top offenders should hold.
- **Unverified:** I have not proven the `Trivy` check still goes red on a genuinely new CRITICAL/HIGH. It has been `neutral` recently, and "neutral now" is not evidence either way. Worth confirming rather than assuming — this repo's CLAUDE.md has the scar tissue on treating a green check as proof.

## 🔗 Related

- #747 — triage of the 54 restored findings
- #647 — where the de-duplication removed the coverage

---
_Generated by [Claude Code](https://claude.ai/code/session_013tMciHkPE8To7V67CsgKKc)_