### PR TITLE
fix(authentik): providers signed ID tokens with HS256, which OIDC clients reject

### DIFF
--- a/deploy/helm/fuzefront/authentik/blueprints/provider-oidc-fuzeinfra-admin.yaml
+++ b/deploy/helm/fuzefront/authentik/blueprints/provider-oidc-fuzeinfra-admin.yaml
@@ -154,6 +154,22 @@ entries:
       include_claims_in_id_token: true
       authorization_flow: !Find [authentik_flows.flow, [slug, fuzeinfra-admin-authorization-implicit-consent]]
       invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+      # REQUIRED, and its absence is why Kafka UI could never complete a login.
+      #
+      # With no signing_key an Authentik OAuth2 provider signs the ID token with
+      # HS256 — symmetric, HMAC over the client secret — and advertises
+      # id_token_signing_alg_values_supported: ["HS256"]. Spring Security refuses
+      # that outright:
+      #     [invalid_id_token] Unsupported algorithm of HS256
+      # surfaced to the user only as a generic "Invalid credentials".
+      #
+      # Setting an RSA keypair switches the provider to RS256, which is what every
+      # conformant OIDC client expects. Verified against the live IdP: exactly one
+      # keypair exists, key_type rsa, named below.
+      #
+      # Grafana masked this — its generic-OAuth flow does not enforce the ID-token
+      # algorithm, so it worked on HS256 while ArgoCD and Kafka UI could not.
+      signing_key: !Find [authentik_crypto.certificatekeypair, [name, "authentik Self-signed Certificate"]]
       # REQUIRED on Authentik 2026.x (prod runs server:2026.5.5). A provider
       # created without grant_types has an EMPTY allow-list and rejects every
       # authorize request — the browser is bounced straight back to the client's
@@ -199,6 +215,22 @@ entries:
       include_claims_in_id_token: true
       authorization_flow: !Find [authentik_flows.flow, [slug, fuzeinfra-admin-authorization-implicit-consent]]
       invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+      # REQUIRED, and its absence is why Kafka UI could never complete a login.
+      #
+      # With no signing_key an Authentik OAuth2 provider signs the ID token with
+      # HS256 — symmetric, HMAC over the client secret — and advertises
+      # id_token_signing_alg_values_supported: ["HS256"]. Spring Security refuses
+      # that outright:
+      #     [invalid_id_token] Unsupported algorithm of HS256
+      # surfaced to the user only as a generic "Invalid credentials".
+      #
+      # Setting an RSA keypair switches the provider to RS256, which is what every
+      # conformant OIDC client expects. Verified against the live IdP: exactly one
+      # keypair exists, key_type rsa, named below.
+      #
+      # Grafana masked this — its generic-OAuth flow does not enforce the ID-token
+      # algorithm, so it worked on HS256 while ArgoCD and Kafka UI could not.
+      signing_key: !Find [authentik_crypto.certificatekeypair, [name, "authentik Self-signed Certificate"]]
       # REQUIRED on Authentik 2026.x (prod runs server:2026.5.5). A provider
       # created without grant_types has an EMPTY allow-list and rejects every
       # authorize request — the browser is bounced straight back to the client's
@@ -251,6 +283,22 @@ entries:
       include_claims_in_id_token: true
       authorization_flow: !Find [authentik_flows.flow, [slug, fuzeinfra-admin-authorization-implicit-consent]]
       invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+      # REQUIRED, and its absence is why Kafka UI could never complete a login.
+      #
+      # With no signing_key an Authentik OAuth2 provider signs the ID token with
+      # HS256 — symmetric, HMAC over the client secret — and advertises
+      # id_token_signing_alg_values_supported: ["HS256"]. Spring Security refuses
+      # that outright:
+      #     [invalid_id_token] Unsupported algorithm of HS256
+      # surfaced to the user only as a generic "Invalid credentials".
+      #
+      # Setting an RSA keypair switches the provider to RS256, which is what every
+      # conformant OIDC client expects. Verified against the live IdP: exactly one
+      # keypair exists, key_type rsa, named below.
+      #
+      # Grafana masked this — its generic-OAuth flow does not enforce the ID-token
+      # algorithm, so it worked on HS256 while ArgoCD and Kafka UI could not.
+      signing_key: !Find [authentik_crypto.certificatekeypair, [name, "authentik Self-signed Certificate"]]
       # REQUIRED on Authentik 2026.x (prod runs server:2026.5.5). A provider
       # created without grant_types has an EMPTY allow-list and rejects every
       # authorize request — the browser is bounced straight back to the client's
@@ -318,6 +366,22 @@ entries:
       include_claims_in_id_token: true
       authorization_flow: !Find [authentik_flows.flow, [slug, fuzeinfra-admin-authorization-implicit-consent]]
       invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+      # REQUIRED, and its absence is why Kafka UI could never complete a login.
+      #
+      # With no signing_key an Authentik OAuth2 provider signs the ID token with
+      # HS256 — symmetric, HMAC over the client secret — and advertises
+      # id_token_signing_alg_values_supported: ["HS256"]. Spring Security refuses
+      # that outright:
+      #     [invalid_id_token] Unsupported algorithm of HS256
+      # surfaced to the user only as a generic "Invalid credentials".
+      #
+      # Setting an RSA keypair switches the provider to RS256, which is what every
+      # conformant OIDC client expects. Verified against the live IdP: exactly one
+      # keypair exists, key_type rsa, named below.
+      #
+      # Grafana masked this — its generic-OAuth flow does not enforce the ID-token
+      # algorithm, so it worked on HS256 while ArgoCD and Kafka UI could not.
+      signing_key: !Find [authentik_crypto.certificatekeypair, [name, "authentik Self-signed Certificate"]]
       # REQUIRED on Authentik 2026.x (prod runs server:2026.5.5). A provider
       # created without grant_types has an EMPTY allow-list and rejects every
       # authorize request — the browser is bounced straight back to the client's
@@ -384,6 +448,22 @@ entries:
       include_claims_in_id_token: true
       authorization_flow: !Find [authentik_flows.flow, [slug, fuzeinfra-admin-authorization-implicit-consent]]
       invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+      # REQUIRED, and its absence is why Kafka UI could never complete a login.
+      #
+      # With no signing_key an Authentik OAuth2 provider signs the ID token with
+      # HS256 — symmetric, HMAC over the client secret — and advertises
+      # id_token_signing_alg_values_supported: ["HS256"]. Spring Security refuses
+      # that outright:
+      #     [invalid_id_token] Unsupported algorithm of HS256
+      # surfaced to the user only as a generic "Invalid credentials".
+      #
+      # Setting an RSA keypair switches the provider to RS256, which is what every
+      # conformant OIDC client expects. Verified against the live IdP: exactly one
+      # keypair exists, key_type rsa, named below.
+      #
+      # Grafana masked this — its generic-OAuth flow does not enforce the ID-token
+      # algorithm, so it worked on HS256 while ArgoCD and Kafka UI could not.
+      signing_key: !Find [authentik_crypto.certificatekeypair, [name, "authentik Self-signed Certificate"]]
       # REQUIRED on Authentik 2026.x — see the identical note on the four
       # providers above. Without it every authorize request comes back as
       # error=invalid_request.
@@ -446,6 +526,22 @@ entries:
       authorization_flow: !Find [authentik_flows.flow, [slug, fuzeinfra-admin-authorization-implicit-consent]]
       # Without this the entry fails SILENTLY and no provider is created.
       invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+      # REQUIRED, and its absence is why Kafka UI could never complete a login.
+      #
+      # With no signing_key an Authentik OAuth2 provider signs the ID token with
+      # HS256 — symmetric, HMAC over the client secret — and advertises
+      # id_token_signing_alg_values_supported: ["HS256"]. Spring Security refuses
+      # that outright:
+      #     [invalid_id_token] Unsupported algorithm of HS256
+      # surfaced to the user only as a generic "Invalid credentials".
+      #
+      # Setting an RSA keypair switches the provider to RS256, which is what every
+      # conformant OIDC client expects. Verified against the live IdP: exactly one
+      # keypair exists, key_type rsa, named below.
+      #
+      # Grafana masked this — its generic-OAuth flow does not enforce the ID-token
+      # algorithm, so it worked on HS256 while ArgoCD and Kafka UI could not.
+      signing_key: !Find [authentik_crypto.certificatekeypair, [name, "authentik Self-signed Certificate"]]
       # REQUIRED on Authentik 2026.x — see the identical note on the providers
       # above. Without it every authorize request comes back as
       # error=invalid_request.


### PR DESCRIPTION
Root cause of the Kafka UI login failure. **Read from the pod log, not inferred** — this is what raising the log level was for.

```
o.s.s.w.s.a.AuthenticationWebFilter: Authentication failed:
    [invalid_id_token] Unsupported algorithm of HS256
```

## What was wrong

An Authentik OAuth2 provider with **no `signing_key`** signs the ID token with **HS256** — symmetric, HMAC over the client secret — and advertises `id_token_signing_alg_values_supported: ["HS256"]`. The live discovery document confirmed exactly that.

Spring Security requires an asymmetric algorithm and refuses it, surfacing to the user only as a generic **"Invalid credentials"** that names neither the algorithm nor the ID token.

**No provider in this repo set `signing_key`**, so all of them were affected.

## Why it hid for so long

The clients disagree about strictness:

| client | enforces ID-token alg? | on HS256 |
|---|---|---|
| Grafana (generic OAuth) | no | **worked** |
| ArgoCD | yes | broken |
| Kafka UI (Spring Security) | yes | broken |

A working Grafana was taken as evidence the IdP was configured correctly. It wasn't — Grafana was just the lenient client.

## The fix

Sets the RSA keypair on all six admin-plane providers, switching them to RS256.

**Verified against the live IdP before committing** — exactly one keypair exists, `key_type: rsa`, named `authentik Self-signed Certificate`. That check matters: a `!Find` matching nothing fails the entry **silently** and deletes the provider, which is the same failure mode as the missing `invalidation_flow` earlier.

## Deliberately not changed

`provider-oidc.yaml` (the FuzeFront product provider) and the mendys providers have the **same latent defect**, but they serve live logins today. Switching a working provider's signing algorithm is a change those consumers should be tested against on their own, not bundled here.

## Honest note on the path here

Four earlier fixes were each necessary and none sufficient — the `http` issuer, the missing `grant_types`, the group pin, the roll triggers. This is the one actually producing the error, and it was only findable by raising the log level instead of reasoning about it. The lesson is the method, not the fix.

## Verified

Blueprint parses; 6/6 providers carry `signing_key` **and** `grant_types`; `helm lint` clean; keypair name checked against the live API.

**Not verified:** that the login completes. Checking after this syncs and the Authentik pods roll on `checksum/blueprints`.
