### PR TITLE
fix(ci): scope allowed_bots to `claude`, and add a CI queue watchdog that measures progression

### DIFF
--- a/.github/workflows/a2a-maintain.yml
+++ b/.github/workflows/a2a-maintain.yml
@@ -68,13 +68,32 @@ jobs:
         uses: anthropics/claude-code-action@428971d2ecd6e3a7cb0ee0da2a3a8b33fdb3678d  # v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          # Every FuzeFront agent PR is authored by the `claude` bot; dependabot and
-          # github-actions[bot] (governance-sync commit-back) also open/push PRs. Without
-          # this, claude-code-action's actor check hard-fails those runs with
-          # "Workflow initiated by non-human actor ... Add bot to allowed_bots list or use
-          # '*'", turning a2a-maintain red on every bot-authored PR. Allow all bots so the
-          # A2A upkeep stream runs (or no-ops) instead of blocking the PR.
-          allowed_bots: "*"
+          # allowed_bots: scoped to `claude`, deliberately NOT `*`.
+          #
+          # The gate exists because claude-code-action hard-fails a Bot actor:
+          #   "Workflow initiated by non-human actor: claude (type: Bot).
+          #    Add bot to allowed_bots list or use '*' to allow all bots."
+          # Nearly every PR here is pushed by the `claude` bot (governance-sync's
+          # commit-back flips the triggering actor User -> Bot), so the gate fired on
+          # almost all of them -- and it fires LATE, after the prompt is printed and
+          # "Trigger result: true", so a skimmed log looks like the maintainer ran.
+          #
+          # `*` allows EVERY bot, and this repo runs dependabot (.github/dependabot.yml,
+          # package-ecosystem: github-actions). Under `*`, a dependabot PR -- whose body
+          # carries upstream release notes this repo does not author -- can start an
+          # agent run holding ANTHROPIC_API_KEY and repo write. That is the exact
+          # arbitrary-bot-drives-an-agent case the actor gate is for, so widening it to
+          # `*` defeats the gate rather than configuring it.
+          #
+          # `claude` is a LOGIN allowlist matched against the actor with `[bot]` stripped
+          # -- not a vendor or product name. This family's other bot is `fuzeone-bot`,
+          # which triggers only scheduled workflows (governance-nightly, nightly-*), none
+          # of which call this action; adding it here would grant an unused permission.
+          #
+          # The fork case stays closed independently: the trigger is `pull_request` (not
+          # `pull_request_target`), so a fork PR gets no secrets, ANTHROPIC_API_KEY is
+          # empty, and the guard step above skips the run entirely.
+          allowed_bots: "claude"
           prompt: |
             You are the **a2a-maintainer** for this repo (follow `.claude/agents/a2a-maintainer.md`
             exactly — same scope, boundaries, and done-contract). This is an automated CI run on

--- a/.github/workflows/a2a-maintain.yml
+++ b/.github/workflows/a2a-maintain.yml
@@ -105,7 +105,10 @@ jobs:
         id: guard
         env:
           KEY: ${{ secrets.LITELLM_FUZE_KEY }}
-          GATEWAY: http://litellm.fuzeinfra.svc.cluster.local:4000
+          # FUZE_LLM_BASE_URL is the FAMILY-facing name — vendor-agnostic, and the
+          # one knob to change if the gateway ever moves or is replaced. Declared as
+          # a repo/org variable; the LiteLLM address is only the default.
+          GATEWAY: ${{ vars.FUZE_LLM_BASE_URL || 'http://litellm.fuzeinfra.svc.cluster.local:4000' }}
         run: |
           # preflight already proved the key exists and the surface is declared, so
           # anything that fails here is a RUNNER placement problem, not a secrets one.
@@ -146,7 +149,12 @@ jobs:
           # Vendor independence: every agent call leaves through LiteLLM. Set here
           # rather than relying on the action's default provider resolution, which
           # would silently reach api.anthropic.com with a virtual key and 401.
-          ANTHROPIC_BASE_URL: http://litellm.fuzeinfra.svc.cluster.local:4000
+          # NAMING: FUZE_LLM_BASE_URL is what this family declares; ANTHROPIC_BASE_URL
+          # is what the SDK inside claude-code-action actually reads. This is a
+          # mapping, not a rename — renaming the right-hand side would leave the SDK
+          # reading nothing, silently resolving to api.anthropic.com, and 401ing on a
+          # virtual key. The vendor-agnostic name lives on the side we control.
+          ANTHROPIC_BASE_URL: ${{ vars.FUZE_LLM_BASE_URL || 'http://litellm.fuzeinfra.svc.cluster.local:4000' }}
           ANTHROPIC_AUTH_TOKEN: ${{ secrets.LITELLM_FUZE_KEY }}
         with:
           # Routed through LiteLLM for cross-provider failover — this repo holds no

--- a/.github/workflows/a2a-maintain.yml
+++ b/.github/workflows/a2a-maintain.yml
@@ -8,7 +8,20 @@ name: A2A Maintain
 # can't (fork PR / first-time build), it opens a separate `auto-merge`-labelled follow-up
 # PR. It never fabricates a role's product behaviour, never handles creds, never deploys.
 #
-# Requires repo secret ANTHROPIC_API_KEY. No key -> SKIPS (never red). The `a2a-maintainer`
+# Requires repo secret LITELLM_FUZE_KEY (a LiteLLM VIRTUAL key, not a provider key —
+# the family routes every agent call through the gateway so no repo is bound to one
+# vendor, and a key can be revoked centrally).
+#
+# CONTRACT, and it changed. It used to be "no key -> SKIPS (never red)". That made a
+# check which passes by not running: a repo declaring an A2A surface could go
+# indefinitely with that surface unmaintained while the check sat green. The rule now
+# keys off the MANIFEST, because that is what distinguishes an absence from a gap:
+#
+#   a2a.enabled not declared  -> skip. There is no surface; that is the truth.
+#   a2a.enabled true, no key   -> FAIL. A declared surface nobody can maintain.
+#   a2a.enabled true, key set  -> run.
+#
+# The `a2a-maintainer`
 # agent def is stamped by sdlc-bootstrap into .claude/agents/ and reconciled by
 # governance-sync; this workflow just invokes it.
 
@@ -26,20 +39,83 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Runs on a HOSTED runner and always reports. Split out from the maintainer on
+  # purpose: the maintainer itself needs in-cluster access to reach LiteLLM, and a
+  # job on a self-hosted pool that is not serving QUEUES FOREVER with no red X, no
+  # log and no timeout — measured 2026-08-23, 175 jobs queued on `fuzesdlc` with
+  # zero running for 36 hours. A misconfiguration that produces no signal at all is
+  # worse than one that produces a red, so the check that must never be silent runs
+  # where it cannot be silenced.
+  preflight:
+    name: a2a-maintain preflight
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      declared: ${{ steps.check.outputs.declared }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      - name: Is a2a-maintain declared, and can it actually be maintained?
+        id: check
+        env:
+          KEY: ${{ secrets.LITELLM_FUZE_KEY }}
+        shell: bash
+        run: |
+          set -uo pipefail
+          declared=$(python3 -c "import json;print(str((json.load(open('.fuze/manifest.json')).get('a2a') or {}).get('enabled', False)).lower())" 2>/dev/null || echo false)
+          echo "declared=$declared" >> "$GITHUB_OUTPUT"
+
+          if [ "$declared" != "true" ]; then
+            echo "::notice title=a2a-maintain::.fuze/manifest.json does not declare a2a.enabled — nothing to maintain. Skipping is correct here: there is no surface."
+            exit 0
+          fi
+
+          # Declared. From here a missing key is a MISCONFIGURATION, not an
+          # environmental gap, and it fails.
+          #
+          # This workflow used to skip when the key was absent, under a "no key ->
+          # skip, never red" contract. That contract is the vacuous-gate pattern
+          # this repo has spent a sweep removing: it made a check that passes by not
+          # running, so a repo declaring an A2A/MCP surface could go indefinitely
+          # with that surface unmaintained while the check sat green. `gate-authz`
+          # ended in `|| true` and `gate-identifier` shipped an opt-in flag nobody
+          # set; both reached the same place — a check that cannot fail.
+          #
+          # Skipping stays correct for the undeclared case above, because there the
+          # absence of a surface is the truth, not a gap.
+          if [ -z "${KEY:-}" ]; then
+            echo "::error title=a2a-maintain::.fuze/manifest.json declares a2a.enabled=true, but LITELLM_FUZE_KEY is not set — the a2a-maintain surface cannot be maintained and this repo has no way to know it has drifted. Mint a key with FuzeInfra scripts/mint-litellm-fuze-key.sh and add it as the LITELLM_FUZE_KEY repo secret."
+            exit 1
+          fi
+          echo "::notice title=a2a-maintain::a2a declared and LITELLM_FUZE_KEY present."
+
   a2a-maintain:
+    needs: preflight
     # Loop guard: never run on our own maintenance branches.
-    if: ${{ !startsWith(github.event.pull_request.head.ref, 'a2a-maintain/') }}
+    # Two conditions, one key (a duplicate `if:` is a YAML syntax error, not an AND):
+    #   - preflight said the surface is declared. When it is not, there is nothing to
+    #     maintain and the maintainer must not run at all.
+    #   - not our own follow-up branch, or the maintainer re-triggers on its own push.
+    if: >-
+      needs.preflight.outputs.declared == 'true' &&
+      !startsWith(github.event.pull_request.head.ref, 'a2a-maintain/')
     runs-on: ubuntu-latest
     steps:
       - name: Skip if key absent or repo not onboarded
         id: guard
         env:
-          KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          KEY: ${{ secrets.LITELLM_FUZE_KEY }}
+          GATEWAY: http://litellm.fuzeinfra.svc.cluster.local:4000
         run: |
-          if [ ! -f .fuze/manifest.json ] 2>/dev/null; then :; fi
+          # preflight already proved the key exists and the surface is declared, so
+          # anything that fails here is a RUNNER placement problem, not a secrets one.
+          if ! curl -fsS --max-time 10 -o /dev/null "${GATEWAY}/health/liveliness" 2>/dev/null; then
+            echo "::error::LiteLLM gateway ${GATEWAY} is unreachable from this runner. This job must run on a self-hosted in-cluster runner — declare ci.runner in .fuze/manifest.json and re-stamp. The external host is Access-gated on purpose and must not be bypassed."
+            exit 1
+          fi
           if [ -z "$KEY" ]; then
-            echo "::notice::ANTHROPIC_API_KEY not set — A2A maintain skipped (set it to enable)."
-            echo "ok=false" >> "$GITHUB_OUTPUT"
+            echo "::error::LITELLM_FUZE_KEY vanished between preflight and here."
+            exit 1
           else
             echo "ok=true" >> "$GITHUB_OUTPUT"
           fi
@@ -66,8 +142,18 @@ jobs:
       - name: Run a2a-maintainer
         if: steps.guard.outputs.ok == 'true' && steps.marker.outputs.run == 'true'
         uses: anthropics/claude-code-action@428971d2ecd6e3a7cb0ee0da2a3a8b33fdb3678d  # v1
+        env:
+          # Vendor independence: every agent call leaves through LiteLLM. Set here
+          # rather than relying on the action's default provider resolution, which
+          # would silently reach api.anthropic.com with a virtual key and 401.
+          ANTHROPIC_BASE_URL: http://litellm.fuzeinfra.svc.cluster.local:4000
+          ANTHROPIC_AUTH_TOKEN: ${{ secrets.LITELLM_FUZE_KEY }}
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Routed through LiteLLM for cross-provider failover — this repo holds no
+          # provider key. Same shape as gate-code-review in harden-gate.yml: the CLI
+          # reads ANTHROPIC_AUTH_TOKEN, some SDK paths still read ANTHROPIC_API_KEY,
+          # so both are set to the virtual key.
+          anthropic_api_key: ${{ secrets.LITELLM_FUZE_KEY }}
           # allowed_bots: scoped to `claude`, deliberately NOT `*`.
           #
           # The gate exists because claude-code-action hard-fails a Bot actor:

--- a/.github/workflows/ci-queue-watch.yml
+++ b/.github/workflows/ci-queue-watch.yml
@@ -1,0 +1,76 @@
+name: CI Queue Watchdog
+
+# Answers one question, every 15 minutes, for every runner pool in the fleet:
+# is it PROGRESSING? See scripts/ci_queue_watch.py for why that is the measure
+# and not "how long has this job been waiting".
+#
+# RUNS ON ubuntu-latest, DELIBERATELY. A watchdog scheduled onto the runner
+# fleet it monitors cannot report that fleet being down -- it just queues with
+# everything else and stays silent, which is the exact failure it exists to
+# catch. This repo is public, so GitHub-hosted minutes are unmetered and this
+# job is independent of ARC and of the account's Actions budget.
+
+on:
+  schedule:
+    - cron: '*/15 * * * *'
+  workflow_dispatch:
+    inputs:
+      stall_minutes:
+        description: 'Queued work plus no start within this many minutes = STALLED'
+        required: false
+        default: '30'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-queue-watch
+  cancel-in-progress: true
+
+jobs:
+  watch:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      # Reading another repository's Actions queue needs a token with fleet
+      # scope; the job's own GITHUB_TOKEN is scoped to this repository alone and
+      # would report a fleet of one. No token means this watchdog cannot do its
+      # job -- say so loudly and exit 0. Never red a scheduled run on a missing
+      # secret: an environmental condition must not look like a fleet outage,
+      # which is the same inversion the actor gate caused in a2a-maintain.
+      - name: Check for a fleet-scoped token
+        id: tok
+        env:
+          FLEET_READ_PAT: ${{ secrets.FLEET_READ_PAT }}
+        run: |
+          if [ -z "$FLEET_READ_PAT" ]; then
+            echo "::warning::FLEET_READ_PAT is not set — the watchdog can only see this repo, so it is skipping. Set a PAT with read access to Actions across the fleet (scope: repo, or fine-grained Actions:read on the Fuze* repos)."
+            echo "ok=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "ok=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Observe the fleet CI queue
+        if: steps.tok.outputs.ok == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.FLEET_READ_PAT }}
+          STALL: ${{ inputs.stall_minutes || '30' }}
+        run: |
+          set -o pipefail
+          python3 scripts/ci_queue_watch.py \
+            --stall-minutes "$STALL" \
+            --fail-on-stall \
+            | tee queue.txt
+          {
+            echo '## Fleet CI queue'
+            echo
+            echo '```'
+            cat queue.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci-queue-watch.yml
+++ b/.github/workflows/ci-queue-watch.yml
@@ -41,8 +41,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: '3.12'
       - name: Run watchdog self-tests
@@ -58,9 +58,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: '3.12'
 

--- a/.github/workflows/ci-queue-watch.yml
+++ b/.github/workflows/ci-queue-watch.yml
@@ -13,6 +13,11 @@ name: CI Queue Watchdog
 on:
   schedule:
     - cron: '*/15 * * * *'
+  pull_request:
+    paths:
+      - 'scripts/ci_queue_watch.py'
+      - 'scripts/__tests__/test_ci_queue_watch.py'
+      - '.github/workflows/ci-queue-watch.yml'
   workflow_dispatch:
     inputs:
       stall_minutes:
@@ -28,7 +33,28 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Self-tests run on any PR touching the watchdog, and they assert the script
+  # REFUSES when it cannot see the fleet -- not merely that it reports correctly
+  # when it can. A watchdog wired to nothing passes every "does it work" test
+  # ever written, which is exactly how the vacuous gates in this family survived.
+  selftest:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Run watchdog self-tests
+        run: |
+          test -f scripts/__tests__/test_ci_queue_watch.py || {
+            echo "::error::watchdog self-tests are missing — refusing to ship the watchdog without them"
+            exit 1
+          }
+          python3 -m unittest discover -s scripts/__tests__ -p 'test_ci_queue_watch*.py' -v
+
   watch:
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/.github/workflows/mcp-maintain.yml
+++ b/.github/workflows/mcp-maintain.yml
@@ -75,13 +75,32 @@ jobs:
         uses: anthropics/claude-code-action@428971d2ecd6e3a7cb0ee0da2a3a8b33fdb3678d  # v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          # Every FuzeFront agent PR is authored by the `claude` bot; dependabot and
-          # github-actions[bot] (governance-sync commit-back) also open/push PRs. Without
-          # this, claude-code-action's actor check hard-fails those runs with
-          # "Workflow initiated by non-human actor ... Add bot to allowed_bots list or use
-          # '*'", turning mcp-maintain red on every bot-authored PR. Allow all bots so the
-          # MCP upkeep stream runs (or no-ops) instead of blocking the PR — mirrors a2a-maintain.
-          allowed_bots: "*"
+          # allowed_bots: scoped to `claude`, deliberately NOT `*`.
+          #
+          # The gate exists because claude-code-action hard-fails a Bot actor:
+          #   "Workflow initiated by non-human actor: claude (type: Bot).
+          #    Add bot to allowed_bots list or use '*' to allow all bots."
+          # Nearly every PR here is pushed by the `claude` bot (governance-sync's
+          # commit-back flips the triggering actor User -> Bot), so the gate fired on
+          # almost all of them -- and it fires LATE, after the prompt is printed and
+          # "Trigger result: true", so a skimmed log looks like the maintainer ran.
+          #
+          # `*` allows EVERY bot, and this repo runs dependabot (.github/dependabot.yml,
+          # package-ecosystem: github-actions). Under `*`, a dependabot PR -- whose body
+          # carries upstream release notes this repo does not author -- can start an
+          # agent run holding ANTHROPIC_API_KEY and repo write. That is the exact
+          # arbitrary-bot-drives-an-agent case the actor gate is for, so widening it to
+          # `*` defeats the gate rather than configuring it.
+          #
+          # `claude` is a LOGIN allowlist matched against the actor with `[bot]` stripped
+          # -- not a vendor or product name. This family's other bot is `fuzeone-bot`,
+          # which triggers only scheduled workflows (governance-nightly, nightly-*), none
+          # of which call this action; adding it here would grant an unused permission.
+          #
+          # The fork case stays closed independently: the trigger is `pull_request` (not
+          # `pull_request_target`), so a fork PR gets no secrets, ANTHROPIC_API_KEY is
+          # empty, and the guard step above skips the run entirely.
+          allowed_bots: "claude"
           prompt: |
             You are the **mcp-maintainer** for this repo (follow `.claude/agents/mcp-maintainer.md`
             exactly — same scope, boundaries, and done-contract). This is an automated CI run on

--- a/.github/workflows/mcp-maintain.yml
+++ b/.github/workflows/mcp-maintain.yml
@@ -105,7 +105,10 @@ jobs:
         id: guard
         env:
           KEY: ${{ secrets.LITELLM_FUZE_KEY }}
-          GATEWAY: http://litellm.fuzeinfra.svc.cluster.local:4000
+          # FUZE_LLM_BASE_URL is the FAMILY-facing name — vendor-agnostic, and the
+          # one knob to change if the gateway ever moves or is replaced. Declared as
+          # a repo/org variable; the LiteLLM address is only the default.
+          GATEWAY: ${{ vars.FUZE_LLM_BASE_URL || 'http://litellm.fuzeinfra.svc.cluster.local:4000' }}
         run: |
           # preflight already proved the key exists and the surface is declared, so
           # anything that fails here is a RUNNER placement problem, not a secrets one.
@@ -150,7 +153,12 @@ jobs:
           # Vendor independence: every agent call leaves through LiteLLM. Set here
           # rather than relying on the action's default provider resolution, which
           # would silently reach api.anthropic.com with a virtual key and 401.
-          ANTHROPIC_BASE_URL: http://litellm.fuzeinfra.svc.cluster.local:4000
+          # NAMING: FUZE_LLM_BASE_URL is what this family declares; ANTHROPIC_BASE_URL
+          # is what the SDK inside claude-code-action actually reads. This is a
+          # mapping, not a rename — renaming the right-hand side would leave the SDK
+          # reading nothing, silently resolving to api.anthropic.com, and 401ing on a
+          # virtual key. The vendor-agnostic name lives on the side we control.
+          ANTHROPIC_BASE_URL: ${{ vars.FUZE_LLM_BASE_URL || 'http://litellm.fuzeinfra.svc.cluster.local:4000' }}
           ANTHROPIC_AUTH_TOKEN: ${{ secrets.LITELLM_FUZE_KEY }}
         with:
           # Routed through LiteLLM for cross-provider failover — this repo holds no

--- a/.github/workflows/mcp-maintain.yml
+++ b/.github/workflows/mcp-maintain.yml
@@ -14,7 +14,16 @@ name: MCP Maintain
 # data directly. Different surfaces, different contracts, different failure modes — so
 # one agent per surface rather than one that half-understands both.
 #
-# Requires repo secret ANTHROPIC_API_KEY. No key -> SKIPS (never red).
+# Requires repo secret LITELLM_FUZE_KEY (a LiteLLM VIRTUAL key, not a provider key —
+# the family routes every agent call through the gateway so no repo is bound to one
+# vendor, and a key can be revoked centrally).
+#
+# CONTRACT, and it changed. It used to be "no key -> SKIPS (never red)", which made a
+# check that passes by not running. The rule now keys off the MANIFEST:
+#
+#   mcp.enabled not declared  -> skip. There is no surface; that is the truth.
+#   mcp.enabled true, no key   -> FAIL. A declared surface nobody can maintain.
+#   mcp.enabled true, key set  -> run.
 
 on:
   pull_request:
@@ -30,9 +39,66 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Runs on a HOSTED runner and always reports. Split out from the maintainer on
+  # purpose: the maintainer itself needs in-cluster access to reach LiteLLM, and a
+  # job on a self-hosted pool that is not serving QUEUES FOREVER with no red X, no
+  # log and no timeout — measured 2026-08-23, 175 jobs queued on `fuzesdlc` with
+  # zero running for 36 hours. A misconfiguration that produces no signal at all is
+  # worse than one that produces a red, so the check that must never be silent runs
+  # where it cannot be silenced.
+  preflight:
+    name: mcp-maintain preflight
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      declared: ${{ steps.check.outputs.declared }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      - name: Is mcp-maintain declared, and can it actually be maintained?
+        id: check
+        env:
+          KEY: ${{ secrets.LITELLM_FUZE_KEY }}
+        shell: bash
+        run: |
+          set -uo pipefail
+          declared=$(python3 -c "import json;print(str((json.load(open('.fuze/manifest.json')).get('mcp') or {}).get('enabled', False)).lower())" 2>/dev/null || echo false)
+          echo "declared=$declared" >> "$GITHUB_OUTPUT"
+
+          if [ "$declared" != "true" ]; then
+            echo "::notice title=mcp-maintain::.fuze/manifest.json does not declare mcp.enabled — nothing to maintain. Skipping is correct here: there is no surface."
+            exit 0
+          fi
+
+          # Declared. From here a missing key is a MISCONFIGURATION, not an
+          # environmental gap, and it fails.
+          #
+          # This workflow used to skip when the key was absent, under a "no key ->
+          # skip, never red" contract. That contract is the vacuous-gate pattern
+          # this repo has spent a sweep removing: it made a check that passes by not
+          # running, so a repo declaring an A2A/MCP surface could go indefinitely
+          # with that surface unmaintained while the check sat green. `gate-authz`
+          # ended in `|| true` and `gate-identifier` shipped an opt-in flag nobody
+          # set; both reached the same place — a check that cannot fail.
+          #
+          # Skipping stays correct for the undeclared case above, because there the
+          # absence of a surface is the truth, not a gap.
+          if [ -z "${KEY:-}" ]; then
+            echo "::error title=mcp-maintain::.fuze/manifest.json declares mcp.enabled=true, but LITELLM_FUZE_KEY is not set — the mcp-maintain surface cannot be maintained and this repo has no way to know it has drifted. Mint a key with FuzeInfra scripts/mint-litellm-fuze-key.sh and add it as the LITELLM_FUZE_KEY repo secret."
+            exit 1
+          fi
+          echo "::notice title=mcp-maintain::mcp declared and LITELLM_FUZE_KEY present."
+
   mcp-maintain:
+    needs: preflight
     # Loop guard: never run on our own maintenance branches.
-    if: ${{ !startsWith(github.event.pull_request.head.ref, 'mcp-maintain/') }}
+    # Two conditions, one key (a duplicate `if:` is a YAML syntax error, not an AND):
+    #   - preflight said the surface is declared. When it is not, there is nothing to
+    #     maintain and the maintainer must not run at all.
+    #   - not our own follow-up branch, or the maintainer re-triggers on its own push.
+    if: >-
+      needs.preflight.outputs.declared == 'true' &&
+      !startsWith(github.event.pull_request.head.ref, 'mcp-maintain/')
     runs-on: ubuntu-latest
     steps:
       - name: Skip if key absent
@@ -41,8 +107,8 @@ jobs:
           KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
           if [ -z "$KEY" ]; then
-            echo "::notice::ANTHROPIC_API_KEY not set — MCP maintain skipped (set it to enable)."
-            echo "ok=false" >> "$GITHUB_OUTPUT"
+            echo "::error::LITELLM_FUZE_KEY vanished between preflight and here."
+            exit 1
           else
             echo "ok=true" >> "$GITHUB_OUTPUT"
           fi
@@ -73,8 +139,18 @@ jobs:
       - name: Run mcp-maintainer
         if: steps.guard.outputs.ok == 'true' && steps.marker.outputs.run == 'true'
         uses: anthropics/claude-code-action@428971d2ecd6e3a7cb0ee0da2a3a8b33fdb3678d  # v1
+        env:
+          # Vendor independence: every agent call leaves through LiteLLM. Set here
+          # rather than relying on the action's default provider resolution, which
+          # would silently reach api.anthropic.com with a virtual key and 401.
+          ANTHROPIC_BASE_URL: http://litellm.fuzeinfra.svc.cluster.local:4000
+          ANTHROPIC_AUTH_TOKEN: ${{ secrets.LITELLM_FUZE_KEY }}
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Routed through LiteLLM for cross-provider failover — this repo holds no
+          # provider key. Same shape as gate-code-review in harden-gate.yml: the CLI
+          # reads ANTHROPIC_AUTH_TOKEN, some SDK paths still read ANTHROPIC_API_KEY,
+          # so both are set to the virtual key.
+          anthropic_api_key: ${{ secrets.LITELLM_FUZE_KEY }}
           # allowed_bots: scoped to `claude`, deliberately NOT `*`.
           #
           # The gate exists because claude-code-action hard-fails a Bot actor:

--- a/.github/workflows/mcp-maintain.yml
+++ b/.github/workflows/mcp-maintain.yml
@@ -104,8 +104,15 @@ jobs:
       - name: Skip if key absent
         id: guard
         env:
-          KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          KEY: ${{ secrets.LITELLM_FUZE_KEY }}
+          GATEWAY: http://litellm.fuzeinfra.svc.cluster.local:4000
         run: |
+          # preflight already proved the key exists and the surface is declared, so
+          # anything that fails here is a RUNNER placement problem, not a secrets one.
+          if ! curl -fsS --max-time 10 -o /dev/null "${GATEWAY}/health/liveliness" 2>/dev/null; then
+            echo "::error::LiteLLM gateway ${GATEWAY} is unreachable from this runner. This job must run on a self-hosted in-cluster runner — declare ci.runner in .fuze/manifest.json and re-stamp. The external host is Access-gated on purpose and must not be bypassed."
+            exit 1
+          fi
           if [ -z "$KEY" ]; then
             echo "::error::LITELLM_FUZE_KEY vanished between preflight and here."
             exit 1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,6 +147,67 @@ This is not cosmetic. Each worktree is a full checkout (~2k files, plus `node_mo
 
 **This is also why the continuous-push rule matters twice over**: an agent that holds work only on local disk can have its worktree reaped-blocked (skipped, cluttering the box) and, if the box is wiped, lose the work entirely. Push early — the reaper only cleans what is safely on origin.
 
+## `slug` and the federated serve path are INDEPENDENT — stop deriving one from the other
+
+This has been re-litigated four times across the fleet, each time by someone reasoning
+from a document instead of from the code, and each round mutated live manifests. The
+code settles it in one line.
+
+**`frontend/src/utils/loadFederatedApp.ts:71` is the entire mechanism:**
+
+```ts
+const resolved = new URL(remoteEntry, origin)
+```
+
+The host resolves `integration.remoteEntry` against its own origin and loads it. **The
+slug is not an input.** No code path anywhere derives a serve path from a slug, and none
+derives a slug from a path. The `/apps/<slug>/…` phrasing in that file's doc comment is
+describing a habit, not a contract — reading it as a contract is what started this.
+
+### The two rules that follow
+
+**1. `slug` is immutable and is never edited by any PR, in either direction.** Owner
+ruling 2026-08-19 (`packages/onboarding-kit/README.md` §"prefix ON the slug, OFF the
+display string"): the field is *"not checked, in either direction"*, and *"None of these
+are to be migrated"* — naming `deploy`, `call`, `executive`, `finance`, `keys`, `market`,
+`picker` as de-prefixed slugs to leave alone and `fuzex`, `fuzebi` as prefixed ones not to
+be "corrected". Editing a slug does not rename an app: `PUT /apps/{slug}` has no rename
+operation, so a redeploy **registers a second app** and strands the first — orphaned
+Permit grants, CASCADE-deleted `app_installations` rows, a ghost tile in the launcher.
+The guidance to prefix applies to a **genuinely new** product only, and is guidance, not
+a gate. `docs/runbooks/app-slug-deprefix-migration.md` is RETIRED; its tables are a
+historical snapshot, not a worklist.
+
+**2. The serve path is free-form, and must agree with itself across four layers.** A
+mismatch at any one of them yields the signature failure — `remoteEntry.js` returns 200
+and every chunk it references 404s, so the panel is blank while the healthcheck is green:
+
+| Layer | File |
+|---|---|
+| `integration.remoteEntry` | `registration/manifest.json` **and** its vendored Helm copy (kept byte-identical) |
+| Vite/webpack `base` | the remote's `vite.config.*` (with `assetsDir: ''`) |
+| Ingress `path` | the chart's federated-mount Ingress |
+| nginx `location` / `alias` | the chart's nginx ConfigMap, or the baked `nginx.conf` |
+
+**Convention, to keep one mental model: use `/apps/<the repo's existing slug>/`** —
+whatever that slug already is, prefixed or not. It is derivable, needs no judgement, and
+matches what most repos already assume. It is a naming convention for a free variable,
+**not** evidence about the slug: never edit a slug to make it match a path. Fix the path.
+
+### Two things that are NOT evidence of a slug error
+
+- **`routing.path` differing from `slug`** (e.g. slug `plan`, path `/app/fuzeplan`).
+  Independent fields; this is normal and was misread as a contradiction.
+- **`backend/src/routes/appRegistry.ts` deriving a slug from a name.** That is the
+  CI/local-only fallback, gated on `APP_REGISTRY_LOCAL_ADAPTER=1`, default off. Production
+  is `backend/applications/src/app-registry/service.ts`, which stores `slug: row.slug`
+  verbatim. Citing the fallback as the production mechanism caused three wrong migrations.
+
+Also unconsumed, and inconsistent with `builtins.ts`: `services/app-registry-service/seed/*.manifest.json`
+is a documentation fixture (grep finds only comments referencing it). Only the four entries
+in `BUILTIN_MANIFESTS` take their slug from FuzeFront's seed — `fuzesocial`, `fuzeagent`,
+`clock`, `fuzequality`. Every other product self-registers and owns its own slug.
+
 ## Entity identifiers — the owning service mints them, and references carry their type
 
 Full standard: **`governance/identifier-standard.md`** (enforced by `gate-identifier`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -191,6 +191,41 @@ Every agent-created branch must reach one of these terminal states — never lef
 
 Draft PRs are only legitimate when a session explicitly labels them `wip`, `hold`, or `blocked`.
 
+## FIX is the rule — reporting a defect is not addressing it
+
+**Finding a problem obliges you to fix it, not to describe it.** Pinning a
+regression test, filing an issue, adding a `::warning::`, writing it into a
+table, or telling the user about it are all ways of *recording* a defect. None
+of them is a fix, and a repo full of well-documented known-broken things is the
+state this rule exists to prevent.
+
+This is not a style preference — it is the difference between the two halves of
+every failure this codebase has accumulated. A vacuous gitleaks config, a
+`gate-authz` ending in `|| true`, a `gate-identifier` flag nobody set, an
+`a2a-maintain` that skipped when unkeyed: every one of them was *known*. What
+was missing was not knowledge, it was the fix.
+
+**So: when you find a defect, fix it — however many agents and however many
+branches that takes.** Fan out one agent per repo if the defect is fleet-wide.
+Branch sub-branches off sub-branches, merge them upward, and PR the result to
+master. Scale is not a reason to downgrade a fix into a report.
+
+The narrow, honest exceptions, and they must be *stated* rather than assumed:
+
+- **You genuinely cannot** — the fix needs a credential, a cluster, or an
+  approval this session does not hold. Then produce the exact commands or PR
+  that someone with those rights can apply, and name what is blocked. "I filed
+  an issue" is only acceptable when the issue is addressed to someone who *can*
+  act and the action is named precisely.
+- **The fix is out of the requested scope and would change behaviour the user
+  did not ask about.** Say so in one sentence and offer it; do not silently
+  widen the blast radius of a task.
+- **You are not the owner.** FuzeInfra is never edited from a consuming repo.
+  Delegate via `@claude`, with the concrete change spelled out.
+
+Everything else gets fixed. A finding without a fix or one of those three
+statements attached is unfinished work, not a deliverable.
+
 ## Done
 
 Finish work as a **merged PR**, not local commits — but respect the deploy window above. Every domain agent reports `SCOPE DONE (verified)` + `OUT OF SCOPE — NOT DONE`; only the orchestrator calls a feature complete.

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -421,14 +421,45 @@ export async function buildHealthPayload() {
   }
 }
 
-// Main health check endpoint (without /api prefix)
-app.get('/health', async (req, res) => {
+// ── LIVENESS: /health. Always 200 while the process is alive. ───────────────
+//
+// Deliberately does NOT reflect `status: 'degraded'` in its HTTP code, and that
+// is the whole point of the split below. This path backs the LIVENESS probe, and
+// a liveness probe that fails on a downstream dependency turns a database blip
+// into a restart loop: the kubelet kills a process that was working fine, the
+// replacement cannot reach the database either, and the pod crashloops while the
+// actual fault is elsewhere. Restarting never fixes a dependency.
+//
+// The payload still carries the real verdict for humans and dashboards.
+app.get('/health', async (_req, res) => {
   res.json(await buildHealthPayload())
 })
 
-// Add /api/health endpoint to match frontend expectations
-app.get('/api/health', async (req, res) => {
+app.get('/api/health', async (_req, res) => {
   res.json(await buildHealthPayload())
+})
+
+// ── READINESS: /ready. 503 when a dependency is down. ───────────────────────
+//
+// THE BUG THIS FIXES. `buildHealthPayload()` computes `status: 'ok' | 'degraded'`
+// from the database and the Permit sync — and then `res.json()` returned HTTP 200
+// either way. Both the readiness AND liveness probes pointed at /health, so the
+// kubelet saw 200, marked the pod Ready, the ReplicaSet reported fully available,
+// and **Argo CD reported the Application Healthy while the database was
+// disconnected.** The check computed the right answer and discarded it.
+//
+// Argo has no HTTP health polling and no `healthPath` property — its built-in
+// Deployment assessment reads Kubernetes resource status, which comes from these
+// probes. So the probe IS the Argo health signal, and the only way to make Argo
+// report Degraded is to make readiness fail. No Lua and no custom resource
+// health check is required for this; both would be the wrong tool.
+//
+// Readiness failing removes the pod from the Service endpoints, which is correct:
+// a backend that cannot reach its database cannot serve requests, and should not
+// receive them.
+app.get(['/ready', '/api/ready'], async (_req, res) => {
+  const payload = await buildHealthPayload()
+  res.status(payload.status === 'ok' ? 200 : 503).json(payload)
 })
 
 // Error handling middleware

--- a/deploy/argocd/project.yaml
+++ b/deploy/argocd/project.yaml
@@ -1,0 +1,76 @@
+# =============================================================================
+# Argo CD AppProject — fuzefront
+# =============================================================================
+# MOVED HERE FROM FuzeInfra (argocd/projects/fuzefront.yaml) as part of the
+# family's decentralisation: a repo owns its own deploy/** — Helm, Argo
+# Applications, SealedSecrets, and now its AppProject. FuzeInfra's
+# `argocd-register` workflow applies this directory once (its `path` input is
+# documented as holding "Argo Application/AppProject manifests" and it runs
+# `kubectl apply -f "$DIR/"`), after which Argo polls and self-syncs from here.
+#
+# FuzeInfra's copy MUST BE DELETED once this lands. Until then both exist and
+# registration is last-write-wins, so whichever ran most recently is what the
+# cluster holds. Tracked in FuzeInfra#625.
+#
+# ── THE ONE RULE THAT IS NOT NEGOTIABLE ─────────────────────────────────────
+# `fuzeinfra` IS DELIBERATELY NOT A DESTINATION, and this is the whole reason
+# the project was centralised in the first place. FuzeFront previously
+# self-created a `fuzefront` project that granted itself the `fuzeinfra`
+# namespace, and used it to redeploy a DUPLICATE FuzeInfra: split-brain
+# Postgres/Kafka, control-plane saturation, cluster-wide 502
+# (FuzeFront#95 / FuzeInfra#93, boundary added in FuzeInfra#99).
+#
+# Owning this file again does not re-open that door — the boundary travels with
+# the file. A consumer that needs an infra service reaches it over in-cluster
+# service DNS (`<svc>.fuzeinfra.svc.cluster.local`); cross-namespace networking
+# needs no Argo destination. If you ever find yourself wanting `fuzeinfra` here,
+# the thing you actually want is a DNS name.
+#
+# ── LEAST PRIVILEGE, DERIVED FROM THIS REPO'S OWN CHARTS ────────────────────
+# FuzeInfra's copy carried `clusterResourceWhitelist: {group: "*", kind: "*"}`,
+# which let an Application in this project create ClusterRoles,
+# ClusterRoleBindings and CRDs — and, combined with the `argocd` destination
+# below, modify AppProjects, including this one. The object whose sole purpose
+# is to BE the security boundary could be used to rewrite that boundary.
+#
+# Measured instead: every `kind:` rendered by this repo's three charts
+# (deploy/helm/fuzefront, deploy/helm/unleash,
+# FuzeQuality/deploy/helm/fuzequality). The only cluster-scoped one is
+# Namespace. Role and RoleBinding are namespaced, not cluster-scoped.
+# So the whitelist is exactly Namespace. Re-derive it if a chart starts
+# rendering something new — do not widen it back to a wildcard.
+# =============================================================================
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: fuzefront
+  namespace: argocd
+spec:
+  description: FuzeFront products (consumers of FuzeInfra) — may deploy ONLY into their assigned namespaces.
+  sourceRepos:
+    - https://github.com/izzywdev/FuzeFront.git
+  destinations:
+    # The product's workloads.
+    - namespace: fuzefront
+      server: https://kubernetes.default.svc
+    # FuzeQuality is maintained in this repository but has an isolated workload
+    # namespace and consumes shared infrastructure over service DNS.
+    - namespace: fuzequality
+      server: https://kubernetes.default.svc
+    # JUSTIFIED, and only because this repo genuinely has an app-of-apps:
+    # deploy/argocd/app-of-apps.yaml is an Application whose destination
+    # namespace is `argocd` and which creates the child Applications under
+    # deploy/argocd/applications/. A repo WITHOUT an app-of-apps must not list
+    # this — it is write access to the namespace where AppProjects live.
+    - namespace: argocd
+      server: https://kubernetes.default.svc
+    # NOTE: `fuzeinfra` is deliberately absent. See the rule above.
+  clusterResourceWhitelist:
+    # Narrowed from `*/*`. FuzeQuality's chart renders a Namespace; nothing in
+    # this repo renders any other cluster-scoped kind.
+    - group: ''
+      kind: Namespace
+  namespaceResourceWhitelist:
+    # Unrestricted is fine here — it is already scoped to the destinations above.
+    - group: '*'
+      kind: '*'

--- a/deploy/helm/fuzefront/templates/applications.yaml
+++ b/deploy/helm/fuzefront/templates/applications.yaml
@@ -109,8 +109,13 @@ spec:
                   optional: true
             {{- end }}
           readinessProbe:
+            # /ready, not /health: readiness must reflect dependency state so a
+            # degraded backend leaves the Service endpoints AND Argo's built-in
+            # Deployment assessment reports Degraded. /health stays 200-always and
+            # backs liveness below — a liveness probe that fails on a downstream
+            # dependency turns a database blip into a restart loop.
             httpGet:
-              path: /health
+              path: /ready
               port: http
             initialDelaySeconds: 15
             periodSeconds: 10

--- a/scripts/__tests__/test_ci_queue_watch.py
+++ b/scripts/__tests__/test_ci_queue_watch.py
@@ -119,6 +119,41 @@ class VerdictLogic(unittest.TestCase):
             self.assertFalse(self.v(queued=0, running=0, oldest=0, last=last)[1])
 
 
+class RequestSurface(unittest.TestCase):
+    """urllib speaks more than HTTP, and repo names reach request paths.
+
+    Neither is a live vulnerability here -- the base URL comes from env and the
+    names come from the API -- but "it came from an API" is precisely the
+    assumption that produces traversal bugs, so both are enforced rather than
+    reasoned about.
+    """
+
+    def setUp(self):
+        import importlib.util
+        spec = importlib.util.spec_from_file_location("ciqw", SCRIPT)
+        self.m = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(self.m)
+
+    def test_non_http_scheme_is_refused(self):
+        r = run(["--repos", "izzywdev/FuzeFront"], token="pretend-token")
+        # the harness points the API at http://127.0.0.1:9, so this asserts the
+        # allowed scheme still gets through to a (failed) connection
+        self.assertNotIn("refusing non-HTTP scheme", r.stdout + r.stderr)
+
+    def test_file_scheme_never_reaches_urlopen(self):
+        env = dict(os.environ, CI_QUEUE_WATCH_API="file:///etc", GITHUB_TOKEN="x")
+        r = subprocess.run([sys.executable, SCRIPT, "--repos", "izzywdev/FuzeFront"],
+                           capture_output=True, text=True, env=env, timeout=120)
+        self.assertIn("refusing non-HTTP scheme", r.stderr + r.stdout)
+
+    def test_repo_name_shape_is_enforced(self):
+        self.assertTrue(self.m._valid_repo("izzywdev/FuzeFront"))
+        self.assertTrue(self.m._valid_repo("izzywdev/fuze-market.v2"))
+        for bad in ("../../etc/passwd", "izzywdev/Fuze Front", "no-slash",
+                    "a/b/c", "izzywdev/x?y=1", ""):
+            self.assertFalse(self.m._valid_repo(bad), bad)
+
+
 class StartsThatNeverHappened(unittest.TestCase):
     """runner_id 0 == the job was never picked up. Counting those as starts is
     how a dead pool reads as alive, so the filter is asserted directly."""

--- a/scripts/__tests__/test_ci_queue_watch.py
+++ b/scripts/__tests__/test_ci_queue_watch.py
@@ -1,0 +1,144 @@
+"""Tests for the fleet CI queue watchdog.
+
+These exist because of one property that is invisible on inspection: a
+watchdog that cannot see the fleet stays GREEN. It reports no stalls, because
+it observed no pools, and green reads as "the fleet is fine". That is the same
+shape as the gitleaks config with no rules and the Semgrep gate ending in
+`|| true` — a check satisfied by not doing its job.
+
+So the load-bearing test is `test_token_present_but_no_fleet_is_a_hard_failure`,
+which asserts the script REFUSES rather than shrugs. A test that only confirmed
+it reports correctly on a healthy fleet would pass just as happily against a
+watchdog wired to nothing.
+"""
+import json
+import os
+import subprocess
+import sys
+import unittest
+
+REPO = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+SCRIPT = os.path.join(REPO, "scripts", "ci_queue_watch.py")
+sys.path.insert(0, os.path.join(REPO, "scripts"))
+
+
+def run(args, token=None):
+    env = dict(os.environ)
+    env.pop("GITHUB_TOKEN", None)
+    env.pop("GH_TOKEN", None)
+    if token:
+        env["GITHUB_TOKEN"] = token
+    # Point discovery at a host that cannot answer, so no test touches the
+    # network or depends on the real fleet's current state.
+    env["CI_QUEUE_WATCH_API"] = "http://127.0.0.1:9"
+    return subprocess.run([sys.executable, SCRIPT] + args,
+                          capture_output=True, text=True, env=env, timeout=120)
+
+
+class BlindWatchdogMustNotLookHealthy(unittest.TestCase):
+    """The regression this file exists for."""
+
+    def test_token_present_but_no_fleet_is_a_hard_failure(self):
+        """THE test. A token is set, so the account IS reachable in principle;
+        discovering nothing therefore means the token's scope is wrong, not that
+        the fleet is empty. Exiting 0 here would paint a blind watchdog green."""
+        r = run([], token="pretend-token")
+        self.assertEqual(r.returncode, 2, r.stderr)
+        self.assertIn("::error::", r.stderr)
+        self.assertIn("scope problem", r.stderr)
+
+    def test_no_token_skips_cleanly(self):
+        """The mirror image, and equally deliberate: with no credential there is
+        nothing to misconfigure. An environmental gap must never render as an
+        outage — that inversion is what made a2a-maintain's red meaningless."""
+        r = run([])
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.assertIn("::warning::", r.stderr)
+        self.assertNotIn("::error::", r.stderr)
+
+    def test_explicit_repo_list_bypasses_the_floor(self):
+        """--repos is an operator saying exactly what to watch, so the
+        fleet-size floor does not apply; otherwise debugging a single repo
+        would be impossible."""
+        r = run(["--repos", "izzywdev/FuzeFront", "--min-repos", "99"],
+                token="pretend-token")
+        self.assertNotEqual(r.returncode, 2, r.stderr)
+
+
+class VerdictLogic(unittest.TestCase):
+    """Pure decision table — the part that must not regress to wait-time."""
+
+    def setUp(self):
+        import importlib.util
+        spec = importlib.util.spec_from_file_location("ciqw", SCRIPT)
+        self.m = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(self.m)
+
+    def v(self, queued, running, oldest, last, stall=30):
+        return self.m.verdict({"queued": queued, "running": running,
+                               "oldest_wait": oldest, "last_start": last}, stall)
+
+    def test_deep_queue_that_is_moving_is_not_an_incident(self):
+        """The whole point. 500 jobs queued behind 4 runners is capacity, and
+        paging on it is how the real alert gets muted."""
+        v, stall = self.v(queued=500, running=4, oldest=900, last=2)
+        self.assertFalse(stall)
+        self.assertEqual(v, "SATURATED")
+
+    def test_long_wait_alone_never_stalls(self):
+        """A four-day wait on a pool that started a job a minute ago is healthy.
+        This is the exact case a wait-time threshold gets wrong, and it was
+        observed live: ubuntu-latest, 5698m oldest wait, serving normally."""
+        v, stall = self.v(queued=6, running=1, oldest=5698, last=1)
+        self.assertFalse(stall)
+
+    def test_queued_with_no_recent_start_is_stalled(self):
+        v, stall = self.v(queued=121, running=0, oldest=1180, last=2120)
+        self.assertTrue(stall)
+        self.assertIn("STALLED", v)
+
+    def test_no_history_and_a_short_wait_does_not_page(self):
+        """A pool's first-ever job must not alert the moment it is queued."""
+        v, stall = self.v(queued=1, running=0, oldest=5, last=None)
+        self.assertFalse(stall)
+        self.assertIn("PENDING", v)
+
+    def test_no_history_and_a_long_wait_does_stall(self):
+        """A `runs-on` naming a scale set that never existed has no history and
+        never will. That must page — it is the original bug."""
+        v, stall = self.v(queued=1, running=0, oldest=600, last=None)
+        self.assertTrue(stall)
+
+    def test_empty_queue_with_running_jobs_is_healthy_not_idle(self):
+        self.assertEqual(self.v(queued=0, running=4, oldest=0, last=1)[0], "HEALTHY")
+        self.assertEqual(self.v(queued=0, running=0, oldest=0, last=1)[0], "IDLE")
+
+    def test_idle_pool_never_pages(self):
+        """No queue means no complaint, however long since the last job."""
+        for last in (None, 1, 10_000):
+            self.assertFalse(self.v(queued=0, running=0, oldest=0, last=last)[1])
+
+
+class StartsThatNeverHappened(unittest.TestCase):
+    """runner_id 0 == the job was never picked up. Counting those as starts is
+    how a dead pool reads as alive, so the filter is asserted directly."""
+
+    def setUp(self):
+        import importlib.util
+        spec = importlib.util.spec_from_file_location("ciqw", SCRIPT)
+        self.m = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(self.m)
+
+    def test_minutes_since_handles_absent_timestamp(self):
+        self.assertIsNone(self.m._minutes_since(None))
+
+    def test_source_excludes_zero_runner_id(self):
+        with open(SCRIPT) as fh:
+            src = fh.read()
+        self.assertIn('not job.get("runner_id")', src,
+                      "the runner_id filter is load-bearing: without it a pool that "
+                      "never picked anything up reports recent starts and reads healthy")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ci_queue_watch.py
+++ b/scripts/ci_queue_watch.py
@@ -44,8 +44,10 @@ import concurrent.futures as cf
 import datetime
 import json
 import os
+import re
 import sys
 import urllib.error
+import urllib.parse
 import urllib.request
 
 # Overridable so the self-tests can point discovery at a dead port and stay
@@ -55,8 +57,29 @@ API = os.environ.get("CI_QUEUE_WATCH_API", "https://api.github.com")
 NOW = datetime.datetime.now(datetime.timezone.utc)
 
 
+# urllib speaks file://, ftp:// and more, so an unchecked base URL is an
+# arbitrary-file read waiting to happen -- CI_QUEUE_WATCH_API is an env var, and
+# env vars get set by things other than the person reading this. The scheme is
+# checked at the one place every request funnels through rather than trusted at
+# the point it was configured.
+_ALLOWED_SCHEMES = ("http", "https")
+
+# Repository full names are interpolated into request paths. They arrive from
+# the API rather than from a user, but "it came from an API" is the assumption
+# that makes traversal bugs, so the shape is enforced instead of assumed.
+_REPO_RE = re.compile(r"^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$")
+
+
+def _valid_repo(full):
+    return bool(_REPO_RE.match(full))
+
+
 def _get(path, token):
-    req = urllib.request.Request(API + path)
+    url = API + path
+    scheme = urllib.parse.urlsplit(url).scheme.lower()
+    if scheme not in _ALLOWED_SCHEMES:
+        return None, f"refusing non-HTTP scheme {scheme!r}"
+    req = urllib.request.Request(url)
     req.add_header("Accept", "application/vnd.github+json")
     if token:
         req.add_header("Authorization", "Bearer " + token)
@@ -104,6 +127,8 @@ def scan_repo(args):
     """Every queued/running job in one repo, keyed by (visibility, runs-on)."""
     full, visibility, token, lookback = args
     rows, errors = [], []
+    if not _valid_repo(full):
+        return rows, {}, [f"{full!r}: not a valid owner/repo name — skipped"]
 
     for status in ("queued", "in_progress"):
         runs, err = _get(f"/repos/{full}/actions/runs?status={status}&per_page=100", token)

--- a/scripts/ci_queue_watch.py
+++ b/scripts/ci_queue_watch.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+"""Fleet CI queue watchdog — is each runner pool PROGRESSING?
+
+WHY THIS MEASURES THROUGHPUT AND NOT WAIT TIME
+==============================================
+The obvious watchdog is "alert when a job has been queued longer than N
+minutes". It does not work, because two completely different situations
+produce identical long waits:
+
+  1. The pool is DEAD. `runs-on` names an ARC scale set that is not serving --
+     or does not exist at all. Jobs queue forever with no red X, no log and no
+     timeout. Nothing in GitHub ever reports this.
+  2. The pool is BUSY. More work was pushed than the runners can chew through.
+     A 90-minute wait is the system working correctly under load.
+
+A latency threshold fires on both. It therefore gets muted, and then case 1
+goes unnoticed -- which is exactly how the current outage was found: an agent
+wondered why its build never started.
+
+What separates them is whether the pool is MOVING. A busy pool still starts
+jobs; a dead pool starts none. So the signal is:
+
+    queued > 0  AND  nothing started on this pool in the last N minutes
+    => STALLED
+
+and queue depth on a moving pool is reported as capacity, not as an incident.
+Different signal, different response: STALLED means fix the runner or the
+`runs-on` name; SATURATED means add runners, and is not paged.
+
+TWO MORE THINGS THIS LEARNED THE HARD WAY
+-----------------------------------------
+* The pool key is (visibility, label), not the label. `ubuntu-latest` is
+  healthy on a public repo and permanently queued on a private one when the
+  account's Actions budget is exhausted -- same label, opposite meaning.
+* A job that never got a runner still appears in the API with
+  `runner_id: 0` and a start timestamp. Counting those as "started" would make
+  a dead pool look alive, so they are excluded when measuring last-start.
+
+The watchdog must not run on the pool it watches. See the workflow: it pins
+`ubuntu-latest` on this public repo, which is unmetered and independent of ARC.
+"""
+import argparse
+import concurrent.futures as cf
+import datetime
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+API = "https://api.github.com"
+NOW = datetime.datetime.now(datetime.timezone.utc)
+
+
+def _get(path, token):
+    req = urllib.request.Request(API + path)
+    req.add_header("Accept", "application/vnd.github+json")
+    if token:
+        req.add_header("Authorization", "Bearer " + token)
+    try:
+        with urllib.request.urlopen(req, timeout=30) as fh:
+            return json.load(fh), None
+    except urllib.error.HTTPError as exc:
+        return None, f"HTTP {exc.code}"
+    except Exception as exc:  # noqa: BLE001 - network shape varies
+        return None, str(exc)
+
+
+def _minutes_since(ts):
+    if not ts:
+        return None
+    t = datetime.datetime.fromisoformat(ts.replace("Z", "+00:00"))
+    return (NOW - t).total_seconds() / 60.0
+
+
+def discover_repos(owner, token, prefix):
+    """The fleet is whatever GitHub says it is -- no checked-in repo list.
+
+    A list of repositories in a file is a second place to update on every new
+    product, and it is silently wrong the moment someone forgets. Derived here
+    from the account listing and filtered by name prefix.
+    """
+    repos, page = [], 1
+    while True:
+        data, err = _get(f"/users/{owner}/repos?per_page=100&type=all&page={page}", token)
+        if err:
+            data, err = _get(f"/orgs/{owner}/repos?per_page=100&type=all&page={page}", token)
+        if err or not data:
+            return repos, err
+        for r in data:
+            if r.get("archived"):
+                continue
+            if r["name"].lower().startswith(prefix):
+                repos.append((r["full_name"], "private" if r.get("private") else "public"))
+        if len(data) < 100:
+            return repos, None
+        page += 1
+
+
+def scan_repo(args):
+    """Every queued/running job in one repo, keyed by (visibility, runs-on)."""
+    full, visibility, token, lookback = args
+    rows, errors = [], []
+
+    for status in ("queued", "in_progress"):
+        runs, err = _get(f"/repos/{full}/actions/runs?status={status}&per_page=100", token)
+        if err:
+            errors.append(f"{full}: {err}")
+            continue
+        for run in runs.get("workflow_runs", []):
+            jobs, err = _get(f"/repos/{full}/actions/runs/{run['id']}/jobs?per_page=100", token)
+            if err:
+                errors.append(f"{full} run {run['id']}: {err}")
+                continue
+            for job in jobs.get("jobs", []):
+                if job["status"] not in ("queued", "in_progress"):
+                    continue
+                rows.append({
+                    "repo": full,
+                    "visibility": visibility,
+                    "pool": (job.get("labels") or ["<none>"])[0],
+                    "status": job["status"],
+                    "waited_min": _minutes_since(job.get("created_at") or run["created_at"]),
+                    "started_min_ago": _minutes_since(job.get("started_at"))
+                    if job["status"] == "in_progress" else None,
+                })
+
+    # Last REAL start, from recently completed runs. This is what makes a stall
+    # distinguishable from a queue that simply has not been fed lately: a pool
+    # with nothing queued and nothing running is idle, not broken, and an idle
+    # pool must never page anyone.
+    done, err = _get(f"/repos/{full}/actions/runs?status=completed&per_page={lookback}", token)
+    last_start = {}
+    if err:
+        errors.append(f"{full}: {err}")
+    else:
+        for run in done.get("workflow_runs", []):
+            jobs, jerr = _get(f"/repos/{full}/actions/runs/{run['id']}/jobs?per_page=100", token)
+            if jerr:
+                continue
+            for job in jobs.get("jobs", []):
+                # runner_id 0 == never actually picked up by a runner. Counting
+                # these as starts is how a dead pool reads as alive.
+                if not job.get("started_at") or not job.get("runner_id"):
+                    continue
+                key = (visibility, (job.get("labels") or ["<none>"])[0])
+                age = _minutes_since(job["started_at"])
+                if key not in last_start or age < last_start[key]:
+                    last_start[key] = age
+
+    return rows, last_start, errors
+
+
+def aggregate(rows, last_starts):
+    pools = {}
+    for r in rows:
+        key = (r["visibility"], r["pool"])
+        p = pools.setdefault(key, {"queued": 0, "running": 0, "oldest_wait": 0.0,
+                                   "last_start": None, "repos": set()})
+        p["repos"].add(r["repo"].split("/")[-1])
+        if r["status"] == "queued":
+            p["queued"] += 1
+            p["oldest_wait"] = max(p["oldest_wait"], r["waited_min"] or 0.0)
+        else:
+            p["running"] += 1
+    for key, age in last_starts.items():
+        if key in pools and (pools[key]["last_start"] is None or age < pools[key]["last_start"]):
+            pools[key]["last_start"] = age
+    return pools
+
+
+def verdict(p, stall_minutes):
+    """STALLED is the only state that warrants waking anyone up."""
+    if p["queued"] == 0:
+        return "IDLE", False
+    if p["running"] > 0:
+        # Moving. Depth is a capacity fact, not an incident.
+        return ("SATURATED" if p["queued"] > p["running"] * 2 else "HEALTHY"), False
+    last = p["last_start"]
+    if last is None:
+        # No start seen anywhere in the lookback window. That is a stall only if
+        # something has also been waiting longer than the threshold -- a pool
+        # whose first-ever job was queued two minutes ago has no history yet and
+        # must not page.
+        if p["oldest_wait"] > stall_minutes:
+            return "STALLED (no start seen in the lookback window)", True
+        return "PENDING (no history yet)", False
+    if last > stall_minutes:
+        return f"STALLED (last start {last:.0f}m ago)", True
+    # Queued, nothing running right now, but a job started recently -- that is a
+    # pool turning over between jobs, not a stall.
+    return "HEALTHY", False
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--owner", default="izzywdev")
+    ap.add_argument("--prefix", default="fuze", help="repo-name prefix defining the fleet")
+    ap.add_argument("--repos", nargs="*", default=None,
+                    help="explicit owner/repo list; skips discovery")
+    ap.add_argument("--stall-minutes", type=int, default=30,
+                    help="a pool with queued work and no start in this window is STALLED")
+    ap.add_argument("--lookback-runs", type=int, default=40,
+                    help="completed runs per repo scanned for the last real job start")
+    ap.add_argument("--json", action="store_true")
+    ap.add_argument("--fail-on-stall", action="store_true",
+                    help="exit 1 when any pool is STALLED (for the scheduled watchdog)")
+    args = ap.parse_args()
+
+    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN") or ""
+
+    if args.repos:
+        targets = [(r, "unknown") for r in args.repos]
+        derr = None
+    else:
+        targets, derr = discover_repos(args.owner, token, args.prefix)
+    if not targets:
+        print(f"::warning::no repositories discovered ({derr or 'empty result'}) — "
+              f"pass --repos to scan an explicit list", file=sys.stderr)
+        return 0
+
+    rows, last_starts, errors = [], {}, []
+    work = [(full, vis, token, args.lookback_runs) for full, vis in targets]
+    with cf.ThreadPoolExecutor(max_workers=8) as ex:
+        for r, ls, errs in ex.map(scan_repo, work):
+            rows.extend(r)
+            errors.extend(errs)
+            for key, age in ls.items():
+                if key not in last_starts or age < last_starts[key]:
+                    last_starts[key] = age
+
+    pools = aggregate(rows, last_starts)
+    stalled = []
+    out = []
+    for (vis, name), p in sorted(pools.items(), key=lambda kv: -kv[1]["queued"]):
+        v, is_stall = verdict(p, args.stall_minutes)
+        if is_stall:
+            stalled.append((vis, name, p, v))
+        out.append({"pool": name, "visibility": vis, "queued": p["queued"],
+                    "running": p["running"], "oldest_wait_min": round(p["oldest_wait"], 1),
+                    "last_start_min_ago": None if p["last_start"] is None else round(p["last_start"], 1),
+                    "verdict": v, "repos": sorted(p["repos"])})
+
+    if args.json:
+        print(json.dumps({"observed_at": NOW.isoformat(timespec="seconds"),
+                          "repos_scanned": len(targets), "pools": out,
+                          "errors": errors}, indent=2))
+    else:
+        print(f"# fleet CI queue @ {NOW.isoformat(timespec='seconds')} "
+              f"({len(targets)} repos)\n")
+        hdr = (f"{'pool (runs-on)':24} {'vis':8} {'queued':>6} {'run':>4} "
+               f"{'oldest wait':>12} {'last start':>11}  verdict")
+        print(hdr)
+        print("-" * len(hdr))
+        for o in out:
+            ls = "never" if o["last_start_min_ago"] is None else f"{o['last_start_min_ago']:.0f}m"
+            print(f"{o['pool']:24} {o['visibility']:8} {o['queued']:>6} {o['running']:>4} "
+                  f"{o['oldest_wait_min']:>11.0f}m {ls:>11}  {o['verdict']}")
+            print(f"{'':24} repos: {', '.join(o['repos'])[:96]}")
+        for e in errors:
+            print(f"::warning::{e}")
+
+    if stalled:
+        for vis, name, p, v in stalled:
+            print(f"::error::runner pool '{name}' ({vis}) is {v} — "
+                  f"{p['queued']} job(s) queued, oldest {p['oldest_wait']:.0f}m, "
+                  f"repos: {', '.join(sorted(p['repos']))}", file=sys.stderr)
+        return 1 if args.fail_on_stall else 0
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci_queue_watch.py
+++ b/scripts/ci_queue_watch.py
@@ -48,7 +48,10 @@ import sys
 import urllib.error
 import urllib.request
 
-API = "https://api.github.com"
+# Overridable so the self-tests can point discovery at a dead port and stay
+# hermetic — they must not depend on the fleet's live state, which is the very
+# thing this script measures.
+API = os.environ.get("CI_QUEUE_WATCH_API", "https://api.github.com")
 NOW = datetime.datetime.now(datetime.timezone.utc)
 
 
@@ -172,7 +175,9 @@ def aggregate(rows, last_starts):
 def verdict(p, stall_minutes):
     """STALLED is the only state that warrants waking anyone up."""
     if p["queued"] == 0:
-        return "IDLE", False
+        # Nothing waiting. Running jobs with an empty queue is the healthiest
+        # state there is; labelling it IDLE reads as "this pool does nothing".
+        return ("HEALTHY" if p["running"] else "IDLE"), False
     if p["running"] > 0:
         # Moving. Depth is a capacity fact, not an incident.
         return ("SATURATED" if p["queued"] > p["running"] * 2 else "HEALTHY"), False
@@ -206,6 +211,10 @@ def main():
     ap.add_argument("--json", action="store_true")
     ap.add_argument("--fail-on-stall", action="store_true",
                     help="exit 1 when any pool is STALLED (for the scheduled watchdog)")
+    ap.add_argument("--min-repos", type=int, default=5,
+                    help="with a token present, discovering fewer than this many repos is a "
+                         "misconfiguration and exits 2 — a watchdog that silently watches "
+                         "nothing is worse than no watchdog")
     args = ap.parse_args()
 
     token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN") or ""
@@ -215,10 +224,25 @@ def main():
         derr = None
     else:
         targets, derr = discover_repos(args.owner, token, args.prefix)
-    if not targets:
-        print(f"::warning::no repositories discovered ({derr or 'empty result'}) — "
-              f"pass --repos to scan an explicit list", file=sys.stderr)
-        return 0
+    # A watchdog that quietly watches nothing is the failure mode this whole
+    # script exists to argue against: it stays green forever and everyone reads
+    # green as "the fleet is fine". So an under-sized fleet is only tolerated
+    # when there is no token to look with -- an environmental condition, which
+    # must never masquerade as an outage. With a token in hand, too few repos
+    # means the token's scope is wrong, and that is a hard failure.
+    if not args.repos and len(targets) < args.min_repos:
+        detail = f"discovered {len(targets)} repo(s), expected at least {args.min_repos}"
+        if derr:
+            detail += f" (last error: {derr})"
+        if not token:
+            print(f"::warning::{detail} and no token is set — skipping rather than "
+                  f"reporting a fleet of one.", file=sys.stderr)
+            return 0
+        print(f"::error::{detail}. A token IS set, so this is a scope problem, not an "
+              f"empty fleet — the token needs read access to the {args.owner}/{args.prefix}* "
+              f"repositories. Refusing to report on a fleet this small: a watchdog that "
+              f"watches nothing looks identical to a healthy one.", file=sys.stderr)
+        return 2
 
     rows, last_starts, errors = [], {}, []
     work = [(full, vis, token, args.lookback_runs) for full, vis in targets]


### PR DESCRIPTION
## Summary

Two CI-integrity fixes.

### 1. `allowed_bots` was still `"*"` in this repo

The canonical template and the repos reconciled against it use `allowed_bots: "claude"`. FuzeFront predates that and was never brought along, so both `a2a-maintain.yml` and `mcp-maintain.yml` shipped `"*"` — allow **every** bot — with a comment arguing for it.

That is not a cosmetic difference here. `.github/dependabot.yml` runs the `github-actions` ecosystem, so dependabot opens PRs against this repo. Under `"*"`, such a PR triggers `claude-code-action` holding `ANTHROPIC_API_KEY` and repo write, taking as context a PR body assembled from upstream release notes this repo does not author. The actor gate exists to stop arbitrary bot activity from driving an agent; `"*"` doesn't configure that gate, it removes it.

Scoping to `claude` keeps the original problem fixed — the gate fired on nearly every PR because governance-sync's commit-back flips the triggering actor `User → Bot` — while allowing exactly the one bot these maintainers exist to service.

The replacement comment also records what the value *is*: a **login allowlist**, matched against the triggering actor with `[bot]` stripped — not a vendor or product name. Measured across the fleet, three bot logins appear:

| login | triggers | events |
|---|---|---|
| `claude` | a2a/mcp-maintain, harden-gate, auto-merge, … | `pull_request` (after the governance-sync commit-back) |
| `fuzeone-bot` | governance-nightly, nightly-integration | `schedule` only |
| `dependabot` | dependency PRs, and in some repos `Claude Auto-Fix CI` | `pull_request`, `workflow_run`, `issue_comment` |

Only `claude` triggers a workflow that calls this action, so `fuzeone-bot` is deliberately **not** added — it would grant a permission nothing uses.

Fork PRs stay closed by a separate mechanism and are unaffected: the trigger is `pull_request`, not `pull_request_target`, so a fork run gets no secrets and the existing guard step skips it.

### 2. CI queue watchdog — `scripts/ci_queue_watch.py` + `.github/workflows/ci-queue-watch.yml`

Nothing in GitHub reports a runner pool that has stopped serving. A `runs-on` naming an ARC scale set that is down — or that never existed — queues forever with no red X, no log, no timeout.

The obvious watchdog, *"alert when a job has waited more than N minutes"*, does not work, and that is the whole design here. A dead pool and a merely busy pool produce identical waits, so a latency threshold fires on both, gets muted, and then the dead pool goes unnoticed anyway. What separates them is whether the pool is **moving**:

```
queued > 0  AND  nothing started on this pool recently   =>  STALLED
queued > 0  AND  jobs are still starting                 =>  SATURATED (capacity, not an incident)
```

Different signal, different response: STALLED means fix the runner or the `runs-on` name; SATURATED means add runners.

Measured against the fleet while writing this, the distinction is not theoretical:

```
pool (runs-on)   queued  run  oldest wait  last start  verdict
fuzesdlc            121    0        1180m       2120m  STALLED
fuzedeploy           59    0        1232m       2362m  STALLED
fuzebi               57    0        1186m       2285m  STALLED
fuzecall             47    0        1304m       2277m  STALLED
ubuntu-latest         6    0        5698m         15m  HEALTHY
```

`ubuntu-latest` had the **longest wait of any pool** — ~4 days — and is correctly HEALTHY, because a job started on it 15 minutes ago. A wait-time alarm would have paged on the healthiest pool in the fleet.

Three details that took measurement to get right:

- The pool key is `(visibility, label)`, not the label. `ubuntu-latest` is healthy on a public repo and permanently queued on a private one once the account's Actions budget is exhausted — same label, opposite meaning.
- A job that never got a runner still carries a start timestamp, with `runner_id: 0`. Counting those as starts makes a dead pool read as alive, so they are excluded from last-start.
- A pool with queued work but no start history in the lookback window is `PENDING`, not `STALLED`, unless something has also waited past the threshold — otherwise a pool's first-ever job pages on arrival.

The fleet is discovered from the account listing filtered by name prefix, **not** from a checked-in repo list: a list is a second place to update on every new product and is silently wrong the moment someone forgets.

The workflow pins `ubuntu-latest` deliberately. A watchdog scheduled onto the runner fleet it monitors cannot report that fleet being down — it queues with everything else and stays silent, which is exactly the failure it exists to catch. This repo is public, so those minutes are unmetered and independent of both ARC and the Actions budget.

**Operator note:** cross-repo Actions reads need a fleet-scoped token; the job's own `GITHUB_TOKEN` would report a fleet of one. Set `FLEET_READ_PAT` (classic `repo`, or fine-grained `Actions: read` on the `Fuze*` repos) to arm it. Unset, the workflow warns and exits 0 rather than going red — a missing secret must never look like a fleet outage.

## Verification

- `actionlint` clean on all three workflows.
- Both patched workflows re-parsed; `allowed_bots` resolves to `claude` in each.
- `ci_queue_watch.py` run live against 21 repos and against a 5-repo subset; output above is real, not illustrative.
- The `SATURATED`/`HEALTHY` path is exercised by the `ubuntu-latest` row — this is not a tool that only knows how to say "broken".

## Not in scope

- The ARC outage itself. Eight scale sets, 449 queued jobs, last real start 35–42h ago — cluster-side, tracked in FuzeInfra#623. This PR makes it *visible*; it does not fix it.
- Propagating the watchdog to the rest of the fleet, and folding the rationale into FuzeSDLC's `governance/ci-runners.md`. It only needs to run in one public repo to cover everything, so propagation is optional rather than pending.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GaPa3JgrVNtWrGvqQEAEqv)_