### PR TITLE
docs(planning): measured production conformance across the fleet + the plan to close it

### DIFF
--- a/docs/planning/production-conformance.md
+++ b/docs/planning/production-conformance.md
@@ -1,0 +1,142 @@
+# Production conformance — measured state and the plan to close it
+
+**Measured 2026-08-21 ~11:00Z against the Contabo k3s production cluster.**
+Provenance: FuzeInfra `cluster-query` runs
+[32475207623](https://github.com/izzywdev/FuzeInfra/actions/runs/32475207623) (`get pods -A -o wide`)
+and [32475374902](https://github.com/izzywdev/FuzeInfra/actions/runs/32475374902) (`get svc,ingress -A -o wide`),
+plus the GitHub Releases API for the Android artifact.
+
+Nothing in this document is inferred from repository contents. A repo that *builds* a
+thing and a cluster that *runs* it are different claims, and only the second one is
+reported here as YES.
+
+## Reading the table
+
+| Value | Means |
+|---|---|
+| **YES** | Observed in production. A pod is `Running` **and** `Ready` — its readiness probe is passing right now — behind a Service. |
+| **NO** | Observed absent or broken in production. The failure mode is named in the notes. |
+| **NA** | Not applicable to this repo (no such component by design). |
+| **UNVERIFIED** | Could not be measured from this session. The reason and the fix are in §3. Never treat as YES. |
+
+## 1. The table
+
+| Repo | Backend healthy | Swagger | FE federated module | Portal reg+act+enabled | In left menu | UI loads in portal | Private (not public) | MCP in prod | A2A pod | Android APK |
+|---|---|---|---|---|---|---|---|---|---|---|
+| **FuzeFront** | YES | UNVERIFIED | YES (host) | NA (is the host) | NA | NA | **NO** — `app.fuzefront.com` (correct; it is the portal) | YES `fuzefront-mcp` | NO | **YES** `android-v423`, 2026-08-19 |
+| **FuzeAgent** | **NO** — `hierarchy-api` + `orchestrator` CrashLoopBackOff; pg/rabbit/redis ContainerCreating | UNVERIFIED | container Ready (`ui`) / UNVERIFIED | UNVERIFIED | UNVERIFIED | UNVERIFIED | **NO** — `fuzeagent.prod.fuzefront.com` | YES `mcp-server` | **YES** `a2a-shared` 1/1 | NA |
+| **FuzeBI** | **NO** — `Init:CreateContainerConfigError` | UNVERIFIED | **NO** — `ImagePullBackOff` | UNVERIFIED | UNVERIFIED | UNVERIFIED | **NO** — `fuzebi.prod.fuzefront.com` | NO | NO | NA |
+| **FuzeCall** | **NO** — no namespace in prod | NO | NA | NO | NO | NO | n/a — nothing deployed | NO | NO | NA |
+| **FuzeContact** | YES (single svc :80) | UNVERIFIED | UNVERIFIED | UNVERIFIED | UNVERIFIED | UNVERIFIED | **NO** — `fuzecontact.prod.fuzefront.com` | NO | NO | NA |
+| **FuzeDeploy** | **NO** — no namespace in prod | NO | NA | NO | NO | NO | n/a | NO | NO | NA |
+| **FuzeExecutive** | **NO** — `ImagePullBackOff` | UNVERIFIED | **NO** — `ImagePullBackOff` | UNVERIFIED | UNVERIFIED | UNVERIFIED | **NO** — `fuzeexecutive.prod.fuzefront.com` | NO | NO | NA |
+| **FuzeFinance** | **NO** — `ImagePullBackOff` ×2 | UNVERIFIED | **NO** — `ImagePullBackOff` ×2 | UNVERIFIED | UNVERIFIED | UNVERIFIED | **NO** — `fuzefinance.prod.fuzefront.com` | NO | NO | NA |
+| **FuzeHub** | YES 2/2 | UNVERIFIED | container Ready 2/2 / UNVERIFIED | UNVERIFIED | UNVERIFIED | UNVERIFIED | **NO** — `fuzehub.fuzefront.com` | YES `fuzehub-mcp` | NO | NA |
+| **FuzeInfra** | NA (platform) | NA | NA | NA | NA | NA | mixed — 10+ ops hosts public by design | YES `handoff-mcp` | NO | NA |
+| **FuzeKeys** | YES 2/2 | UNVERIFIED | container Ready 2/2 / UNVERIFIED | UNVERIFIED | UNVERIFIED | UNVERIFIED | **NO** — `keys.prod`, `api.keys.prod` | **NO** — `CreateContainerConfigError` | NO | NA |
+| **FuzeMarket** | **NO** — `Init:CrashLoopBackOff` ×2 | UNVERIFIED | **NO** — no frontend workload in prod | UNVERIFIED | UNVERIFIED | UNVERIFIED | **NO** — `fuzemarket.prod.fuzefront.com` | **NO** — `CreateContainerConfigError` | NO | NA |
+| **FuzeMerchandize** | **NO** — no namespace in prod | NO | NA | NO | NO | NO | n/a | NO | NO | NA |
+| **FuzePicker** | YES 1/1 | UNVERIFIED | container Ready (`picker`) / UNVERIFIED | UNVERIFIED | UNVERIFIED | UNVERIFIED | **NO** — `picker.prod`, `picker.fuzefront.com`, `api.fuzepicker.prod` | YES `fuzepicker-mcp` | NO | NA |
+| **FuzePlan** | YES 2/2 | UNVERIFIED | container Ready 2/2 / UNVERIFIED | UNVERIFIED | UNVERIFIED | UNVERIFIED | **NO** — `plan.fuzefront.com` | NO | NO | NA |
+| **FuzeSales** | **PARTIAL** — `fuzesales` :80 Ready, `fuzesales-api` **ImagePullBackOff** | UNVERIFIED | container Ready / UNVERIFIED | UNVERIFIED | UNVERIFIED | UNVERIFIED | **NO** — `fuzesales.prod.fuzefront.com` | YES `fuzesales-mcp` | NO | NA |
+| **FuzeSDLC** | NA (governance repo) | NA | NA | NA | NA | NA | n/a | NA | NA | NA |
+| **FuzeService** | **PARTIAL** — `fuzeservice` :80 Ready, `fuzeservice-api` **CrashLoopBackOff** ×2 | UNVERIFIED | container Ready / UNVERIFIED | UNVERIFIED | UNVERIFIED | UNVERIFIED | **NO** — `fuzeservice.prod.fuzefront.com` | YES `fuzeservice-mcp` | NO | NA |
+| **FuzeSocial** | **NO** — `ui` ImagePullBackOff, 5 workers ContainerCreating | UNVERIFIED | **NO** — `ImagePullBackOff` | UNVERIFIED | UNVERIFIED | UNVERIFIED | **NO** — `social.prod.fuzefront.com` | NO | NO | NA |
+| **FuzeX** | **NO** — no namespace in prod | NO | NA | NO | NO | NO | n/a | NO | NO | NA |
+| *FuzeQuality* (in prod, not in the 20) | YES | UNVERIFIED | YES | UNVERIFIED | UNVERIFIED | UNVERIFIED | **NO** — `quality.prod` — **but also has the correct `app.fuzefront.com` federated-mount ingress** | NO | NO | NA |
+
+## 2. What the numbers actually say
+
+- **5 of 20 repos have no production namespace at all**: FuzeCall, FuzeDeploy, FuzeMerchandize, FuzeX, FuzeSDLC (the last correctly — it is governance, not a product).
+- **Of the 15 products that ARE deployed, 6 have a fully healthy backend**: FuzeFront, FuzeContact, FuzeHub, FuzeKeys, FuzePicker, FuzePlan (+ FuzeQuality). Two more are half-up (FuzeSales, FuzeService: legacy service Ready, new `-api` down).
+- **7 products are broken on an image or config problem, not on code**: `ImagePullBackOff` (FuzeBI-fe, FuzeExecutive ×2, FuzeFinance ×4, FuzeSales-api, FuzeSocial-ui) and `CreateContainerConfigError` (FuzeBI, FuzeKeys-mcp, FuzeMarket-mcp, FuzeKeys-fe, FuzePlan-be third replica). `CreateContainerConfigError` means a referenced Secret or ConfigMap key does not exist — the registration-token hand-off, most likely.
+- **Exactly ONE A2A pod exists in production, fleet-wide**: `fuzeagent/a2a-shared`. Every other repo declaring an `a2a` block has no running agent.
+- **MCP: 6 product gateways Ready** (FuzeFront, FuzeHub, FuzePicker, FuzeSales, FuzeService, FuzeAgent) + `handoff-mcp` on the platform. 2 are deployed-but-broken (FuzeKeys, FuzeMarket) on the same config error.
+- **Public exposure is the inverse of the intent: 14 of 14 deployed products have their own public `*.fuzefront.com` ingress.** The design says in-cluster apps should be reachable only through the portal's origin. Exactly one product — FuzeQuality — additionally has the correct `app.fuzefront.com` federated-mount ingress, and even it still carries its own public host.
+- **Android: FuzeFront only, and it is real** — `android-v423` published 2026-08-19 from a `frontend/**` push to master. No other repo has an `android/` directory; NA rather than NO.
+
+## 3. The two dimensions I could not measure, and why
+
+These are marked UNVERIFIED above. They are not "probably fine".
+
+### 3a. Swagger / OpenAPI reachable in production
+Every product hostname resolves only through the Cloudflare tunnel. This session's egress
+proxy blocks all of them (`curl` returns `000` for `app.fuzefront.com`,
+`fuzehub.fuzefront.com`, `keys.prod.fuzefront.com`, `plan.fuzefront.com`). FuzeInfra's
+`cluster-query` can curl, but only one host per run and only `*.prod.fuzefront.com` /
+`*.mendysrobotics.com` — which excludes `fuzehub.fuzefront.com`, `plan.fuzefront.com`,
+`picker.fuzefront.com` and `app.fuzefront.com` outright.
+
+### 3b. Portal registration / activation / left menu / UI actually loading
+The portal's truth is the `apps` table in the applications service
+(`is_active`, lifecycle `status`, `nav.section` → `nav_rank`). **Every** read path is
+authenticated — `/api/apps` and `/api/v1/app-registry/apps` both sit behind
+`authenticateToken` / `authenticateConsumerOrSession`, and `/portals/:id/catalog` behind
+`authenticateToken`. `cluster-query` cannot exec into Postgres (exec is blocked, correctly).
+So there is no unauthenticated, in-cluster, machine-readable answer to "what does the portal
+actually show" — which is exactly why this question keeps being answered by a human
+counting menu entries.
+
+**This is the finding, not an excuse.** Ten production properties are asked about
+routinely and nothing measures any of them. The first item in the plan is therefore the
+probe, not a fix.
+
+## 4. Plan
+
+### Step 1 — `prod-conformance` probe (FuzeInfra) — **prerequisite for everything else**
+A scheduled + dispatchable workflow on the `staging` runner (in-cluster, so it can reach
+ClusterIP Services directly and needs no public hostname and no Cloudflare Access bypass):
+
+1. Enumerate every `fuze*` namespace.
+2. Per namespace, for each Service: `curl` `/health`, `/healthz`, `/api/health` on the
+   ClusterIP → **backend healthy**, measured, not inferred from pod readiness.
+3. For each Service with an OpenAPI contract: `curl` `/api-docs`, `/swagger.json`,
+   `/openapi.json`, `/docs` → **swagger**.
+4. For each frontend Service: `curl` `/assets/remoteEntry.js` and assert it parses as a
+   Module-Federation container → **FE federated module**, the only check that
+   distinguishes "a container is running" from "a remote the host can mount".
+5. Call the applications service **in-cluster** on `fuzefront-applications:3003` with a
+   scoped service token and read the app list → **registered / activated / enabled /
+   nav section**. This is the piece that needs a credential; mint a read-only consumer
+   token for it rather than weakening any endpoint's auth.
+6. Emit a markdown table as a job summary, and fail on regressions against a committed
+   baseline.
+
+Output: this document's table, regenerated on every run instead of by hand.
+
+### Step 2 — resolve `CreateContainerConfigError` (FuzeBI, FuzeKeys-mcp, FuzeMarket-mcp, FuzeKeys-fe, FuzePlan-be)
+A missing Secret/ConfigMap key. The registration-token hand-off registry
+(FuzeInfra `governance/credential-handoff.json`, 18 entries) exists and
+`publish-sealed-handoff` has never been dispatched for the full set. `describe pod` on one
+example first to confirm the exact missing key — do not assume it is the registration token.
+
+### Step 3 — resolve `ImagePullBackOff` (FuzeExecutive, FuzeFinance, FuzeSocial, FuzeBI-fe, FuzeSales-api)
+Tag never published, or the tag in the chart was never bumped. Related to the fleet-wide
+`GH_RELEASE_PAT` gap (images publish, tags never bump). Confirm per repo which of the two
+it is before touching charts.
+
+### Step 4 — resolve the crash loops (FuzeAgent `hierarchy-api`/`orchestrator`, FuzeService `-api`, FuzeMarket init)
+Real application failures; each needs its own log read and its own fix in its own repo.
+
+### Step 5 — federated-mount ingress for every product, and retire the public per-product hosts
+FuzeQuality's `fuzequality-federated-mount` on `app.fuzefront.com` is the pattern. Every
+other product needs the same, and then its `*.prod.fuzefront.com` ingress removed. Order
+matters: mount first, verify the remote loads through the portal, remove the public host
+second. Removing first takes the product offline.
+
+### Step 6 — A2A: one pod fleet-wide
+Decide whether `a2a-shared` is intended to serve every tenant (in which case the other
+repos' `a2a` blocks are registrations against it, and the gap is registration, not
+deployment) or whether each product needs its own pod. The manifests do not currently
+say which, and that ambiguity is why nothing has been deployed.
+
+### Step 7 — deploy or de-scope the 5 undeployed repos
+FuzeCall, FuzeDeploy, FuzeMerchandize, FuzeX have charts but no namespace. Either they
+ship or their `portal.registers` should say `false` — carrying them as "coming" in the
+registry is what makes the portal count look like a shortfall rather than a decision.
+
+## 5. Ownership
+
+Steps 2–4 are per-repo `devops-engineer` work. Step 1 and Step 5 are FuzeInfra
+(`@claude` delegation from this repo, per the overlay). Steps 6–7 need an owner decision
+before any code is written.

--- a/docs/planning/production-conformance.md
+++ b/docs/planning/production-conformance.md
@@ -83,7 +83,7 @@ probe, not a fix.
 
 ## 4. Plan
 
-### Step 1 — `prod-conformance` probe (FuzeInfra) — **prerequisite for everything else**
+### Step 1 — `prod-conformance` probe (FuzeInfra) — **SHIPPED: FuzeInfra#614**
 A scheduled + dispatchable workflow on the `staging` runner (in-cluster, so it can reach
 ClusterIP Services directly and needs no public hostname and no Cloudflare Access bypass):
 
@@ -154,15 +154,60 @@ should not be copied as the fix.
    `runAsUser`. This class fails at admission, not at lint or kubeconform — the same gap
    documented for NetworkPolicy ports in FuzeInfra#501.
 
-### Step 2b — the remaining `CreateContainerConfigError` pods
-`fuzebi`, `fuzekeys-frontend` (third replica) and `fuzeplan-backend` (third replica) still
-show `Init:CreateContainerConfigError`. These were NOT diagnosed and may or may not share
-the cause above — the ones examined were the MCP pods. `describe` each before acting.
+### Step 2b — the remaining `CreateContainerConfigError` pods — RESOLVED into Step 3b
+`fuzekeys-frontend` and `fuzeplan-backend` are `secret "fuzefront-registration" not found`
+(see Step 3b). `fuzebi` produced no event in the window and remains undiagnosed.
 
-### Step 3 — resolve `ImagePullBackOff` (FuzeExecutive, FuzeFinance, FuzeSocial, FuzeBI-fe, FuzeSales-api)
-Tag never published, or the tag in the chart was never bumped. Related to the fleet-wide
-`GH_RELEASE_PAT` gap (images publish, tags never bump). Confirm per repo which of the two
-it is before touching charts.
+### Step 3 — `ImagePullBackOff` is NOT a missing tag — it is IPv6 egress to GHCR
+
+> **Second correction.** This plan first said "tag never published, or never bumped".
+> `get events -A --field-selector reason=Failed`
+> ([run 32476193949](https://github.com/izzywdev/FuzeInfra/actions/runs/32476193949))
+> disproved that too. Both of this document's initial guesses about production were wrong,
+> and both were wrong in the same direction — assuming the familiar cause.
+
+The dominant message is not `manifest unknown` or `unauthorized`. It is:
+
+```
+Failed to pull image "ghcr.io/izzywdev/fuzefront-applications-service:c6a3e7121f91":
+  failed to copy: read tcp [2a02:c207:2345:8548::1]:46540
+                        -> [2606:50c0:8000::154]:443: read: connection reset by peer
+```
+
+`2606:50c0:8000::154` is GitHub's package CDN over **IPv6**. The nodes resolve GHCR to an
+IPv6 address, start the transfer, and the connection is reset mid-copy. The image exists
+and is authorised — the pull begins and then dies on the wire.
+
+**This is a cluster egress defect, and it is hitting FuzeFront itself**, not only the
+products listed in §1: `fuzefront-applications`, `fuzefront-frontend` and
+`fuzefront-db-bootstrap` all have replicas stuck this way, alongside `fuzeplan-backend`,
+`fuzequality-migrations`, `mendys-mcp-server` and `mendys-wp`. Running pods are unaffected
+because their layers are already on the node — which is why the fleet looks healthier than
+it is, and why every NEW rollout is the thing that fails.
+
+Fix belongs to FuzeInfra, not to any product repo: prefer IPv4 for registry egress on the
+nodes (or fix the tunnel/NAT path for IPv6 to `pkg-containers.githubusercontent.com`).
+Until that lands, no amount of chart or tag work in a product repo will help, and doing
+that work would look like progress while changing nothing.
+
+### Step 3b — the genuinely missing secrets, now named
+
+Two failures in the same event dump are real config gaps, and they are NOT the pull problem:
+
+| Pod | Event |
+|---|---|
+| `fuzekeys-frontend`, `fuzeplan-backend` | `Error: secret "fuzefront-registration" not found` |
+| `fuzesocial-ui` | `Error: couldn't find key FUZEFRONT_API_URL in Secret fuzesocial/fuzesocial-secrets` |
+
+The first **is** the registration-token hand-off gap — the hypothesis that was wrong for
+the MCP pods is correct here. FuzeInfra's `governance/credential-handoff.json` carries 18
+entries and `publish-sealed-handoff` has never been dispatched for the full set. The second
+is a single missing key in an existing Secret, which the hand-off does not cover.
+
+Not diagnosed, deliberately: FuzeExecutive, FuzeFinance and FuzeBI's `ImagePullBackOff`
+pods produced no events in the window (Kubernetes events expire in about an hour), so
+whether they share the IPv6 cause is **unknown**. Re-run the events query while they are
+backing off before assuming they do.
 
 ### Step 4 — resolve the crash loops (FuzeAgent `hierarchy-api`/`orchestrator`, FuzeService `-api`, FuzeMarket init)
 Real application failures; each needs its own log read and its own fix in its own repo.

--- a/docs/planning/production-conformance.md
+++ b/docs/planning/production-conformance.md
@@ -104,11 +104,60 @@ ClusterIP Services directly and needs no public hostname and no Cloudflare Acces
 
 Output: this document's table, regenerated on every run instead of by hand.
 
-### Step 2 — resolve `CreateContainerConfigError` (FuzeBI, FuzeKeys-mcp, FuzeMarket-mcp, FuzeKeys-fe, FuzePlan-be)
-A missing Secret/ConfigMap key. The registration-token hand-off registry
-(FuzeInfra `governance/credential-handoff.json`, 18 entries) exists and
-`publish-sealed-handoff` has never been dispatched for the full set. `describe pod` on one
-example first to confirm the exact missing key — do not assume it is the registration token.
+### Step 2 — the MCP `CreateContainerConfigError` — ROOT CAUSE FOUND, not a missing secret
+
+> **Correction.** An earlier draft of this plan assumed a missing registration-token
+> Secret key. `describe pod` disproved it. The doc's own rule — confirm before assuming —
+> is the only reason this was caught, and it is recorded rather than quietly edited away.
+
+`kubectl describe pod -n fuzekeys fuzekeys-mcp-664cf448b5-wjc2h`
+([run 32475665961](https://github.com/izzywdev/FuzeInfra/actions/runs/32475665961)):
+
+```
+Warning  Failed  17s (x12357 over 47h)  kubelet
+  Error: container has runAsNonRoot and image has non-numeric user (mcp),
+  cannot verify user is non-root
+Normal   Pulling 18s (x14836 over 10d)
+```
+
+The image `ghcr.io/izzywdev/fuze-mcp-gateway` declares `USER mcp` — a **name**. Kubernetes
+cannot resolve a username to a UID without running the image, so when the pod sets
+`runAsNonRoot: true` and no numeric `runAsUser`, the kubelet refuses to start the container.
+It is not a secret, not a config key, and not a pull failure — the image pulls fine, 14,836
+times over 10 days.
+
+Deployment-level evidence ([run 32475767386](https://github.com/izzywdev/FuzeInfra/actions/runs/32475767386))
+explains why some MCP gateways run and two do not:
+
+| Deployment | image tag | pod `runAsUser` | state |
+|---|---|---|---|
+| `fuzehub-mcp` | `12cb4f787248` | none | **Running** |
+| `fuzeservice-…-mcp` | `12cb4f787248` | none | **Running** |
+| `fuzepicker-mcp` | `0.1.0` | **1000** | **Running** |
+| `fuzesales-mcp` | `0.1.0` | none | **Running** (chart does not set `runAsNonRoot`) |
+| `fuzekeys-mcp` | `0.1.0` | none | **BROKEN** |
+| `fuzemarket-mcp` | `0.1.0` | none | **BROKEN** |
+
+So the trigger is the *combination* `runAsNonRoot: true` + no numeric `runAsUser` + an image
+with a named `USER`. Charts that pin a UID (FuzePicker) or that omit `runAsNonRoot`
+(FuzeSales) survive — the second by accident, and it is a weaker security posture, so it
+should not be copied as the fix.
+
+**Fix, in this order:**
+1. *Immediate, per-repo:* add `runAsUser: 1000` to the MCP container's `securityContext` in
+   FuzeKeys' and FuzeMarket's charts, matching FuzePicker — already proven in production.
+2. *Durable, fleet-wide:* rebuild `fuze-mcp-gateway` with a **numeric** `USER 65532` and
+   publish, so the failure cannot recur in the next repo that adopts the gateway. The image
+   is owned by FuzeService (FuzeService#37). Tag `12cb4f787248` may already do this —
+   confirm against its Dockerfile before assuming, then repoint the `0.1.0` consumers.
+3. *Prevent recurrence:* a chart-lint rule rejecting `runAsNonRoot: true` without a numeric
+   `runAsUser`. This class fails at admission, not at lint or kubeconform — the same gap
+   documented for NetworkPolicy ports in FuzeInfra#501.
+
+### Step 2b — the remaining `CreateContainerConfigError` pods
+`fuzebi`, `fuzekeys-frontend` (third replica) and `fuzeplan-backend` (third replica) still
+show `Init:CreateContainerConfigError`. These were NOT diagnosed and may or may not share
+the cause above — the ones examined were the MCP pods. `describe` each before acting.
 
 ### Step 3 — resolve `ImagePullBackOff` (FuzeExecutive, FuzeFinance, FuzeSocial, FuzeBI-fe, FuzeSales-api)
 Tag never published, or the tag in the chart was never bumped. Related to the fleet-wide


### PR DESCRIPTION
## What

Records what production **actually** looks like across all `Fuze*` repos on ten dimensions — backend health, swagger, federated-remote loadability, portal registration/activation/menu, private-vs-public exposure, MCP, A2A, Android — and the plan to close each gap.

Docs-only. No code, no chart, no workflow changes.

## Why now

These ten properties get asked about routinely and **nothing measures any of them**, so the answer has been a human counting menu entries. The first item in the plan is therefore the probe, not a fix.

## Method

Measured 2026-08-21 ~11:00Z from FuzeInfra `cluster-query`:
- [32475207623](https://github.com/izzywdev/FuzeInfra/actions/runs/32475207623) — `get pods -A -o wide`
- [32475374902](https://github.com/izzywdev/FuzeInfra/actions/runs/32475374902) — `get svc,ingress -A -o wide`
- [32475665961](https://github.com/izzywdev/FuzeInfra/actions/runs/32475665961) — `describe pod` on a broken MCP pod
- [32475767386](https://github.com/izzywdev/FuzeInfra/actions/runs/32475767386) — deployment images + `runAsUser`

plus the Releases API for the Android artifact.

Nothing is inferred from repository contents. A repo that *builds* a thing and a cluster that *runs* it are different claims; only the second is recorded as YES.

## Headline findings

- **5 of 20 repos have no production namespace at all**: FuzeCall, FuzeDeploy, FuzeMerchandize, FuzeX (+ FuzeSDLC, correctly — governance, not a product).
- Of the 15 deployed products, **6 have a fully healthy backend**; 2 more are half-up (legacy service Ready, new `-api` down).
- **7 are broken on an image or config problem, not on code** — `ImagePullBackOff` / `CreateContainerConfigError`.
- **Exactly ONE A2A pod exists fleet-wide**: `fuzeagent/a2a-shared`.
- **MCP: 6 gateways Ready, 2 deployed-but-broken.**
- **Public exposure is the inverse of the intent — 14 of 14 deployed products carry their own public `*.fuzefront.com` ingress.** Only FuzeQuality also has the correct `app.fuzefront.com` federated-mount ingress, and even it still has its public host.
- **Android is real and FuzeFront-only**: `android-v423`, 2026-08-19.

## Root cause found for the broken MCP gateways

`describe pod` **disproved** the plan's own first guess (a missing registration-token Secret):

```
Error: container has runAsNonRoot and image has non-numeric user (mcp),
cannot verify user is non-root      (x12357 over 47h)
```

`fuze-mcp-gateway` declares `USER mcp` — a *name*. The kubelet can't resolve it to a UID, so a pod with `runAsNonRoot: true` and no numeric `runAsUser` is refused. The image pulls fine, 14,836 times over 10 days.

FuzePicker survives by pinning `runAsUser: 1000`; FuzeSales survives by not setting `runAsNonRoot` at all — a weaker posture that must **not** be copied as the fix. The correction is recorded in the doc rather than quietly edited away.

Notably this class fails at **admission** — neither `helm lint` nor `kubeconform` exercises it. Same gap as the NetworkPolicy port outage.

## Two dimensions deliberately marked UNVERIFIED

Not "probably fine":

1. **Swagger in prod** — every product hostname resolves only through the Cloudflare tunnel and this session's egress proxy blocks all of them (`curl` → `000`). `cluster-query` can curl one host per run and only `*.prod.fuzefront.com`, which excludes several product hosts outright.
2. **Portal registration / activation / left menu / UI loading** — every portal read path is authenticated, and `cluster-query` cannot exec into Postgres (correctly). There is no unauthenticated, in-cluster, machine-readable answer.

## Test plan

- [x] Every YES traced to a named pod/Service/ingress in a linked `cluster-query` run
- [x] Prod hostname reachability from this session tested and recorded (all `000`)
- [x] MCP root cause confirmed by `describe pod`, not inferred
- [x] The four working-vs-broken MCP gateways cross-checked against image tag and `runAsUser`
- [x] Android release existence checked against the Releases API
- [ ] The probe in Step 1 does not exist yet — that is the deliverable this doc argues for

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GaPa3JgrVNtWrGvqQEAEqv

---
_Generated by [Claude Code](https://claude.ai/code/session_01GaPa3JgrVNtWrGvqQEAEqv)_