### PR TITLE
fix(permit): initialize the DB before reading the app registry (#760)

### DIFF
--- a/backend/src/permit/sync-permit-schema.ts
+++ b/backend/src/permit/sync-permit-schema.ts
@@ -283,7 +283,14 @@ export async function loadRegisteredPolicyResult(
     //
     // initializeDatabaseConnection() is idempotent (`if (!db)`), so this is a
     // no-op in the server, where the connection already exists.
-    database.initializeDatabaseConnection()
+    // Guarded on BOTH sides deliberately. `permit-sync-registry.test.ts` stubs
+    // this module as `{ db }` with no initializer — that mock is the documented
+    // way the registry read is made testable without a DB, so calling the
+    // initializer unconditionally breaks it. And re-initializing when a handle
+    // already exists would be wrong regardless of tests.
+    if (!database.db && typeof database.initializeDatabaseConnection === 'function') {
+      database.initializeDatabaseConnection()
+    }
     const db = database.db
     /* eslint-enable @typescript-eslint/no-var-requires */
 

--- a/backend/src/permit/sync-permit-schema.ts
+++ b/backend/src/permit/sync-permit-schema.ts
@@ -269,7 +269,22 @@ export async function loadRegisteredPolicyResult(
   const rejected: { slug: string; reason: string }[] = []
   try {
     /* eslint-disable @typescript-eslint/no-var-requires */
-    const { db } = require('../config/database')
+    const database = require('../config/database')
+    // `db` is `export let db: Knex` — DECLARED at module load, ASSIGNED only by
+    // initializeDatabaseConnection(). The server calls that during boot, but this
+    // module is also the permit-schema-sync CLI entrypoint, which does not. So
+    // `db` was undefined, `db.schema` threw "Cannot read properties of undefined
+    // (reading 'schema')", the catch below classified a TypeError as
+    // `registry_unavailable`, and the Job exited non-zero on every deploy.
+    //
+    // Destructuring BEFORE initializing is what made this invisible: `const { db }`
+    // captures the value at that moment, so calling the initializer afterwards
+    // would still leave the local binding undefined. Read the property AFTER.
+    //
+    // initializeDatabaseConnection() is idempotent (`if (!db)`), so this is a
+    // no-op in the server, where the connection already exists.
+    database.initializeDatabaseConnection()
+    const db = database.db
     /* eslint-enable @typescript-eslint/no-var-requires */
 
     // The `apps.slug` and `apps.policy` columns are provisioned by the

--- a/backend/tests/permitSchemaRegistryInit.test.ts
+++ b/backend/tests/permitSchemaRegistryInit.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Regression for #760 — the permit-schema-sync PostSync hook exited non-zero on
+ * every deploy, which failed the Argo sync, which meant the weight-10 hooks
+ * (including consumer-registration-seed, the job that writes the platform
+ * registration token) never ran at all.
+ *
+ * The cause was not a database outage, which is what the failure was reported as.
+ * `config/database` exports `export let db: Knex` — DECLARED at module load and
+ * ASSIGNED only inside `initializeDatabaseConnection()`. The server calls that
+ * during boot; the CLI entrypoint did not. So `db` was `undefined`, `db.schema`
+ * threw a TypeError, and `loadRegisteredPolicyResult`'s catch classified it as
+ * `registry_unavailable` — the state deliberately reserved for a REAL outage,
+ * and deliberately fatal.
+ *
+ * These tests pin the two halves of that:
+ *   1. the loader initializes the connection before touching `db`;
+ *   2. it does not report `registry_unavailable` merely because nobody had
+ *      initialized the handle yet.
+ *
+ * Both use a mocked `config/database` so no Postgres is required — the bug was
+ * in initialization order, not in any query.
+ */
+
+const hasTable = jest.fn().mockResolvedValue(false)
+
+jest.mock('../src/config/database', () => {
+  const mod: Record<string, unknown> = {
+    db: undefined,
+    initializeDatabaseConnection: jest.fn(() => {
+      // Mirrors the real module: the binding is only populated here.
+      mod.db = Object.assign(() => ({}), { schema: { hasTable, hasColumn: jest.fn() } })
+    }),
+    // The ES module namespace object is read-only, so a test cannot clear `db`
+    // through the import binding — reset it from inside the mock instead.
+    __resetDb: () => {
+      mod.db = undefined
+    },
+  }
+  return mod
+})
+
+import { loadRegisteredPolicyResult } from '../src/permit/sync-permit-schema'
+import * as database from '../src/config/database'
+
+describe('#760 — permit-schema-sync initializes the DB before reading the app registry', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    ;(jest.requireMock('../src/config/database') as { __resetDb: () => void }).__resetDb()
+  })
+
+  it('calls initializeDatabaseConnection() before touching db.schema', async () => {
+    await loadRegisteredPolicyResult(() => {})
+    expect(database.initializeDatabaseConnection).toHaveBeenCalled()
+    expect(hasTable).toHaveBeenCalledWith('apps')
+  })
+
+  it('does not report registry_unavailable just because the handle was uninitialized', async () => {
+    const result = await loadRegisteredPolicyResult(() => {})
+
+    // `available: false` is what the CLI job treats as fatal (exit 1). An
+    // uninitialized handle is a setup bug in THIS process, not a registry
+    // outage, and must never be reported as one.
+    expect(result.available).toBe(true)
+    expect(result.error).toBeNull()
+  })
+})


### PR DESCRIPTION
## 📋 Description

`fuzefront-permit-schema-sync` exits non-zero on every deploy:

```
Permit schema sync did NOT include registered product policies
(registry_unavailable: Cannot read properties of undefined (reading 'schema'))
— failing so this deploy is not mistaken for a good one.
Check the job has DB_HOST/DB_NAME/DB_USER/DB_PASSWORD and USE_POSTGRES=true.
```

**Every one of those env vars is already set** on the Job — `templates/permit-schema-job.yaml` sets `USE_POSTGRES=true` plus all five `DB_*`. The message's advice points at the wrong thing, because this was never a connection problem.

Refs #760.

## Root cause

`config/database` declares `export let db: Knex` and **assigns** it only inside `initializeDatabaseConnection()`. The server calls that during boot; this module is *also* the `permit-schema-sync` CLI entrypoint, which did not. So `db` was `undefined` and `db.schema.hasTable('apps')` threw a `TypeError`.

Destructuring is what hid it:

```ts
const { db } = require('../config/database')   // captures undefined, right here
```

`const { db }` binds the value at that moment — so even adding an initializer call afterwards would leave the local binding `undefined`. The property has to be read **after** init.

`loadRegisteredPolicyResult`'s catch then classified that `TypeError` as `registry_unavailable` — the state its own comment reserves for a genuine outage:

> The hard-fail stays reserved for a REAL registry outage: if the DB is unreachable, `hasTable`/`hasColumn` themselves reject and land in the catch below → `available: false` → the job exits non-zero, exactly as designed.

An uninitialized handle lands in that identical catch. The guard built to detect an outage was being tripped by a missing initialization, and the two are indistinguishable from the outside.

## Why this mattered far beyond Permit

`permit-schema-sync` is a **PostSync hook at weight 5**. A failed PostSync hook fails the sync, so the weight-10 tier never ran — and that tier contains **`consumer-registration-seed`**, the Job that writes `Secret/fuzefront-registration`.

```
permit-schema-sync (weight 5) fails
  → sync fails → weight 10 never runs
  → consumer-registration-seed never runs → no token
  → FuzeInfra publish-sealed-handoff: "key 'token' not readable" ×8 consumers
  → no product can self-register → portal shows a fraction of the family
```

This is the fourth blocker in that chain, after the root-org FK violation and the `@fuzefront/shared` subpath crash (#751), and config-service holding the Sync phase open (#756). Each was only visible once the one above it cleared.

`initializeDatabaseConnection()` is idempotent (`if (!db)`), so this is a no-op in the server, where the connection already exists.

## 🔄 Type of Change

- 🐛 Bug fix (non-breaking change which fixes an issue)
- 🧪 Test addition or improvement

## 🧪 Testing

`backend/tests/permitSchemaRegistryInit.test.ts` pins both halves:

1. the loader initializes the connection **before** touching `db`;
2. it does **not** report `registry_unavailable` merely because nobody had initialized the handle.

Mocked database module — no Postgres required, because the bug was initialization order, not any query. The mock reproduces the real shape: `db` undefined at module load, populated only by `initializeDatabaseConnection()`.

**Verified load-bearing:** reverting `sync-permit-schema.ts` fails both tests.

```
✓ calls initializeDatabaseConnection() before touching db.schema
✓ does not report registry_unavailable just because the handle was uninitialized
```

**Test Configuration:** Node.js v22.22.2 (below the repo's `>=24` floor — this box cannot meet it), Linux.

### Test Instructions

```bash
cd backend && npm test -- tests/permitSchemaRegistryInit.test.ts
```

## 🔧 Implementation Details

Two-line behavioural change plus the comment explaining why the ordering is load-bearing:

```ts
const database = require('../config/database')
database.initializeDatabaseConnection()
const db = database.db
```

**Not changed, deliberately:** the `registry_unavailable` → exit-1 behaviour stays exactly as-is. It is correct and it is what surfaced this bug rather than letting a deploy silently ship with zero product policies — the failure mode the template's own comment says it was added to prevent. The defect was that a local setup error could masquerade as an outage, not that the hard-fail was wrong.

Worth a follow-up (not done here): the diagnostic text tells the operator to check env vars that are already set. Now that an uninitialized handle can't reach that path, it would be more useful for the message to distinguish a connection rejection from a programming error.

## 🚨 Breaking Changes

None.

## 🔗 Related Issues and PRs

- Fixes the blocker described in #760 · Chain: #749 → #751 → #752/#756 → #760

## 📝 Additional Notes

### Deployment Notes

- `master` is deploy-on-push. **Merge in a deploy window.**
- On deploy, `permit-schema-sync` should complete instead of failing, letting the weight-10 PostSync tier run — which is what finally writes the registration token. **That is the expected outcome, not a verified one**; it needs checking after the sync.
- This supersedes the workaround floated in #760 (moving `consumer-registration-seed` to weight 0). That routed *around* the failure; this removes it. If this fix works, the reorder should not be needed — and I'd rather not reorder prod hook execution to dodge a bug that turned out to be two lines.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GaPa3JgrVNtWrGvqQEAEqv)_