### PR TITLE
fix(fuzequality): bridge portal token through federation context

### DIFF
--- a/FuzeQuality/apps/web/src/api.ts
+++ b/FuzeQuality/apps/web/src/api.ts
@@ -23,6 +23,13 @@ const REQUEST_TIMEOUT_MS = 15_000
 type TokenProvider = () => string | null | undefined
 let platformToken: TokenProvider | undefined
 
+function portalToken(): string | null | undefined {
+  const context = (window as Window & {
+    __FRONTFUSE_CONTEXT__?: { getAccessToken?: TokenProvider }
+  }).__FRONTFUSE_CONTEXT__
+  return context?.getAccessToken?.()
+}
+
 /**
  * Receives the portal account-vault token from the Module Federation host.
  * A remote must never read the host's storage directly: the host remains the
@@ -39,7 +46,7 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
   const controller = new AbortController()
   const timeout = window.setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS)
   try {
-    const token = platformToken?.()
+    const token = platformToken?.() ?? portalToken()
     const response = await fetch(`${API_BASE}${path}`, {
       ...init,
       signal: controller.signal,

--- a/frontend/src/components/FederatedAppLoader.tsx
+++ b/frontend/src/components/FederatedAppLoader.tsx
@@ -88,6 +88,11 @@ export function FederatedAppLoader({ appId }: FederatedAppLoaderProps) {
         apps,
         activeApp: app,
         isPlatformMode: true,
+        // Federated applications receive a resolver, never the token value.
+        // This keeps account selection and refresh owned by the portal while
+        // also surviving federation wrappers that do not preserve function
+        // component props.
+        getAccessToken: getActiveAuthToken,
       }
     }
   }, [user, app, apps, portalStatus, portal])


### PR DESCRIPTION
## Summary\n- expose the active account token resolver through FuzeFront's federated-app context\n- use that host bridge if a Module Federation wrapper does not preserve the component function prop\n\n## Verification\n- npm run type-check (FuzeQuality)