### PR TITLE
fix(fuzequality): do not block portal rollout on Kafka topic job

### DIFF
--- a/FuzeQuality/deploy/helm/fuzequality/templates/kafka-topics.yaml
+++ b/FuzeQuality/deploy/helm/fuzequality/templates/kafka-topics.yaml
@@ -5,7 +5,11 @@ metadata:
   name: fuzequality-kafka-topics-{{ .Release.Revision }}
   labels:
     {{- include "fuzequality.labels" . | nindent 4 }}
-spec:`n  # Topic provisioning must not block the portal ingress or UI rollout.`n  # It remains idempotent and will fail visibly instead of running forever.`n  activeDeadlineSeconds: 180`n  backoffLimit: 4
+spec:
+  # Topic provisioning must not block the portal ingress or UI rollout.
+  # It remains idempotent and will fail visibly instead of running forever.
+  activeDeadlineSeconds: 180
+  backoffLimit: 4
   template:
     metadata: { labels: { app.kubernetes.io/name: fuzequality, app.kubernetes.io/component: kafka-topics } }
     spec:

--- a/FuzeQuality/deploy/helm/fuzequality/templates/kafka-topics.yaml
+++ b/FuzeQuality/deploy/helm/fuzequality/templates/kafka-topics.yaml
@@ -5,12 +5,7 @@ metadata:
   name: fuzequality-kafka-topics-{{ .Release.Revision }}
   labels:
     {{- include "fuzequality.labels" . | nindent 4 }}
-  annotations:
-    argocd.argoproj.io/hook: Sync
-    argocd.argoproj.io/sync-wave: "-1"
-    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation,HookSucceeded
-spec:
-  backoffLimit: 4
+spec:`n  # Topic provisioning must not block the portal ingress or UI rollout.`n  # It remains idempotent and will fail visibly instead of running forever.`n  activeDeadlineSeconds: 180`n  backoffLimit: 4
   template:
     metadata: { labels: { app.kubernetes.io/name: fuzequality, app.kubernetes.io/component: kafka-topics } }
     spec:


### PR DESCRIPTION
Allow the same-origin FuzeQuality portal remote to deploy even when Kafka topic provisioning is delayed; bound the initializer job to 3 minutes.