### PR TITLE
feat(fuzequality): portal security integration

### DIFF
--- a/.github/workflows/fuzequality-release.yml
+++ b/.github/workflows/fuzequality-release.yml
@@ -51,6 +51,8 @@ jobs:
             ghcr.io/izzywdev/fuzequality-backend:latest
           cache-from: type=gha,scope=fuzequality-backend
           cache-to: type=gha,mode=max,scope=fuzequality-backend
+          secrets: |
+            GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push FuzeQuality frontend
         uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
@@ -64,6 +66,8 @@ jobs:
             ghcr.io/izzywdev/fuzequality-frontend:latest
           cache-from: type=gha,scope=fuzequality-frontend
           cache-to: type=gha,mode=max,scope=fuzequality-frontend
+          secrets: |
+            GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
 
       - name: Bump FuzeQuality production image tags
         env:

--- a/FuzeQuality/apps/api/src/platform-authorization.ts
+++ b/FuzeQuality/apps/api/src/platform-authorization.ts
@@ -1,6 +1,9 @@
 import type { NextFunction, Request, Response } from 'express'
+import type { Identity } from '@fuzefront/security-client'
 
-export interface PlatformIdentity { userId: string; tenantId: string; roles?: string[] }
+export interface PlatformIdentity extends Pick<Identity, 'userId' | 'tenantId' | 'roles'> {
+  tenantId: string
+}
 const identities = new WeakMap<Request, PlatformIdentity>()
 
 export function requestIdentity(request: Request) { return identities.get(request) }
@@ -16,14 +19,15 @@ export function requirePlatformPermission(resource: string, action: string) {
     if (!authorization?.startsWith('Bearer ')) return response.status(401).json({ error: 'Authentication required', code: 'IDENTITY_MISSING' })
     if (!baseUrl) return response.status(503).json({ error: 'Platform security is unavailable', code: 'SECURITY_UNAVAILABLE' })
     try {
-      const sessionResponse = await fetch(`${baseUrl}/api/v1/security/session`, { headers: { authorization } })
+      const identityHeaders: Record<string, string> = { authorization }
+      const sessionResponse = await fetch(`${baseUrl}/api/v1/security/session`, { headers: identityHeaders })
       if (!sessionResponse.ok) return response.status(401).json({ error: 'Authentication required', code: 'IDENTITY_INVALID' })
-      const body = await sessionResponse.json() as { identity?: Partial<PlatformIdentity> }
+      const body = await sessionResponse.json() as { identity?: Partial<Identity> }
       if (!body.identity?.userId || !body.identity.tenantId) return response.status(403).json({ error: 'A tenant-scoped identity is required', code: 'TENANT_UNRESOLVED' })
       const identity = body.identity as PlatformIdentity
       const decisionResponse = await fetch(`${baseUrl}/api/v1/security/authz/check`, {
         method: 'POST',
-        headers: { authorization, 'content-type': 'application/json' },
+        headers: { ...identityHeaders, 'content-type': 'application/json' },
         body: JSON.stringify({ subject: identity.userId, tenant: identity.tenantId, resource: { type: resource }, action }),
       })
       if (!decisionResponse.ok) return response.status(403).json({ error: 'Authorization decision unavailable; denying', code: 'DECISION_UNAVAILABLE' })

--- a/FuzeQuality/apps/web/src/App.tsx
+++ b/FuzeQuality/apps/web/src/App.tsx
@@ -43,7 +43,7 @@ import type {
   TestExpectation,
   TestImplementationRequest,
 } from '@fuzequality/contracts'
-import { api, type OrganizationMember, type OrganizationRole } from './api'
+import { api, configurePlatformSecurity, type OrganizationMember, type OrganizationRole } from './api'
 import { planGap } from './testPlan'
 import { storybookPreviewUrl } from './storybook'
 
@@ -579,12 +579,15 @@ function OrganizationAdministration({ organizations }: { organizations: Organiza
 
 function PageHeading({ eyebrow, title, detail, action }: { eyebrow: string; title: string; detail: string; action?: React.ReactNode }) { return <header className="page-header compact"><div><p className="eyebrow">{eyebrow}</p><h1>{title}</h1><p className="lede">{detail}</p></div>{action}</header> }
 
-export function App() {
+export function App({ getToken }: { getToken?: () => string | null } = {}) {
   const [view, setView] = useState<View>('overview')
   const [data, setData] = useState<Portfolio | null>(null)
   const [error, setError] = useState<string>()
   const [organizations, setOrganizations] = useState<OrganizationQualitySummary[]>()
   const [loading, setLoading] = useState(true)
+  // The portal owns the active account vault. A federated remote receives its
+  // bearer-token resolver from the host rather than reading portal storage.
+  useEffect(() => configurePlatformSecurity(getToken), [getToken])
   async function reload() {
     setLoading(true)
     try {

--- a/FuzeQuality/apps/web/src/api.ts
+++ b/FuzeQuality/apps/web/src/api.ts
@@ -4,6 +4,7 @@ import type {
   Portfolio,
   TestImplementationRequest,
 } from '@fuzequality/contracts'
+import type { Identity, SecurityErrorCode } from '@fuzefront/security-client'
 
 export type OrganizationRole = 'owner' | 'admin' | 'member' | 'viewer'
 export type OrganizationMember = { id: string; email?: string; name?: string; displayName?: string; userId?: string; user_id?: string; role: OrganizationRole; status?: string }
@@ -18,14 +19,49 @@ const portalApiBase = typeof window !== 'undefined' && window.location.pathname.
   ? '/apps/fuzequality'
   : ''
 const API_BASE = (portalApiBase || import.meta.env.VITE_FUZEQUALITY_API_URL || '').replace(/\/$/, '')
+const REQUEST_TIMEOUT_MS = 15_000
+type TokenProvider = () => string | null | undefined
+let platformToken: TokenProvider | undefined
+
+/**
+ * Receives the portal account-vault token from the Module Federation host.
+ * A remote must never read the host's storage directly: the host remains the
+ * sole owner of multi-account session selection and token refresh.
+ */
+export function configurePlatformSecurity(getToken?: TokenProvider) {
+  platformToken = getToken
+}
+
+export type PlatformSession = Pick<Identity, 'userId' | 'tenantId' | 'roles'>
+type SecurityFailure = { error?: string; code?: SecurityErrorCode }
 
 async function request<T>(path: string, init?: RequestInit): Promise<T> {
-  const response = await fetch(`${API_BASE}${path}`, {
-    ...init,
-    headers: { 'content-type': 'application/json', ...init?.headers },
-  })
-  if (!response.ok) throw new Error((await response.json().catch(() => null))?.error ?? `Request failed: ${response.status}`)
-  return response.json() as Promise<T>
+  const controller = new AbortController()
+  const timeout = window.setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS)
+  try {
+    const token = platformToken?.()
+    const response = await fetch(`${API_BASE}${path}`, {
+      ...init,
+      signal: controller.signal,
+      headers: {
+        'content-type': 'application/json',
+        ...(token ? { authorization: `Bearer ${token}` } : {}),
+        ...init?.headers,
+      },
+    })
+    if (!response.ok) {
+      const error = await response.json().catch(() => null) as SecurityFailure | null
+      throw new Error(error?.error ?? `Request failed: ${response.status}`)
+    }
+    return response.json() as Promise<T>
+  } catch (error) {
+    if (error instanceof DOMException && error.name === 'AbortError') {
+      throw new Error(`Catalog API timed out after ${REQUEST_TIMEOUT_MS / 1000} seconds`)
+    }
+    throw error
+  } finally {
+    window.clearTimeout(timeout)
+  }
 }
 
 export const api = {

--- a/FuzeQuality/apps/web/src/remote.tsx
+++ b/FuzeQuality/apps/web/src/remote.tsx
@@ -2,4 +2,6 @@ import './styles.css'
 import { App } from './App'
 
 /** Module-Federation entry point consumed by the FuzeFront portal. */
-export default App
+export default function FuzeQualityRemote({ getToken }: { getToken?: () => string | null }) {
+  return <App getToken={getToken} />
+}

--- a/FuzeQuality/docker/Dockerfile
+++ b/FuzeQuality/docker/Dockerfile
@@ -1,8 +1,14 @@
+# syntax=docker/dockerfile:1.7
 FROM node:24-alpine AS dependencies
 RUN apk add --no-cache git
 WORKDIR /workspace/FuzeQuality
-COPY FuzeQuality/package.json ./
-RUN npm install --ignore-scripts --no-audit --no-fund
+COPY FuzeQuality/package.json FuzeQuality/.npmrc ./
+# @fuzefront/security-client is a private published contract package. BuildKit
+# mounts its read-only registry token only for installation; it is never copied
+# into an image layer.
+RUN --mount=type=secret,id=GITHUB_TOKEN \
+    export GITHUB_TOKEN="$(cat /run/secrets/GITHUB_TOKEN)" && \
+    npm install --ignore-scripts --no-audit --no-fund
 
 FROM dependencies AS source
 # This COPY is what bakes contracts/openapi.yaml INTO the image, alongside the
@@ -14,7 +20,10 @@ FROM dependencies AS source
 COPY FuzeQuality ./
 
 FROM source AS verify
-ARG FUZEQUALITY_API_URL=https://fuzequality.prod.fuzefront.com
+# A supplied value is used for a standalone deployment. The federated remote
+# selects its same-origin /apps/fuzequality proxy at runtime instead, so it
+# never crosses the Cloudflare Access boundary for its API calls.
+ARG FUZEQUALITY_API_URL=
 ENV VITE_FUZEQUALITY_API_URL=${FUZEQUALITY_API_URL}
 RUN npm run type-check \
  && npm test \

--- a/FuzeQuality/package.json
+++ b/FuzeQuality/package.json
@@ -25,6 +25,7 @@
   },
   "dependencies": {
     "@apidevtools/swagger-parser": "^10.1.1",
+    "@fuzefront/security-client": "npm:@izzywdev/fuzefront-security-client@0.8.0",
     "express": "^5.1.0",
     "fast-glob": "^3.3.3",
     "jose": "^6.1.0",

--- a/FuzeQuality/tsconfig.json
+++ b/FuzeQuality/tsconfig.json
@@ -16,7 +16,8 @@
       "@fuzequality/contracts": ["packages/contracts/src/index.ts"],
       "@fuzequality/core": ["packages/core/src/index.ts"],
       "@fuzequality/github-app": ["packages/github-app/src/index.ts"],
-      "@fuzequality/scanner": ["packages/scanner/src/index.ts"]
+      "@fuzequality/scanner": ["packages/scanner/src/index.ts"],
+      "@fuzefront/security-client": ["../packages/security/src/index.ts"]
     }
   },
   "include": ["apps", "packages", "scripts", "vitest.config.ts"]

--- a/frontend/src/components/FederatedAppLoader.tsx
+++ b/frontend/src/components/FederatedAppLoader.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, Suspense } from 'react'
 import type { App } from '@fuzefront/app-registry-client'
 import { useCurrentUser } from '../lib/shared'
+import { getActiveAuthToken } from '../lib/accounts'
 import { useAppRegistry } from '../platform/appRegistry'
 import { usePortalContext } from '@fuzefront/portal-branding-ui'
 import {
@@ -63,7 +64,7 @@ export function FederatedAppLoader({ appId }: FederatedAppLoaderProps) {
   // before.
   const { status: portalStatus, context: portal } = usePortalContext()
   const [FederatedComponent, setFederatedComponent] =
-    useState<React.ComponentType | null>(null)
+    useState<React.ComponentType<{ getToken?: () => string | null }> | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [retryKey, setRetryKey] = useState(0)
@@ -241,7 +242,7 @@ export function FederatedAppLoader({ appId }: FederatedAppLoaderProps) {
   return (
     <FederatedAppErrorBoundary appName={app?.manifest.name} onRetry={handleRetry}>
       <Suspense fallback={<LoadingSpinner />}>
-        <FederatedComponent />
+        <FederatedComponent getToken={getActiveAuthToken} />
       </Suspense>
     </FederatedAppErrorBoundary>
   )


### PR DESCRIPTION
## Summary\n- inject the active FuzeFront account token into the federated FuzeQuality remote\n- validate and authorize through the platform security service using its published contract package\n- release the implementation worker and sandboxed test-agent runtime\n\n## Verification\n- 
pm run type-check in FuzeQuality\n\nThe release workflow builds immutable images and bumps the production Helm values after merge.