### PR TITLE
fix(security): allow FuzeQuality platform checks

### DIFF
--- a/deploy/helm/fuzefront/templates/security-networkpolicy.yaml
+++ b/deploy/helm/fuzefront/templates/security-networkpolicy.yaml
@@ -71,4 +71,15 @@ spec:
       ports:
         - protocol: TCP
           port: {{ $np.port | default 3002 | int }}
+    # FuzeQuality's API and workers validate a caller session and request
+    # authorization decisions through the platform security boundary. This is
+    # intentionally namespace-scoped; FuzeQuality is not part of the broader
+    # intra-fuzefront allowance above.
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ $np.fuzeQualityNamespace | default "fuzequality" | quote }}
+      ports:
+        - protocol: TCP
+          port: {{ $np.port | default 3002 | int }}
 {{- end }}

--- a/deploy/helm/fuzefront/values.yaml
+++ b/deploy/helm/fuzefront/values.yaml
@@ -234,6 +234,10 @@ securityService:
     # mendys-prod's datasets-service authenticates against this Service
     # in-cluster (session verify + authz check/grants). Issue: FuzeFront#493.
     mendysProdNamespace: mendys-prod
+    # FuzeQuality verifies a portal bearer token and asks this service for
+    # authorization decisions. Keeping this namespace explicit prevents a
+    # quality-worker pod from gaining access merely by sharing an app label.
+    fuzeQualityNamespace: fuzequality
   image:
     repository: fuzefront/security-service
     tag: local


### PR DESCRIPTION
Allows only the uzequality namespace to reach uzefront-security:3002 for session verification and authorization decisions. Helm lint/template validation passed.