### PR TITLE
chore(auth): bump @fuzefront/auth to 0.2.1

### DIFF
--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fuzefront/auth",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "engines": {
     "node": ">=24.0.0",
     "npm": ">=10.0.0"


### PR DESCRIPTION
Bump version to trigger a working publish of the package that includes the compiled dist folder.