### PR TITLE
fix(federation): bypass stale cached remote entry

### DIFF
--- a/frontend/src/utils/loadFederatedApp.ts
+++ b/frontend/src/utils/loadFederatedApp.ts
@@ -101,7 +101,16 @@ async function loadRemoteModule(
   scope: string,
   module: string
 ): Promise<LoadedModule> {
-  const remoteEntry = resolveRemoteEntry(remoteEntryInput)
+  const resolvedEntry = resolveRemoteEntry(remoteEntryInput)
+  const entryUrl = new URL(resolvedEntry)
+  // Vite emits content-hashed chunks but keeps remoteEntry.js stable. A CDN can
+  // otherwise serve a previous entry that points to chunks removed by the next
+  // deployment. Cache-bust only same-origin entries; external providers retain
+  // control of their own cache policy.
+  if (entryUrl.origin === window.location.origin) {
+    entryUrl.searchParams.set('__mf', String(Date.now()))
+  }
+  const remoteEntry = entryUrl.toString()
   const cacheKey = `${remoteEntry}:${scope}:${module}`
 
   // Return cached module if available


### PR DESCRIPTION
Module Federation remoteEntry.js is a stable filename while its Vite chunks are content-hashed. On a rollout, an edge-cached older entry can reference chunks removed by the new image. Add a per-load cache-buster only for same-origin remotes, preserving external remote cache ownership.