### PR TITLE
fix(app-registry): accept `modes` — every kit-built manifest was rejected

### DIFF
--- a/backend/applications/src/app-registry/manifest.schema.ts
+++ b/backend/applications/src/app-registry/manifest.schema.ts
@@ -191,6 +191,29 @@ export const appManifestSchema = z
     description: z.string().max(1024).optional(),
     icon: iconSchema.optional(),
     mode: appModeSchema,
+    // `modes` is the MULTI-VALUED form of `mode`, and accepting it is what makes
+    // registration work at all for every consumer built with @fuzefront/onboarding-kit.
+    //
+    // The kit's manifest.schema.json defines `modes` ("Every surface this app
+    // supports, in preference order") and its templates/manifest.json emits BOTH
+    // keys -- `mode: "portal"` and `modes: ["portal","standalone"]`. This schema is
+    // .strict() and knew only the singular, so every such manifest was rejected:
+    //
+    //   HTTP 400 {"error":"validation_error","fields":[{"path":"manifest",
+    //     "message":"Unrecognized key(s) in object: 'modes'"}]}
+    //
+    // Observed live in fuzefinance: the `fuzefront-register` init container reached
+    // this API, POSTed, got the 400, and went CrashLoopBackOff -- so the pod never
+    // became Ready and the app never appeared in the portal. Argo Application,
+    // image, namespace and registration token were all fine; only this key stood
+    // between a deployed product and a listed one. It is fail-closed by design, so
+    // one unrecognised key is enough to stop the whole thing.
+    //
+    // Additive on purpose: `mode` stays REQUIRED and unchanged, so nothing that
+    // registers today can break. Consumers already send both, so this only stops
+    // rejecting what they have been sending all along. Same enum on both sides
+    // (portal | standalone), checked rather than assumed.
+    modes: z.array(appModeSchema).min(1).optional(),
     builtin: z.boolean().optional(),
     integration: integrationSchema,
     chrome: chromeSchema.optional(),

--- a/backend/applications/tests/app-registry.unit.test.ts
+++ b/backend/applications/tests/app-registry.unit.test.ts
@@ -238,7 +238,24 @@ describe('onboarding-kit manifest template', () => {
   it('parses cleanly through the registry schema', () => {
     const template = JSON.parse(require('fs').readFileSync(templatePath, 'utf8'))
     const result = appManifestSchema.safeParse(template)
-    expect(result.success ? null : result.error.issues).toBeNull()
+    if (!result.success) {
+      // Same explicit cast as the validation test above, and for the same reason
+      // documented there: this service compiles with `strict: false`, so tsc will
+      // not discriminate zod's SafeParseSuccess | SafeParseError union on its
+      // `success` literal and rejects `.error` even inside this guard (TS2339).
+      // The runtime guard is what makes it safe; the cast just tells tsc what the
+      // guard already proved.
+      //
+      // Reporting the issues rather than asserting a bare boolean is the point:
+      // a failure here must say WHICH key drifted, or the next person gets
+      // "expected true, received false" and has to rediscover all of this.
+      const issues = (result as z.SafeParseError<unknown>).error.issues
+      throw new Error(
+        'onboarding-kit template no longer validates against the registry schema:\n' +
+          JSON.stringify(issues, null, 2)
+      )
+    }
+    expect(result.success).toBe(true)
   })
 
   it('accepts `modes` alongside `mode`, which is what consumers actually send', () => {

--- a/backend/applications/tests/app-registry.unit.test.ts
+++ b/backend/applications/tests/app-registry.unit.test.ts
@@ -203,3 +203,61 @@ describe('app-registry manifest validation', () => {
     if (r.success) expect(r.data.status).toBe('online')
   })
 })
+
+// ---------------------------------------------------------------------------
+// Contract with @fuzefront/onboarding-kit.
+//
+// These two schemas describe the SAME object from opposite ends: the kit's
+// manifest.schema.json is what consumers author against, this Zod schema is
+// what the registry accepts. They drifted, and because this schema is
+// .strict(), the drift was fatal rather than cosmetic -- the kit added a
+// multi-valued `modes` alongside `mode`, its templates emitted both, and every
+// manifest built from them was rejected:
+//
+//   HTTP 400 {"error":"validation_error","fields":[{"path":"manifest",
+//     "message":"Unrecognized key(s) in object: 'modes'"}]}
+//
+// Seen live in fuzefinance: the register init container POSTed, got the 400,
+// and CrashLoopBackOff'd, so the pod never went Ready and the product never
+// reached the portal. Nothing upstream was wrong.
+//
+// Parsing the kit's OWN template through this schema is the check that would
+// have caught it, and is the point of these tests: it fails the moment the two
+// definitions disagree again, instead of waiting for a pod to crash in prod.
+describe('onboarding-kit manifest template', () => {
+  const templatePath = require('path').resolve(
+    __dirname,
+    '../../../packages/onboarding-kit/templates/manifest.json'
+  )
+
+  it('the kit template exists (guards against a silent path change)', () => {
+    // Without this, a moved template turns the test below into a vacuous pass.
+    expect(require('fs').existsSync(templatePath)).toBe(true)
+  })
+
+  it('parses cleanly through the registry schema', () => {
+    const template = JSON.parse(require('fs').readFileSync(templatePath, 'utf8'))
+    const result = appManifestSchema.safeParse(template)
+    expect(result.success ? null : result.error.issues).toBeNull()
+  })
+
+  it('accepts `modes` alongside `mode`, which is what consumers actually send', () => {
+    const result = appManifestSchema.safeParse({
+      ...baseManifest,
+      modes: ['portal', 'standalone'],
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('still rejects a genuinely unknown key — .strict() is not weakened', () => {
+    // The fix must not become "accept anything". This is the half that proves
+    // the schema is still closed.
+    const result = appManifestSchema.safeParse({ ...baseManifest, notAThing: true })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects an empty modes array and an invalid mode value', () => {
+    expect(appManifestSchema.safeParse({ ...baseManifest, modes: [] }).success).toBe(false)
+    expect(appManifestSchema.safeParse({ ...baseManifest, modes: ['nope'] }).success).toBe(false)
+  })
+})


### PR DESCRIPTION
**This is why the portal still shows 8 apps.** Not the Argo Application, not the image, not the registration token — all of those were fine. The registry API was rejecting the manifest.

Observed live in the `fuzefinance` namespace:

```
[fuzefront-register] not registered — registering
[fuzefront-register] FATAL: register failed: HTTP 400
  {"error":"validation_error","fields":[{"path":"manifest",
    "message":"Unrecognized key(s) in object: 'modes'"}]}
```

```
fuzefinance-frontend-...  Pending
  back-off 5m0s restarting failed container=fuzefront-register  reason:CrashLoopBackOff
```

The init container reached the API, POSTed, took the 400, and crash-looped. It is fail-closed by design, so the pod never went Ready and the product never appeared in the portal. **One unrecognised key was the entire distance between a deployed product and a listed one.**

## Cause: two schemas for the same object, drifted apart

`@fuzefront/onboarding-kit`'s `manifest.schema.json` defines `modes` — the multi-valued form of `mode`, *"every surface this app supports, in preference order"* — and its `templates/manifest.json` emits **both** keys:

```json
"mode":  "portal",
"modes": ["portal", "standalone"]
```

This Zod schema knew only the singular and is `.strict()`, so the extra key was fatal rather than ignored. FuzeFinance's deployed manifest carries both because it was generated from that template — and so does every other consumer built the same way.

Same shape as the `ci`-block failure in FuzeSDLC#135 earlier today: a producer emits a key the consumer's strict schema rejects. Twice in one day, in unrelated subsystems.

## The change

Additive on purpose. `mode` stays **required** and untouched, so nothing that registers today can break — this only stops rejecting what consumers have been sending all along. Same enum on both sides (`portal | standalone`), checked rather than assumed.

## Verification — positive and negative control

Against the **real manifest** that produced the live 400 (`fuzefinance/registration/manifest.json`):

| | Result |
|---|---|
| patched | **PASS** — `parsed.modes = ["portal","standalone"]` |
| unpatched | rejects: `Unrecognized key(s) in object: 'modes'` |

So the change is demonstrably what fixes it, not something incidental to the run.

## Tests

Added a block that parses the **kit's own template** through this schema. That is the check that would have caught this, and it fails the moment the two definitions disagree again rather than waiting for a pod to crash in prod. It also asserts:

- the template **path exists** — a moved file would otherwise make the parse test vacuously pass
- `.strict()` is **not weakened** — an unknown key must still be rejected, so the fix doesn't become "accept anything"
- an empty `modes: []` and an invalid `modes: ['nope']` both fail

**CI caught a defect in these tests and it is fixed in `84797ca`.** The first run reported `Test Suites: 1 failed, 11 passed` with `Tests: 164 passed, 164 total` — zero failures and one red suite, which is the signature of a suite that failed to *compile*. My new tests never executed. The cause was reading `result.error` off zod's `SafeParseReturnType`; this service compiles with `strict: false`, so TypeScript will not discriminate that union on its `success` literal. The existing test twelve lines above already documented this and used an explicit cast — now matched.

**Not run locally, stated plainly:** jest cannot start in this environment because `tests/jest.setup.ts` imports `@izzywdev/fuzefront-identity` and GitHub Packages returns 401 here. Pre-existing and unrelated. CI has registry auth and executes them; the schema behaviour itself was verified directly above.

## Deploy note

~~`master` is deploy-on-push here, so this should merge in a deploy window rather than be bot-merged.~~

**Corrected.** That instruction was based on a stale rule. Merging here **is** the deploy, and auto-merge is the intended path — `auto-merge.yml` arms the merge and `dispatch-release` then dispatches `release.yml`. The stale prose is fixed in FuzeSDLC#139 (canonical `governance/hardening-convention.md`) and FuzeFront#771 (overlay pointer). Auto-merge is armed on this PR deliberately.