### PR TITLE
fix(chart): seed Job image is distroless and cannot exec /bin/sh

### DIFF
--- a/.github/workflows/helm-validate.yml
+++ b/.github/workflows/helm-validate.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
     paths:
       - 'deploy/helm/**'
+      - 'deploy/scripts/**'
       - '.github/workflows/helm-validate.yml'
 
 permissions:
@@ -97,52 +98,29 @@ jobs:
             -summary \
             rendered/fuzefront/templates/
 
-      - name: Guard seed-Job image is pullable (${{ matrix.values }})
+      - name: Guard shell-launched containers can run their interpreter (${{ matrix.values }})
         run: |
-          # WHY THIS EXISTS. `helm lint` and kubeconform validate that `image:` is a
-          # non-empty string. They cannot tell a real tag from one that was deleted
-          # out from under us -- and that is exactly the failure that happened:
-          # consumer-registration-seed was pinned to `bitnami/kubectl:1.29`, Broadcom
-          # removed the free bitnami/* images from Docker Hub in Aug 2025, the pod
-          # ImagePullBackOff'd, and Secret/fuzefront-registration was silently never
-          # published. Eight days of FuzeInfra's credential handoff failing every 6h
-          # was the only signal, and it pointed at the wrong repo (FuzeInfra#552,
-          # FuzeFront#688). CI stayed green throughout.
+          # REPLACES a narrower guard that asserted the seed Job's tag RESOLVED on
+          # registry.k8s.io. That guard was green on 2026-08-20 while the Job could
+          # not start at all: the image had been moved to `registry.k8s.io/kubectl`,
+          # which is DISTROLESS, and the Job invokes `/bin/sh -c`. Every pod died at
+          # runc init with `exec: "/bin/sh": no such file or directory`, printed
+          # nothing, and blocked the whole registration handoff.
           #
-          # SCOPE, deliberately narrow: only the seed Job's image, and only when it is
-          # hosted on registry.k8s.io. That registry serves manifests anonymously and
-          # does not rate-limit, so the check is deterministic. Extending this to every
-          # image in the chart would mean authenticating to ghcr.io and absorbing
-          # Docker Hub's anonymous pull limits -- i.e. trading a real check for a flaky
-          # one. If the image is moved off registry.k8s.io this step SKIPS, and says so
-          # loudly, because a check that quietly stops checking is worse than no check.
+          # The old guard asserted the PREVIOUS failure mode (a deleted bitnami tag,
+          # FuzeFront#688) and had an explicit warn-and-skip for any image not on
+          # registry.k8s.io -- so moving the image off that registry would have
+          # silently disarmed it too. Resolving a manifest is not evidence the image
+          # can execute the command the manifest gives it, so this runs the
+          # interpreter. See deploy/scripts/check-job-interpreters.sh for the detail.
+          #
+          # Scope is now every shell-launched container in the rendered chart, not
+          # just the seed Job. First-party ghcr.io/izzywdev/* images are reported and
+          # skipped (pulling them needs auth; their bases are pinned by our
+          # Dockerfiles). The script hard-errors rather than skipping if docker or
+          # PyYAML is missing, and fails if the scan matches nothing.
           set -euo pipefail
-          img=$(awk '/^          image: /{print $2; exit}' \
-                rendered/fuzefront/templates/consumer-registration-seed-job.yaml)
-          if [ -z "$img" ]; then
-            echo "::error::could not extract the seed Job image from the rendered chart"
-            exit 1
-          fi
-          echo "seed image: $img"
-          case "$img" in
-            registry.k8s.io/*) ;;
-            *)
-              echo "::warning::seed image '$img' is not on registry.k8s.io — pullability NOT verified by this gate"
-              exit 0
-              ;;
-          esac
-          repo="${img%:*}"; tag="${img##*:}"
-          path="${repo#registry.k8s.io/}"
-          code=$(curl -sSL -o /dev/null -w '%{http_code}' \
-            -H 'Accept: application/vnd.oci.image.index.v1+json' \
-            -H 'Accept: application/vnd.docker.distribution.manifest.list.v2+json' \
-            -H 'Accept: application/vnd.docker.distribution.manifest.v2+json' \
-            "https://registry.k8s.io/v2/${path}/manifests/${tag}")
-          if [ "$code" != "200" ]; then
-            echo "::error::registry.k8s.io/${path}:${tag} does not resolve (HTTP $code) — this image would ImagePullBackOff in the cluster"
-            exit 1
-          fi
-          echo "OK: ${img} resolves (HTTP 200)"
+          ./deploy/scripts/check-job-interpreters.sh rendered/fuzefront/templates
 
       - name: Guard NetworkPolicy port values (${{ matrix.values }})
         run: |

--- a/.github/workflows/helm-validate.yml
+++ b/.github/workflows/helm-validate.yml
@@ -119,7 +119,13 @@ jobs:
           # skipped (pulling them needs auth; their bases are pinned by our
           # Dockerfiles). The script hard-errors rather than skipping if docker or
           # PyYAML is missing, and fails if the scan matches nothing.
+          # Self-test FIRST, deliberately, mirroring gate-identifier: assert the
+          # probe still FAILS on a known-distroless image before trusting it to
+          # pass on ours. A gate observed only passing proves nothing -- the guard
+          # this replaces was green for the entire life of the bug it should have
+          # caught.
           set -euo pipefail
+          ./deploy/scripts/check-job-interpreters.sh --self-test
           ./deploy/scripts/check-job-interpreters.sh rendered/fuzefront/templates
 
       - name: Guard NetworkPolicy port values (${{ matrix.values }})

--- a/deploy/helm/fuzefront/values.yaml
+++ b/deploy/helm/fuzefront/values.yaml
@@ -79,17 +79,40 @@ database:
 # (templates/consumer-registration-seed-job.yaml). It needs nothing but a shell and
 # kubectl, so it uses Kubernetes' own community-published image.
 #
-# DO NOT put a bitnami/* image here. This field exists because the Job was pinned to
-# `bitnami/kubectl:1.29`, and in Aug 2025 Broadcom removed the free bitnami/* images
-# from Docker Hub (old tags moved to docker.io/bitnamilegacy/*). The tag stopped
-# pulling, the Job pod ImagePullBackOff'd, and Secret/fuzefront-registration was never
-# published -- which is what broke FuzeInfra's credential handoff for eight days
-# (FuzeFront#688, FuzeInfra#552). registry.k8s.io is auth-free and not rate-limited.
+# THE IMAGE MUST CONTAIN A SHELL. The Job runs `command: ["/bin/sh","-c", …]`.
+#
+# DO NOT put a bitnami/* image here. The Job was pinned to `bitnami/kubectl:1.29`,
+# and in Aug 2025 Broadcom removed the free bitnami/* images from Docker Hub (old
+# tags moved to docker.io/bitnamilegacy/*). The tag stopped pulling, the pod
+# ImagePullBackOff'd, and Secret/fuzefront-registration was never published --
+# which broke FuzeInfra's credential handoff for eight days (FuzeFront#688,
+# FuzeInfra#552).
+#
+# DO NOT put a DISTROLESS image here either -- that was the replacement, and it
+# failed differently and more quietly. `registry.k8s.io/kubectl` ships the kubectl
+# binary and NO shell, so on 2026-08-20 every pod died at runc init with
+# `exec: "/bin/sh": stat /bin/sh: no such file or directory`. It never ran one line
+# of the script, so none of its FATAL diagnostics printed and `kubectl logs` was
+# empty. The CI guard added after #688 asserted the tag RESOLVED -- which it did --
+# so CI was green the whole time. Resolving is not the same as being able to run.
+# `deploy/scripts/check-job-interpreters.sh` now executes the interpreter instead.
+#
+# alpine/k8s = kubectl + busybox sh. FuzeInfra already runs this exact image in
+# this cluster (runners/arc/gitops/controller-selfheal.yaml) for the same reason.
+# The tag TRACKS THE K3S SERVER VERSION: the server is v1.36.2+k3s1 and reports
+# minCompatibilityMinor "35", so the previous v1.29.10 pin was seven minors below
+# the server's own stated minimum, well outside the kubectl skew policy.
+# Re-check this tag whenever the cluster is upgraded.
+#
+# Tradeoff, stated rather than buried: this is Docker Hub, which rate-limits
+# anonymous pulls, where registry.k8s.io did not. It is accepted because the image
+# is already resident on the nodes and the tag is not `latest`, so pulls are rare
+# -- and an image that cannot start is worse than one that occasionally throttles.
 #
 # The default is declared HERE, visibly, rather than only as a `| default` at the
 # render site -- per this repo's Helm values-hygiene rule.
 consumerRegistrationSeed:
-  image: "registry.k8s.io/kubectl:v1.29.10"
+  image: "alpine/k8s:1.36.2"
 
 # Secret handling. Either let the chart create a Secret from the values here
 # (DEV ONLY — override!), or point at an existing Secret via `existingSecret`.

--- a/deploy/scripts/check-job-interpreters.sh
+++ b/deploy/scripts/check-job-interpreters.sh
@@ -26,9 +26,19 @@
 # that actually proves it — it runs the interpreter.
 #
 # Usage: check-job-interpreters.sh <rendered-templates-dir>
+#        check-job-interpreters.sh --self-test
 set -euo pipefail
 
-DIR="${1:?usage: check-job-interpreters.sh <rendered-templates-dir>}"
+# The image that caused the outage. Used as the self-test's negative control --
+# it is genuinely distroless, so the probe MUST fail against it.
+SELF_TEST_DISTROLESS="registry.k8s.io/kubectl:v1.29.10"
+
+MODE="check"
+case "${1:-}" in
+  --self-test) MODE="self-test" ;;
+  "") echo "usage: check-job-interpreters.sh <rendered-templates-dir> | --self-test" >&2; exit 2 ;;
+  *) DIR="$1" ;;
+esac
 
 # Probe the DAEMON, not the CLI. `command -v docker` succeeds in plenty of
 # environments that cannot run a container (the CLI is installed but no daemon is
@@ -42,6 +52,32 @@ if ! docker info >/dev/null 2>&1; then
        "The CLI alone is not enough — this check runs each image. If you are running" \
        "this locally without a daemon, run it in CI instead." >&2
   exit 1
+fi
+
+# SELF-TEST. A gate that has only ever been observed passing is not evidence of
+# anything -- the guard this replaces was green for the entire life of the bug.
+# So prove the probe can still FAIL, using the exact image that caused the
+# outage as a negative control. If this ever starts passing, the probe has been
+# broken (or upstream added a shell) and the whole check is worthless.
+#
+# Only the negative case needs a dedicated control: every real run exercises the
+# positive case against the chart's own images and would fail loudly if the probe
+# stopped succeeding on a shell-bearing image.
+if [ "$MODE" = "self-test" ]; then
+  echo "SELF-TEST: $SELF_TEST_DISTROLESS must NOT be able to exec /bin/sh"
+  if ! docker pull --quiet "$SELF_TEST_DISTROLESS" >/dev/null 2>&1; then
+    echo "::error::self-test could not pull $SELF_TEST_DISTROLESS — cannot prove the probe still detects a shell-less image." >&2
+    exit 1
+  fi
+  if docker run --rm --entrypoint /bin/sh "$SELF_TEST_DISTROLESS" -c '' >/dev/null 2>&1; then
+    echo "::error::SELF-TEST FAILED: $SELF_TEST_DISTROLESS executed /bin/sh." \
+         "This image is distroless and must not have a shell, so the probe is no" \
+         "longer detecting the failure it exists to catch. Do not trust a green" \
+         "run of this gate until this is understood." >&2
+    exit 1
+  fi
+  echo "SELF-TEST OK: the probe correctly rejects a distroless image."
+  exit 0
 fi
 
 # Emit "image<TAB>interpreter" for every container/initContainer whose command[0]

--- a/deploy/scripts/check-job-interpreters.sh
+++ b/deploy/scripts/check-job-interpreters.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# check-job-interpreters.sh — assert that every rendered container which is
+# launched through a shell can ACTUALLY EXECUTE that shell.
+#
+# WHY THIS EXISTS. The seed Job was pinned to `bitnami/kubectl:1.29`; Broadcom
+# removed the free bitnami/* images from Docker Hub in Aug 2025, the pod
+# ImagePullBackOff'd, and Secret/fuzefront-registration was silently never
+# published (FuzeFront#688, FuzeInfra#552). The fix repinned it to
+# `registry.k8s.io/kubectl`, and a CI guard was added asserting the tag RESOLVES.
+#
+# That guard was green on 2026-08-20 while the Job could not start at all:
+#
+#   Error: failed to create containerd task: ... OCI runtime create failed:
+#   runc create failed: unable to start container process: error during
+#   container init: exec: "/bin/sh": stat /bin/sh: no such file or directory
+#
+# `registry.k8s.io/kubectl` is DISTROLESS — it ships the kubectl binary and no
+# shell — but the Job invokes `command: ["/bin/sh","-c", …]`. The image pulled
+# fine, so the pullability guard passed; the container never ran a single line,
+# so not one of the script's carefully-worded FATAL diagnostics was ever
+# printed and `kubectl logs` came back empty.
+#
+# The lesson, and the reason this check is shaped the way it is: the previous
+# guard asserted the PREVIOUS failure mode. Resolving a manifest is not evidence
+# the image can run the command it is given. So this one does the only thing
+# that actually proves it — it runs the interpreter.
+#
+# Usage: check-job-interpreters.sh <rendered-templates-dir>
+set -euo pipefail
+
+DIR="${1:?usage: check-job-interpreters.sh <rendered-templates-dir>}"
+
+# Probe the DAEMON, not the CLI. `command -v docker` succeeds in plenty of
+# environments that cannot run a container (the CLI is installed but no daemon is
+# reachable), which produces a confusing per-image "could not be pulled" for every
+# entry instead of one clear message about the real problem.
+#
+# Deliberately a hard error, not a skip. A check that quietly stops checking is
+# exactly how the distroless bug above survived; if this cannot run, say so.
+if ! docker info >/dev/null 2>&1; then
+  echo "::error::a working Docker daemon is required to verify container interpreters." \
+       "The CLI alone is not enough — this check runs each image. If you are running" \
+       "this locally without a daemon, run it in CI instead." >&2
+  exit 1
+fi
+
+# Emit "image<TAB>interpreter" for every container/initContainer whose command[0]
+# is an absolute shell path. Images we build ourselves are reported and skipped:
+# pulling them needs ghcr.io auth, and their bases are pinned by our Dockerfiles.
+mapfile -t PAIRS < <(python3 - "$DIR" <<'PY'
+import os, sys, glob
+try:
+    import yaml
+except ImportError:
+    sys.stderr.write("::error::PyYAML is required to parse the rendered chart.\n")
+    sys.exit(1)
+
+SHELLS = {"/bin/sh", "/bin/bash", "/bin/ash", "/bin/dash",
+          "/usr/bin/sh", "/usr/bin/bash", "/usr/bin/env"}
+seen, scanned = set(), 0
+
+for path in glob.glob(os.path.join(sys.argv[1], "**", "*.yaml"), recursive=True):
+    with open(path) as fh:
+        try:
+            docs = list(yaml.safe_load_all(fh))
+        except yaml.YAMLError as exc:
+            sys.stderr.write(f"::error::could not parse {path}: {exc}\n")
+            sys.exit(1)
+    for doc in docs:
+        if not isinstance(doc, dict):
+            continue
+        scanned += 1
+        # Find every PodSpec regardless of the enclosing kind (Job, CronJob,
+        # Deployment, …) rather than enumerating kinds and missing one.
+        stack, specs = [doc], []
+        while stack:
+            node = stack.pop()
+            if isinstance(node, dict):
+                if "containers" in node and isinstance(node.get("containers"), list):
+                    specs.append(node)
+                stack.extend(node.values())
+            elif isinstance(node, list):
+                stack.extend(node)
+        for spec in specs:
+            for c in (spec.get("containers") or []) + (spec.get("initContainers") or []):
+                cmd, image = c.get("command"), c.get("image")
+                if not cmd or not image:
+                    continue
+                if cmd[0] in SHELLS:
+                    seen.add((image, cmd[0]))
+
+# A scan that matched nothing must not pass silently — that is the same
+# vacuous-green failure this whole file exists to prevent.
+if scanned == 0:
+    sys.stderr.write("::error::no Kubernetes manifests found to scan.\n")
+    sys.exit(1)
+
+for image, interp in sorted(seen):
+    print(f"{image}\t{interp}")
+PY
+)
+
+if [ "${#PAIRS[@]}" -eq 0 ]; then
+  echo "No shell-launched containers in the rendered chart — nothing to verify."
+  exit 0
+fi
+
+rc=0
+for pair in "${PAIRS[@]}"; do
+  image="${pair%%$'\t'*}"
+  interp="${pair##*$'\t'}"
+
+  case "$image" in
+    ghcr.io/izzywdev/*)
+      echo "SKIP  $image ($interp) — first-party image, pulling it needs ghcr.io auth"
+      continue
+      ;;
+  esac
+
+  echo "CHECK $image needs $interp"
+  # Retry the pull. Docker Hub rate-limits anonymous pulls per source IP, and
+  # GitHub-hosted runners share IPs with a lot of other traffic, so an occasional
+  # 429 is expected and is NOT a defect in the chart. Retrying a few times keeps
+  # this gate honest without making it flaky-red on unrelated PRs. A persistent
+  # failure still fails -- it is never downgraded to a skip.
+  pull_ok=0
+  for attempt in 1 2 3; do
+    if pull_err=$(docker pull --quiet "$image" 2>&1); then pull_ok=1; break; fi
+    [ "$attempt" -lt 3 ] && sleep $(( attempt * 10 ))
+  done
+  if [ "$pull_ok" -ne 1 ]; then
+    # Report what docker actually said. A blocked egress proxy and a deleted tag
+    # both surface as "pull failed", and calling both ImagePullBackOff sends the
+    # reader after the wrong bug — the precise mistake this file is about.
+    echo "::error::$image could not be pulled. If the tag is gone this would" \
+         "ImagePullBackOff in the cluster; if this runner has no registry egress" \
+         "the check itself is unable to run. docker said: ${pull_err}"
+    rc=1
+    continue
+  fi
+  # `-c ''` is the same invocation shape the manifest uses, so a shell that
+  # exists but cannot be exec'd as an entrypoint still fails here.
+  if ! docker run --rm --entrypoint "$interp" "$image" -c '' >/dev/null 2>&1; then
+    echo "::error::$image cannot execute '$interp'. The manifest launches it via" \
+         "\`command: [\"$interp\", \"-c\", …]\`, so the container will fail at" \
+         "runc init with 'no such file or directory' and the pod will never run a" \
+         "single line of its script. Distroless images (registry.k8s.io/kubectl," \
+         "gcr.io/distroless/*) ship no shell — use an image that does, e.g." \
+         "alpine/k8s, which FuzeInfra already runs in this cluster."
+    rc=1
+    continue
+  fi
+  echo "OK    $image can execute $interp"
+done
+
+exit "$rc"


### PR DESCRIPTION
## 📋 Description

`consumer-registration-seed` has failed on **every** sync since its image was repinned. #761 cleared the PostSync weight-5 blocker, so the weight-10 tier finally ran tonight — and this is what it did:

```
Error: failed to create containerd task: failed to create shim task:
OCI runtime create failed: runc create failed: unable to start container process:
error during container init: exec: "/bin/sh": stat /bin/sh: no such file or directory
```

`registry.k8s.io/kubectl` is **distroless** — it ships the `kubectl` binary and no shell — while the Job runs `command: ["/bin/sh","-c", …]`. The container never executed a single line.

That detail is why this hid so well:

- **No logs.** `kubectl logs job/consumer-registration-seed` returned *empty*. The script's carefully-worded `FATAL` diagnostics — the ones naming exactly which precondition failed — never printed, because nothing ran.
- **No evidence afterwards.** `backoffLimit: 3` was reached and the job controller **deleted the pod**, taking its terminated-container state with it. Only namespace `events` still held the error.

Job state in prod (`2e8f79ba25be`):

| Job | Status |
|---|---|
| `fuzefront-permit-schema-sync` | Complete 1/1, 34s ← fixed by #761 |
| `fuzefront-security-seed-admin` | Complete 1/1, 30s |
| `fuzefront-billing-db-bootstrap` | Complete 1/1, 7s |
| `fuzefront-notification-db-migrate` | Complete 1/1, 9s |
| **`consumer-registration-seed`** | **Failed 0/1, 2m12s** |

## Root cause

This image was the fix for #688: `bitnami/kubectl:1.29` stopped pulling when Broadcom removed the free `bitnami/*` images, the pod `ImagePullBackOff`'d, and `Secret/fuzefront-registration` went unpublished for eight days (FuzeFront#688, FuzeInfra#552).

**It fixed the pull and broke the exec.**

## The fix

Repin to **`alpine/k8s:1.36.2`** — kubectl + busybox `sh`. Not a new dependency: FuzeInfra already runs this exact image in this cluster, for this exact reason:

```yaml
# FuzeInfra runners/arc/gitops/controller-selfheal.yaml
- name: selfheal
  # alpine/k8s = kubectl + busybox sh. Tag tracks the k3s server
  # version (v1.36.2+k3s1) to stay inside the kubectl skew policy.
  image: alpine/k8s:1.36.2
```

**Second defect fixed by the same line.** The server reports `v1.36.2+k3s1` with `minCompatibilityMinor: "35"`, so the old `v1.29.10` pin was *seven minors below the server's own stated minimum* — well outside the kubectl skew policy. The new tag tracks the server.

**Tradeoff, stated not buried:** this is Docker Hub, which rate-limits anonymous pulls where `registry.k8s.io` did not. Accepted because the image is already resident on the nodes and the tag is not `latest`, so pulls are rare — and an image that cannot start is strictly worse than one that occasionally throttles. It's written into `values.yaml` so the next person sees the reasoning.

## 🧪 Why CI did not catch it

The guard added after #688 asserted the tag **resolved** — and it was green the entire time. It asserted the *previous* failure mode. It also carried an explicit warn-and-skip for any image not on `registry.k8s.io`, so moving the image would have quietly disarmed it too.

Replaced with `deploy/scripts/check-job-interpreters.sh`, which **runs the interpreter** rather than trusting a manifest HEAD. For every shell-launched container in the rendered chart it pulls the image and execs `command[0] -c ''`.

- **Scope widened** from the seed Job to the whole chart — it also now covers `postgres:15` in the billing bootstrap.
- First-party `ghcr.io/izzywdev/*` images are **reported and skipped** (pulling needs auth; bases are pinned by our Dockerfiles).
- **It hard-errors rather than skipping when it cannot do its job**: no Docker daemon, no PyYAML, or a scan matching zero manifests are all failures. A check that quietly stops checking is how the original bug survived.
- Pulls retry with backoff so a Docker Hub 429 doesn't red an unrelated PR — but a persistent failure still fails, never downgraded to a skip.
- Pull errors now quote docker's actual message, so a blocked proxy is not misreported as `ImagePullBackOff`.

### Test Instructions

```bash
helm template fuzefront deploy/helm/fuzefront -f deploy/helm/fuzefront/values-prod.yaml --output-dir rendered
./deploy/scripts/check-job-interpreters.sh rendered/fuzefront/templates
```

**Verified locally:** the parser scans 54 rendered docs and finds exactly the two shell-launched containers (`alpine/k8s:1.36.2`, `postgres:15`). Reverting the values change makes it flag the distroless image.

**NOT verified locally, deliberately called out:** the pull/exec half. This sandbox has the Docker CLI but no reachable daemon, and its egress to container registries is blocked. That half is proven by CI on this PR, not by me. `values-local.yaml` fails to render here for an unrelated pre-existing reason (`authentikClientSecret`) — byte-identical before and after this change.

## 🔧 Implementation Details

`consumerRegistrationSeed.image` is the only reference in the chart, so the blast radius is one value. The `values.yaml` comment now records **both** forbidden options and why — no `bitnami/*` (deleted upstream), no distroless (no shell) — since the previous comment documented only the first and the next person would have repeated this.

## 🚨 Breaking Changes

None.

## 🔗 Related Issues and PRs

Chain: #749 → #751 → #752/#756/#759 → #760/#761 → **this**. Fifth blocker; each was only visible once the one above it cleared.

Follow-ups **not** done here, to keep this reviewable:
- `permit-schema-job.yaml` still has no `activeDeadlineSeconds` (#760).
- `backoffLimit` deleting the failed pod destroys the diagnostics the script works hard to produce — worth a `podFailurePolicy` or a longer-lived pod on failure.
- `helm-validate` still validates against **Kubernetes 1.29** kubeconform schemas while the server is 1.36 — same staleness class as the kubectl pin, but changing it could red unrelated things.
- The Job could arguably be removed entirely by sealing `fuzefront-registration` directly, rather than materialising it from another Secret at PostSync.

## 📝 Additional Notes

`master` is deploy-on-push — **merge in a deploy window**. On deploy the seed should Complete and publish `Secret/fuzefront-registration`, which unblocks FuzeInfra's `publish-sealed-handoff` for eight consumers. **That is the expected outcome, not a verified one** — it needs checking after the sync, and I'll do that rather than assume it.

Note that the token is necessary but **not sufficient** for those products to appear in the portal: `GH_RELEASE_PAT` is unset in at least FuzeX, FuzeFinance and FuzeExecutive, so their images publish but `values-prod.yaml` is never bumped (FuzeSDLC#131, owner action).

---
_Generated by [Claude Code](https://claude.ai/code/session_01GaPa3JgrVNtWrGvqQEAEqv)_