### PR TITLE
fix(e2e): provider create races Authentik's own blueprint worker

### DIFF
--- a/deploy/e2e/provision-authentik-oidc.sh
+++ b/deploy/e2e/provision-authentik-oidc.sh
@@ -200,10 +200,43 @@ if [ -z "$PROVIDER_PK" ] || [ "$PROVIDER_PK" = "null" ]; then
     -o /tmp/provider_create.json -w "%{http_code}" -d "$PROVIDER_BODY")
   PROVIDER_RAW=$(cat /tmp/provider_create.json)
   echo "Provider create HTTP $PROVIDER_HTTP: $PROVIDER_RAW"
-  [ "$PROVIDER_HTTP" = "201" ] || { echo "::error::failed to create OAuth2 provider (HTTP $PROVIDER_HTTP)"; exit 1; }
-  PROVIDER_PK=$(echo "$PROVIDER_RAW" | jq -r '.pk // empty' 2>/dev/null || true)
-  [ -n "$PROVIDER_PK" ] && [ "$PROVIDER_PK" != "null" ] || { echo "::error::no pk in provider create response"; exit 1; }
-  echo "Created OAuth2 provider pk=$PROVIDER_PK"
+  if [ "$PROVIDER_HTTP" = "201" ]; then
+    PROVIDER_PK=$(echo "$PROVIDER_RAW" | jq -r '.pk // empty' 2>/dev/null || true)
+    [ -n "$PROVIDER_PK" ] && [ "$PROVIDER_PK" != "null" ] || { echo "::error::no pk in provider create response"; exit 1; }
+    echo "Created OAuth2 provider pk=$PROVIDER_PK"
+  else
+    # We are not the only writer. Authentik's blueprint worker provisions this
+    # same provider from blueprints/provider-oidc.yaml, and the ORM lookup above
+    # and this POST are not atomic, so a blueprint apply landing in the gap turns
+    # the create into
+    #   400 {"client_id":["OAuth2/OpenID Provider with this Client ID already exists."]}
+    # which is not a failure: the object we wanted now exists.
+    #
+    # The comment above the lookup already anticipated the blueprint racing the
+    # READ (that is why it uses the ORM instead of REST search). This is the same
+    # race on the WRITE, which was left unhandled.
+    #
+    # Re-resolve instead of aborting. This is NOT a blanket suppression and not
+    # `|| true`: any other failure leaves the pk unresolved and still aborts
+    # below, with the HTTP code in the message. The only behaviour that changes
+    # is losing a race we were always able to lose.
+    echo "Create returned HTTP $PROVIDER_HTTP; re-resolving in case the blueprint worker won the race"
+    PROVIDER_RETRY_OUTPUT=$($COMPOSE exec -T authentik-worker python - <<'PYORM'
+import os
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "authentik.root.settings")
+import django
+django.setup()
+from authentik.providers.oauth2.models import OAuth2Provider
+
+p = OAuth2Provider.objects.filter(client_id="fuzefront-oidc-client").first()
+print("PROVIDER_PK=" + (str(p.pk) if p else ""))
+PYORM
+)
+    PROVIDER_PK=$(echo "$PROVIDER_RETRY_OUTPUT" | grep "^PROVIDER_PK=" | head -1 | cut -d= -f2 | tr -d '
+ ')
+    [ -n "$PROVIDER_PK" ] && [ "$PROVIDER_PK" != "null" ] || { echo "::error::failed to create OAuth2 provider (HTTP $PROVIDER_HTTP) and no existing provider resolved for client_id=fuzefront-oidc-client"; exit 1; }
+    echo "Resolved existing OAuth2 provider pk=$PROVIDER_PK"
+  fi
 else
   echo "OAuth2 provider already exists pk=$PROVIDER_PK"
 fi

--- a/deploy/e2e/provision-authentik-oidc.sh
+++ b/deploy/e2e/provision-authentik-oidc.sh
@@ -232,8 +232,7 @@ p = OAuth2Provider.objects.filter(client_id="fuzefront-oidc-client").first()
 print("PROVIDER_PK=" + (str(p.pk) if p else ""))
 PYORM
 )
-    PROVIDER_PK=$(echo "$PROVIDER_RETRY_OUTPUT" | grep "^PROVIDER_PK=" | head -1 | cut -d= -f2 | tr -d '
- ')
+    PROVIDER_PK=$(echo "$PROVIDER_RETRY_OUTPUT" | grep "^PROVIDER_PK=" | head -1 | cut -d= -f2 | tr -d '\r\n ')
     [ -n "$PROVIDER_PK" ] && [ "$PROVIDER_PK" != "null" ] || { echo "::error::failed to create OAuth2 provider (HTTP $PROVIDER_HTTP) and no existing provider resolved for client_id=fuzefront-oidc-client"; exit 1; }
     echo "Resolved existing OAuth2 provider pk=$PROVIDER_PK"
   fi

--- a/deploy/e2e/provision-authentik-oidc.sh
+++ b/deploy/e2e/provision-authentik-oidc.sh
@@ -232,7 +232,7 @@ p = OAuth2Provider.objects.filter(client_id="fuzefront-oidc-client").first()
 print("PROVIDER_PK=" + (str(p.pk) if p else ""))
 PYORM
 )
-    PROVIDER_PK=$(echo "$PROVIDER_RETRY_OUTPUT" | grep "^PROVIDER_PK=" | head -1 | cut -d= -f2 | tr -d '
+    PROVIDER_PK=$(echo "$PROVIDER_RETRY_OUTPUT" | grep "^PROVIDER_PK=" | head -1 | cut -d= -f2 | tr -d '
  ')
     [ -n "$PROVIDER_PK" ] && [ "$PROVIDER_PK" != "null" ] || { echo "::error::failed to create OAuth2 provider (HTTP $PROVIDER_HTTP) and no existing provider resolved for client_id=fuzefront-oidc-client"; exit 1; }
     echo "Resolved existing OAuth2 provider pk=$PROVIDER_PK"


### PR DESCRIPTION
The E2E sign-in stack fails to provision, intermittently:

```
Provider create HTTP 400: {"client_id":["OAuth2/OpenID Provider with this Client ID already exists."]}
::error::failed to create OAuth2 provider (HTTP 400)
```

## The race

`provision-authentik-oidc.sh` looks the provider up, finds nothing, and POSTs a create — but **it is not the only writer**. Authentik's blueprint worker provisions the same provider from `blueprints/provider-oidc.yaml`, and an apply landing between the lookup and the POST turns the create into a 400 the script treats as fatal.

The comment above the lookup **already anticipated the blueprint racing the READ** — that is why it uses the Django ORM rather than REST search, which isn't warm on a fresh Authentik. This is the identical race on the **WRITE**, left unhandled.

It surfaces disproportionately on PRs that edit a blueprint, because changing the ConfigMap shifts the worker's apply timing. It failed #762 on first run and **passed unchanged on re-run** — the signature of a race, not a defect in that PR.

## The fix

Re-resolve the pk when the create does not return 201, because an "already exists" response means the object we wanted is present.

Deliberately **not** a blanket suppression and **not** `|| true`: any other failure leaves the pk unresolved and still aborts, with the HTTP code in the message. The only behaviour that changes is losing a race we were always able to lose.

## Provenance

The fatal line came from `e836741841c94de56e70fc581b37ba09ad99afe8` — *"fix(ci): stand E2E (sign-in) up from real Authentik auth, no bcrypt shim (#304)"*, session `f636c22e-1cd7-401e-8843-97e3e3a4ba01`. A later commit (`ad5d9bd1`) made the **application** create idempotent and left the **provider** create as it was.

## Why this is a retry, stated plainly

An earlier version of this was reverted after `oidc-plumbing-e2e` went red in the same window, which I attributed to the script change.

**That attribution now looks wrong.** A Docker Hub 502 pulling `postgres:15-alpine` was taking E2E stacks down at the time and independently explains it.

This version is smaller — no refactor of the lookup into a function, just the failure branch — and both paths were exercised against a stub before pushing:

| case | behaviour |
|---|---|
| 400, provider present | resolves and continues |
| 500, provider absent | still aborts |

CI is the adjudicator.

## Verified

`bash -n` clean; both branches exercised.

**Not verified:** that the race is closed. It only reproduces when the apply lands in the gap, so a green run is not proof. What *is* proven is that an existing provider no longer aborts provisioning.
