### PR TITLE
fix(deps): bump axios 1.11.0 → 1.19.0 (clears 29 findings)

### DIFF
--- a/fuzefront-website/frontend/package-lock.json
+++ b/fuzefront-website/frontend/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@fuzefront/website-frontend",
       "version": "1.0.0",
       "dependencies": {
-        "axios": "^1.7.9",
+        "axios": "^1.19.0",
         "clsx": "^2.1.1",
         "framer-motion": "^11.15.0",
         "lucide-react": "^0.468.0",
@@ -4105,14 +4105,40 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
-      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.19.0.tgz",
+      "integrity": "sha512-ht/iuYZXEjFxLH/Hkezgd7m6JKlHHXEUSneaDz8uZe1Gj5QZtCnpyDsckvAiEnT89OEbCLmnte4R4sn7P0EKFw==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
-        "proxy-from-env": "^1.1.0"
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.6",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/axios/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/babel-jest": {
@@ -4786,7 +4812,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
       "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -5492,9 +5517,9 @@
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -5529,16 +5554,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -5835,9 +5860,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -7169,7 +7194,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/mz": {
@@ -7795,10 +7819,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/fuzefront-website/frontend/package.json
+++ b/fuzefront-website/frontend/package.json
@@ -21,7 +21,7 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "axios": "^1.7.9",
+    "axios": "^1.19.0",
     "clsx": "^2.1.1",
     "framer-motion": "^11.15.0",
     "lucide-react": "^0.468.0",
@@ -33,6 +33,9 @@
     "tailwind-merge": "^2.6.0"
   },
   "devDependencies": {
+    "@babel/core": "^7.26.0",
+    "@babel/preset-env": "^7.26.0",
+    "@types/jest": "^29.5.14",
     "@types/node": "^24.13.3",
     "@types/react": "^19.2.0",
     "@types/react-dom": "^19.2.0",
@@ -40,22 +43,15 @@
     "@typescript-eslint/parser": "^8.18.2",
     "@vitejs/plugin-react": "^4.3.4",
     "autoprefixer": "^10.4.21",
+    "babel-jest": "^29.7.0",
     "eslint": "^8.57.0",
     "eslint-plugin-react-hooks": "^5.1.0",
     "eslint-plugin-react-refresh": "^0.4.20",
+    "jest": "^29.7.0",
+    "jsdom": "^25.0.1",
     "postcss": "^8.5.6",
     "tailwindcss": "^3.4.0",
     "typescript": "~5.3.3",
-    "vite": "^7.0.5",
-    "jest": "^29.7.0",
-    "jsdom": "^25.0.1",
-    "@types/jest": "^29.5.14",
-    "@babel/core": "^7.26.0",
-    "@babel/preset-env": "^7.26.0",
-    "babel-jest": "^29.7.0"
-  },
-  "engines": {
-    "node": ">=24.0.0",
-    "npm": ">=10.0.0"
+    "vite": "^7.0.5"
   }
 }


### PR DESCRIPTION
## 📋 Description

First item off the **#747** triage list, sequenced first because it is by far the largest single win: **one dependency bump in one manifest clears 29 fixable findings.**

Every axios finding in the repo was concentrated in `fuzefront-website/frontend/package-lock.json`, pinned at `1.11.0` by a `^1.7.9` range. Fix floor was `>=1.18.0`; npm resolved **1.19.0**.

Refs #747.

## 🔄 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## 🔧 Implementation Details

```diff
-    "axios": "^1.7.9",
+    "axios": "^1.19.0",
```

Regenerated with `npm install --package-lock-only`, so the change is the lockfile plus that one range — no `node_modules` churn.

Minor-version bump within axios v1, so semver-compatible. `axios` is used here only by the marketing website frontend, not the platform runtime.

## 🧪 Testing

Verified by **rescanning the manifest at the exact config CI now uses** (`--severity UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL --scanners vuln --ignore-unfixed`) rather than assuming the bump worked:

| | before | after |
|---|---|---|
| axios findings | **29** | **0** |
| total in this manifest | 35 | 6 |

The 6 remaining are `react-router` (4) and `@remix-run/router` (2) — the deliberately-deferred **major** bump, tracked in #747 and explicitly not batched here.

- [x] `node scripts/gate-toolchain.mjs` — passes
- [x] `node scripts/check-workspace-deps.mjs` — passes
- [x] `node scripts/check-dockerfile-lockfile.mjs` — passes
- [x] Both JSON files parse
- [x] Diff confined to the intended manifest

### Bonus

Carries one transitive fix that was its own line item on the triage list: **`follow-redirects` 1.15.9 → 1.16.0**.

### Code Quality

- [x] Self-review of code completed
- [x] Code follows conventional commit format

## 📌 Incidental finding — filed separately, not fixed here

npm normalised this manifest's **duplicate `engines` block** down to one. Both copies were identical, so nothing changes behaviourally.

But **36 manifests repo-wide carry the same duplication**, and `gate-toolchain` is structurally blind to it: `JSON.parse` silently keeps the last occurrence, so the gate sees one valid value and passes. If the two copies ever diverge, behaviour depends on which parser reads the file — npm, the gate, and any tooling that reads raw text could disagree.

Not widened into this PR; being filed on its own.

## Caveat

The before/after counts come from a **cached vulnerability DB dated 2026-08-16** (live pull returns `ghcr.io: DENIED` in this environment). CI runs a fresh DB, so exact numbers may shift — but axios going to zero is a version fact, not a DB-dependent one.

---
_Generated by [Claude Code](https://claude.ai/code/session_013tMciHkPE8To7V67CsgKKc)_