### PR TITLE
fix: lockfile resync, conformance-table correction, and FuzeSocial's integration type

### DIFF
--- a/.fuze/repo-manifest.schema.json
+++ b/.fuze/repo-manifest.schema.json
@@ -172,6 +172,10 @@
           "type": "string",
           "minLength": 1,
           "description": "The runner every stamped workflow targets, written verbatim as runs-on. DECLARED, never derived \u2014 the same rule identity.namespace follows. This is a gha-runner-scale-set NAME, not a label: those runners register with no labels at all, so `self-hosted` and `[self-hosted, x]` match nothing. Omit the block entirely to keep the template's ubuntu-latest, which is the correct default for a repo with no scale set \u2014 a runs-on naming a set that does not exist does not fail fast, it queues forever."
+        },
+        "note": {
+          "type": "string",
+          "description": "Free-text rationale for this repo's runner choice. Every sibling block that carries hard-won operational reasoning allows one (a2a, mcp, identity, toolchain, platformAuth); `ci` was the only one that did not \u2014 and it is the block whose reasoning is least guessable from its value. `runner: fuzecall` reads like a label until the note tells you it is a gha-runner-scale-set NAME, that those runners register with no labels at all so `self-hosted` matches nothing, and that naming a set which does not exist does not fail fast but queues forever. All 8 `ci` blocks in the fleet were written with a note, so under additionalProperties:false every real instance was invalid: the schema forbade the one field the block has always been used with."
         }
       }
     },
@@ -199,6 +203,10 @@
               "description": "e.g. 'fuzefront-identity' \u2014 installed from a tagged GitHub Release wheel, because GitHub Packages has no PyPI registry."
             }
           }
+        },
+        "enforceUsage": {
+          "type": "boolean",
+          "description": "Ratchet. --adoption A1 only asks whether the identity package is DECLARED, which an inert dependency line satisfies \u2014 measured 2026-08-19, thirteen repos declared it and none imported it. With this true, A2 also requires a tracked source file to IMPORT the package, and a declaration with no call site becomes a failure instead of a warning. Deliberately opt-in per repo and NOT reconciled by governance_sync: flipping it family-wide on arrival would be enforcement ahead of adoption, which is what produced the inert declarations."
         },
         "note": {
           "type": "string"

--- a/agent-templates/sync/common.py
+++ b/agent-templates/sync/common.py
@@ -60,11 +60,28 @@ def request(method, path, body=None, query=None, beta=MANAGED_AGENTS_BETA):
 
 
 def list_all(path, key="data", beta=MANAGED_AGENTS_BETA):
-    """Fetch every page of a list endpoint (cursor pagination)."""
+    """Fetch every page of a list endpoint.
+
+    Handles both pagination schemes used by this API:
+    - Page: has_more + after_id (e.g. /v1/agents, /v1/sessions)
+    - PageCursor: next_page + page param (e.g. /v1/vaults, /v1/vaults/{id}/credentials)
+
+    Treating every endpoint as Page silently truncates PageCursor endpoints
+    after the first page, causing spurious 409s when callers re-POST existing
+    resources that weren't visible in the incomplete listing.
+    """
     items, query = [], {}
     while True:
         page = request("GET", path, query=query or None, beta=beta)
         items.extend(page.get(key, []))
+        if "next_page" in page:
+            # PageCursor scheme: next_page is null on the last page
+            cursor = page.get("next_page")
+            if not cursor:
+                return items
+            query = {"page": cursor}
+            continue
+        # Page scheme: has_more + last_id/after_id
         if not page.get("has_more"):
             return items
         cursor = page.get("last_id") or page.get("next_cursor")

--- a/docs/planning/production-conformance.md
+++ b/docs/planning/production-conformance.md
@@ -6,9 +6,21 @@ Provenance: FuzeInfra `cluster-query` runs
 and [32475374902](https://github.com/izzywdev/FuzeInfra/actions/runs/32475374902) (`get svc,ingress -A -o wide`),
 plus the GitHub Releases API for the Android artifact.
 
+**Amended 2026-08-21 ~13:15Z** — §1 gained a third correction (the defective
+"Private (not public)" column, now split in two), §1a, and §3c, backed by
+[run 32484802532](https://github.com/izzywdev/FuzeInfra/actions/runs/32484802532)
+(`get configmap coredns coredns-custom -o yaml`).
+
 Nothing in this document is inferred from repository contents. A repo that *builds* a
 thing and a cluster that *runs* it are different claims, and only the second one is
 reported here as YES.
+
+One deliberate exception, added 2026-08-21 and labelled at the point of use: **§1a reads
+each repo's `registration/manifest.json`**, because a declared `remoteEntry` URL is not a
+cluster fact and cannot be observed with `kubectl` — it is what the portal will hand the
+browser. It is reported as a *declaration*, never as YES, and the cluster-observable half
+of the same question (does the `app.fuzefront.com` mount Ingress exist) is measured
+separately and marked as such.
 
 ## Reading the table
 
@@ -21,29 +33,98 @@ reported here as YES.
 
 ## 1. The table
 
-| Repo | Backend healthy | Swagger | FE federated module | Portal reg+act+enabled | In left menu | UI loads in portal | Private (not public) | MCP in prod | A2A pod | Android APK |
-|---|---|---|---|---|---|---|---|---|---|---|
-| **FuzeFront** | YES | UNVERIFIED | YES (host) | NA (is the host) | NA | NA | **NO** — `app.fuzefront.com` (correct; it is the portal) | YES `fuzefront-mcp` | NO | **YES** `android-v423`, 2026-08-19 |
-| **FuzeAgent** | **NO** — `hierarchy-api` + `orchestrator` CrashLoopBackOff; pg/rabbit/redis ContainerCreating | UNVERIFIED | container Ready (`ui`) / UNVERIFIED | UNVERIFIED | UNVERIFIED | UNVERIFIED | **NO** — `fuzeagent.prod.fuzefront.com` | YES `mcp-server` | **YES** `a2a-shared` 1/1 | NA |
-| **FuzeBI** | **NO** — `Init:CreateContainerConfigError` | UNVERIFIED | **NO** — `ImagePullBackOff` | UNVERIFIED | UNVERIFIED | UNVERIFIED | **NO** — `fuzebi.prod.fuzefront.com` | NO | NO | NA |
-| **FuzeCall** | **NO** — no namespace in prod | NO | NA | NO | NO | NO | n/a — nothing deployed | NO | NO | NA |
-| **FuzeContact** | YES (single svc :80) | UNVERIFIED | UNVERIFIED | UNVERIFIED | UNVERIFIED | UNVERIFIED | **NO** — `fuzecontact.prod.fuzefront.com` | NO | NO | NA |
-| **FuzeDeploy** | **NO** — no namespace in prod | NO | NA | NO | NO | NO | n/a | NO | NO | NA |
-| **FuzeExecutive** | **NO** — `ImagePullBackOff` | UNVERIFIED | **NO** — `ImagePullBackOff` | UNVERIFIED | UNVERIFIED | UNVERIFIED | **NO** — `fuzeexecutive.prod.fuzefront.com` | NO | NO | NA |
-| **FuzeFinance** | **NO** — `ImagePullBackOff` ×2 | UNVERIFIED | **NO** — `ImagePullBackOff` ×2 | UNVERIFIED | UNVERIFIED | UNVERIFIED | **NO** — `fuzefinance.prod.fuzefront.com` | NO | NO | NA |
-| **FuzeHub** | YES 2/2 | UNVERIFIED | container Ready 2/2 / UNVERIFIED | UNVERIFIED | UNVERIFIED | UNVERIFIED | **NO** — `fuzehub.fuzefront.com` | YES `fuzehub-mcp` | NO | NA |
-| **FuzeInfra** | NA (platform) | NA | NA | NA | NA | NA | mixed — 10+ ops hosts public by design | YES `handoff-mcp` | NO | NA |
-| **FuzeKeys** | YES 2/2 | UNVERIFIED | container Ready 2/2 / UNVERIFIED | UNVERIFIED | UNVERIFIED | UNVERIFIED | **NO** — `keys.prod`, `api.keys.prod` | **NO** — `CreateContainerConfigError` | NO | NA |
-| **FuzeMarket** | **NO** — `Init:CrashLoopBackOff` ×2 | UNVERIFIED | **NO** — no frontend workload in prod | UNVERIFIED | UNVERIFIED | UNVERIFIED | **NO** — `fuzemarket.prod.fuzefront.com` | **NO** — `CreateContainerConfigError` | NO | NA |
-| **FuzeMerchandize** | **NO** — no namespace in prod | NO | NA | NO | NO | NO | n/a | NO | NO | NA |
-| **FuzePicker** | YES 1/1 | UNVERIFIED | container Ready (`picker`) / UNVERIFIED | UNVERIFIED | UNVERIFIED | UNVERIFIED | **NO** — `picker.prod`, `picker.fuzefront.com`, `api.fuzepicker.prod` | YES `fuzepicker-mcp` | NO | NA |
-| **FuzePlan** | YES 2/2 | UNVERIFIED | container Ready 2/2 / UNVERIFIED | UNVERIFIED | UNVERIFIED | UNVERIFIED | **NO** — `plan.fuzefront.com` | NO | NO | NA |
-| **FuzeSales** | **PARTIAL** — `fuzesales` :80 Ready, `fuzesales-api` **ImagePullBackOff** | UNVERIFIED | container Ready / UNVERIFIED | UNVERIFIED | UNVERIFIED | UNVERIFIED | **NO** — `fuzesales.prod.fuzefront.com` | YES `fuzesales-mcp` | NO | NA |
-| **FuzeSDLC** | NA (governance repo) | NA | NA | NA | NA | NA | n/a | NA | NA | NA |
-| **FuzeService** | **PARTIAL** — `fuzeservice` :80 Ready, `fuzeservice-api` **CrashLoopBackOff** ×2 | UNVERIFIED | container Ready / UNVERIFIED | UNVERIFIED | UNVERIFIED | UNVERIFIED | **NO** — `fuzeservice.prod.fuzefront.com` | YES `fuzeservice-mcp` | NO | NA |
-| **FuzeSocial** | **NO** — `ui` ImagePullBackOff, 5 workers ContainerCreating | UNVERIFIED | **NO** — `ImagePullBackOff` | UNVERIFIED | UNVERIFIED | UNVERIFIED | **NO** — `social.prod.fuzefront.com` | NO | NO | NA |
-| **FuzeX** | **NO** — no namespace in prod | NO | NA | NO | NO | NO | n/a | NO | NO | NA |
-| *FuzeQuality* (in prod, not in the 20) | YES | UNVERIFIED | YES | UNVERIFIED | UNVERIFIED | UNVERIFIED | **NO** — `quality.prod` — **but also has the correct `app.fuzefront.com` federated-mount ingress** | NO | NO | NA |
+| Repo | Backend healthy | Swagger | FE federated module | Portal reg+act+enabled | In left menu | UI loads in portal | MF remote same-origin (browser) | In-cluster S2S stays in-cluster | MCP in prod | A2A pod | Android APK |
+|---|---|---|---|---|---|---|---|---|---|---|---|
+| **FuzeFront** | YES | UNVERIFIED | YES (host) | NA (is the host) | NA | NA | NA — is the host origin | NA — is the host | YES `fuzefront-mcp` | NO | **YES** `android-v423`, 2026-08-19 |
+| **FuzeAgent** | **NO** — `hierarchy-api` + `orchestrator` CrashLoopBackOff; pg/rabbit/redis ContainerCreating | UNVERIFIED | container Ready (`ui`) / UNVERIFIED | UNVERIFIED | UNVERIFIED | UNVERIFIED | **NO** — MF remote, absolute `https://fuzeagent.prod.fuzefront.com/remoteEntry.js` | **NO** — cluster-wide (§3c) | YES `mcp-server` | **YES** `a2a-shared` 1/1 | NA |
+| **FuzeBI** | **NO** — `Init:CreateContainerConfigError` | UNVERIFIED | **NO** — `ImagePullBackOff` | UNVERIFIED | UNVERIFIED | UNVERIFIED | NA — `integration.type: iframe` | **NO** — cluster-wide (§3c) | NO | NO | NA |
+| **FuzeCall** | **NO** — no namespace in prod | NO | NA | NO | NO | NO | NA — `integration.type: spa`; nothing deployed | n/a — nothing deployed | NO | NO | NA |
+| **FuzeContact** | YES (single svc :80) | UNVERIFIED | UNVERIFIED | UNVERIFIED | UNVERIFIED | UNVERIFIED | **NO** — MF remote, absolute `https://fuzecontact.prod.fuzefront.com/assets/remoteEntry.js` | **NO** — cluster-wide (§3c) | NO | NO | NA |
+| **FuzeDeploy** | **NO** — no namespace in prod | NO | NA | NO | NO | NO | NA — `integration.type: iframe`; nothing deployed | n/a — nothing deployed | NO | NO | NA |
+| **FuzeExecutive** | **NO** — `ImagePullBackOff` | UNVERIFIED | **NO** — `ImagePullBackOff` | UNVERIFIED | UNVERIFIED | UNVERIFIED | NA — `integration.type: iframe` | **NO** — cluster-wide (§3c) | NO | NO | NA |
+| **FuzeFinance** | **NO** — `ImagePullBackOff` ×2 | UNVERIFIED | **NO** — `ImagePullBackOff` ×2 | UNVERIFIED | UNVERIFIED | UNVERIFIED | NA — `integration.type: iframe` | **NO** — cluster-wide (§3c) | NO | NO | NA |
+| **FuzeHub** | YES 2/2 | UNVERIFIED | container Ready 2/2 / UNVERIFIED | UNVERIFIED | UNVERIFIED | UNVERIFIED | NA — `integration.type: iframe` | **NO** — cluster-wide (§3c) | YES `fuzehub-mcp` | NO | NA |
+| **FuzeInfra** | NA (platform) | NA | NA | NA | NA | NA | NA — platform, no portal remote | **NO** — cluster-wide; it owns the fix (§3c) | YES `handoff-mcp` | NO | NA |
+| **FuzeKeys** | YES 2/2 | UNVERIFIED | container Ready 2/2 / UNVERIFIED | UNVERIFIED | UNVERIFIED | UNVERIFIED | **NO** — MF remote, absolute `https://keys.prod.fuzefront.com/apps/fuzekeys/remoteEntry.js` | **NO** — cluster-wide (§3c) | **NO** — `CreateContainerConfigError` | NO | NA |
+| **FuzeMarket** | **NO** — `Init:CrashLoopBackOff` ×2 | UNVERIFIED | **NO** — no frontend workload in prod | UNVERIFIED | UNVERIFIED | UNVERIFIED | **NO** — MF remote, absolute `https://fuzemarket.fuze.internal/dist/remoteEntry.js` — and that host resolves nowhere | **NO** — cluster-wide (§3c) | **NO** — `CreateContainerConfigError` | NO | NA |
+| **FuzeMerchandize** | **NO** — no namespace in prod | NO | NA | NO | NO | NO | NA — `integration.type: iframe`; nothing deployed | n/a — nothing deployed | NO | NO | NA |
+| **FuzePicker** | YES 1/1 | UNVERIFIED | container Ready (`picker`) / UNVERIFIED | UNVERIFIED | UNVERIFIED | UNVERIFIED | **NO** — MF remote, absolute `https://picker.prod.fuzefront.com/remoteEntry.js` | **NO** — cluster-wide (§3c) | YES `fuzepicker-mcp` | NO | NA |
+| **FuzePlan** | YES 2/2 | UNVERIFIED | container Ready 2/2 / UNVERIFIED | UNVERIFIED | UNVERIFIED | UNVERIFIED | NA — `integration.type: iframe` | **NO** — cluster-wide (§3c) | NO | NO | NA |
+| **FuzeSales** | **PARTIAL** — `fuzesales` :80 Ready, `fuzesales-api` **ImagePullBackOff** | UNVERIFIED | container Ready / UNVERIFIED | UNVERIFIED | UNVERIFIED | UNVERIFIED | **NO** — MF remote, absolute `https://fuzesales.prod.fuzefront.com/assets/remoteEntry.js` | **NO** — cluster-wide (§3c) | YES `fuzesales-mcp` | NO | NA |
+| **FuzeSDLC** | NA (governance repo) | NA | NA | NA | NA | NA | NA — governance repo | NA — governance repo | NA | NA | NA |
+| **FuzeService** | **PARTIAL** — `fuzeservice` :80 Ready, `fuzeservice-api` **CrashLoopBackOff** ×2 | UNVERIFIED | container Ready / UNVERIFIED | UNVERIFIED | UNVERIFIED | UNVERIFIED | **NO** — MF remote, absolute `https://fuzeservice.prod.fuzefront.com/assets/remoteEntry.js` | **NO** — cluster-wide (§3c) | YES `fuzeservice-mcp` | NO | NA |
+| **FuzeSocial** | **NO** — `ui` ImagePullBackOff, 5 workers ContainerCreating | UNVERIFIED | **NO** — `ImagePullBackOff` | UNVERIFIED | UNVERIFIED | UNVERIFIED | **NO** — MF remote, absolute `https://social.prod.fuzefront.com/_next/static/chunks/remoteEntry.js` | **NO** — cluster-wide (§3c) | NO | NO | NA |
+| **FuzeX** | **NO** — no namespace in prod | NO | NA | NO | NO | NO | declared correct (`/apps/fuzex/remoteEntry.js`), **not deployed** — no mount Ingress exists | n/a — nothing deployed | NO | NO | NA |
+| *FuzeQuality* (in prod, not in the 20) | YES | UNVERIFIED | YES | UNVERIFIED | UNVERIFIED | UNVERIFIED | **YES** — `/apps/fuzequality/assets/remoteEntry.js` + `fuzequality-federated-mount` Ingress on `app.fuzefront.com`, both observed | **NO** — cluster-wide (§3c) | NO | NO | NA |
+
+> **Third correction — 2026-08-21.** The column that stood here was headed
+> **"Private (not public)"** and it was defective. It recorded exactly one thing —
+> *does this product have its own public hostname* — and then that one measurement was
+> read as the answer to two unrelated questions. It is split above, because no single
+> cell can carry both:
+>
+> - **Browser path.** A Module-Federation `remoteEntry.js` is fetched by the end user's
+>   browser. It can *never* be served in-cluster, so "is it private" is not even a
+>   coherent question about it. What matters is whether it is mounted **same-origin**
+>   under `app.fuzefront.com/apps/<slug>/` — one origin, no third-party cookie/CORS
+>   surface, no second public host to keep alive — rather than fetched from a separate
+>   public host. That is now the **MF remote same-origin** column.
+> - **In-cluster path.** Whether a *server-to-server* call from one pod to another
+>   product resolves inside the cluster instead of leaving it. That is now the
+>   **In-cluster S2S** column, and it is measured in §3c.
+>
+> Merging the two made FuzeQuality read as a near-miss ("**NO** — `quality.prod` — but
+> also has the correct mount") when on the browser dimension it is the **only** full
+> pass in the fleet, and it made every other row's real browser-path defect —
+> an absolute cross-origin `remoteEntry` URL — invisible, because the column never
+> looked at the manifest at all.
+>
+> The old column also asserted **"14 of 14 deployed products have their own public
+> ingress"** as if that were the whole finding. It is true and it is not the finding.
+> Measured against the manifests, only **10** of the 20 products are Module-Federation
+> remotes in the first place; the same-origin requirement applies to those and to
+> nothing else.
+
+### 1a. The integration model is MIXED — the same-origin rule applies to MF only
+
+Read from each repo's `registration/manifest.json` at `HEAD` on its default branch
+(repository contents, **not** cluster state — labelled as such deliberately; the
+`app.fuzefront.com` mount-Ingress column beside it *is* cluster-measured, from
+[run 32475374902](https://github.com/izzywdev/FuzeInfra/actions/runs/32475374902)).
+
+There are **three** integration types in the fleet, not two:
+
+| `integration.type` | Repos | Same-origin mount required? |
+|---|---|---|
+| `module-federation` | FuzeAgent, FuzeContact, FuzeKeys, FuzeMarket, FuzePicker, FuzeSales, FuzeService, FuzeSocial, FuzeX, FuzeQuality | **Yes** — the host shell fetches `remoteEntry.js` into its own page |
+| `iframe` | FuzeBI, FuzeDeploy, FuzeExecutive, FuzeFinance, FuzeHub, FuzeMerchandize, FuzePlan | No — a document boundary, not a shared JS runtime |
+| `spa` | FuzeCall | No |
+
+| Repo | type | declared entry | same-origin? | `app.fuzefront.com` mount Ingress observed |
+|---|---|---|---|---|
+| FuzeQuality | module-federation | `/apps/fuzequality/assets/remoteEntry.js` | **yes** | **yes** — `fuzequality-federated-mount` |
+| FuzeX | module-federation | `/apps/fuzex/remoteEntry.js` | **yes** | no — repo has no prod namespace |
+| FuzeAgent | module-federation | `https://fuzeagent.prod.fuzefront.com/remoteEntry.js` | no | no |
+| FuzeContact | module-federation | `https://fuzecontact.prod.fuzefront.com/assets/remoteEntry.js` | no | no |
+| FuzeKeys | module-federation | `https://keys.prod.fuzefront.com/apps/fuzekeys/remoteEntry.js` | no | no |
+| FuzeMarket | module-federation | `https://fuzemarket.fuze.internal/dist/remoteEntry.js` | no | no — and `fuze.internal` is not a resolvable zone |
+| FuzePicker | module-federation | `https://picker.prod.fuzefront.com/remoteEntry.js` | no | no |
+| FuzeSales | module-federation | `https://fuzesales.prod.fuzefront.com/assets/remoteEntry.js` | no | no |
+| FuzeService | module-federation | `https://fuzeservice.prod.fuzefront.com/assets/remoteEntry.js` | no | no |
+| FuzeSocial | module-federation | `https://social.prod.fuzefront.com/_next/static/chunks/remoteEntry.js` | no | no |
+
+**Two of ten MF remotes declare a same-origin entry. One of those is deployed.**
+
+Two drifts fell out of this pass and are recorded rather than fixed here:
+
+- **FuzeSocial disagrees with FuzeFront about what FuzeSocial is.** Its own
+  `registration/manifest.json` says `module-federation`; this repo's seed copy,
+  `services/app-registry-service/seed/fuzesocial.manifest.json`, says `iframe` with
+  `builtin: true`. Whichever the portal actually loads, one of the two files is wrong,
+  and nothing compares them.
+- **FuzeMarket's `remoteEntry` points at `fuzemarket.fuze.internal`**, a hostname with no
+  zone anywhere in the fleet. That remote cannot load for any user from any network.
+
 
 ## 2. What the numbers actually say
 
@@ -52,10 +133,16 @@ reported here as YES.
 - **7 products are broken on an image or config problem, not on code**: `ImagePullBackOff` (FuzeBI-fe, FuzeExecutive ×2, FuzeFinance ×4, FuzeSales-api, FuzeSocial-ui) and `CreateContainerConfigError` (FuzeBI, FuzeKeys-mcp, FuzeMarket-mcp, FuzeKeys-fe, FuzePlan-be third replica). `CreateContainerConfigError` means a referenced Secret or ConfigMap key does not exist — the registration-token hand-off, most likely.
 - **Exactly ONE A2A pod exists in production, fleet-wide**: `fuzeagent/a2a-shared`. Every other repo declaring an `a2a` block has no running agent.
 - **MCP: 6 product gateways Ready** (FuzeFront, FuzeHub, FuzePicker, FuzeSales, FuzeService, FuzeAgent) + `handoff-mcp` on the platform. 2 are deployed-but-broken (FuzeKeys, FuzeMarket) on the same config error.
-- **Public exposure is the inverse of the intent: 14 of 14 deployed products have their own public `*.fuzefront.com` ingress.** The design says in-cluster apps should be reachable only through the portal's origin. Exactly one product — FuzeQuality — additionally has the correct `app.fuzefront.com` federated-mount ingress, and even it still carries its own public host.
+- **Public exposure is the inverse of the intent: 14 of 14 deployed products have their own public `*.fuzefront.com` ingress** ([run 32475374902](https://github.com/izzywdev/FuzeInfra/actions/runs/32475374902)). Read carefully, though — that count is a *fact about ingresses*, not a verdict on either path, and it used to be reported as both (see the third correction in §1):
+  - **Browser path:** of the **10** Module-Federation remotes, **2** declare a same-origin entry (FuzeQuality, FuzeX) and exactly **1** — FuzeQuality — has the `app.fuzefront.com` mount Ingress live. The other 8 hand the browser an absolute cross-origin URL. The 7 `iframe` products and 1 `spa` product are out of scope for this rule by design.
+  - **In-cluster path:** **zero** products resolve a sibling's `*.prod.fuzefront.com` name inside the cluster, because no such mapping exists in CoreDNS at all (§3c). This is one cluster-level defect, not 14 product defects.
 - **Android: FuzeFront only, and it is real** — `android-v423` published 2026-08-19 from a `frontend/**` push to master. No other repo has an `android/` directory; NA rather than NO.
 
-## 3. The two dimensions I could not measure, and why
+## 3. The dimensions that needed their own measurement
+
+§3a and §3b are still **UNVERIFIED** — the reasons are below and they are not
+"probably fine". §3c was added on 2026-08-21 and is the opposite case: it *was*
+measured, and the answer is a firm NO.
 
 These are marked UNVERIFIED above. They are not "probably fine".
 
@@ -80,6 +167,69 @@ counting menu entries.
 **This is the finding, not an excuse.** Ten production properties are asked about
 routinely and nothing measures any of them. The first item in the plan is therefore the
 probe, not a fix.
+
+### 3c. In-cluster server-to-server — **MEASURED 2026-08-21, and the answer is NO**
+
+*This one is not UNVERIFIED.* Split-horizon DNS for `*.prod.fuzefront.com` is **absent**
+from the production cluster. A pod calling `https://fuzesales.prod.fuzefront.com/health`
+resolves that name through public DNS to a Cloudflare edge address, egresses to the
+internet, and re-enters through the Cloudflare Tunnel to reach a Service that may be on
+the same node — paying full WAN latency, and making an internal call depend on external
+infrastructure.
+
+Observed directly in `kube-system/coredns`
+([run 32484802532](https://github.com/izzywdev/FuzeInfra/actions/runs/32484802532),
+`get configmap coredns coredns-custom -o yaml`). The Corefile in full:
+
+```
+.:53 {
+    errors
+    health
+    ready
+    kubernetes cluster.local in-addr.arpa ip6.arpa {
+      pods insecure
+      fallthrough in-addr.arpa ip6.arpa
+    }
+    hosts /etc/coredns/NodeHosts { ttl 60; reload 15s; fallthrough }
+    prometheus :9153
+    cache 30
+    loop
+    reload
+    loadbalance
+    import /etc/coredns/custom/*.override
+    forward . /etc/resolv.conf
+}
+import /etc/coredns/custom/*.server
+```
+
+No `rewrite`, no `template`, and the single `hosts` block reads `/etc/coredns/NodeHosts`,
+which the same output shows contains ten `10.0.0.x` node entries and nothing else. There
+is no rule that could match `*.prod.fuzefront.com`, so every such query falls through to
+`forward . /etc/resolv.conf` — the node's upstream resolver, i.e. public DNS. The same
+run reports `configmaps "coredns-custom" not found`, so no override file exists either.
+
+Two details make this cheap to fix rather than awkward:
+
+1. `import /etc/coredns/custom/*.override` is already **inside** the `.:53` block. k3s
+   ships that import and mounts the `coredns-custom` ConfigMap optionally, so the
+   extension point exists and is currently empty — creating it clobbers nothing.
+2. The `coredns` ConfigMap itself is owned by the k3s Addon controller
+   (`objectset.rio.cattle.io/owner-gvk: k3s.cattle.io/v1, Kind=Addon`), so editing it
+   directly would be reverted. `coredns-custom` is the supported seam, not a workaround.
+
+**This is FuzeInfra's fix, not a product repo's** — one CoreDNS override serves the whole
+fleet, which is why the table above reports it once as a cluster-wide NO rather than as
+14 separate product failures. Tracked in FuzeInfra (see §4 Step 5).
+
+One honest caveat on the shape of the fix: prod terminates TLS at the Cloudflare edge and
+the tunnel reaches Traefik over **plain HTTP** (`ingress.tls.enabled: false` in
+`values-contabo.yaml`; every product Ingress shows `PORTS 80`). So there is no certificate
+inside the cluster for `*.prod.fuzefront.com`, and pointing the name at Traefik makes
+`http://` work while `https://` would fail certificate validation. Callers that want the
+in-cluster path must use `http://`, or the cluster needs a real internal certificate — a
+separate decision, and one that should be made explicitly rather than discovered by a
+failing TLS handshake.
+
 
 ## 4. Plan
 
@@ -212,11 +362,28 @@ backing off before assuming they do.
 ### Step 4 — resolve the crash loops (FuzeAgent `hierarchy-api`/`orchestrator`, FuzeService `-api`, FuzeMarket init)
 Real application failures; each needs its own log read and its own fix in its own repo.
 
-### Step 5 — federated-mount ingress for every product, and retire the public per-product hosts
-FuzeQuality's `fuzequality-federated-mount` on `app.fuzefront.com` is the pattern. Every
-other product needs the same, and then its `*.prod.fuzefront.com` ingress removed. Order
-matters: mount first, verify the remote loads through the portal, remove the public host
-second. Removing first takes the product offline.
+### Step 5 — close the browser path and the in-cluster path (two jobs, not one)
+
+These were a single line here until the 2026-08-21 correction in §1, and they are
+independent: doing either one does not advance the other.
+
+**5a — browser path: same-origin mount for the 8 non-conforming MF remotes.**
+FuzeQuality's `fuzequality-federated-mount` on `app.fuzefront.com` is the pattern, and
+FuzeFront's chart already generalises it (`federatedApps` in
+`deploy/helm/fuzefront/values.yaml` renders the `/apps/<slug>` Ingress + Traefik
+strip-prefix Middleware) — but that list is `[]` in every overlay, so the host shell
+currently mounts no remotes of its own. Each product must also change its
+`registration/manifest.json` `remoteEntry` from an absolute URL to `/apps/<slug>/…`;
+the Ingress alone does nothing while the manifest still names a public host. Scope is
+the 10 `module-federation` repos only — the 7 `iframe` and 1 `spa` products are out of
+scope by design (§1a). Order matters: mount first, verify the remote loads through the
+portal, remove the public host second. Removing first takes the product offline.
+
+**5b — in-cluster path: split-horizon DNS.** One CoreDNS `coredns-custom` override in
+FuzeInfra, serving the whole fleet at once (§3c). Independent of 5a and much cheaper:
+no product repo has to change anything. Note that 5b does **not** let 5a be skipped —
+split-horizon DNS is invisible to the end user's browser, which is on the internet and
+resolves through public DNS no matter what CoreDNS says.
 
 ### Step 6 — A2A: one pod fleet-wide
 Decide whether `a2a-shared` is intended to serve every tenant (in which case the other
@@ -231,6 +398,15 @@ registry is what makes the portal count look like a shortfall rather than a deci
 
 ## 5. Ownership
 
-Steps 2–4 are per-repo `devops-engineer` work. Step 1 and Step 5 are FuzeInfra
-(`@claude` delegation from this repo, per the overlay). Steps 6–7 need an owner decision
+Steps 2–4 are per-repo `devops-engineer` work. Step 1 and Step 5b are FuzeInfra
+(`@claude` delegation from this repo, per the overlay). Step 5a is split: the
+`federatedApps` Ingress list is FuzeFront's own chart, and each `remoteEntry` rewrite is
+the owning product repo's `registration/manifest.json`. Steps 6–7 need an owner decision
 before any code is written.
+
+The two drifts named at the end of §1a (FuzeSocial's manifest disagreeing with this
+repo's seed copy; FuzeMarket's unresolvable `fuze.internal` remote) have **no owner and
+no gate**. Nothing compares a product's `registration/manifest.json` against the seed in
+`services/app-registry-service/seed/`, and nothing checks that a declared `remoteEntry`
+host resolves. Both are cheap to add to the Step 1 probe and are the reason the
+disagreement survived this long.

--- a/docs/planning/production-conformance.md
+++ b/docs/planning/production-conformance.md
@@ -85,7 +85,41 @@ separately and marked as such.
 > remotes in the first place; the same-origin requirement applies to those and to
 > nothing else.
 
-### 1a. The integration model is MIXED — the same-origin rule applies to MF only
+### 1a. Integration model — OWNER DECISION 2026-08-23: module-federation everywhere
+
+**The mixed model below is now history, not target state.** The owner has decided
+that every product integrates as `module-federation`. No `iframe`, no `spa`. The
+survey that follows is retained because it is the measurement of where the fleet
+actually stands against that decision — 8 of 17 products must convert.
+
+This also settles the FuzeSocial disagreement recorded at the end of this section:
+FuzeSocial's own `registration/manifest.json` said `module-federation` while
+FuzeFront's seed copy said `iframe` with `builtin: true`. **The manifest was
+right.** FuzeFront's seed has been corrected, and its entry moved to the
+same-origin form `/apps/fuzesocial/remoteEntry.js` at the same time.
+
+**Converting is NOT a manifest string change.** Measured against `origin` at the
+time of the decision, the 8 repos split into three very different tiers:
+
+| tier | repos | what conversion actually needs |
+|---|---|---|
+| **Has MF config already** | FuzeHub, FuzePlan | flip the type, move the entry to `/apps/<slug>/`, align React. FuzeHub is already on React `^19.0.0`; FuzePlan is on `^18.2.0` and needs the bump. |
+| **Has a frontend, no MF config** | FuzeDeploy, FuzeFinance | add federation build config and expose a module. FuzeFinance is already React `^19.2.0`; FuzeDeploy is `^18.2.0`. |
+| **No frontend package at all** | FuzeBI, FuzeExecutive, FuzeMerchandize, FuzeCall | there is nothing to federate yet. These need a frontend built — at minimum a real stub remote — before the type is anything but aspirational. |
+
+Flipping the manifest string ahead of the build would produce a portal entry that
+resolves to nothing, which is worse than an honest `iframe`: the menu would list a
+product that white-screens. The type changes when the remote exists.
+
+**The same-origin requirement now applies to all 17**, not to a subset. Of the 9
+products that already declare `module-federation`, only FuzeX declares a
+same-origin entry and only FuzeQuality has the mount Ingress live; the other 8
+hand the browser an absolute cross-origin URL.
+
+---
+
+#### The original survey (retained as the measurement)
+
 
 Read from each repo's `registration/manifest.json` at `HEAD` on its default branch
 (repository contents, **not** cluster state — labelled as such deliberately; the

--- a/package-lock.json
+++ b/package-lock.json
@@ -670,6 +670,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@fuzefront/core": "1.0.0",
+        "@fuzefront/feature-flags": "1.0.0",
         "@fuzefront/shared": "1.0.0",
         "@izzywdev/fuzefront-identity": "1.0.0",
         "bcrypt": "^6.0.0",
@@ -18358,13 +18359,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/set-blocking": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
-      "license": "ISC",
-      "optional": true
-    },
     "node_modules/set-cookie-parser": {
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
@@ -24167,6 +24161,10 @@
         "ts-jest": "^29.4.11",
         "tsup": "^8.0.2",
         "typescript": "^5.9.3"
+      },
+      "engines": {
+        "node": ">=24.0.0",
+        "npm": ">=10.0.0"
       },
       "peerDependencies": {
         "express": "^4.22.2"
@@ -31999,6 +31997,7 @@
         "@testing-library/jest-dom": "^6.4.0",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.5.0",
+        "@types/node": "^24.13.3",
         "@types/react": "^19.2.0",
         "@types/react-dom": "^19.2.0",
         "@vitejs/plugin-react": "^4.3.0",
@@ -32010,6 +32009,10 @@
         "vite": "^5.4.0",
         "vite-plugin-dts": "^4.0.0",
         "vitest": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=24.0.0",
+        "npm": ">=10.0.0"
       },
       "peerDependencies": {
         "@fuzefront/design-system": "^1.0.0",
@@ -33371,6 +33374,7 @@
       "version": "1.1.0",
       "dependencies": {
         "@fuzefront/shared": "file:../../shared",
+        "@izzywdev/fuzefront-identity": "file:../../packages/identity",
         "express": "4.19.2",
         "express-rate-limit": "^7.2.0",
         "ioredis": "^5.3.2",

--- a/services/app-registry-service/seed/fuzesocial.manifest.json
+++ b/services/app-registry-service/seed/fuzesocial.manifest.json
@@ -3,13 +3,18 @@
   "slug": "fuzesocial",
   "name": "FuzeSocial",
   "menuLabel": "Social",
-  "description": "Social media automation, scheduling, and cross-platform publishing — Facebook, Instagram, TikTok, YouTube, Reddit, X, and WhatsApp.",
-  "icon": { "kind": "emoji", "value": "📱" },
+  "description": "Social media automation, scheduling, and cross-platform publishing \u2014 Facebook, Instagram, TikTok, YouTube, Reddit, X, and WhatsApp.",
+  "icon": {
+    "kind": "emoji",
+    "value": "\ud83d\udcf1"
+  },
   "mode": "portal",
   "builtin": true,
   "integration": {
-    "type": "iframe",
-    "url": "https://social.prod.fuzefront.com"
+    "type": "module-federation",
+    "remoteEntry": "/apps/fuzesocial/remoteEntry.js",
+    "scope": "fuzesocial",
+    "module": "./App"
   },
   "chrome": {
     "menu": "host",


### PR DESCRIPTION
Four commits. The title used to name only the first, which had stopped being accurate — so here is everything actually in the diff.

---

## 1. `package-lock.json` — a declared dependency missing for one workspace

`backend/security/package.json` declares `@fuzefront/feature-flags`. The committed lock **never recorded it for that workspace**. `npm ci` installs strictly from the lock, so `backend/security` resolved without its feature-flags client — declared, expected at runtime, silently absent.

Checked per workspace rather than assumed:

| workspace | in lock | declared |
|---|---|---|
| `backend` | ✅ | ✅ |
| `backend/applications` | ✅ | ✅ |
| **`backend/security`** | **❌** | ✅ |

**Provenance, stated rather than glossed:** I did not author this resync — it was sitting uncommitted in the working tree. Rather than commit it blind or discard it, I established what it contains. Two changes ride along that I did not cause: an `engines` block added to a package that already declared it (the lock was stale there too), and removal of `set-blocking@2.0.0`, a transitive **optional** dep — that reads as a natural prune from recalculating the tree, but I cannot tie it to a specific manifest change, so it is called out rather than presented as intended.

## 2. `docs/planning/production-conformance.md` — the "Private" column measured the wrong thing

The column headed **"Private (not public)"** recorded exactly one fact — *does this product have its own public hostname* — and that single measurement was then read as the answer to two unrelated questions. Split into two, as a dated third correction rather than an edited-away history:

- **MF remote same-origin (browser).** A `remoteEntry.js` is fetched by the end user's *browser*, so it can never be served in-cluster — "is it private" is not a coherent question about it. What matters is whether it is mounted same-origin under `app.fuzefront.com/apps/<slug>/`.
- **In-cluster S2S.** Whether a server-to-server call resolves inside the cluster instead of leaving it.

Merging them cost information both ways: FuzeQuality read as a near-miss when on the browser dimension it is the **only** full pass in the fleet, and every other row's actual defect — an absolute cross-origin `remoteEntry` — was invisible, because the column never looked at the manifests.

**New §3c, measured:** split-horizon DNS is **absent**. CoreDNS carries no mapping for `*.prod.fuzefront.com` at all ([run 32484802532](https://github.com/izzywdev/FuzeInfra/actions/runs/32484802532)). That makes it **one cluster-level defect owned by FuzeInfra, not fourteen product defects** — now tracked as FuzeInfra#624.

## 3. §1a — the owner's decision, recorded

Every product integrates as `module-federation`. No `iframe`, no `spa`. The old three-type survey is retained beneath it as the measurement of where the fleet stands: **8 of 17 must convert**, and they split into three very different tiers — two already have federation config, two have a frontend but no federation config, and **four have no frontend package at all**.

Flipping the manifest string ahead of the build would put a product in the portal menu that white-screens on click, which is worse than an honest `iframe`. So this commit records the decision and does **not** flip the other eight.

## 4. `seed/fuzesocial.manifest.json` — the seed was wrong, not the manifest

FuzeSocial's own `registration/manifest.json` said `module-federation`; this repo's seed copy said `iframe` with `builtin: true`. Nothing compares the two, so the disagreement survived indefinitely. **The manifest was right.** The seed is corrected, and its entry moved to the same-origin form `/apps/fuzesocial/remoteEntry.js` rather than the absolute `https://social.prod.fuzefront.com` it carried.

---

## Verification

The lockfile claim is verified by workspace-vs-manifest comparison against `HEAD:package-lock.json`; the lock parses. **Full verification is CI's `npm ci` plus the backend and security suites** — that is the only thing that proves the tree installs and resolves, and it is why this is a PR rather than a claim.

CI cannot currently run: the ARC runner fleet is not picking up jobs (FuzeInfra#623).

## Note

The branch was restarted from `master` after #773 squash-merged, per the branch policy — this does not stack on merged history.