### PR TITLE
fix(fuzequality): configure platform security service

### DIFF
--- a/FuzeQuality/deploy/helm/fuzequality/templates/_helpers.tpl
+++ b/FuzeQuality/deploy/helm/fuzequality/templates/_helpers.tpl
@@ -12,6 +12,8 @@ helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version }}
   valueFrom: { secretKeyRef: { name: {{ .Values.secret.existingSecret }}, key: FUZEQUALITY_API_TOKEN } }
 - name: KAFKA_BROKERS
   value: {{ .Values.config.kafkaBrokers | quote }}
+- name: FUZEFRONT_SECURITY_URL
+  value: {{ .Values.config.fuzefrontSecurityUrl | quote }}
 - name: LITELLM_URL
   value: {{ .Values.config.litellmUrl | quote }}
 - name: FUZEQUALITY_LLM_MODEL

--- a/FuzeQuality/deploy/helm/fuzequality/values.yaml
+++ b/FuzeQuality/deploy/helm/fuzequality/values.yaml
@@ -43,6 +43,10 @@ workers:
       limits: { cpu: 500m, memory: 512Mi }
 
 config:
+  # The platform security service is the authority for portal bearer tokens and
+  # scoped authorization checks. This is deliberately the in-cluster Service,
+  # not the public host: FuzeQuality is a FuzeFront federated workload.
+  fuzefrontSecurityUrl: http://fuzefront-security.fuzefront.svc.cluster.local:3002
   kafkaBrokers: fuzeinfra-kafka.fuzeinfra.svc.cluster.local:9092
   litellmUrl: http://litellm.fuzeinfra.svc.cluster.local:4000/v1
   chromaUrl: http://fuzeinfra-chromadb.fuzeinfra.svc.cluster.local:8000


### PR DESCRIPTION
## Summary
- inject the FuzeFront security-service DNS URL into FuzeQuality API and workers
- allow federated portal bearer tokens to reach the platform identity and authorization checks

## Verification
- helm template fuzequality FuzeQuality/deploy/helm/fuzequality -f FuzeQuality/deploy/helm/fuzequality/values-prod.yaml
- npm --prefix FuzeQuality run type-check