### PR TITLE
fix(auth-ui): import missing CSS so Google Sign-in button renders correctly

### DIFF
--- a/FuzeQuality/apps/web/src/api.ts
+++ b/FuzeQuality/apps/web/src/api.ts
@@ -8,6 +8,7 @@ import type {
 export type OrganizationRole = 'owner' | 'admin' | 'member' | 'viewer'
 export type OrganizationMember = { id: string; email?: string; name?: string; displayName?: string; userId?: string; user_id?: string; role: OrganizationRole; status?: string }
 
+
 // The standalone dashboard uses same-origin API calls. When mounted as a
 // FuzeFront federated remote, the browser origin is app.fuzefront.com, so the
 // API origin is injected at build time and remains independent of the host.

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -13,6 +13,7 @@ import App from './App.tsx'
 // LanguageSelector — depend on. Imported before index.css so the host's own
 // color theme (defined there) still wins where the two overlap.
 import '@fuzefront/design-system/styles.css'
+import '@fuzefront/auth-ui/styles.css'
 import './index.css'
 import { registerServiceWorker } from './registerServiceWorker'
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -21,6 +21,12 @@ const identityUiSrc = fileURLToPath(
 const authUiSrc = fileURLToPath(
   new URL('../packages/auth-ui/src/index.ts', import.meta.url)
 )
+// Stylesheet subpath (@fuzefront/auth-ui/styles.css) must be aliased
+// separately, pointing at the source CSS. Without this Vite appends
+// /styles.css to the index.ts file path → ENOTDIR at build time.
+const authUiStyles = fileURLToPath(
+  new URL('../packages/auth-ui/src/styles.css', import.meta.url)
+)
 const designSystemSrc = fileURLToPath(
   new URL('../design-system/index.js', import.meta.url)
 )
@@ -131,6 +137,8 @@ export default defineConfig({
   resolve: {
     alias: {
       '@fuzefront/identity-ui': identityUiSrc,
+      // Subpath alias MUST precede the bare alias — same pattern as chat-ui.
+      '@fuzefront/auth-ui/styles.css': authUiStyles,
       '@fuzefront/auth-ui': authUiSrc,
       '@fuzefront/account-security-ui': accountSecurityUiSrc,
       '@fuzefront/portal-admin-ui': portalAdminUiSrc,

--- a/packages/auth-ui/src/styles.css
+++ b/packages/auth-ui/src/styles.css
@@ -75,6 +75,14 @@
   cursor: pointer;
 }
 
+.fzf-auth-panel__google-button:hover:not(:disabled) {
+  background-color: var(--bg-secondary);
+}
+
+.fzf-auth-panel__google-button:active:not(:disabled) {
+  background-color: var(--bg-tertiary, var(--bg-secondary));
+}
+
 .fzf-auth-panel__google-button:disabled {
   cursor: not-allowed;
   opacity: 0.6;


### PR DESCRIPTION
## Summary

- **Root cause**: `@fuzefront/auth-ui/styles.css` was never imported in `frontend/src/main.tsx`. The browser received zero CSS rules for `.fzf-auth-panel__google-button`, so it rendered as a completely unstyled native `<button>` — no background, border, border-radius, or padding. The Google logo and text were visible but floating with no button container.
- **Fix**: Added `import '@fuzefront/auth-ui/styles.css'` to `frontend/src/main.tsx` alongside the existing design-system import.
- **Bonus**: Added `:hover` and `:active` states to the Google button CSS — the button had no visual feedback on hover at all.

## Test plan

- [ ] Load `app.fuzefront.com/login` in a browser — Google Sign-in button should appear as a white bordered button with the Google G logo and "Sign in with Google" text
- [ ] Hover over the button — background should lighten slightly
- [ ] Dark mode: button should use `--bg-primary` (light surface) with `--border-color` border, distinct from the card background
- [ ] Console: 0 errors, 0 CSP violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)