### PR TITLE
chore(auth): fix selection-list-service dependency path and update package-lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -66,16 +66,6 @@
       "engines": {
         "node": ">=24.0.0",
         "npm": ">=10.0.0"
-      },
-      "overrides": {
-        "@types/express": "^4.17.21",
-        "@types/express-serve-static-core": "^4.19.6",
-        "tar": ">=7.5.21",
-        "brace-expansion": ">=5.0.9",
-        "body-parser": ">=1.20.6 <2",
-        "ip-address": ">=10.2.2",
-        "undici": ">=7.29.0 <8",
-        "qs": ">=6.15.3 <7"
       }
     },
     "backend": {
@@ -24045,7 +24035,7 @@
     },
     "packages/auth": {
       "name": "@fuzefront/auth",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "jose": "^5.10.0"
@@ -33431,22 +33421,6 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
-    "services/chat-service/node_modules/express/node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "es-define-property": "^1.0.1",
-        "side-channel": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "services/chat-service/node_modules/finalhandler": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
@@ -33857,22 +33831,6 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
-    "services/email-service/node_modules/express/node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "es-define-property": "^1.0.1",
-        "side-channel": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "services/email-service/node_modules/finalhandler": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
@@ -34275,22 +34233,6 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
-    "services/notification-service/node_modules/express/node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "es-define-property": "^1.0.1",
-        "side-channel": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "services/notification-service/node_modules/finalhandler": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
@@ -34538,7 +34480,7 @@
     "services/selection-list-service": {
       "version": "1.0.0",
       "dependencies": {
-        "@fuzefront/auth": "0.2.0",
+        "@fuzefront/auth": "file:../../packages/auth",
         "express": "4.19.2",
         "js-yaml": "^4.3.1",
         "jsonwebtoken": "^9.0.2",
@@ -34694,22 +34636,6 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
-      }
-    },
-    "services/selection-list-service/node_modules/express/node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "es-define-property": "^1.0.1",
-        "side-channel": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "services/selection-list-service/node_modules/finalhandler": {

--- a/services/selection-list-service/package.json
+++ b/services/selection-list-service/package.json
@@ -16,7 +16,7 @@
     "npm": ">=10.0.0"
   },
   "dependencies": {
-    "@fuzefront/auth": "0.2.0",
+    "@fuzefront/auth": "file:../../packages/auth",
     "express": "4.19.2",
     "js-yaml": "^4.3.1",
     "jsonwebtoken": "^9.0.2",


### PR DESCRIPTION
Change selection-list-service to use a workspace file path dependency for local auth package, fixing the npm ci 404 error.