### PR TITLE
fix(config-service): schema-qualify every table, and fail loudly instead of serving nothing

### DIFF
--- a/deploy/helm/fuzefront/templates/config-service-deployment.yaml
+++ b/deploy/helm/fuzefront/templates/config-service-deployment.yaml
@@ -66,8 +66,11 @@ spec:
               # (src/middleware/authz.ts) instead of an embedded Permit.io SDK.
               value: "http://fuzefront-security:{{ .Values.securityService.port }}"
           readinessProbe:
+            # /health/ready pings the DB; /health (liveness, below) does not.
+            # Splitting them means a database outage takes this pod OUT OF THE
+            # SERVICE without restarting an otherwise-healthy process.
             httpGet:
-              path: /health
+              path: /health/ready
               port: {{ .Values.configService.port }}
             initialDelaySeconds: 10
             periodSeconds: 10

--- a/services/config-service/src/app.ts
+++ b/services/config-service/src/app.ts
@@ -43,6 +43,40 @@ export function createApp(deps?: AppDeps): Application {
     res.json({ status: 'ok', service: 'config-service', configManagementEnabled });
   });
 
+  // Readiness — SEPARATE from `/health` on purpose, and pointed at by the
+  // readinessProbe only.
+  //
+  // `/health` above is deliberately shallow and is what the LIVENESS probe
+  // uses: a database outage must not restart an otherwise-healthy process,
+  // which would turn a recoverable dependency blip into a restart loop.
+  // Readiness is the probe that should fail in that case — it removes the pod
+  // from the Service until the DB answers again, with no restart.
+  //
+  // This exists because the alternative had already bitten: with only an
+  // unconditional `/health` behind BOTH probes, a config-service whose
+  // migrations had failed reported Ready and served 500s from every `/v1/*`
+  // route. A probe that cannot distinguish "up" from "working" is not a probe.
+  app.get('/health/ready', async (_req: Request, res: Response) => {
+    if (!deps?.pool) {
+      // No DB configured (the health-check-only skeleton). Nothing to verify,
+      // and nothing DB-backed is served, so this is legitimately ready.
+      res.json({ status: 'ready', service: 'config-service', database: 'not-configured' });
+      return;
+    }
+    try {
+      await deps.pool.query('SELECT 1');
+      res.json({ status: 'ready', service: 'config-service', database: 'ok' });
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error('[config-service] readiness check failed:', err);
+      res.status(503).json({
+        status: 'not-ready',
+        service: 'config-service',
+        database: 'unreachable',
+      });
+    }
+  });
+
   // Swagger UI + published spec (FFRNT-258 / FF-EPIC-17-S9). Always mounted
   // (the contract is static and needs no DB), authenticated-developer only —
   // see src/routes/docs.routes.ts for the full exposure policy.

--- a/services/config-service/src/index.ts
+++ b/services/config-service/src/index.ts
@@ -27,19 +27,26 @@ async function main(): Promise<void> {
       // eslint-disable-next-line no-console
       console.log('[config-service] DB migrations complete');
     } catch (err) {
+      // FAIL FAST. Continuing here produced the worst possible outcome: the
+      // process listened, `/health` answered 200 unconditionally, both probes
+      // went green, and every `/v1/*` route 500'd on a missing relation — a
+      // rollout that LOOKS healthy while serving nothing. A crash-loop is
+      // strictly better: it is visible, it blocks the rollout, and it names
+      // the cause in the pod logs.
       // eslint-disable-next-line no-console
-      console.error('[config-service] DB migration failed:', err);
+      console.error('[config-service] DB migration failed — refusing to start:', err);
+      throw err;
     }
   } else {
     // eslint-disable-next-line no-console
     console.warn('[config-service] DATABASE_URL missing — serving /health only');
   }
 
-  // A DB-unreachable start (config.databaseUrl set but runMigrations threw
-  // above) still wires the /v1/* routes — EPIC-17-S7 AC3 ("the health probe
-  // reports unhealthy rather than serving requests that would resolve every
-  // key to its default") is that story's concern for /health itself; this PR
-  // does not change /health's behaviour, only whether /v1/* exists at all.
+  // Reaching here means migrations succeeded (the catch above rethrows), so
+  // the /v1/* routes are only ever wired over a schema that actually exists.
+  // Liveness stays on the shallow `/health`; readiness uses `/health/ready`,
+  // which pings the DB — so a database that disappears LATER takes the pod
+  // out of the Service without triggering a liveness restart loop.
   const app = createApp(pool ? { pool } : undefined);
   const server = app.listen(config.port, () => {
     // eslint-disable-next-line no-console

--- a/services/config-service/src/migrations/001_config_namespaces.sql
+++ b/services/config-service/src/migrations/001_config_namespaces.sql
@@ -14,7 +14,7 @@
 -- default would let a row be inserted without going through mintId(), which
 -- is the only sanctioned id constructor.
 
-CREATE TABLE IF NOT EXISTS config_namespaces (
+CREATE TABLE IF NOT EXISTS config.config_namespaces (
   id            UUID        PRIMARY KEY,
   namespace     TEXT        NOT NULL UNIQUE,
   display_name  TEXT        NOT NULL,

--- a/services/config-service/src/migrations/002_config_key_definitions.sql
+++ b/services/config-service/src/migrations/002_config_key_definitions.sql
@@ -13,9 +13,9 @@
 -- cross-service reference, which never gets one — see CLAUDE.md "reference
 -- cross-service entities by ID, no cross-service FK").
 
-CREATE TABLE IF NOT EXISTS config_key_definitions (
+CREATE TABLE IF NOT EXISTS config.config_key_definitions (
   id                UUID        PRIMARY KEY,
-  namespace_id      UUID        NOT NULL REFERENCES config_namespaces(id) ON DELETE CASCADE,
+  namespace_id      UUID        NOT NULL REFERENCES config.config_namespaces(id) ON DELETE CASCADE,
   key               TEXT        NOT NULL,
   display_name      TEXT        NOT NULL,
   description       TEXT,
@@ -56,4 +56,4 @@ CREATE TABLE IF NOT EXISTS config_key_definitions (
 );
 
 CREATE INDEX IF NOT EXISTS config_key_definitions_namespace_category_idx
-  ON config_key_definitions (namespace_id, category);
+  ON config.config_key_definitions (namespace_id, category);

--- a/services/config-service/src/migrations/003_config_values.sql
+++ b/services/config-service/src/migrations/003_config_values.sql
@@ -27,9 +27,9 @@
 -- write — the L0 layer of governance/identifier-standard.md §5. Existence
 -- verification (L1+) is not built in this PR.
 
-CREATE TABLE IF NOT EXISTS config_values (
+CREATE TABLE IF NOT EXISTS config.config_values (
   id              UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
-  definition_id   UUID        NOT NULL REFERENCES config_key_definitions(id) ON DELETE CASCADE,
+  definition_id   UUID        NOT NULL REFERENCES config.config_key_definitions(id) ON DELETE CASCADE,
   scope_type      TEXT        NOT NULL CHECK (scope_type IN ('platform', 'portal', 'org', 'user')),
   -- NULL exactly when scope_type = 'platform' (a singleton tier).
   scope_id        UUID,
@@ -51,19 +51,19 @@ CREATE TABLE IF NOT EXISTS config_values (
 -- let the 'platform' singleton tier (scope_id always NULL) acquire unlimited
 -- rows per definition instead of at most one.
 CREATE UNIQUE INDEX IF NOT EXISTS config_values_unique_platform
-  ON config_values (definition_id)
+  ON config.config_values (definition_id)
   WHERE scope_type = 'platform';
 
 CREATE UNIQUE INDEX IF NOT EXISTS config_values_unique_scoped
-  ON config_values (definition_id, scope_type, scope_id)
+  ON config.config_values (definition_id, scope_type, scope_id)
   WHERE scope_type <> 'platform';
 
 -- The resolution engine's hot-path lookup: "every value at any tier in the
 -- caller's chain, for this namespace's definitions" — fetched per definition,
 -- so an index on the FK is the one that matters most.
 CREATE INDEX IF NOT EXISTS config_values_definition_idx
-  ON config_values (definition_id);
+  ON config.config_values (definition_id);
 
 -- Supports "every value at a given scope" (e.g. an org's settings page).
 CREATE INDEX IF NOT EXISTS config_values_scope_idx
-  ON config_values (scope_type, scope_id);
+  ON config.config_values (scope_type, scope_id);

--- a/services/config-service/src/repositories/key-definition.repository.ts
+++ b/services/config-service/src/repositories/key-definition.repository.ts
@@ -149,7 +149,7 @@ export class PgKeyDefinitionRepository implements KeyDefinitionRepository {
 
   async listByNamespace(namespaceId: NamespaceEntityId): Promise<KeyDefinition[]> {
     const res = await this.pool.query<KeyDefinitionRow>(
-      `SELECT ${SELECT_COLUMNS} FROM config_key_definitions
+      `SELECT ${SELECT_COLUMNS} FROM config.config_key_definitions
         WHERE namespace_id = $1
         ORDER BY category NULLS FIRST, sort_order, key`,
       [toUuid(namespaceId)],
@@ -159,7 +159,7 @@ export class PgKeyDefinitionRepository implements KeyDefinitionRepository {
 
   async findByKey(namespaceId: NamespaceEntityId, key: string): Promise<KeyDefinition | null> {
     const res = await this.pool.query<KeyDefinitionRow>(
-      `SELECT ${SELECT_COLUMNS} FROM config_key_definitions
+      `SELECT ${SELECT_COLUMNS} FROM config.config_key_definitions
         WHERE namespace_id = $1 AND key = $2`,
       [toUuid(namespaceId), key],
     );
@@ -179,7 +179,7 @@ export class PgKeyDefinitionRepository implements KeyDefinitionRepository {
 
     const id = toUuid(mintId('keyDefinition'));
     const res = await this.pool.query<KeyDefinitionRow>(
-      `INSERT INTO config_key_definitions (
+      `INSERT INTO config.config_key_definitions (
          id, namespace_id, key, display_name, description, help_url, category, sort_order, tags,
          value_type, schema, enum_values, default_value, allowed_scopes,
          is_system, is_hidden, is_secret, is_readonly, precedence, requires_restart, replaced_by
@@ -228,7 +228,7 @@ export class PgKeyDefinitionRepository implements KeyDefinitionRepository {
     }
 
     const res = await this.pool.query<KeyDefinitionRow>(
-      `UPDATE config_key_definitions SET
+      `UPDATE config.config_key_definitions SET
          display_name = $2, description = $3, help_url = $4, category = $5, sort_order = $6, tags = $7::jsonb,
          value_type = $8, schema = $9::jsonb, enum_values = $10::jsonb, default_value = $11::jsonb, allowed_scopes = $12,
          is_system = $13, is_hidden = $14, is_secret = $15, is_readonly = $16, precedence = $17,
@@ -263,7 +263,7 @@ export class PgKeyDefinitionRepository implements KeyDefinitionRepository {
   async deprecate(ids: KeyDefinitionEntityId[]): Promise<void> {
     if (ids.length === 0) return;
     await this.pool.query(
-      `UPDATE config_key_definitions SET deprecated_at = now(), updated_at = now()
+      `UPDATE config.config_key_definitions SET deprecated_at = now(), updated_at = now()
         WHERE id = ANY($1::uuid[]) AND deprecated_at IS NULL`,
       [ids.map((id) => toUuid(id))],
     );
@@ -295,7 +295,7 @@ export class PgKeyDefinitionRepository implements KeyDefinitionRepository {
     const limitParamIdx = params.length;
 
     const res = await this.pool.query<KeyDefinitionRow>(
-      `SELECT ${SELECT_COLUMNS} FROM config_key_definitions
+      `SELECT ${SELECT_COLUMNS} FROM config.config_key_definitions
         WHERE ${conds.join(' AND ')}
         ORDER BY key ASC
         LIMIT $${limitParamIdx}`,

--- a/services/config-service/src/repositories/namespace.repository.ts
+++ b/services/config-service/src/repositories/namespace.repository.ts
@@ -64,7 +64,7 @@ export class PgNamespaceRepository implements NamespaceRepository {
   async findByName(namespace: string): Promise<Namespace | null> {
     const res = await this.pool.query<NamespaceRow>(
       `SELECT id, namespace, display_name, description, owner_app_id, created_at, updated_at
-         FROM config_namespaces
+         FROM config.config_namespaces
         WHERE namespace = $1`,
       [namespace],
     );
@@ -74,7 +74,7 @@ export class PgNamespaceRepository implements NamespaceRepository {
   async findById(id: NamespaceEntityId): Promise<Namespace | null> {
     const res = await this.pool.query<NamespaceRow>(
       `SELECT id, namespace, display_name, description, owner_app_id, created_at, updated_at
-         FROM config_namespaces
+         FROM config.config_namespaces
         WHERE id = $1`,
       [toUuid(id)],
     );
@@ -88,7 +88,7 @@ export class PgNamespaceRepository implements NamespaceRepository {
     // accidentally re-mint or skip minting on.
     const id = toUuid(mintId('namespace'));
     const res = await this.pool.query<NamespaceRow & { inserted: boolean }>(
-      `INSERT INTO config_namespaces (id, namespace, display_name, description, owner_app_id)
+      `INSERT INTO config.config_namespaces (id, namespace, display_name, description, owner_app_id)
             VALUES ($1, $2, $3, $4, $5)
        ON CONFLICT (namespace) DO UPDATE
             SET display_name = EXCLUDED.display_name,
@@ -119,7 +119,7 @@ export class PgNamespaceRepository implements NamespaceRepository {
 
     const res = await this.pool.query<NamespaceRow>(
       `SELECT id, namespace, display_name, description, owner_app_id, created_at, updated_at
-         FROM config_namespaces
+         FROM config.config_namespaces
          ${where}
         ORDER BY created_at DESC, id DESC
         LIMIT $${limitParamIdx}`,

--- a/services/config-service/src/repositories/value.repository.ts
+++ b/services/config-service/src/repositories/value.repository.ts
@@ -159,7 +159,7 @@ export class PgValueRepository implements ValueRepository {
 
     const res = await this.pool.query<ValueRow>(
       `SELECT id, definition_id, scope_type, scope_id, value, is_locked, lock_reason, set_by_user_id, created_at, updated_at
-         FROM config_values
+         FROM config.config_values
         WHERE definition_id = ANY($1::uuid[]) AND (${scopeConds.join(' OR ')})`,
       params,
     );
@@ -182,7 +182,7 @@ export class PgValueRepository implements ValueRepository {
         : `(definition_id, scope_type, scope_id) WHERE scope_type <> 'platform'`;
 
     const res = await this.pool.query<ValueRow>(
-      `INSERT INTO config_values (definition_id, scope_type, scope_id, value, is_locked, lock_reason, set_by_user_id)
+      `INSERT INTO config.config_values (definition_id, scope_type, scope_id, value, is_locked, lock_reason, set_by_user_id)
             VALUES ($1, $2, $3, $4::jsonb, $5, $6, $7)
        ON CONFLICT ${conflictTarget} DO UPDATE
             SET value = EXCLUDED.value,
@@ -207,7 +207,7 @@ export class PgValueRepository implements ValueRepository {
   async listAllForDefinition(definitionId: KeyDefinitionEntityId): Promise<ConfigValue[]> {
     const res = await this.pool.query<ValueRow>(
       `SELECT id, definition_id, scope_type, scope_id, value, is_locked, lock_reason, set_by_user_id, created_at, updated_at
-         FROM config_values
+         FROM config.config_values
         WHERE definition_id = $1`,
       [toUuid(definitionId)],
     );
@@ -218,12 +218,12 @@ export class PgValueRepository implements ValueRepository {
     const storageScopeId = assertValidScopeAndToStorageId(scope);
     if (scope.scopeType === 'platform') {
       await this.pool.query(
-        `DELETE FROM config_values WHERE definition_id = $1 AND scope_type = 'platform'`,
+        `DELETE FROM config.config_values WHERE definition_id = $1 AND scope_type = 'platform'`,
         [toUuid(definitionId)],
       );
     } else {
       await this.pool.query(
-        `DELETE FROM config_values WHERE definition_id = $1 AND scope_type = $2 AND scope_id = $3`,
+        `DELETE FROM config.config_values WHERE definition_id = $1 AND scope_type = $2 AND scope_id = $3`,
         [toUuid(definitionId), scope.scopeType, storageScopeId],
       );
     }

--- a/services/config-service/tests/db.test.ts
+++ b/services/config-service/tests/db.test.ts
@@ -36,6 +36,31 @@ describe('migrations directory', () => {
     }
   });
 
+  // REGRESSION GUARD. Unqualified DDL is why config-service could never start
+  // in prod: config_svc's search_path resolves to "$user", public; no config_svc
+  // schema exists; so DDL targeted `public`, where a non-owner has no CREATE on
+  // PG15 -> "permission denied for schema public". The `config` schema the
+  // bootstrap Job provisions was never used. Every table reference must carry
+  // the schema, exactly as billing-service does (billing.customers).
+  it('schema-qualifies every table reference (config.<table>) — never bare', () => {
+    const files = fs.readdirSync(MIGRATIONS_DIR).filter((f) => f.endsWith('.sql'));
+    const tables = ['config_namespaces', 'config_key_definitions', 'config_values'];
+    for (const file of files) {
+      const code = withoutComments(readMigration(file));
+      for (const table of tables) {
+        // A bare reference is the table name NOT preceded by "config."
+        const bare = new RegExp(`(?<!config\\.)\\b${table}\\b`);
+        const offending = code
+          .split('\n')
+          .filter((l) => bare.test(l))
+          // index NAMES legitimately embed the table name (config_values_scope_idx)
+          .filter((l) => !/^\s*CREATE\s+(UNIQUE\s+)?INDEX/i.test(l))
+          .filter((l) => !/CONSTRAINT\s+config_/i.test(l));
+        expect({ file, offending }).toEqual({ file, offending: [] });
+      }
+    }
+  });
+
   it('does NOT run CREATE EXTENSION or CREATE SCHEMA (least-privilege runtime role cannot)', () => {
     const files = fs.readdirSync(MIGRATIONS_DIR).filter((f) => f.endsWith('.sql'));
     for (const file of files) {
@@ -50,7 +75,7 @@ describe('001_config_namespaces.sql — S2 AC1 shape', () => {
   const sql = readMigration('001_config_namespaces.sql');
 
   it('creates config_namespaces idempotently', () => {
-    expect(sql).toMatch(/CREATE TABLE IF NOT EXISTS config_namespaces/i);
+    expect(sql).toMatch(/CREATE TABLE IF NOT EXISTS config\.config_namespaces/i);
   });
 
   it('has no id DEFAULT (ids are app-minted via mintId, never gen_random_uuid())', () => {
@@ -67,7 +92,7 @@ describe('002_config_key_definitions.sql — S2 AC1 shape', () => {
   const sql = readMigration('002_config_key_definitions.sql');
 
   it('creates config_key_definitions idempotently', () => {
-    expect(sql).toMatch(/CREATE TABLE IF NOT EXISTS config_key_definitions/i);
+    expect(sql).toMatch(/CREATE TABLE IF NOT EXISTS config\.config_key_definitions/i);
   });
 
   it('has every column required by S2 AC1', () => {
@@ -112,7 +137,7 @@ describe('002_config_key_definitions.sql — S2 AC1 shape', () => {
   });
 
   it('references config_namespaces(id) with ON DELETE CASCADE (intra-service FK)', () => {
-    expect(sql).toMatch(/REFERENCES config_namespaces\(id\) ON DELETE CASCADE/);
+    expect(sql).toMatch(/REFERENCES config\.config_namespaces\(id\) ON DELETE CASCADE/);
   });
 });
 
@@ -120,7 +145,7 @@ describe('003_config_values.sql — S3 AC1 shape', () => {
   const sql = readMigration('003_config_values.sql');
 
   it('creates config_values idempotently', () => {
-    expect(sql).toMatch(/CREATE TABLE IF NOT EXISTS config_values/i);
+    expect(sql).toMatch(/CREATE TABLE IF NOT EXISTS config\.config_values/i);
   });
 
   it('has every column required by S3 AC1', () => {
@@ -131,7 +156,7 @@ describe('003_config_values.sql — S3 AC1 shape', () => {
   });
 
   it('references config_key_definitions(id) — intra-service FK', () => {
-    expect(sql).toMatch(/REFERENCES config_key_definitions\(id\) ON DELETE CASCADE/);
+    expect(sql).toMatch(/REFERENCES config\.config_key_definitions\(id\) ON DELETE CASCADE/);
   });
 
   it('has NO real FK on scope_id (polymorphic, cross-table — S3 risk note)', () => {
@@ -149,7 +174,7 @@ describe('003_config_values.sql — S3 AC1 shape', () => {
     // A plain UNIQUE(...) would not stop the platform singleton tier
     // (scope_id always NULL) from acquiring multiple rows per definition —
     // Postgres treats NULL <> NULL for uniqueness. Two partial indexes fix that.
-    expect(sql).toMatch(/CREATE UNIQUE INDEX IF NOT EXISTS config_values_unique_platform\s*\n\s*ON config_values \(definition_id\)\s*\n\s*WHERE scope_type = 'platform'/);
-    expect(sql).toMatch(/CREATE UNIQUE INDEX IF NOT EXISTS config_values_unique_scoped\s*\n\s*ON config_values \(definition_id, scope_type, scope_id\)\s*\n\s*WHERE scope_type <> 'platform'/);
+    expect(sql).toMatch(/CREATE UNIQUE INDEX IF NOT EXISTS config_values_unique_platform\s*\n\s*ON config\.config_values \(definition_id\)\s*\n\s*WHERE scope_type = 'platform'/);
+    expect(sql).toMatch(/CREATE UNIQUE INDEX IF NOT EXISTS config_values_unique_scoped\s*\n\s*ON config\.config_values \(definition_id, scope_type, scope_id\)\s*\n\s*WHERE scope_type <> 'platform'/);
   });
 });

--- a/services/config-service/tests/repositories/key-definition.repository.test.ts
+++ b/services/config-service/tests/repositories/key-definition.repository.test.ts
@@ -156,7 +156,7 @@ describe('PgKeyDefinitionRepository.update — FFRNT-158 manifest reconciliation
       allowedScopes: ['user', 'org'],
     });
 
-    expect(capturedSql).toMatch(/UPDATE config_key_definitions SET/);
+    expect(capturedSql).toMatch(/UPDATE config\.config_key_definitions SET/);
     expect(capturedSql).toMatch(/deprecated_at = NULL/);
     expect(capturedSql).toMatch(/WHERE id = \$1/);
     expect(capturedParams[0]).toBeDefined(); // toUuid(DEFINITION_ID) — the native storage form, not the TypeID itself
@@ -188,7 +188,7 @@ describe('PgKeyDefinitionRepository.deprecate', () => {
     const idB = 'ckd_01kzrds7mdfwsscregja4h3qjq' as KeyDefinitionEntityId;
     await repo.deprecate([idA, idB]);
 
-    expect(capturedSql).toMatch(/UPDATE config_key_definitions SET deprecated_at = now\(\)/);
+    expect(capturedSql).toMatch(/UPDATE config\.config_key_definitions SET deprecated_at = now\(\)/);
     expect(capturedSql).toMatch(/AND deprecated_at IS NULL/);
     expect((capturedParams[0] as string[])).toHaveLength(2);
   });

--- a/services/config-service/tests/repositories/namespace.repository.test.ts
+++ b/services/config-service/tests/repositories/namespace.repository.test.ts
@@ -42,7 +42,7 @@ describe('PgNamespaceRepository.upsert', () => {
     expect(namespace.displayName).toBe('Chat');
     // Server-minted, wire-typed: cns_ prefix, never the raw uuid.
     expect(namespace.id).toMatch(/^cns_[0-9a-hjkmnp-tv-z]{26}$/);
-    expect(capturedSql).toMatch(/INSERT INTO config_namespaces/);
+    expect(capturedSql).toMatch(/INSERT INTO config\.config_namespaces/);
     expect(capturedSql).toMatch(/ON CONFLICT \(namespace\) DO UPDATE/);
     // The create body never lets a caller choose the id — it is minted here,
     // not read off `input`.


### PR DESCRIPTION
## 📋 Description

config-service could never have started in prod — and would not have told anyone. Found by `gate-code-review` on #766; both findings verified against source before acting on them. This fixes the cause and the silence, and unblocks the enable flip.

Refs #752. Unblocks #766.

### Root cause — the migrations cannot succeed

The migrations create **unqualified** tables (`config_namespaces`, `config_key_definitions`, `config_values`), and all **15** repository query sites are unqualified too. Meanwhile:

- `config-service-db-bootstrap-job.yaml` provisions `config AUTHORIZATION config_svc` but grants config_svc only `USAGE ON SCHEMA public` — no `CREATE`.
- `DATABASE_URL` is composed with no `options=-c search_path=...`.
- `grep -rn search_path` across the service **and** its chart returns nothing, anywhere.

So connections resolve `"$user", public`; no `config_svc` schema exists; DDL targets `public`, where a non-owner has no CREATE on PG15 → **permission denied for schema public**. The `config` schema the bootstrap Job had just created was never touched.

`billing-service` — cited as the precedent — avoids this by qualifying every table (`billing.customers`), and sets no `search_path` either. config-service copied the chart pattern but not the SQL convention. This restores it: `config.<table>` on every `CREATE TABLE`, index target and intra-service FK, and on all 15 query sites.

### Why it would have been silent

`index.ts` caught the migration error, logged it, and fell through to `app.listen`. `/health` returned `{status:'ok'}` unconditionally with no DB check. **Both** probes pointed at `/health`. The pod would have reported Running **and Ready** while every `/v1/*` route 500'd on a missing relation.

That matters beyond this bug: it means "pods Running, readiness green" was not a usable success signal for the go-live. A probe that cannot distinguish *up* from *working* is not a probe.

- Migration failure now **rethrows**; `main().catch` already exits 1, so it surfaces as CrashLoopBackOff naming the cause.
- New **`/health/ready`** pings the DB and is what `readinessProbe` uses. `/health` stays shallow for `livenessProbe`, so a later DB outage takes the pod out of the Service **without** a restart loop.

## 🔄 Type of Change

- 🐛 Bug fix (non-breaking change which fixes an issue)

## 🧪 Testing

- **`db.test.ts` gains a regression guard** asserting no bare table reference survives. **Verified load-bearing**: un-qualifying one table makes it fail; restoring it makes it pass.
- **Suite: 111 passed / 0 failed**, against a **110 / 0** baseline measured on clean master. The +1 is the new guard.
- **No regressions**: the same **11** pre-existing suite-level TypeScript failures appear before and after (unbuilt workspace packages — `@fuzefront/auth`, identity types — environmental in a bare container, resolved in CI which builds packages first). Diffed the FAIL lists explicitly; the set is identical.
- `helm lint` passes.
- **`configService.enabled=false` still renders zero config-service resources**, so this change deploys nothing on its own.
- With `--set configService.enabled=true`: `readinessProbe → /health/ready`, `livenessProbe → /health`.

## 🚨 Breaking Changes

None. config-service is disabled in prod, so nothing runs this code today. The tables have never been successfully created in any environment (the migrations always failed), so there is no existing data in `public` to migrate — the qualified DDL creates them in `config` on first successful start.

## 📝 Additional Notes

### Deployment Notes

- `master` is deploy-on-push, but this PR changes no rendered resource while `configService.enabled` is `false`.
- Merge this **before** #766. The flip is only safe once this is on master.

### Questions for Reviewers

- Tables are qualified as `config.config_namespaces` rather than renamed to `config.namespaces` (billing's shape). Renaming would be tidier, but `config.values` collides with the SQL reserved word `VALUES` and would need quoting everywhere — the prefix is kept as the lower-risk option. Say the word if you'd rather rename.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CD1KiuhuHZAooZJMFRbkpo)_