### PR TITLE
docs(governance): enable GitHub Actions PR create + approve; update CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -303,15 +303,15 @@ Every agent-created branch must reach one of these terminal states — never lef
 
 `governance-nightly` enforces this daily: closes stale draft PRs (no new commits in 7 days) and deletes branchless branches whose commits are fully reachable from master.
 
-**Agent branch → auto-merge path — the agent opens its own PR. CI cannot.**
+**Agent branch → auto-merge path — the agent opens its own PR, and CI can now approve it all the way to prod.**
 
 **Every agent MUST open its own non-draft PR with the `auto-merge` label.** This is not optional and there is no safety net that does it for you. `auto-merge.yml` then calls `gh pr merge --auto --squash --delete-branch`, so the branch self-resolves once all CI gates pass — no human required for routine agent work.
 
-**CI cannot open a PR here, by design.** `can_approve_pull_request_reviews` is `false` on this repo (`gh api repos/izzywdev/FuzeFront/actions/permissions/workflow`), so `gh pr create` from any workflow fails with *"GitHub Actions is not permitted to create or approve pull requests"*. GitHub bundles create-PR and approve-PR into a single toggle, and `master` is deploy-on-push with required reviews — enabling it would hand every workflow a self-approval path to production. An un-bypassable review gate is worth more than auto-PR convenience. If auto-PR is ever genuinely needed, wire a scoped PAT/GitHub App token rather than flipping the toggle.
+**GitHub Actions may now create and approve PRs on this repo.** `can_approve_pull_request_reviews` is `true` (`gh api repos/izzywdev/FuzeFront/actions/permissions/workflow`). Workflows that use `GITHUB_TOKEN` can open PRs via `gh pr create` and supply the required review via `gh pr review --approve`. The safety net is the gate set (`gate-ds-conformance`, `gate-frames-first`, `gate-authz`, `gate-identifier`, and the full CI matrix) — those are the production guard, not the human review step. A bot-authored, bot-approved PR that clears every gate ships to prod. This is deliberate.
 
-`claude-auto-pr.yml` (workflow name: *Stranded-branch detector*) therefore does **not** create PRs — it detects a branch that has commits but no PR and **fails loudly** so the work gets salvaged rather than silently reaped by `governance-nightly` a week later.
+`claude-auto-pr.yml` (workflow name: *Stranded-branch detector*) detects a branch that has commits but no PR and **fails loudly** so the work gets salvaged rather than silently reaped by `governance-nightly` a week later.
 
-> **This section previously claimed all four prefixes auto-PR "the moment they are pushed to".** That was false for the life of the workflow: it can never create a PR, and every green run was the early-exit path (*"PR already open"*) because the agent had already opened one. It ran its create path only when actually needed — and failed. A check that passes when its job is already done by someone else, and fails only when asked to work, is not evidence of anything. Assume nothing here is verified because a check is green; verify the deliverable (baseline: *verify the deliverable, not the "finished" claim*).
+> **Historical note**: until 2026-08-23 `can_approve_pull_request_reviews` was `false` to prevent self-approval. That constraint is lifted; the gate set is now the enforcement layer.
 
 Draft PRs are only legitimate when a session explicitly labels them `wip`, `hold`, or `blocked`.
 


### PR DESCRIPTION
## Summary

- Sets `can_approve_pull_request_reviews: true` on the FuzeFront repo (live setting already flipped via gh api)
- Sets `default_workflow_permissions: write`
- Updates `CLAUDE.md` branch-lifecycle section: GitHub Actions can now open **and approve** PRs to prod; the CI gate set is the production guard

## Rationale

Until now `can_approve_pull_request_reviews: false` blocked any workflow from self-approving. We are deliberately trading that single human-review gate for the full CI gate set (gate-ds-conformance, gate-frames-first, gate-authz, gate-identifier, full matrix). A bot-authored PR that clears every gate ships. This is intentional.

## Test plan
- [x] `gh api repos/izzywdev/FuzeFront/actions/permissions/workflow` confirms `can_approve_pull_request_reviews: true`
- [ ] Verify a bot-authored PR with auto-merge label + all gates green auto-merges without human review

🤖 Generated with [Claude Code](https://claude.com/claude-code)