### PR TITLE
chore(auth): bump version to 0.2.2 to fix missing dist

### DIFF
--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fuzefront/auth",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "engines": {
     "node": ">=24.0.0",
     "npm": ">=10.0.0"


### PR DESCRIPTION
Bumps @fuzefront/auth version to 0.2.2 to trigger the package publishing workflow with compiled dist folder.