### PR TITLE
fix(authentik): stop routing the Admin API to the internet

### DIFF
--- a/deploy/helm/fuzefront/templates/_helpers.tpl
+++ b/deploy/helm/fuzefront/templates/_helpers.tpl
@@ -74,12 +74,28 @@ behind Cloudflare Access.
 Do NOT re-add "/if", and do not add "/if/user": FuzeFront owns its own profile
 and MFA UI (mfa_factors is native, not an Authentik stage).
 
-/api/v3 has to stay for now — Authentik's flow-executor page is a SPA that calls
-it from the browser, and fuzefront-backend currently reaches Authentik's Admin API
-by hairpinning out through this same public edge (it sets no AUTHENTIK_BASE_URL,
-so authentik-admin.ts falls back to deriving it from AUTHENTIK_ISSUER_URL). It is
-authenticated — /api/v3/core/users/me/ returns 403 unauthenticated — but it is
-surface that should shrink once that hairpin is repointed in-cluster.
+/api/v3 is NO LONGER exposed wholesale. It used to be, for two reasons, and both
+are now gone:
+  1. The flow-executor SPA calls the API from the browser. Measured against
+     2026.5.5 (full network capture of an anonymous load of
+     /if/flow/default-authentication-flow/), the ONLY /api/v3 path it touches is
+     /api/v3/flows/executor/. Config and branding arrive embedded in the initial
+     HTML, not via /api/v3/root/config/ or /api/v3/core/brands/current/.
+     /api/v3/root/config is kept anyway: it is anonymous-safe, and a flow variant
+     that bootstraps from it would otherwise fail to render a login page.
+  2. fuzefront-backend reached the Admin API by hairpinning out through this
+     public edge, because backend.yaml set no AUTHENTIK_BASE_URL and
+     authentik-admin.ts falls back to deriving it from AUTHENTIK_ISSUER_URL.
+     backend.yaml now sets AUTHENTIK_BASE_URL to the in-cluster Service, the same
+     way security.yaml already did.
+
+So /api/v3/core/*, /api/v3/providers/*, /api/v3/policies/* and the rest of the
+Admin API are no longer routable from the internet at all. They were previously
+reachable and merely *rejected* (403) by Authentik's own authorization — defence
+by application authz alone, with no network boundary behind it.
+
+Do NOT widen this back to a bare /api/v3. If a login flow breaks, capture the
+browser's network log and add the ONE specific prefix it needs.
 */}}
 {{- define "fuzefront.authentikPublicPaths" -}}
 - /application
@@ -90,7 +106,8 @@ surface that should shrink once that hairpin is repointed in-cluster.
 - /ws
 - /-
 - /outpost.goauthentik.io
-- /api/v3
+- /api/v3/flows/executor
+- /api/v3/root/config
 - /static/dist
 - /static/authentik
 {{- end -}}

--- a/deploy/helm/fuzefront/templates/backend.yaml
+++ b/deploy/helm/fuzefront/templates/backend.yaml
@@ -159,6 +159,22 @@ spec:
               value: {{ .Values.authentik.oidc.issuerUrl | quote }}
             - name: AUTHENTIK_REDIRECT_URI
               value: {{ .Values.authentik.oidc.redirectUri | quote }}
+            # Server-side base for Authentik's Admin API (M2M client provisioning,
+            # backend/src/authentik/authentik-admin.ts). Points at the IN-CLUSTER
+            # Service, mirroring security.yaml.
+            #
+            # NOT cosmetic. getAuthentikBaseUrl() falls back to AUTHENTIK_ISSUER_URL
+            # stripped of its /application/o/... suffix — i.e. the PUBLIC host — so
+            # without this the backend called the Admin API by hairpinning out
+            # through Cloudflare and back in. That hairpin was the only remaining
+            # reason a bare /api/v3 had to be publicly routable
+            # (see fuzefront.authentikPublicPaths). Removing this env var re-opens
+            # the whole Authentik Admin API to the internet.
+            #
+            # In-cluster reachability is guaranteed by authentik-networkpolicy.yaml,
+            # whose "intra-fuzefront" rule admits any pod in this namespace on 9000.
+            - name: AUTHENTIK_BASE_URL
+              value: {{ .Values.authentik.oidc.internalUrl | default "http://authentik-server:9000" | quote }}
             # M2M provisioning (backend/src/authentik/provision-m2m-clients.ts)
             # authenticates to the Authentik Admin API with the akadmin bootstrap
             # token — which Authentik issues as a full API token — so we reuse the


### PR DESCRIPTION
Implements the ruling that **Authentik must not be reachable from the public network — only FuzeFront's security API.**

## What was wrong

`fuzefront.authentikPublicPaths` allowlisted a bare **`/api/v3`** on *both* public Authentik surfaces (the `app.fuzefront.com` OIDC reverse-proxy and `auth.fuzefront.com`). That routed Authentik's entire Admin API — `/api/v3/core/*`, `/api/v3/providers/*`, `/api/v3/policies/*` — to the internet.

It was not anonymously *usable* (Authentik returns 403), but the only thing between the internet and the Admin API was Authentik's own application authz. No network boundary behind it.

## Why the bare prefix was there, and why it no longer needs to be

**1. The flow-executor SPA calls the API from the browser.**
Measured rather than assumed — a full network capture of an anonymous load of `/if/flow/default-authentication-flow/` on 2026.5.5 shows exactly **one** `/api/v3` path:

| path | used by anonymous login |
|---|---|
| `/api/v3/flows/executor/` | ✅ the only one |
| `/api/v3/root/config/` | ❌ not called (config is embedded in the initial HTML) |
| `/api/v3/core/brands/current/` | ❌ not called (branding also embedded) |

`/api/v3/root/config` is kept anyway: anonymous-safe, and cheap insurance against a flow variant that bootstraps from it otherwise rendering no login page.

**2. `fuzefront-backend` hairpinned out through this same public edge.**
`backend.yaml` set no `AUTHENTIK_BASE_URL`, and `getAuthentikBaseUrl()` falls back to `AUTHENTIK_ISSUER_URL` stripped of its `/application/o/...` suffix — the **public** host. So M2M provisioning left the cluster and came back in through Cloudflare. `backend.yaml` now sets it to the in-cluster Service, exactly as `security.yaml` already did.

`authentik-networkpolicy.yaml`'s intra-fuzefront rule already admits any pod in the namespace on 9000, so no policy change is required.

## Customer login is untouched

`/api/v3/flows/executor` stays public — that is what FuzeFront sign-in, MendysRobotics platform + datasets sign-in, and `frontend/e2e/post-prod/live-smoke.spec.ts` all exercise. Verified before this change that all three OIDC clients 302 anonymous users to the login flow.

## Verification

- `helm lint` clean.
- `helm template` against `values-prod.yaml`, diffed against the pre-change render. The **only** differences are the added `AUTHENTIK_BASE_URL` env and the two narrowed ingress paths — nothing else moved.

**Not verified:** a real browser login after the narrowing — that needs a live deploy. The risk is concentrated in one place: if some flow stage calls an `/api/v3` path the capture missed, the fix is to add that one specific prefix, not to restore the bare `/api/v3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)