### PR TITLE
docs(argocd): the app-of-apps header told maintainers to delete the AppProject this repo now owns

### DIFF
--- a/deploy/argocd/app-of-apps.yaml
+++ b/deploy/argocd/app-of-apps.yaml
@@ -1,8 +1,26 @@
 # Root "app of apps": apply this once after bootstrap and Argo manages the rest.
 #   kubectl apply -f deploy/argocd/app-of-apps.yaml
-# NOTE: the `fuzefront` AppProject is owned & provisioned by FuzeInfra (FuzeInfra#99).
-# Do NOT apply a fuzefront AppProject from this repo — re-applying a stale copy would
-# re-widen prod cross-namespace access to fuzeinfra (issue #502).
+# NOTE: the `fuzefront` AppProject now lives in THIS repo, at
+# deploy/argocd/project.yaml — decentralised from FuzeInfra along with the rest
+# of the family. FuzeInfra's copy (argocd/projects/fuzefront.yaml) is pending
+# deletion, tracked in FuzeInfra#625; until that lands both exist and
+# registration is last-write-wins.
+#
+# This header previously said the opposite — "owned & provisioned by FuzeInfra
+# (FuzeInfra#99). Do NOT apply a fuzefront AppProject from this repo" — which
+# now reads as an instruction to refuse to apply, or to delete, the very file
+# that carries the isolation boundary. What FuzeInfra#99 established is the
+# RULE, not the file's location: `fuzeinfra` is never a destination for a
+# consumer project. That rule travels with deploy/argocd/project.yaml and is
+# restated at length in its header. Issue #502 was a stale, WIDER copy being
+# re-applied; the in-repo copy is strictly narrower than FuzeInfra's
+# (clusterResourceWhitelist is Namespace-only instead of `*/*`), so applying it
+# cannot re-widen anything.
+#
+# `project: fuzefront` below — and on every Application under
+# deploy/argocd/applications/ — is what makes that AppProject enforce anything
+# at all. An Application left on `project: default` resolves against the
+# permissive cluster-wide project and never consults the narrow one.
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:


### PR DESCRIPTION
## Context

This came out of a fleet-wide audit of the "narrow AppProject landed, but the Applications still say `spec.project: default`" defect. **FuzeFront itself is clean on that count** — all five Applications already reference `project: fuzefront`:

| File | `spec.project` |
|---|---|
| `deploy/argocd/app-of-apps.yaml` | `fuzefront` |
| `deploy/argocd/applications/fuzefront.yaml` | `fuzefront` |
| `deploy/argocd/applications/fuzefront-sealed.yaml` | `fuzefront` |
| `deploy/argocd/applications/unleash.yaml` | `fuzefront` |
| `FuzeQuality/deploy/argocd/fuzequality.yaml` | `fuzefront` |

What is **not** clean is the header of `app-of-apps.yaml`.

## The defect

`deploy/argocd/project.yaml` has landed — the `fuzefront` AppProject is decentralised into this repo like the rest of the family. The app-of-apps header still said the opposite:

```yaml
# NOTE: the `fuzefront` AppProject is owned & provisioned by FuzeInfra (FuzeInfra#99).
# Do NOT apply a fuzefront AppProject from this repo — re-applying a stale copy would
# re-widen prod cross-namespace access to fuzeinfra (issue #502).
```

As written, that instructs a maintainer to refuse to apply — or to delete — **the very file that now carries the isolation boundary.** It is a directive, in the first thing anyone reads in this directory, pointing the wrong way.

## Why the old warning no longer applies

- **FuzeInfra#99 established the RULE, not the file's location.** The rule is: `fuzeinfra` is never a destination for a consumer project. That rule travels with `deploy/argocd/project.yaml` and is restated at length in its own header. `fuzeinfra` is absent from its `destinations`.
- **Issue #502 was a stale, WIDER copy being re-applied.** The in-repo copy is strictly **narrower** than FuzeInfra's:

  | | FuzeInfra `argocd/projects/fuzefront.yaml` | this repo's `deploy/argocd/project.yaml` |
  |---|---|---|
  | `clusterResourceWhitelist` | `group: "*", kind: "*"` | `group: "", kind: Namespace` |
  | destinations | fuzefront, fuzequality, argocd | fuzefront, fuzequality, argocd |
  | `fuzeinfra` destination | absent | absent |

  Applying the narrower copy cannot re-widen anything. It is the wildcard whitelist — which could create ClusterRoleBindings and CRDs, and, with the `argocd` destination, rewrite AppProjects including itself — that the in-repo copy removes.
- FuzeInfra's copy is pending deletion (FuzeInfra#625). Until that lands both exist and registration is last-write-wins; the new header says so plainly instead of implying only one is legitimate.

## Whitelist re-derivation (checked, not assumed)

`clusterResourceWhitelist: Namespace` only is correct for this repo — every `kind:` rendered by all three charts:

| Chart | Rendered kinds | Cluster-scoped |
|---|---|---|
| `deploy/helm/fuzefront` | ConfigMap, Deployment, Ingress, Job, Middleware, NetworkPolicy, Role, RoleBinding, SealedSecret, Secret, Service, ServiceAccount | none |
| `deploy/helm/unleash` | Deployment, Ingress, Job, Service | none |
| `FuzeQuality/deploy/helm/fuzequality` | CronJob, Deployment, Ingress, Job, Middleware, Namespace, NetworkPolicy, SealedSecret, Service | **Namespace** |

`Role`/`RoleBinding` are namespaced, not cluster-scoped. `Middleware` (Traefik) is namespaced. The one cluster-scoped kind, `Namespace`, is exactly what the whitelist permits. **No whitelist change is needed and none is made here** — this PR does not touch `project.yaml` at all.

## Also recorded in the header

Why `project: fuzefront` matters at all: an Application left on `project: default` resolves against the permissive cluster-wide project and never consults the narrow one — the AppProject then exists as a file and enforces nothing. That is the fleet-wide defect this is a companion to (FuzePlan#197, FuzeExecutive#41).

## Scope and risk

**Comment-only.** No rendered Kubernetes object changes. Verified the manifest still parses to exactly one Application — `fuzefront-apps`, `project: fuzefront`, `destination.namespace: argocd`.

No `auto-merge` label, deliberately: `master` here is deploy-on-push, and this repo's rule is to merge in a deploy window rather than bot-merge. Left as PENDING-REVIEW for the owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GaPa3JgrVNtWrGvqQEAEqv

---
_Generated by [Claude Code](https://claude.ai/code/session_01GaPa3JgrVNtWrGvqQEAEqv)_