### PR TITLE
fix(config-service): ship packages/auth's runtime deps, and gate the whole class

### DIFF
--- a/scripts/check-dockerfile-lockfile.mjs
+++ b/scripts/check-dockerfile-lockfile.mjs
@@ -24,6 +24,20 @@
 //      noticed, because the install still exits 0. A missing manifest is not a
 //      build error, it is a runtime crash days later.
 //
+// R3 — if a production stage COPYs a local `file:`-linked package's dist/, and
+//      that package declares RUNTIME dependencies, it must COPY that package's
+//      node_modules too. A `file:` dep is installed as a SYMLINK: the consuming
+//      service's lockfile carries only a link entry
+//      ({"resolved":"../../packages/x","link":true}) and NO entry for the
+//      target's own dependencies, so `npm ci` installs none of them. The image
+//      then builds clean, the symlink resolves, dist/ is present — and the pod
+//      dies at module load. config-service shipped exactly this: packages/auth
+//      requires `jose`, nothing copied packages/auth/node_modules, and the very
+//      first prod rollout crash-looped on "Cannot find module 'jose'".
+//      This is the static half of the gap image-reproducibility.yml names in its
+//      own header: "static checks cannot prove an image runs". This particular
+//      failure IS statically visible, so it should never reach a cluster again.
+//
 // Dependency-free. Run from the repo root: `node scripts/check-dockerfile-lockfile.mjs`.
 
 import { readFileSync, existsSync } from 'node:fs'
@@ -127,6 +141,32 @@ for (const file of dockerfiles) {
         `${file} — installs at the root but does not COPY ${missing.length} workspace ` +
           `manifest(s): ${missing.join(', ')}. npm hoists against the full set; with any ` +
           `missing it computes a different tree than the lockfile and drops packages silently.`
+      )
+    }
+  }
+
+  // R3 — a file:-linked package's runtime deps must reach the production image.
+  const distCopies = [...code.matchAll(/COPY\s+--from=\S+\s+\S*packages\/([A-Za-z0-9._-]+)\/dist\b/g)]
+  for (const m of distCopies) {
+    const pkg = m[1]
+    const manifestPath = `${root}/packages/${pkg}/package.json`
+    if (!existsSync(manifestPath)) continue
+    let deps
+    try {
+      deps = JSON.parse(readFileSync(manifestPath, 'utf8')).dependencies || {}
+    } catch {
+      continue
+    }
+    const names = Object.keys(deps)
+    if (!names.length) continue
+    const copiesModules = new RegExp(`COPY\\s+--from=\\S+\\s+\\S*packages/${pkg}/node_modules\\b`).test(code)
+    if (!copiesModules) {
+      violations.push(
+        `${file} — COPYs packages/${pkg}/dist into the production stage but not ` +
+          `packages/${pkg}/node_modules, and packages/${pkg} declares runtime ` +
+          `dependencies (${names.join(', ')}). A file: dep is a symlink; the consuming ` +
+          `lockfile has no entry for these, so npm ci installs none of them. The image ` +
+          `builds clean and the pod dies at module load ("Cannot find module '${names[0]}'").`
       )
     }
   }

--- a/services/config-service/Dockerfile
+++ b/services/config-service/Dockerfile
@@ -50,6 +50,11 @@ COPY services/config-service/ ./services/config-service/
 # config-service.
 RUN cd packages/identity && npm install --ignore-scripts && npm run build
 RUN cd packages/auth && npm install --ignore-scripts && npm run build
+# packages/auth has a RUNTIME dependency (jose) that must reach the production
+# image. The install above pulls in devDeps too (tsup/jest/typescript) because
+# the build needs them; prune them here so the node_modules copied below is
+# production-only.
+RUN cd packages/auth && npm prune --omit=dev
 RUN cd services/config-service && npm run build
 # tsc does NOT copy non-TS assets. runMigrations reads
 # dist/migrations/*.sql at startup; without this the pod logs
@@ -87,6 +92,16 @@ COPY --from=build /app/packages/identity/dist ./packages/identity/dist
 # to a symlink with nothing behind it).
 COPY --from=build /app/packages/auth/package.json ./packages/auth/package.json
 COPY --from=build /app/packages/auth/dist ./packages/auth/dist
+# ...AND its runtime dependencies. packages/auth requires `jose` at module load
+# (packages/auth/dist/index.js), and NOTHING else puts it in this image:
+# config-service installs from its OWN lockfile, where @fuzefront/auth appears
+# only as a link entry ({"resolved":"../../packages/auth","link":true}) with no
+# `jose` entry at all — so `npm ci` in the base stage creates the symlink and
+# installs no dependency for it. Without this COPY the symlink resolves, dist/
+# is present, and the pod still dies at startup with
+# "Cannot find module 'jose'" — which is exactly what happened in prod the
+# first time config-service was enabled.
+COPY --from=build /app/packages/auth/node_modules ./packages/auth/node_modules
 
 # Remove declaration files from production image
 RUN find ./services/config-service/dist -name "*.d.ts" -type f -delete


### PR DESCRIPTION
## 📋 Description

config-service is **crash-looping in prod right now**, on:

```
Error: Cannot find module 'jose'
Require stack: /app/packages/auth/dist/index.js
  ← config-service/dist/middleware/authz.js
```

It dies at **module load** — before any of its own code runs, so neither #767's schema fix nor its migrations were ever reached. Observed directly via FuzeInfra `cluster-query`; two pods `CrashLoopBackOff`.

Refs #752.

## Cause

`@fuzefront/auth` is a `file:` dependency, so npm installs it as a **symlink**. config-service installs from its **own** lockfile, and that lockfile carries only the link entry —

```json
"node_modules/@fuzefront/auth": { "resolved": "../../packages/auth", "link": true }
```

— with **no `jose` entry anywhere**. So `npm ci` in the base stage creates the symlink and installs none of the target's dependencies. The *build* stage does install them, but the *production* stage copied only `packages/auth/package.json` and `packages/auth/dist`, never its `node_modules`.

Every individual piece looked right: the image built clean, the symlink resolved, `dist/` was present. The dependency simply wasn't there.

config-service is the **first and only** consumer of `@fuzefront/auth`, which is why no working precedent existed to copy and nothing caught it.

## Fix

- Prune `packages/auth` to production deps after building it (the build needs tsup/typescript; the runtime does not).
- `COPY` its `node_modules` into the production stage, alongside the `dist` copy that was already there.

## Gate — R3

`check-dockerfile-lockfile.mjs` gains a third rule: a production stage that COPYs a `file:`-linked package's `dist/` must also COPY its `node_modules` when that package declares runtime `dependencies`.

`image-reproducibility.yml`'s own header says *"static checks cannot prove an image runs."* That is true in general — but **this** failure is statically visible, and now it cannot reach a cluster again. It is the third of this family, after #751 (shared subpath) and #753 (billing deep import).

## 🔄 Type of Change

- 🐛 Bug fix (non-breaking change which fixes an issue)

## 🧪 Testing

Docker is unavailable in this session, so the image itself was **not built or run here** — stated plainly. What I did verify:

- **`jose` survives `npm prune --omit=dev`**; devDeps (`typescript`, `tsup`, `jest`) do not.
- **`require.resolve('jose')` from `packages/auth`** resolves to `packages/auth/node_modules/jose/dist/node/cjs/index.js` — the exact lookup that failed in prod.
- **R3 is load-bearing**: reintroducing only the missing `COPY` line reproduces the failure statically and names `jose` in the message; restoring it goes green.
- The gate passes across all **15** Dockerfiles with the fix in place.

CI's `build-images` job builds this Dockerfile pre-merge, which covers the build; the runtime proof is the prod rollout after merge, which I'll verify via `cluster-query`.

## 🚨 Breaking Changes

None. Only config-service's image contents and a CI gate change.

## 📝 Additional Notes

### Deployment Notes

- `master` is deploy-on-push. **Merge in a deploy window.**
- config-service is already `enabled: true` (#766) and failing, so this strictly improves the current state.
- The release run for this merge must land its image-tag bump before the fix is actually running in prod.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CD1KiuhuHZAooZJMFRbkpo)_