### PR TITLE
fix(secrets): drop live cert fetch from seal-sms-secrets.yml

### DIFF
--- a/.github/workflows/seal-sms-secrets.yml
+++ b/.github/workflows/seal-sms-secrets.yml
@@ -28,12 +28,19 @@ name: Seal Twilio + SMS secrets
 # SEPARATE GitOps commit in a deploy window (flip smsService.enabled: true), kept
 # apart so the secret is provably present before the Deployment ever renders.
 #
-# NO cluster access is used: like deploy/scripts/seal-secret.sh, the sealed-secrets
-# PUBLIC cert is fetched over HTTPS from CERT_URL, and the input Secret manifest is
-# built inline (no kubectl). The commit to `master` goes through the same
-# RELEASE_BUMP_SSH_KEY deploy key release.yml uses, because the "Protect Master"
-# ruleset rejects a plain GITHUB_TOKEN push (Changes must be made through a pull
-# request); the DeployKey is a bypass actor on that rule.
+# NO cluster access is used, and NO live network fetch of the sealed-secrets
+# controller cert either. This workflow used to fetch that PUBLIC cert live over
+# HTTPS from CERT_URL — but that URL sits behind Cloudflare Access, which answers
+# an unauthenticated CI request with an HTML login page, not a PEM (the same
+# fragility FuzeInfra's own scripts/seal-secret.sh already hit and fixed). It now
+# seals OFFLINE via scripts/seal-secret.sh against the cert committed at
+# deploy/sealed-secrets/sealing-cert.pem (added in #870 for seal-consumer-secret.yml;
+# reused here, not re-committed), with a guard step that fails loudly if that cert
+# is missing or expired rather than silently sealing something the live controller
+# can't decrypt. The commit to `master` goes through the same RELEASE_BUMP_SSH_KEY
+# deploy key release.yml uses, because the "Protect Master" ruleset rejects a plain
+# GITHUB_TOKEN push (Changes must be made through a pull request); the DeployKey is
+# a bypass actor on that rule.
 
 on:
   workflow_dispatch:
@@ -59,9 +66,10 @@ permissions:
   contents: write
 
 env:
-  # FuzeInfra publishes the sealed-secrets public cert here (same default as
-  # deploy/scripts/seal-secret.sh). Override via repo variable if the URL changes.
-  CERT_URL: https://sealed-secrets.prod.fuzefront.com/v1/cert.pem
+  # The sealed-secrets controller's PUBLIC certificate, committed in-repo (added
+  # in #870; force-added past the blanket *.pem gitignore rule since it's public
+  # key material). No live URL, no cluster access, no kubeconfig.
+  SEALING_CERT: deploy/sealed-secrets/sealing-cert.pem
 
 jobs:
   seal:
@@ -99,6 +107,30 @@ jobs:
           case "$TWILIO_VERIFY_SERVICE_SID" in VA*) :;; *) echo "::warning::TWILIO_VERIFY_SERVICE_SID does not start with 'VA' — double-check it.";; esac
           echo "::notice::All Twilio secrets are present."
 
+      # A stale/missing cert would otherwise fail silently at pod start (the live
+      # controller can't decrypt a SealedSecret sealed against an old key), which
+      # is the worst place to discover it — fail loudly here instead.
+      - name: Verify sealing cert is present and current
+        run: |
+          set -euo pipefail
+          CERT="$SEALING_CERT"
+          REFRESH_HELP="Refresh it (only needed after a sealed-secrets controller key rotation — not a routine step) from an environment with cluster access: kubeseal --controller-namespace kube-system --controller-name sealed-secrets-controller --fetch-cert > \$CERT, then commit with 'git add -f \$CERT' (it is public key material — safe to publish — but matched by the repo's blanket *.pem gitignore rule, so force-add is expected)."
+
+          if [ ! -f "$CERT" ]; then
+            echo "::error::Missing $CERT. Sealing needs the sealed-secrets controller's PUBLIC certificate committed in-repo — this job uses ZERO cluster access and ZERO live network fetch. $REFRESH_HELP"
+            exit 1
+          fi
+
+          if ! openssl x509 -in "$CERT" -noout -checkend 0 >/dev/null 2>&1; then
+            END="$(openssl x509 -in "$CERT" -noout -enddate 2>/dev/null | cut -d= -f2)"
+            echo "::error::$CERT has EXPIRED (notAfter: ${END:-unknown}). Sealing against a stale cert silently produces a SealedSecret the live controller cannot decrypt — it would fail at pod start, not here. Failing loudly now instead. $REFRESH_HELP"
+            exit 1
+          fi
+
+          FPR="$(openssl x509 -in "$CERT" -noout -fingerprint -sha256 2>/dev/null | cut -d= -f2)"
+          END="$(openssl x509 -in "$CERT" -noout -enddate 2>/dev/null | cut -d= -f2)"
+          echo "::notice::Sealing cert OK — SHA256 fingerprint ${FPR}, expires ${END}"
+
       - name: Install kubeseal
         run: |
           KSVER=0.27.3
@@ -120,9 +152,8 @@ jobs:
           d=$(mktemp -d)
           trap 'rm -rf "$d"' EXIT
 
-          # Never echo values. Whitespace-trim each (paste artefacts are common),
-          # then base64 for the Secret's data: block (base64 output is YAML-safe,
-          # so no quoting/escaping pitfalls regardless of the raw value).
+          # Never echo values. Whitespace-trim each (paste artefacts are common);
+          # scripts/seal-secret.sh base64s KEY=@file inputs itself.
           printf '%s' "$TWILIO_ACCOUNT_SID"        | tr -d '[:space:]' > "$d/TWILIO_ACCOUNT_SID"
           printf '%s' "$TWILIO_API_KEY_SID"        | tr -d '[:space:]' > "$d/TWILIO_API_KEY_SID"
           printf '%s' "$TWILIO_API_KEY_SECRET"     | tr -d '[:space:]' > "$d/TWILIO_API_KEY_SECRET"
@@ -131,39 +162,29 @@ jobs:
           # SMS_AUTH_SECRET: mint only if absent, or if rotation was explicitly
           # requested. Re-minting rotates the shared token, so it must be opt-in —
           # Authentik and sms-service both restart to pick up a rotated value.
-          MINT_SMS=1
+          declare -a PAIRS=(
+            "TWILIO_ACCOUNT_SID=@$d/TWILIO_ACCOUNT_SID"
+            "TWILIO_API_KEY_SID=@$d/TWILIO_API_KEY_SID"
+            "TWILIO_API_KEY_SECRET=@$d/TWILIO_API_KEY_SECRET"
+            "TWILIO_VERIFY_SERVICE_SID=@$d/TWILIO_VERIFY_SERVICE_SID"
+          )
           if grep -q 'SMS_AUTH_SECRET' "$MANIFEST" && [ "$ROTATE_SMS_AUTH" != "true" ]; then
-            MINT_SMS=0
             echo "::notice::SMS_AUTH_SECRET already sealed — leaving it untouched (pass rotate_sms_auth=true to rotate)."
           else
             openssl rand -hex 32 | tr -d '\n' > "$d/SMS_AUTH_SECRET"
+            PAIRS+=("SMS_AUTH_SECRET=@$d/SMS_AUTH_SECRET")
             echo "::notice::SMS_AUTH_SECRET will be minted and sealed."
           fi
 
-          # Fetch the sealed-secrets PUBLIC cert over HTTPS (no cluster/kubeconfig,
-          # no decrypt key) — the same source deploy/scripts/seal-secret.sh uses.
-          curl -fsSL "$CERT_URL" -o "$d/cert.pem"
-          echo "::notice::Fetched sealed-secrets public cert from $CERT_URL."
+          # Offline, encrypt-only seal via FuzeInfra's canonical script: needs only
+          # the committed public cert, never a kubeconfig, kubectl, or a live cert
+          # fetch. --merge-into (inside the script) preserves every other key
+          # already in $MANIFEST.
+          bash scripts/seal-secret.sh fuzefront/fuzefront-secrets \
+            "${PAIRS[@]}" \
+            --cert "$SEALING_CERT" \
+            --out "$MANIFEST"
 
-          # Build the input Secret manifest inline (no kubectl dependency). Only
-          # the keys being (re)sealed are listed; --merge-into leaves every other
-          # key in $MANIFEST untouched.
-          {
-            echo "apiVersion: v1"
-            echo "kind: Secret"
-            echo "metadata:"
-            echo "  name: fuzefront-secrets"
-            echo "  namespace: fuzefront"
-            echo "type: Opaque"
-            echo "data:"
-            echo "  TWILIO_ACCOUNT_SID: $(base64 -w0 < "$d/TWILIO_ACCOUNT_SID")"
-            echo "  TWILIO_API_KEY_SID: $(base64 -w0 < "$d/TWILIO_API_KEY_SID")"
-            echo "  TWILIO_API_KEY_SECRET: $(base64 -w0 < "$d/TWILIO_API_KEY_SECRET")"
-            echo "  TWILIO_VERIFY_SERVICE_SID: $(base64 -w0 < "$d/TWILIO_VERIFY_SERVICE_SID")"
-            [ "$MINT_SMS" = "1" ] && echo "  SMS_AUTH_SECRET: $(base64 -w0 < "$d/SMS_AUTH_SECRET")"
-          } > "$d/secret.yaml"
-
-          kubeseal --cert "$d/cert.pem" --format yaml --merge-into "$MANIFEST" < "$d/secret.yaml"
           echo "::notice::Sealed Twilio (+ SMS_AUTH_SECRET if applicable) and merged into $MANIFEST."
 
       - name: Show diff (dry run)


### PR DESCRIPTION
## Summary
- `seal-sms-secrets.yml` fetched the sealed-secrets controller's **public** cert live over HTTPS from `CERT_URL` (`https://sealed-secrets.prod.fuzefront.com/v1/cert.pem`), with no committed-cert fallback. That URL sits behind Cloudflare Access, which answers an unauthenticated CI request with an HTML login page, not a PEM -- the exact fragility already hit and fixed for `seal-consumer-secret.yml` in #870.
- No cluster credential/kubectl was ever used here (confirmed by reading the workflow in full) -- the only network dependency was the live cert fetch, so the fix is scoped to that.
- Reroutes sealing through FuzeFront's existing `scripts/seal-secret.sh` against the cert **already committed** in #870 at `deploy/sealed-secrets/sealing-cert.pem` (reused as-is -- not re-committed, not a second copy). Verified locally: not expired (`notAfter=Jul 22 21:28:22 2036 GMT`).
- Carries the same missing/expired-cert guard step from #870 (`Verify sealing cert is present and current`), so a stale cert fails loudly in CI with the exact refresh command + fingerprint/expiry, instead of silently sealing something the live controller can't decrypt (which would only surface as a pod-start failure later).
- All 5 keys (`TWILIO_ACCOUNT_SID/API_KEY_SID/API_KEY_SECRET/VERIFY_SERVICE_SID` + conditional `SMS_AUTH_SECRET`) are now sealed in a single `scripts/seal-secret.sh` call with multiple `KEY=@file` args, replacing the old inline `kubeseal --merge-into` + hand-built Secret manifest. `--merge-into` semantics (preserve every other key) are unchanged -- they now live inside the script.

## Other workflows checked
Grepped every workflow in `.github/workflows/` for `fetch-cert` / `CERT_URL` / the published cert URL / `KUBE_CONFIG`. Three matches: `rotate-sealed-secret.yml` and `seal-consumer-secret.yml` were already fixed by #870; `seal-sms-secrets.yml` (this PR) was the only one still doing a live fetch. Nothing else references any of these.

## Validation
- `python3 -c "import yaml; yaml.safe_load(open(...))"` -- OK.
- `actionlint` (rhysd/actionlint Docker image) on the changed file -- exit 0, no findings.
- `openssl x509 -in deploy/sealed-secrets/sealing-cert.pem -noout -checkend 0` -- not expired.
- **Not verified**: an actual seal round-trip / controller decrypt -- that needs live cluster access this environment doesn't have, which is precisely what this change removes the dependency on. Verified statically instead (guard-step logic, script wiring, cert content).

CI is currently stuck fleet-wide on GitHub Actions budget exhaustion (jobs queued, no runner), so not waiting on checks that will never run.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session-Id: fe3aa738-cb24-4315-a29b-29834ddea892