### PR TITLE
feat(argocd): register FuzeQuality application

### DIFF
--- a/deploy/argocd/applications/fuzequality.yaml
+++ b/deploy/argocd/applications/fuzequality.yaml
@@ -1,0 +1,33 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: fuzequality
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: fuzefront
+  source:
+    repoURL: https://github.com/izzywdev/FuzeFront.git
+    targetRevision: master
+    path: FuzeQuality/deploy/helm/fuzequality
+    helm:
+      releaseName: fuzequality
+      valueFiles:
+        - values-prod.yaml
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: fuzequality
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 15s
+        factor: 2
+        maxDuration: 5m


### PR DESCRIPTION
Register the FuzeQuality Helm application so Argo creates the namespace, frontend service, and same-origin /apps/fuzequality ingress.