### PR TITLE
fix(design-approval): use dedicated DESIGN_APPROVAL_DEPLOY_KEY, not the overloaded release key

### DIFF
--- a/.github/workflows/design-approval.yml
+++ b/.github/workflows/design-approval.yml
@@ -18,7 +18,9 @@ name: design-approval
 #   4. Staleness    — (only reached for a flow NOT yet approved) compare the issue's
 #      stamp to the current one. Mismatch (or empty) → do NOT flip.
 #   5. Write        — on approve, flip build.flows[<flow>].approved on master via a
-#      DEPLOY KEY (RELEASE_BUMP_SSH_KEY), the SAME write path release.yml uses.
+#      DEPLOY KEY (DESIGN_APPROVAL_DEPLOY_KEY) dedicated to this pipeline — a
+#      separate key from release.yml's RELEASE_BUMP_SSH_KEY, registered the same
+#      way (scripts/register-design-approval-key.sh in FuzeSDLC).
 #      This is deliberate: the "Protect Master" ruleset has a pull_request rule and
 #      GitHub refuses to add the github-actions app as a bypass actor on a
 #      user-owned repo, so a Contents-API commit under GITHUB_TOKEN is REJECTED
@@ -235,17 +237,20 @@ jobs:
             core.setOutput('stamp', computedStamp);
             core.setOutput('manifest_path', manifestPath);
 
-      # The master write path — a DEPLOY KEY, identical to release.yml's tag bump.
+      # The master write path — a DEPLOY KEY dedicated to this pipeline (a separate
+      # key from release.yml's, sharing the same bypass mechanism, not the key
+      # itself — see scripts/register-design-approval-key.sh in FuzeSDLC).
       # The "Protect Master" ruleset has a pull_request rule and refuses the
       # github-actions app as a bypass actor, so a Contents-API/GITHUB_TOKEN commit
       # is rejected with "Repository rule violations found" (the reported bug). The
-      # deploy key IS a registered DeployKey bypass_actor, so its push clears both
-      # the PR rule and required_signatures. If this starts failing with a rule
-      # violation, the DeployKey bypass entry or the deploy key was removed.
+      # deploy key IS covered by the ruleset's DeployKey bypass_actor (a blanket
+      # bypass for any write-access deploy key on the repo), so its push clears
+      # both the PR rule and required_signatures. If this starts failing with a
+      # rule violation, the DeployKey bypass entry or the deploy key was removed.
       - name: Flip approved on master (deploy key)
         if: steps.decide.outputs.flip == 'true'
         env:
-          SSH_KEY: ${{ secrets.RELEASE_BUMP_SSH_KEY }}
+          SSH_KEY: ${{ secrets.DESIGN_APPROVAL_DEPLOY_KEY }}
           FEATURE: ${{ steps.decide.outputs.feature }}
           FLOW: ${{ steps.decide.outputs.flow }}
           AUTHOR: ${{ steps.decide.outputs.author }}
@@ -255,10 +260,10 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p ~/.ssh
-          printf '%s\n' "$SSH_KEY" > ~/.ssh/release_bump
-          chmod 600 ~/.ssh/release_bump
+          printf '%s\n' "$SSH_KEY" > ~/.ssh/design_approval
+          chmod 600 ~/.ssh/design_approval
           ssh-keyscan github.com >> ~/.ssh/known_hosts 2>/dev/null
-          export GIT_SSH_COMMAND="ssh -i ~/.ssh/release_bump -o IdentitiesOnly=yes"
+          export GIT_SSH_COMMAND="ssh -i ~/.ssh/design_approval -o IdentitiesOnly=yes"
           git config user.name  "fuzefront-design"
           git config user.email "design-approve@users.noreply.github.com"
           git remote set-url --push origin "git@github.com:${GITHUB_REPOSITORY}.git"


### PR DESCRIPTION
## Summary
- `design-approval.yml` now pushes its master-branch approval flip using a dedicated `DESIGN_APPROVAL_DEPLOY_KEY` deploy key instead of the shared `RELEASE_BUMP_SSH_KEY`.
- `RELEASE_BUMP_SSH_KEY` was serving **four** unrelated write jobs (release-bump tag, fuzequality release, sealed-secret commit, and this design-approval flip). This PR only repoints design-approval; the other three consumers (`release.yml`, `fuzequality-release.yml`, `seal-sms-secrets.yml`) are **untouched**, and `RELEASE_BUMP_SSH_KEY` is **not deleted** — it still has three users.
- The new key was registered via FuzeSDLC's `scripts/register-design-approval-key.sh` (write access, deploy key id 161848319) as part of a fleet-wide rollout to the 16 repos carrying `design-approval.yml`. FuzeFront's "Protect Master" ruleset already carries a blanket `DeployKey` bypass actor (GitHub's bypass mechanism has no per-key scoping), so the new key is already covered — no ruleset change was needed here.

## Verification
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/design-approval.yml'))"` → YAML OK.
- Confirmed only `.github/workflows/design-approval.yml` changed (`git status`); the other three `RELEASE_BUMP_SSH_KEY` consumers have zero diff.
- Confirmed independently via `gh api`: `DESIGN_APPROVAL_DEPLOY_KEY` secret present on `izzywdev/FuzeFront`, deploy key id `161848319` present with `read_only=false`, and the ruleset's `bypass_actors` already contain `{"actor_type":"DeployKey","actor_id":null}` alongside the repo's pre-existing admin/App bypass actors (all preserved, none removed).

## Out of scope
Moving `release.yml` / `fuzequality-release.yml` / `seal-sms-secrets.yml` off `RELEASE_BUMP_SSH_KEY` onto App-installation tokens, and deleting `RELEASE_BUMP_SSH_KEY` — both depend on the fuze-agent App being wired into stamped workflows (FuzeSDLC PR #250, still open). Not attempted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
