### PR TITLE
chore(governance): declare expertMonitors for fuzefront-expert

### DIFF
--- a/.fuze/manifest.json
+++ b/.fuze/manifest.json
@@ -3,6 +3,15 @@
   "class": "oss-public",
   "tier": "product",
   "expert": "fuzefront-expert",
+  "expertMonitors": [
+    "backend/src/",
+    "frontend/src/",
+    "design-system/",
+    "sdk/",
+    "deploy/helm/fuzefront/",
+    "services/app-registry-service/",
+    ".github/workflows/"
+  ],
   "baselineRef": "v1",
   "agents": [
     "contract-designer",


### PR DESCRIPTION
## Why these paths

`fuzefront-expert.md` makes concrete architecture claims; each monitored path backs one:

- `backend/src/` — the Express + Postgres + Socket.io backend, including local JWT + Authentik OIDC auth and Permit.io authorization the expert describes.
- `frontend/src/` — the Module-Federation host shell (React 19 + Vite), design tokens, nginx-proxy setup.
- `design-system/` — the standalone "fuse seam" design system package the expert names as the brand-defining primitive layer for the whole family.
- `sdk/` — `@izzywdev/fuzefront-sdk-react`, published by `.github/workflows/sdk-publish.yml`.
- `deploy/helm/fuzefront/` — the Helm chart backing the Kubernetes (kind / Contabo k3s) deploy model the expert documents in detail.
- `services/app-registry-service/` — the OpenAPI spec (`openapi.yaml`) that is the frozen contract behind the MCP gateway (`fuzefront-mcp`) declared in this manifest.
- `.github/workflows/` — CI/CD (`ci.yml`, `e2e.yml`, `release.yml`) the expert documents including specific gotchas (workspace overrides, Playwright e2e).

Verified each path exists before declaring it. `expertMonitors` was previously undeclared for this repo.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>