### PR TITLE
fix: unblock the stalled prod rollout — root-org FK violation (#750) and the @fuzefront/shared subpath crash

### DIFF
--- a/backend/applications/src/app-registry/events.ts
+++ b/backend/applications/src/app-registry/events.ts
@@ -67,6 +67,13 @@ interface ProducerLike {
  * resolved lazily from @fuzefront/shared so each send is validated against the
  * frozen contract; if a schema is unavailable we send without local validation
  * (the broker still receives the envelope) rather than dropping the event.
+ *
+ * The subpath must be one @fuzefront/shared declares in `exports`. This used to
+ * say `./dist/kafka`, which is NOT exported — so the require below threw
+ * ERR_PACKAGE_PATH_NOT_EXPORTED, the catch swallowed it, and the documented
+ * "if a schema is unavailable" fallback was in fact the ONLY path ever taken in
+ * the production image: every event has been sent unvalidated. The catch is
+ * meant to be a fallback, not a mask.
  */
 export class KafkaAppRegistryEmitter implements AppRegistryEventEmitter {
   private schemas: Record<string, unknown> = {}
@@ -74,7 +81,7 @@ export class KafkaAppRegistryEmitter implements AppRegistryEventEmitter {
   constructor(private readonly producer: ProducerLike) {
     try {
       // eslint-disable-next-line @typescript-eslint/no-var-requires
-      const shared = require('@fuzefront/shared/dist/kafka')
+      const shared = require('@fuzefront/shared/kafka')
       this.schemas = {
         [TOPIC.APP_REGISTERED]: shared.appRegisteredSchemaV1,
         [TOPIC.APP_ACTIVATED]: shared.appActivatedSchemaV1,
@@ -187,7 +194,7 @@ export function getAppRegistryEmitter(): AppRegistryEventEmitter {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const { Kafka } = require('kafkajs')
     // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const { TypedProducer } = require('@fuzefront/shared/dist/kafka')
+    const { TypedProducer } = require('@fuzefront/shared/kafka')
     const kafka = new Kafka({
       clientId: 'applications-service',
       brokers: brokers.split(',').map((b: string) => b.trim()),

--- a/backend/applications/src/kafka/ref-index.consumer.ts
+++ b/backend/applications/src/kafka/ref-index.consumer.ts
@@ -2,8 +2,17 @@ import { z } from 'zod'
 // Dynamic require so the path resolves against the dist output without a
 // tsconfig `paths` alias (applications-service follows this pattern for all
 // shared/kafka imports — see app-registry/events.ts).
+//
+// The subpath MUST be the one @fuzefront/shared declares in its `exports` map.
+// `./dist/kafka` is not exported, and an `exports` field makes every
+// undeclared subpath unreachable — so requiring it throws
+// ERR_PACKAGE_PATH_NOT_EXPORTED. This require is top-level and unguarded, so
+// that threw at module load and crash-looped the whole service in prod. The
+// pattern was copied from app-registry/events.ts, where the identical deep
+// path has always been broken too — its require just sits inside a try/catch
+// that silently swallowed the failure.
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const { createKafkaClient, TypedConsumer } = require('@fuzefront/shared/dist/kafka')
+const { createKafkaClient, TypedConsumer } = require('@fuzefront/shared/kafka')
 import {
   applyEventToRefIndex,
   REF_INDEX_TOPICS,

--- a/backend/applications/tests/sharedSubpathExports.test.ts
+++ b/backend/applications/tests/sharedSubpathExports.test.ts
@@ -34,7 +34,13 @@ const SHARED_PKG = path.join(REPO_ROOT, 'shared', 'package.json')
  */
 const KNOWN_UNMIGRATED = ['services/billing-service/']
 
-const IMPORT_RE = /['"`]@fuzefront\/shared(\/[^'"`]+)?['"`]/g
+// Matches only real import syntax — `from '...'` / `require('...')` — not any
+// quoted occurrence. An earlier version matched backtick-delimited text too and
+// so flagged the specifier written inside THIS file's own comments. It passed
+// locally purely because `git ls-files` does not list an untracked file, then
+// failed the moment it was committed: the scanner could not see itself until it
+// could, and then it was its own first offender.
+const IMPORT_RE = /(?:from|require\()\s*['"]@fuzefront\/shared(\/[^'"]+)?['"]/g
 
 function trackedSourceFiles(): string[] {
   const out = execFileSync('git', ['ls-files', '-z', '*.ts', '*.tsx', '*.js', '*.mjs', '*.cjs'], {
@@ -61,11 +67,13 @@ describe('@fuzefront/shared subpath imports resolve against its exports map', ()
 
   it('has no import naming an undeclared subpath', () => {
     const offenders: string[] = []
+    let seen = 0
 
     for (const file of trackedSourceFiles()) {
-      if (KNOWN_UNMIGRATED.some(prefix => file.startsWith(prefix))) continue
       const text = fs.readFileSync(path.join(REPO_ROOT, file), 'utf-8')
       for (const m of text.matchAll(IMPORT_RE)) {
+        seen++
+        if (KNOWN_UNMIGRATED.some(prefix => file.startsWith(prefix))) continue
         const subpath = m[1] ? `.${m[1]}` : '.'
         // A wildcard entry ("./dist/*") would cover a family of subpaths.
         const covered =
@@ -75,6 +83,10 @@ describe('@fuzefront/shared subpath imports resolve against its exports map', ()
       }
     }
 
+    // A scan that matched nothing would pass for the wrong reason — a broken
+    // regex or an empty file list is indistinguishable from a clean tree unless
+    // the check asserts it actually looked at something.
+    expect(seen).toBeGreaterThan(0)
     expect(offenders).toEqual([])
   })
 })

--- a/backend/applications/tests/sharedSubpathExports.test.ts
+++ b/backend/applications/tests/sharedSubpathExports.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Every `@fuzefront/shared/<subpath>` import in this repo must name a subpath
+ * the package actually declares in its `exports` map.
+ *
+ * A package.json with an `exports` field makes every UNDECLARED subpath
+ * unreachable — Node throws ERR_PACKAGE_PATH_NOT_EXPORTED rather than falling
+ * back to plain path resolution. `@fuzefront/shared` exports `.` and `./kafka`;
+ * it does not export `./dist/kafka`. Requiring the latter therefore fails at
+ * resolution time, which is what crash-looped applications-service in prod:
+ * `src/kafka/ref-index.consumer.ts` required it at module scope, unguarded.
+ *
+ * Nothing caught it earlier because the two other call sites
+ * (`app-registry/events.ts`) sit inside a `try/catch` that swallowed the same
+ * failure, so the deep path looked like it worked while never once resolving.
+ * Type-checking cannot catch this either — these are untyped `require()` calls,
+ * and a wrong string is still a valid string.
+ */
+import { execFileSync } from 'child_process'
+import fs from 'fs'
+import path from 'path'
+
+const REPO_ROOT = path.resolve(__dirname, '../../..')
+const SHARED_PKG = path.join(REPO_ROOT, 'shared', 'package.json')
+
+/**
+ * billing-service still imports `@fuzefront/shared/dist/kafka`. It does not
+ * crash only because its runtime image copies `shared/dist` WITHOUT
+ * `shared/package.json` (see services/billing-service/Dockerfile), so there is
+ * no `exports` map in the image to enforce — it works by accident, and adding
+ * that one COPY line would break it exactly as applications-service broke.
+ * Recorded here as a known exception rather than silently excluded; migrating
+ * it needs its tsconfig `paths` and jest moduleNameMapper updated too, which
+ * is deliberately not bundled into an incident fix for a different service.
+ */
+const KNOWN_UNMIGRATED = ['services/billing-service/']
+
+const IMPORT_RE = /['"`]@fuzefront\/shared(\/[^'"`]+)?['"`]/g
+
+function trackedSourceFiles(): string[] {
+  const out = execFileSync('git', ['ls-files', '-z', '*.ts', '*.tsx', '*.js', '*.mjs', '*.cjs'], {
+    cwd: REPO_ROOT,
+    encoding: 'utf-8',
+    maxBuffer: 32 * 1024 * 1024,
+  })
+  return out
+    .split('\0')
+    .filter(Boolean)
+    .filter(f => !f.includes('node_modules/'))
+}
+
+describe('@fuzefront/shared subpath imports resolve against its exports map', () => {
+  const exportsMap: Record<string, unknown> = JSON.parse(fs.readFileSync(SHARED_PKG, 'utf-8')).exports
+  const declared = new Set(Object.keys(exportsMap))
+
+  it('declares the subpaths this repo relies on', () => {
+    // Guards the other direction: someone narrowing `exports` would otherwise
+    // break every importer with no test failing here.
+    expect(declared.has('.')).toBe(true)
+    expect(declared.has('./kafka')).toBe(true)
+  })
+
+  it('has no import naming an undeclared subpath', () => {
+    const offenders: string[] = []
+
+    for (const file of trackedSourceFiles()) {
+      if (KNOWN_UNMIGRATED.some(prefix => file.startsWith(prefix))) continue
+      const text = fs.readFileSync(path.join(REPO_ROOT, file), 'utf-8')
+      for (const m of text.matchAll(IMPORT_RE)) {
+        const subpath = m[1] ? `.${m[1]}` : '.'
+        // A wildcard entry ("./dist/*") would cover a family of subpaths.
+        const covered =
+          declared.has(subpath) ||
+          [...declared].some(d => d.includes('*') && matchesWildcard(d, subpath))
+        if (!covered) offenders.push(`${file}: ${subpath}`)
+      }
+    }
+
+    expect(offenders).toEqual([])
+  })
+})
+
+function matchesWildcard(pattern: string, subpath: string): boolean {
+  const [head, tail] = pattern.split('*')
+  return subpath.startsWith(head) && subpath.endsWith(tail ?? '')
+}

--- a/backend/security/src/migrations/014_seed_root_platform_organization.ts
+++ b/backend/security/src/migrations/014_seed_root_platform_organization.ts
@@ -39,9 +39,19 @@ export async function up(knex: Knex): Promise<void> {
     .orderBy('created_at', 'asc')
     .first()
   if (existingPlatform) {
-    console.log(
-      `[014] adopting existing platform organization ${existingPlatform.id} as root ` +
-        `(NOT repointing it to ${ROOT_ORG_ID} — rows already reference its id)`
+    // NOT a benign no-op. `portals.ts`, `security.ts`'s org-tree walk,
+    // `employeeRole.ts`'s ReBAC check and migration 015's backfill all
+    // reference the LITERAL `ROOT_ORG_ID`, so a root org living under some
+    // other id is a state the rest of the service cannot honour. Repointing is
+    // not safe to do unattended (rows already reference the old id), so this
+    // returns — but it must be VISIBLE rather than an info-level log that
+    // reads like success. Resolving it is a deliberate data migration.
+    console.error(
+      `[014] UNSUPPORTED STATE: platform organization ${existingPlatform.id} exists ` +
+        `but ${ROOT_ORG_ID} does not. Every ROOT_ORG_ID call site will miss it. ` +
+        `NOT repointing automatically — rows already reference ${existingPlatform.id}. ` +
+        `Root-org-dependent migrations will skip; resolve with a deliberate ` +
+        `repoint-or-reparent migration.`
     )
     return
   }
@@ -63,10 +73,31 @@ export async function up(knex: Knex): Promise<void> {
     [ROOT_ORG_ID, ROOT_ORG_SLUG, owner.id, JSON.stringify({ root: true })]
   )
 
+  // `rowCount === 0` means "I inserted nothing", NOT "the row I wanted is
+  // there". The untargeted conflict clause above also swallows a conflict on
+  // the `slug` unique index, which a DIFFERENT organization can hold — in which
+  // case no row with ROOT_ORG_ID was created and the membership insert below
+  // would violate `organization_memberships_organization_id_foreign` (23503).
+  // Assert the postcondition instead of inferring it from the conflict.
+  const root = await knex('organizations').where({ id: ROOT_ORG_ID }).first()
+  if (!root) {
+    const slugHolder = await knex('organizations').where({ slug: ROOT_ORG_SLUG }).first()
+    console.error(
+      `[014] FAILED to seed root platform organization ${ROOT_ORG_ID}: ` +
+        (slugHolder
+          ? `slug '${ROOT_ORG_SLUG}' is held by organization ${slugHolder.id} ` +
+            `(type=${slugHolder.type}), so the INSERT was a no-op.`
+          : 'the INSERT was a no-op and the row is still absent.') +
+        ' Skipping the owner-membership insert, which would otherwise violate' +
+        ' organization_memberships_organization_id_foreign.'
+    )
+    return
+  }
+
   if (result.rowCount > 0) {
     console.log(`[014] created root platform organization ${ROOT_ORG_ID}`)
   } else {
-    console.log('[014] root platform organization already present — nothing to do')
+    console.log(`[014] root platform organization ${ROOT_ORG_ID} already present`)
   }
 
   // Owner membership, so the root org is reachable through the same membership

--- a/backend/security/src/migrations/015_root_membership_backfill_and_personal_org_reclassify.ts
+++ b/backend/security/src/migrations/015_root_membership_backfill_and_personal_org_reclassify.ts
@@ -37,27 +37,67 @@ import { ROOT_ORG_ID } from './014_seed_root_platform_organization'
  * on a scratch DB).
  *
  * DEPLOY NOTE: `master` is deploy-on-push and this migration runs on deploy —
+ * PRECONDITION on (a): the `ROOT_ORG_ID` row must exist. It is a hard-coded
+ * constant, not a lookup, and migration 014 has two paths that legitimately
+ * leave it absent (adopt-a-differently-identified platform org; defer when no
+ * user exists). (a) verifies the row before inserting anything that references
+ * it — an unverified reference is a 23503 that aborts the migration chain and
+ * crash-loops the service on boot, which is exactly what happened in prod on
+ * 2026-08-20 (#750). The pre-existing tests only ever ran against a database
+ * where 014 had succeeded, so this path was never exercised.
+ *
+ * DEPLOY NOTE: `master` is deploy-on-push and this migration runs on deploy —
  * land in a deploy window (`deploy-window` label, FF-EPIC-17-S2 DoD).
  */
 export async function up(knex: Knex): Promise<void> {
   // (a) Backfill root membership for every user lacking one.
-  const backfillResult = await knex.raw(
-    `INSERT INTO organization_memberships
-       (id, user_id, organization_id, role, status, joined_at, permissions, metadata)
-     SELECT gen_random_uuid(), u.id, ?, 'member', 'active', NOW(), '{}'::jsonb, '{}'::jsonb
-     FROM users u
-     WHERE NOT EXISTS (
-       SELECT 1 FROM organization_memberships om
-       WHERE om.user_id = u.id AND om.organization_id = ?
-     )
-     ON CONFLICT (user_id, organization_id) DO NOTHING`,
-    [ROOT_ORG_ID, ROOT_ORG_ID]
-  )
-  console.log(
-    `[015] root-membership backfill: inserted ${backfillResult.rowCount ?? 0} row(s)`
-  )
+  //
+  // PRECONDITION: the root org row must actually exist. `ROOT_ORG_ID` is a
+  // hard-coded constant, not a lookup, and migration 014 has two paths that
+  // legitimately leave the row ABSENT — it adopts a pre-existing platform org
+  // under a different id, and it defers entirely when there is no user yet.
+  // Neither is an error there, but inserting memberships that reference a
+  // missing organization is a foreign-key violation (23503) that aborts the
+  // migration chain and crash-loops the service on boot. Verify, don't assume:
+  // a step that cannot tell "nothing to do" from "the thing I need is missing"
+  // eventually reports success for the wrong reason.
+  const rootOrg = await knex('organizations').where({ id: ROOT_ORG_ID }).first()
+  if (!rootOrg) {
+    const platform = await knex('organizations')
+      .where({ type: 'platform' })
+      .orderBy('created_at', 'asc')
+      .first()
+    console.error(
+      `[015] SKIPPING root-membership backfill: organization ${ROOT_ORG_ID} does ` +
+        'not exist. ' +
+        (platform
+          ? `The platform organization in this database is ${platform.id}, which ` +
+            'migration 014 adopted rather than repointed. Resolve that first — ' +
+            'until then every ROOT_ORG_ID call site misses.'
+          : 'No platform organization exists at all; migration 014 deferred.') +
+      ' Not inserting memberships that would violate' +
+      ' organization_memberships_organization_id_foreign.'
+    )
+  } else {
+    const backfillResult = await knex.raw(
+      `INSERT INTO organization_memberships
+         (id, user_id, organization_id, role, status, joined_at, permissions, metadata)
+       SELECT gen_random_uuid(), u.id, ?, 'member', 'active', NOW(), '{}'::jsonb, '{}'::jsonb
+       FROM users u
+       WHERE NOT EXISTS (
+         SELECT 1 FROM organization_memberships om
+         WHERE om.user_id = u.id AND om.organization_id = ?
+       )
+       ON CONFLICT (user_id, organization_id) DO NOTHING`,
+      [ROOT_ORG_ID, ROOT_ORG_ID]
+    )
+    console.log(
+      `[015] root-membership backfill: inserted ${backfillResult.rowCount ?? 0} row(s)`
+    )
+  }
 
   // (b) Reclassify type='personal' -> type='organization'. Nothing deleted.
+  // Independent of (a) and of the root org, so it runs either way.
   const reclassifyResult = await knex.raw(
     `UPDATE organizations
        SET type = 'organization', updated_at = NOW()

--- a/backend/security/src/services/organizationProvisioning.ts
+++ b/backend/security/src/services/organizationProvisioning.ts
@@ -350,6 +350,22 @@ export async function ensureRootMembership(
   userId: string,
   deps: { db: Knex }
 ): Promise<void> {
+  // Same discipline as migrations 014/015: never insert a reference to a row
+  // you have not verified exists. `ROOT_ORG_ID` is a constant, not a lookup,
+  // and migration 014 has paths that legitimately leave the row absent — in
+  // which case this insert raises 23503 and fails provisioning for the user.
+  // Skipping is equivalent to the feature flag being OFF, which is strictly
+  // better than a failed signup, but it must be loud: it means the root org
+  // is missing, not that this user needed no membership.
+  const rootOrg = await deps.db('organizations').where({ id: ROOT_ORG_ID }).first()
+  if (!rootOrg) {
+    logger.error(
+      { userId, rootOrgId: ROOT_ORG_ID },
+      'ensureRootMembership: root organization does not exist — skipping (see migration 014)'
+    )
+    return
+  }
+
   await deps.db('organization_memberships')
     .insert({
       id: toUuid(mintId('membership')),

--- a/backend/security/tests/rootOrgAbsentGuards.test.ts
+++ b/backend/security/tests/rootOrgAbsentGuards.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Security-service mirror of `backend/tests/rootOrgAbsentGuards.test.ts` —
+ * regression for #750. The root org is a hard-coded CONSTANT, not a lookup,
+ * and migration 014 has paths that legitimately leave the row absent. Anything
+ * that then INSERTs a reference to it raises 23503, aborts the migration chain
+ * and crash-loops the service on boot.
+ *
+ * `migrations.rootMembershipBackfill.test.ts` only ever ran against a database
+ * where 014 had already succeeded, so this path had no coverage. Stub knex —
+ * no database, because the point is the control flow, not the SQL.
+ */
+import * as migration014 from '../src/migrations/014_seed_root_platform_organization'
+import * as migration015 from '../src/migrations/015_root_membership_backfill_and_personal_org_reclassify'
+
+const { ROOT_ORG_ID } = migration014
+const ROOT_ORG_SLUG = 'fuzefront'
+
+type Raw = { sql: string; bindings: unknown[] }
+
+function makeKnex(rows: Record<string, Array<Record<string, unknown>>>, rawRowCount = 0) {
+  const raws: Raw[] = []
+  const knex: any = (table: string) => {
+    const wheres: Array<Record<string, unknown>> = []
+    const api: any = {
+      where(cond: Record<string, unknown>) {
+        wheres.push(cond)
+        return api
+      },
+      orderBy() {
+        return api
+      },
+      async first() {
+        return (rows[table] ?? []).find(r =>
+          wheres.every(w => Object.entries(w).every(([k, v]) => r[k] === v))
+        )
+      },
+    }
+    return api
+  }
+  knex.raw = async (sql: string, bindings: unknown[] = []) => {
+    raws.push({ sql, bindings })
+    return { rowCount: rawRowCount }
+  }
+  return { knex, raws }
+}
+
+const membershipInserts = (raws: Raw[]) =>
+  raws.filter(r => /INSERT INTO organization_memberships/i.test(r.sql))
+
+describe('#750 — nothing inserts a reference to an unverified root organization', () => {
+  describe('migration 014 (seed root platform organization)', () => {
+    it('does not insert the owner membership when the org INSERT was swallowed by a slug conflict', async () => {
+      const { knex, raws } = makeKnex({
+        users: [{ id: 'user-1' }],
+        organizations: [{ id: 'some-other-id', slug: ROOT_ORG_SLUG, type: 'organization' }],
+      })
+
+      await migration014.up(knex)
+
+      expect(membershipInserts(raws)).toHaveLength(0)
+    })
+
+    it('inserts nothing at all when it adopts a platform org under a different id', async () => {
+      const { knex, raws } = makeKnex({
+        users: [{ id: 'user-1' }],
+        organizations: [{ id: 'legacy-platform-id', slug: 'legacy', type: 'platform' }],
+      })
+
+      await migration014.up(knex)
+
+      expect(raws).toHaveLength(0)
+    })
+
+    it('is a clean no-op when the root org is already present', async () => {
+      const { knex, raws } = makeKnex({
+        users: [{ id: 'user-1' }],
+        organizations: [{ id: ROOT_ORG_ID, slug: ROOT_ORG_SLUG, type: 'platform' }],
+      })
+
+      await migration014.up(knex)
+
+      expect(raws).toHaveLength(0)
+    })
+  })
+
+  describe('migration 015 (root-membership backfill + personal-org reclassify)', () => {
+    it('skips the backfill when the root organization does not exist', async () => {
+      const { knex, raws } = makeKnex({
+        users: [{ id: 'user-1' }],
+        organizations: [{ id: 'legacy-platform-id', slug: 'legacy', type: 'platform' }],
+      })
+
+      await migration015.up(knex)
+
+      expect(membershipInserts(raws)).toHaveLength(0)
+    })
+
+    it('still runs the personal-org reclassify when the backfill is skipped', async () => {
+      const { knex, raws } = makeKnex({ users: [], organizations: [] })
+
+      await migration015.up(knex)
+
+      expect(raws.filter(r => /UPDATE organizations/i.test(r.sql))).toHaveLength(1)
+    })
+
+    it('backfills when the root organization is present', async () => {
+      const { knex, raws } = makeKnex({
+        users: [{ id: 'user-1' }],
+        organizations: [{ id: ROOT_ORG_ID, slug: ROOT_ORG_SLUG, type: 'platform' }],
+      })
+
+      await migration015.up(knex)
+
+      expect(membershipInserts(raws)).toHaveLength(1)
+    })
+  })
+})

--- a/backend/src/migrations/015_seed_root_platform_organization.ts
+++ b/backend/src/migrations/015_seed_root_platform_organization.ts
@@ -68,9 +68,19 @@ export async function up(knex: Knex): Promise<void> {
     .first()
 
   if (existing && existing.id !== ROOT_ORG_ID) {
-    console.log(
-      `[015] adopting existing platform organization ${existing.id} as root ` +
-        `(NOT repointing it to ${ROOT_ORG_ID} — rows already reference its id)`
+    // NOT a benign no-op. ~30 call sites — `portals.ts`, `security.ts`'s org-tree
+    // walk, `employeeRole.ts`'s ReBAC check, `scopeToPortal.ts`, migration 022's
+    // backfill — reference the LITERAL `ROOT_ORG_ID`, so a root org living under
+    // some other id is a state the rest of the codebase cannot honour. Repointing
+    // is not safe to do unattended (rows already reference the old id), so this
+    // returns, but it must be VISIBLE rather than an info-level log that reads
+    // like success. Resolving it is a deliberate data migration.
+    console.error(
+      `[015] UNSUPPORTED STATE: platform organization ${existing.id} exists but ` +
+        `${ROOT_ORG_ID} does not. Every ROOT_ORG_ID call site will miss it. ` +
+        `NOT repointing automatically — rows already reference ${existing.id}. ` +
+        `Root-org-dependent migrations will skip; resolve with a deliberate ` +
+        `repoint-or-reparent migration.`
     )
     return
   }
@@ -85,10 +95,31 @@ export async function up(knex: Knex): Promise<void> {
     [ROOT_ORG_ID, ROOT_ORG_SLUG, owner.id, JSON.stringify({ root: true })]
   )
 
+  // `rowCount === 0` means "I inserted nothing", NOT "the row I wanted is
+  // there". The untargeted conflict clause above also swallows a conflict on
+  // the `slug` unique index, which a DIFFERENT organization can hold — in which
+  // case no row with ROOT_ORG_ID was created and the membership insert below
+  // would violate `organization_memberships_organization_id_foreign` (23503).
+  // Assert the postcondition instead of inferring it from the conflict.
+  const root = await knex('organizations').where({ id: ROOT_ORG_ID }).first()
+  if (!root) {
+    const slugHolder = await knex('organizations').where({ slug: ROOT_ORG_SLUG }).first()
+    console.error(
+      `[015] FAILED to seed root platform organization ${ROOT_ORG_ID}: ` +
+        (slugHolder
+          ? `slug '${ROOT_ORG_SLUG}' is held by organization ${slugHolder.id} ` +
+            `(type=${slugHolder.type}), so the INSERT was a no-op.`
+          : 'the INSERT was a no-op and the row is still absent.') +
+        ' Skipping the owner-membership insert, which would otherwise violate' +
+        ' organization_memberships_organization_id_foreign.'
+    )
+    return
+  }
+
   if (result.rowCount > 0) {
     console.log(`[015] created root platform organization ${ROOT_ORG_ID}`)
   } else {
-    console.log('[015] root platform organization already present — nothing to do')
+    console.log(`[015] root platform organization ${ROOT_ORG_ID} already present`)
   }
 
   // Owner membership, so the root org is reachable through the same membership

--- a/backend/src/migrations/022_root_membership_backfill_and_personal_org_reclassify.ts
+++ b/backend/src/migrations/022_root_membership_backfill_and_personal_org_reclassify.ts
@@ -40,28 +40,67 @@ import { ROOT_ORG_ID } from './015_seed_root_platform_organization'
  * migrations.rootMembershipBackfill.test.ts` (run + re-run on a scratch DB);
  * this monolith copy is byte-identical SQL, so the same proof applies.
  *
+ * PRECONDITION on (a): the `ROOT_ORG_ID` row must exist. It is a hard-coded
+ * constant, not a lookup, and migration 015 has two paths that legitimately
+ * leave it absent (adopt-a-differently-identified platform org; defer when no
+ * user exists). (a) verifies the row before inserting anything that references
+ * it — an unverified reference is a 23503 that aborts the migration chain and
+ * crash-loops the service on boot, which is exactly what happened in prod on
+ * 2026-08-20 (#750). The pre-existing tests only ever ran against a database
+ * where 015 had succeeded, so this path was never exercised.
+ *
  * DEPLOY NOTE: `master` is deploy-on-push and this migration runs on deploy —
  * land in a deploy window (`deploy-window` label, FF-EPIC-17-S2 DoD).
  */
 export async function up(knex: Knex): Promise<void> {
   // (a) Backfill root membership for every user lacking one.
-  const backfillResult = await knex.raw(
-    `INSERT INTO organization_memberships
-       (id, user_id, organization_id, role, status, joined_at, permissions, metadata)
-     SELECT gen_random_uuid(), u.id, ?, 'member', 'active', NOW(), '{}'::jsonb, '{}'::jsonb
-     FROM users u
-     WHERE NOT EXISTS (
-       SELECT 1 FROM organization_memberships om
-       WHERE om.user_id = u.id AND om.organization_id = ?
-     )
-     ON CONFLICT (user_id, organization_id) DO NOTHING`,
-    [ROOT_ORG_ID, ROOT_ORG_ID]
-  )
-  console.log(
-    `[022] root-membership backfill: inserted ${backfillResult.rowCount ?? 0} row(s)`
-  )
+  //
+  // PRECONDITION: the root org row must actually exist. `ROOT_ORG_ID` is a
+  // hard-coded constant, not a lookup, and migration 015 has two paths that
+  // legitimately leave the row ABSENT — it adopts a pre-existing platform org
+  // under a different id, and it defers entirely when there is no user yet.
+  // Neither is an error there, but inserting memberships that reference a
+  // missing organization is a foreign-key violation (23503) that aborts the
+  // migration chain and crash-loops the service on boot. Verify, don't assume:
+  // a step that cannot tell "nothing to do" from "the thing I need is missing"
+  // eventually reports success for the wrong reason.
+  const rootOrg = await knex('organizations').where({ id: ROOT_ORG_ID }).first()
+  if (!rootOrg) {
+    const platform = await knex('organizations')
+      .where({ type: 'platform' })
+      .orderBy('created_at', 'asc')
+      .first()
+    console.error(
+      `[022] SKIPPING root-membership backfill: organization ${ROOT_ORG_ID} does ` +
+        'not exist. ' +
+        (platform
+          ? `The platform organization in this database is ${platform.id}, which ` +
+            'migration 015 adopted rather than repointed. Resolve that first — ' +
+            'until then every ROOT_ORG_ID call site misses.'
+          : 'No platform organization exists at all; migration 015 deferred.') +
+      ' Not inserting memberships that would violate' +
+      ' organization_memberships_organization_id_foreign.'
+    )
+  } else {
+    const backfillResult = await knex.raw(
+      `INSERT INTO organization_memberships
+         (id, user_id, organization_id, role, status, joined_at, permissions, metadata)
+       SELECT gen_random_uuid(), u.id, ?, 'member', 'active', NOW(), '{}'::jsonb, '{}'::jsonb
+       FROM users u
+       WHERE NOT EXISTS (
+         SELECT 1 FROM organization_memberships om
+         WHERE om.user_id = u.id AND om.organization_id = ?
+       )
+       ON CONFLICT (user_id, organization_id) DO NOTHING`,
+      [ROOT_ORG_ID, ROOT_ORG_ID]
+    )
+    console.log(
+      `[022] root-membership backfill: inserted ${backfillResult.rowCount ?? 0} row(s)`
+    )
+  }
 
   // (b) Reclassify type='personal' -> type='organization'. Nothing deleted.
+  // Independent of (a) and of the root org, so it runs either way.
   const reclassifyResult = await knex.raw(
     `UPDATE organizations
        SET type = 'organization', updated_at = NOW()

--- a/backend/src/services/organizationProvisioning.ts
+++ b/backend/src/services/organizationProvisioning.ts
@@ -441,9 +441,14 @@ export async function ensureRootMembership(
   // is missing, not that this user needed no membership.
   const rootOrg = await db('organizations').where({ id: ROOT_ORG_ID }).first()
   if (!rootOrg) {
+    // `userId` is request-derived, so it never goes into the message string:
+    // an unescaped CR/LF there lets a caller forge log lines (CodeQL
+    // js/log-injection). JSON.stringify escapes them, and it matches the
+    // structured shape the security-service copy logs via pino.
     console.error(
-      `ensureRootMembership: organization ${ROOT_ORG_ID} does not exist — ` +
-        `skipping root membership for user ${userId}. See migration 015.`
+      'ensureRootMembership: root organization does not exist — skipping root ' +
+        'membership. See migration 015.',
+      JSON.stringify({ rootOrgId: ROOT_ORG_ID, userId })
     )
     return
   }

--- a/backend/src/services/organizationProvisioning.ts
+++ b/backend/src/services/organizationProvisioning.ts
@@ -431,6 +431,23 @@ export async function ensureRootMembership(
   overrides?: Partial<Pick<ProvisioningDeps, 'db'>>
 ): Promise<void> {
   const db = overrides?.db ?? defaultDb
+
+  // Same discipline as migrations 015/022: never insert a reference to a row
+  // you have not verified exists. `ROOT_ORG_ID` is a constant, not a lookup,
+  // and migration 015 has paths that legitimately leave the row absent — in
+  // which case this insert raises 23503 and fails provisioning for the user.
+  // Skipping is equivalent to the feature flag being OFF, which is strictly
+  // better than a failed signup, but it must be loud: it means the root org
+  // is missing, not that this user needed no membership.
+  const rootOrg = await db('organizations').where({ id: ROOT_ORG_ID }).first()
+  if (!rootOrg) {
+    console.error(
+      `ensureRootMembership: organization ${ROOT_ORG_ID} does not exist — ` +
+        `skipping root membership for user ${userId}. See migration 015.`
+    )
+    return
+  }
+
   await db('organization_memberships')
     .insert({
       id: toUuid(mintId('membership')),

--- a/backend/tests/rootOrgAbsentGuards.test.ts
+++ b/backend/tests/rootOrgAbsentGuards.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Regression for #750 — the root org is a hard-coded CONSTANT, not a lookup,
+ * and migration 015 has paths that legitimately leave the row absent. Anything
+ * that then INSERTs a reference to it raises 23503, aborts the migration chain
+ * and crash-loops the service on boot. That is what happened in prod on
+ * 2026-08-20.
+ *
+ * The pre-existing migration tests (`rootMembershipBackfillMigration.test.ts`,
+ * `backend/security/tests/migrations.rootMembershipBackfill.test.ts`) all run
+ * against a database where 015 had already SUCCEEDED, so the absent-root path
+ * had no coverage at all. These tests exercise it directly with a stub knex —
+ * no database, because the point is the control flow, not the SQL.
+ */
+import * as migration015 from '../src/migrations/015_seed_root_platform_organization'
+import * as migration022 from '../src/migrations/022_root_membership_backfill_and_personal_org_reclassify'
+
+const { ROOT_ORG_ID } = migration015
+const PLATFORM_REGISTRAR_ID = '00000000-0000-0000-0000-000000000001'
+const ROOT_ORG_SLUG = 'fuzefront'
+
+type Raw = { sql: string; bindings: unknown[] }
+
+/**
+ * Minimal knex stand-in supporting exactly the surface these migrations use:
+ * `knex(table).where(obj).orderBy(...).first()` and `knex.raw(sql, bindings)`.
+ * `rows` is static — a test models "the INSERT was a no-op" simply by not
+ * putting the row there, which is precisely the production state.
+ */
+function makeKnex(rows: Record<string, Array<Record<string, unknown>>>, rawRowCount = 0) {
+  const raws: Raw[] = []
+  const knex: any = (table: string) => {
+    const wheres: Array<Record<string, unknown>> = []
+    const api: any = {
+      where(cond: Record<string, unknown>) {
+        wheres.push(cond)
+        return api
+      },
+      orderBy() {
+        return api
+      },
+      async first() {
+        return (rows[table] ?? []).find(r =>
+          wheres.every(w => Object.entries(w).every(([k, v]) => r[k] === v))
+        )
+      },
+    }
+    return api
+  }
+  knex.raw = async (sql: string, bindings: unknown[] = []) => {
+    raws.push({ sql, bindings })
+    return { rowCount: rawRowCount }
+  }
+  return { knex, raws }
+}
+
+const membershipInserts = (raws: Raw[]) =>
+  raws.filter(r => /INSERT INTO organization_memberships/i.test(r.sql))
+
+describe('#750 — nothing inserts a reference to an unverified root organization', () => {
+  describe('migration 015 (seed root platform organization)', () => {
+    it('does not insert the owner membership when the org INSERT was swallowed by a slug conflict', async () => {
+      // A DIFFERENT organization holds slug 'fuzefront'. It is not
+      // type='platform', so the adopt branch does not fire; the untargeted
+      // ON CONFLICT DO NOTHING then silently swallows the slug collision and
+      // no row with ROOT_ORG_ID is created.
+      const { knex, raws } = makeKnex({
+        users: [{ id: PLATFORM_REGISTRAR_ID }],
+        organizations: [{ id: 'some-other-id', slug: ROOT_ORG_SLUG, type: 'organization' }],
+      })
+
+      await migration015.up(knex)
+
+      expect(membershipInserts(raws)).toHaveLength(0)
+    })
+
+    it('inserts the owner membership once the row is verified present', async () => {
+      const { knex, raws } = makeKnex(
+        {
+          users: [{ id: PLATFORM_REGISTRAR_ID }],
+          organizations: [{ id: ROOT_ORG_ID, slug: ROOT_ORG_SLUG, type: 'platform' }],
+        },
+        1
+      )
+
+      await migration015.up(knex)
+
+      const inserts = membershipInserts(raws)
+      expect(inserts).toHaveLength(1)
+      expect(inserts[0].bindings).toContain(ROOT_ORG_ID)
+    })
+
+    it('inserts nothing at all when it adopts a platform org under a different id', async () => {
+      const { knex, raws } = makeKnex({
+        users: [{ id: PLATFORM_REGISTRAR_ID }],
+        organizations: [{ id: 'legacy-platform-id', slug: 'legacy', type: 'platform' }],
+      })
+
+      await migration015.up(knex)
+
+      expect(raws).toHaveLength(0)
+    })
+  })
+
+  describe('migration 022 (root-membership backfill + personal-org reclassify)', () => {
+    it('skips the backfill when the root organization does not exist', async () => {
+      const { knex, raws } = makeKnex({
+        users: [{ id: PLATFORM_REGISTRAR_ID }],
+        organizations: [{ id: 'legacy-platform-id', slug: 'legacy', type: 'platform' }],
+      })
+
+      await migration022.up(knex)
+
+      expect(membershipInserts(raws)).toHaveLength(0)
+    })
+
+    it('still runs the personal-org reclassify when the backfill is skipped', async () => {
+      // (b) does not reference the root org, so a missing root org must not
+      // silently disable it too.
+      const { knex, raws } = makeKnex({ users: [], organizations: [] })
+
+      await migration022.up(knex)
+
+      expect(raws.filter(r => /UPDATE organizations/i.test(r.sql))).toHaveLength(1)
+    })
+
+    it('backfills when the root organization is present', async () => {
+      const { knex, raws } = makeKnex({
+        users: [{ id: PLATFORM_REGISTRAR_ID }],
+        organizations: [{ id: ROOT_ORG_ID, slug: ROOT_ORG_SLUG, type: 'platform' }],
+      })
+
+      await migration022.up(knex)
+
+      expect(membershipInserts(raws)).toHaveLength(1)
+    })
+  })
+})


### PR DESCRIPTION
## 📋 Description

Three services have been crash-looping in prod since ~23:09 UTC, holding the Argo Sync phase in `Failed`. This PR fixes the two that are code defects in this repo. The third (#752) needs a SealedSecret and is an owner action.

Refs #750. Follow-ups filed: #752, #753.

### Why this blocks the portal

Argo runs PostSync **only after** the Sync phase succeeds. With Sync failing:

```
services crash-loop → Argo Sync PHASE Failed
  → PostSync consumer-registration-seed (fixed in #749) never fires
  → Secret/fuzefront-registration never written
  → FuzeInfra publish-sealed-handoff fails for all 8 consumer namespaces
  → no product can self-register → portal shows 8 of ~19
```

Confirmed on FuzeInfra run `32322759156` (01:55 UTC — *after* the #749 merge and after Argo reached `e410199c`), which reports `FAIL: source fuzefront/fuzefront-registration key 'token' not readable` eight times. That also **retracts an earlier inference**: the seed Job's absence was read as "it ran and was GC'd on success". It is better explained by the Job never being created.

---

## Defect 1 — memberships referencing an unverified root org (`backend`, `security`)

```
INSERT INTO organization_memberships (... organization_id ...)
SELECT gen_random_uuid(), u.id, $1, 'member', ...
violates foreign key constraint "organization_memberships_organization_id_foreign"
  Key (organization_id)=(00000000-0000-0000-0000-000000000010) is not present in table "organizations".
```

**Correction to #750's stated mechanism.** The failing statement is migration **022's** backfill (security-service: `015`), not 015's owner-membership insert as the issue says. That pins the cause: 015's own insert would have raised the same 23503 *first* if it had been reached. It was not — so 015 returned early, via the **adopt-a-pre-existing-platform-org** branch. This database's platform org lives under another id and `ROOT_ORG_ID` has never existed here. The slug-conflict hypothesis in the issue is a real second route to the same state, but not the one that fired.

`ROOT_ORG_ID` is a hard-coded constant, not a lookup, and ~30 call sites use it literally (`portals.ts`, `security.ts`'s org-tree walk, `employeeRole.ts`'s ReBAC check, `scopeToPortal.ts`, migration 019). A root org under a different id is not a benign fallback — it is a state the rest of the codebase cannot honour.

Changes, applied symmetrically to the monolith and its security-service mirror:

- **`022` / security `015`** — verify the root org row exists before inserting any membership referencing it. Absent: log which platform org *is* present, skip step (a), still run step (b), which does not reference the root org.
- **`015` / security `014`** — assert the postcondition. `rowCount === 0` means *"I inserted nothing"*, not *"the row I wanted is there"*: the untargeted `ON CONFLICT DO NOTHING` also swallows a conflict on the `slug` unique index a **different** organization can hold. Read the row back by id; if absent, name the colliding row and skip.
- **`015` / security `014`** — the adopt branch logs at error level and states the consequence, instead of an info line that reads like success.
- **`ensureRootMembership`** (both services) — the same guard at runtime, so a missing root org degrades to "feature flag off" rather than a failed signup. Request-derived `userId` is JSON-encoded rather than interpolated into the message (CodeQL `js/log-injection`).

---

## Defect 2 — `fuzefront-applications` dies at module load

```
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './dist/kafka'
is not defined by "exports" in /app/node_modules/@fuzefront/shared/package.json
```

70 restarts. This is the service that owns the registration endpoint (`app-registry`, `consumer-auth`), so fixing defect 1 alone would not have opened the funnel.

`@fuzefront/shared` exports `.` and `./kafka`. An `exports` field makes every undeclared subpath unreachable, so `./dist/kafka` has never resolved against that package. Three call sites used it. Two are in `app-registry/events.ts` inside a `try/catch`, so the failure was swallowed — the docblock's *"if a schema is unavailable we send without local validation"* fallback was in fact the **only** path ever taken in the production image, and every app-registry event has been published unvalidated. The third, added by #692, is a top-level unguarded `require` in `kafka/ref-index.consumer.ts` imported at module scope by `index.ts`. Its comment says it follows the pattern in `events.ts`; it copied a pattern that only looked like it worked because its failure was being caught.

**Behavioural change to note:** with the path resolving, `events.ts` now loads the shared Zod schemas, so app-registry events are validated against the frozen contract for the first time. That is the documented intent — the catch is a fallback, not a mask.

Why only applications: billing-service imports the same deep path, but its runtime image copies `shared/dist` *without* `shared/package.json`, so no exports map reaches the image to enforce. It works by accident, and adding that one `COPY` line would break it identically. Filed as #753 rather than folded in here — it is healthy, and changing a working service's module resolution mid-incident widens the blast radius for no urgency.

---

## 🔄 Type of Change

- 🐛 Bug fix (non-breaking change which fixes an issue)
- 🧪 Test addition or improvement

## 🧪 Testing

- `backend/tests/rootOrgAbsentGuards.test.ts` + `backend/security/tests/rootOrgAbsentGuards.test.ts` — 12 assertions over the absent-root paths with a stub knex (no database; the point is control flow, not SQL).
- `backend/applications/tests/sharedSubpathExports.test.ts` — asserts every `@fuzefront/shared/<subpath>` import in the repo names a declared export, **and** that `exports` still declares the subpaths in use, so narrowing it also fails. Type-checking cannot catch this: these are untyped `require()` calls and a wrong string is still a valid string. billing-service is recorded in `KNOWN_UNMIGRATED` with a comment, not silently excluded.

**Both suites verified load-bearing.** Reverting the two migration guards fails exactly the two guard tests; reverting the two applications source files fails the subpath test naming all three offending sites.

**Test Configuration:** Node.js v22.22.2 (below the repo's `>=24` floor — this box cannot meet it), Linux. The DB-backed suites could not run locally: `tests/setup.ts` needs a live Postgres and `@izzywdev/fuzefront-identity`, which does not install here (the fleet-wide GitHub Packages auth problem). CI covers those.

### Test Instructions

```bash
cd backend && npm test -- tests/rootOrgAbsentGuards.test.ts
cd backend/security && npm test -- tests/rootOrgAbsentGuards.test.ts
cd backend/applications && npm test -- tests/sharedSubpathExports.test.ts
```

### Note on the `E2E (sign-in)` red

Its `Start and provision the E2E stack` step failed on `7589b5be` at `POST /api/v3/providers/oauth2/ → 400` from Authentik, inside `deploy/e2e/provision-authentik-oidc.sh`. That is Authentik provisioning; nothing in this PR touches the compose stack, that script, or the Authentik image (pinned at `2026.5.5`). Re-running on `3b9643b5`; if it reproduces it gets its own diagnosis rather than being waved off as flake.

## 🔧 Implementation Details

### Why both shipped

Same shape, twice: **a step that cannot tell "I did nothing because it was already done" from "I did nothing because something else was in the way" will eventually report success for the wrong reason.** Defect 1's migration inferred presence from a conflict a different row caused. Defect 2's `try/catch` reported a working import path that never once resolved. The existing migration tests only ever ran against a database where 015 had *succeeded*, so the absent-root path had no coverage at all.

- **Frontend Changes:** none. **SDK Changes:** none.

## 🚨 Breaking Changes

None. No schema change, no prod data mutated.

## 🔗 Related Issues and PRs

- Related to #750 · Follows #749 · Follow-ups #752, #753 · Defect 2 introduced by #692

## 📝 Additional Notes

### Deployment Notes

- **No new migration** — this corrects the behaviour of migrations that already run on every boot.
- `master` is deploy-on-push and these migrations execute on deploy. **Merge in a deploy window.** Opened without the `auto-merge` label for that reason; `auto-merge.yml` self-arms anyway on its owner-login fallback and has been disabled three times so far, once per push. Declining the label is not an opt-out — worth fixing separately.

### Future Work

- Whether to **repoint** this database's platform org onto `ROOT_ORG_ID` or **reparent** it under a new root is a deliberate data migration and an owner decision — not made here. Until it is, both services boot and say plainly what is wrong, but root-membership behaviour stays inert. **This PR restores the rollout; it does not restore that feature.**
- **#751 alone may not turn the Argo sync green.** #752's config-service is still in `CreateContainerConfigError`, and a Deployment that never becomes ready can hold a sync open. Unverified either way.

### Questions for Reviewers

- Is skipping the backfill the right degradation, versus failing the migration with a clearer message? Skipping was chosen because failing is what currently blocks the rollout, and the missing row is not something the migration can safely create.
- Defect 2 turns on event-schema validation that has never actually run in prod. If you would rather stage that, say so and I will split it — but leaving a resolution path Node refuses is not a neutral option.