### PR TITLE
Add @fuzefront/service-auth: runtime S2S auth (client + fail-closed verifier + middleware)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "shared",
         "packages/identity",
         "packages/auth",
+        "packages/service-auth",
         "billing-client",
         "config-client",
         "custom-hostname-client",
@@ -3924,6 +3925,10 @@
     },
     "node_modules/@fuzefront/security-service": {
       "resolved": "backend/security",
+      "link": true
+    },
+    "node_modules/@fuzefront/service-auth": {
+      "resolved": "packages/service-auth",
       "link": true
     },
     "node_modules/@fuzefront/shared": {
@@ -23119,7 +23124,7 @@
       },
       "peerDependencies": {
         "@fuzefront/design-system": "^1.0.0",
-        "@fuzefront/security-client": "^0.5.0",
+        "@fuzefront/security-client": "^0.8.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
       }
@@ -24035,7 +24040,7 @@
     },
     "packages/auth": {
       "name": "@fuzefront/auth",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
         "jose": "^5.10.0"
@@ -28294,7 +28299,7 @@
       },
       "peerDependencies": {
         "@fuzefront/design-system": "^1.0.0",
-        "@fuzefront/security-client": "^0.6.0",
+        "@fuzefront/security-client": "^0.8.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
       }
@@ -29292,7 +29297,7 @@
       "peerDependencies": {
         "@fuzefront/design-system": "^1.0.0",
         "@fuzefront/portal-client": "^1.0.0",
-        "@fuzefront/security-client": "^0.7.0",
+        "@fuzefront/security-client": "^0.8.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
       }
@@ -33170,6 +33175,35 @@
         }
       }
     },
+    "packages/service-auth": {
+      "name": "@fuzefront/service-auth",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@fuzefront/security-client": "0.8.0"
+      },
+      "devDependencies": {
+        "@types/express": "^4.17.25",
+        "@types/jest": "^29.5.14",
+        "@types/node": "^24.13.3",
+        "jest": "^29.7.0",
+        "ts-jest": "^29.4.11",
+        "tsup": "^8.0.2",
+        "typescript": "^5.9.3"
+      },
+      "engines": {
+        "node": ">=24.0.0",
+        "npm": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "express": "^4.22.2"
+      },
+      "peerDependenciesMeta": {
+        "express": {
+          "optional": true
+        }
+      }
+    },
     "portal-client": {
       "name": "@fuzefront/portal-client",
       "version": "1.0.0",
@@ -33292,19 +33326,6 @@
       "engines": {
         "node": ">=24.0.0",
         "npm": ">=10.0.0"
-      }
-    },
-    "services/chat-service/node_modules/@types/express": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
-      "integrity": "sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/body-parser": "*",
-        "@types/express-serve-static-core": "^4.17.33",
-        "@types/qs": "*",
-        "@types/serve-static": "*"
       }
     },
     "services/chat-service/node_modules/@types/supertest": {
@@ -33695,19 +33716,6 @@
       "engines": {
         "node": ">=24.0.0",
         "npm": ">=10.0.0"
-      }
-    },
-    "services/email-service/node_modules/@types/express": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
-      "integrity": "sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/body-parser": "*",
-        "@types/express-serve-static-core": "^4.17.33",
-        "@types/qs": "*",
-        "@types/serve-static": "*"
       }
     },
     "services/email-service/node_modules/@types/supertest": {
@@ -34106,19 +34114,6 @@
         "npm": ">=10.0.0"
       }
     },
-    "services/notification-service/node_modules/@types/express": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
-      "integrity": "sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/body-parser": "*",
-        "@types/express-serve-static-core": "^4.17.33",
-        "@types/qs": "*",
-        "@types/serve-static": "*"
-      }
-    },
     "services/notification-service/node_modules/@types/supertest": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-6.0.2.tgz",
@@ -34509,19 +34504,6 @@
       "engines": {
         "node": ">=24.0.0",
         "npm": ">=10.0.0"
-      }
-    },
-    "services/selection-list-service/node_modules/@types/express": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
-      "integrity": "sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/body-parser": "*",
-        "@types/express-serve-static-core": "^4.17.33",
-        "@types/qs": "*",
-        "@types/serve-static": "*"
       }
     },
     "services/selection-list-service/node_modules/@types/supertest": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "shared",
     "packages/identity",
     "packages/auth",
+    "packages/service-auth",
     "billing-client",
     "config-client",
     "custom-hostname-client",

--- a/packages/service-auth/CHANGELOG.md
+++ b/packages/service-auth/CHANGELOG.md
@@ -1,0 +1,35 @@
+# Changelog — @fuzefront/service-auth
+
+All notable changes to this package are documented here. Versioned
+independently; bump on every interface change (SemVer — the major is the
+contract-stability guarantee consumers may assert on).
+
+## 0.1.0 — Initial release
+
+First runtime implementation of S2S (machine-to-machine) auth for the
+FuzeFront family, closing the gap left by PR #837 (`@fuzefront/security-client`
+shipped generated TYPES for `/api/v1/security/tokens*` but no runtime client
+or middleware, so every consumer hand-rolled its own HTTP calls).
+
+### Added
+
+- `createServiceAuthClient` — obtain/cache/auto-refresh a machine bearer token
+  via `POST /api/v1/security/tokens`. Refreshes before expiry (safety margin,
+  default 30s); concurrent `getToken()` calls during a refresh single-flight
+  into one request.
+- `createMachineTokenVerifier` — fail-closed introspection via
+  `POST /api/v1/security/tokens/introspect`. Branches on the response body's
+  `active` boolean, never on HTTP status (introspection always answers 200).
+  Every ambiguity — network error, timeout, non-200, malformed/missing
+  `active`, missing `subject` — throws `ServiceAuthError` rather than
+  returning a permissive identity. Bounded cache for POSITIVE results only
+  (never for negative — a revocation is visible on the next call), capped by
+  the token's own `exp`.
+- `requireMachineAuth` — Express middleware wrapping the verifier: attaches
+  `req.machineIdentity`, never calls `next()` on a failed/unauthenticated
+  request, and exposes a pluggable `authorize` hook (fail-closed: a throw is a
+  denial) as the seam for the `/authz/*` routes once they're live for machine
+  principals.
+- 27 tests across client/verifier/middleware, weighted toward the fail-closed
+  paths — including the one this package exists for: an inactive token with a
+  200 response is rejected.

--- a/packages/service-auth/README.md
+++ b/packages/service-auth/README.md
@@ -1,0 +1,132 @@
+# @fuzefront/service-auth
+
+Runtime **service-to-service (machine) auth** for the FuzeFront family.
+
+FuzeFront's own consumer docs used to say: "call the same-origin Security API
+with your own fetch/HTTP layer." That meant every consuming service hand-rolled
+its own ~15-line introspection call — and one of them was going to get the one
+subtle part wrong: **`POST /api/v1/security/tokens/introspect` ALWAYS answers
+HTTP 200.** An inactive/expired/revoked token still comes back `200 { active:
+false }`. A caller that checks `res.ok` / `status === 200` instead of the
+`active` boolean in the body fails **open**.
+
+This package is the one implementation everyone imports instead, bound to the
+frozen contract in
+[`@fuzefront/security-client`](https://github.com/izzywdev/FuzeFront/tree/master/packages/security)
+(`packages/security/openapi.yaml`): `POST /api/v1/security/tokens` (issue) and
+`POST /api/v1/security/tokens/introspect` (verify). It never talks to the
+vendor identity provider behind those endpoints — only to FuzeFront.
+
+## Install
+
+```bash
+npm install @fuzefront/service-auth        # + express, if you use the middleware
+```
+
+## The two halves
+
+### 1. Caller — obtain a machine token
+
+```ts
+import { createServiceAuthClient } from '@fuzefront/service-auth'
+
+const auth = createServiceAuthClient({
+  baseUrl: process.env.FUZEFRONT_API_URL!, // e.g. http://backend:3001/api
+  clientId: process.env.SERVICE_CLIENT_ID!,
+  clientSecret: process.env.SERVICE_CLIENT_SECRET!,
+  // scope: 'invoices:read invoices:write',
+})
+
+async function callDownstream() {
+  const token = await auth.getToken() // cached; refreshed BEFORE it expires
+  return fetch('https://billing.internal/invoices', {
+    headers: { authorization: `Bearer ${token}` },
+  })
+}
+```
+
+- The token is cached in memory and reused until it's within
+  `refreshMarginSeconds` (default 30s) of its `expiresIn` — refresh happens
+  proactively on the next `getToken()` call, never reactively after a 401.
+- Concurrent `getToken()` calls during a refresh share **one** in-flight
+  request (single-flight), so N callers racing a refresh never turn into N
+  requests against the issuance endpoint.
+- Call `auth.invalidate()` to force a fresh token on the next call (e.g. if a
+  downstream call ever does get a 401 with this token, invalidate and retry
+  once — don't loop).
+
+### 2. Resource server — verify an incoming machine token
+
+```ts
+import express from 'express'
+import { createMachineTokenVerifier, requireMachineAuth } from '@fuzefront/service-auth'
+
+const verifier = createMachineTokenVerifier({
+  baseUrl: process.env.FUZEFRONT_API_URL!,
+})
+
+const app = express()
+app.use(
+  '/internal',
+  requireMachineAuth({
+    verifier,
+    // Optional: wire in a real policy decision once the /authz/* routes are
+    // live for machine principals. Until then, omit `authorize` and this is
+    // authentication-only gating (any verified machine identity passes).
+    // authorize: async (identity, req) =>
+    //   authzClient.check(
+    //     { subject: identity.subject, tenant: identity.tenantId!, resource: { type: 'invoice' }, action: 'read' },
+    //     bearerFromReq(req),
+    //   ).then(d => d.allow),
+  }),
+)
+
+app.get('/internal/invoices', (req, res) => {
+  res.json({ calledBy: req.machineIdentity!.subject })
+})
+```
+
+- `verifyMachineToken(token)` throws `ServiceAuthError` for every failure mode
+  — never returns a permissive identity. That includes: token inactive
+  (`active: false`, even though the HTTP status was 200), network error,
+  timeout, non-200 status, unparsable body, a body missing `active`.
+- The middleware never calls `next()` for a request that didn't pass: `401`
+  for anything authentication-shaped (no token, garbage header, verification
+  failure), `403` for an `authorize` hook that returned `false` **or threw**
+  (a hook that can't decide is treated as a denial, same as everywhere else in
+  this package).
+- Positive introspection results are cached briefly (`cacheTtlSeconds`,
+  default 5s, capped by the token's own `exp`) to avoid hammering the
+  introspection endpoint on hot paths. **Negative results are never cached at
+  any setting** — a revocation is visible on the very next call.
+
+## Guarantees worth knowing
+
+- **Fail-closed everywhere.** Every ambiguity — network error, timeout,
+  malformed body, a missing/mistyped `active` — is a denial (`ServiceAuthError`
+  thrown, or `401`/`403` from the middleware). There is no "allow on error"
+  path in this package.
+- **Branches on the body, never on HTTP status**, for introspection. This is
+  the one property the whole package exists to get right — see
+  `tests/verifier.test.ts`'s first test.
+- **Single-flight token refresh.** A stampede of callers refreshing at the
+  same instant makes exactly one request, not N.
+
+## Error codes
+
+| Code | Where | Meaning |
+|---|---|---|
+| `MISCONFIGURED` | client/verifier/middleware construction | missing required options |
+| `TOKEN_REQUEST_FAILED` | client | issuance request failed (network, non-2xx) |
+| `MALFORMED_RESPONSE` | client/verifier | response body didn't match the contract |
+| `NO_TOKEN` | verifier/middleware | no/empty token presented |
+| `INTROSPECTION_UNAVAILABLE` | verifier | network error, timeout, or unexpected non-200 from introspect |
+| `TOKEN_INACTIVE` | verifier | introspection answered `{ active: false }` |
+| `FORBIDDEN` | middleware | `authorize` hook denied or threw |
+
+## Types
+
+Request/response shapes (`TokenIssueRequest`, `TokenIssueResponse`,
+`TokenIntrospectRequest`, `TokenIntrospection`) are re-exported from the
+generated `@fuzefront/security-client` — this package never restates the wire
+contract, only builds runtime behavior on top of it.

--- a/packages/service-auth/jest.config.js
+++ b/packages/service-auth/jest.config.js
@@ -1,0 +1,13 @@
+/** @type {import('jest').Config} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/tests'],
+  testMatch: ['**/*.test.ts'],
+  // The package tsconfig is build-shaped (types: ["node"], include: src only), so
+  // tests need their own or the jest globals do not resolve.
+  transform: {
+    '^.+\\.ts$': ['ts-jest', { tsconfig: '<rootDir>/tests/tsconfig.json' }],
+  },
+  testTimeout: 15000,
+}

--- a/packages/service-auth/package.json
+++ b/packages/service-auth/package.json
@@ -1,0 +1,60 @@
+{
+  "name": "@fuzefront/service-auth",
+  "version": "0.1.0",
+  "engines": {
+    "node": ">=24.0.0",
+    "npm": ">=10.0.0"
+  },
+  "description": "Runtime service-to-service (machine) auth for the FuzeFront family: obtain/cache/refresh a client-credentials token, and verify+gate incoming machine tokens via FuzeFront's own /api/v1/security/tokens contract.",
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "license": "MIT",
+  "sideEffects": false,
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com",
+    "access": "restricted"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/izzywdev/FuzeFront.git",
+    "directory": "packages/service-auth"
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "CHANGELOG.md"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "test": "jest",
+    "type-check": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "express": "^4.22.2"
+  },
+  "peerDependenciesMeta": {
+    "express": {
+      "optional": true
+    }
+  },
+  "dependencies": {
+    "@fuzefront/security-client": "0.8.0"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.25",
+    "@types/jest": "^29.5.14",
+    "@types/node": "^24.13.3",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.4.11",
+    "tsup": "^8.0.2",
+    "typescript": "^5.9.3"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    }
+  }
+}

--- a/packages/service-auth/src/client.ts
+++ b/packages/service-auth/src/client.ts
@@ -1,0 +1,178 @@
+/**
+ * @fuzefront/service-auth — the CALLER half.
+ *
+ * Obtains and caches a machine (client-credentials) bearer token from
+ * FuzeFront's `POST /api/v1/security/tokens`. Never talks to the vendor
+ * identity provider directly.
+ *
+ * Caching + refresh:
+ *  - The token is cached in memory and reused until it is within
+ *    `refreshMarginSeconds` of its `expiresIn` — refreshing BEFORE expiry, not
+ *    on failure after it, so a well-behaved caller never presents an expired
+ *    token.
+ *  - Concurrent `getToken()` calls during a refresh share ONE in-flight
+ *    request (single-flight) rather than each firing their own — a stampede
+ *    of N callers refreshing at once would otherwise turn one expiry into N
+ *    requests against the IdP-backed issuance endpoint.
+ */
+
+import { FetchLike, ServiceAuthError, TokenIssueResponse } from './types';
+
+const TOKEN_PATH = '/api/v1/security/tokens';
+const DEFAULT_TIMEOUT_MS = 5000;
+const DEFAULT_REFRESH_MARGIN_SECONDS = 30;
+
+export interface ServiceAuthClientOptions {
+  /** FuzeFront's same-origin API base, e.g. `https://app.fuzefront.com/api` or `http://backend:3001/api`. */
+  baseUrl: string;
+  clientId: string;
+  clientSecret: string;
+  /** Optional requested scope, forwarded verbatim to `TokenIssueRequest.scope`. */
+  scope?: string;
+  /** Inject an alternative fetch (tests, old Node). Defaults to `globalThis.fetch`. */
+  fetch?: FetchLike;
+  /** Per-request timeout. Default 5000ms. */
+  timeoutMs?: number;
+  /**
+   * How long before expiry to proactively refresh, in seconds. Default 30.
+   * Refreshing happens on the NEXT `getToken()` call at or past this margin —
+   * there is no background timer.
+   */
+  refreshMarginSeconds?: number;
+}
+
+export interface ServiceAuthClient {
+  /**
+   * Returns a valid bearer token, refreshing it first if it is missing or
+   * within the refresh margin of expiry. Concurrent calls during a refresh
+   * share the same underlying request.
+   */
+  getToken(): Promise<string>;
+  /** Drop the cached token, forcing the next `getToken()` to fetch a fresh one. */
+  invalidate(): void;
+}
+
+interface CachedToken {
+  accessToken: string;
+  expiresAtMs: number;
+}
+
+/** Build a client bound to FuzeFront's machine-token issuance endpoint. */
+export function createServiceAuthClient(options: ServiceAuthClientOptions): ServiceAuthClient {
+  if (!options?.baseUrl || !options?.clientId || !options?.clientSecret) {
+    throw new ServiceAuthError(
+      'MISCONFIGURED',
+      'createServiceAuthClient requires baseUrl, clientId, and clientSecret.',
+      500,
+    );
+  }
+
+  const base = options.baseUrl.replace(/\/+$/, '');
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const marginMs = (options.refreshMarginSeconds ?? DEFAULT_REFRESH_MARGIN_SECONDS) * 1000;
+
+  const resolvedFetch: FetchLike | undefined =
+    options.fetch ??
+    (typeof globalThis.fetch === 'function'
+      ? (globalThis.fetch.bind(globalThis) as unknown as FetchLike)
+      : undefined);
+
+  if (!resolvedFetch) {
+    throw new ServiceAuthError(
+      'MISCONFIGURED',
+      'No fetch implementation available. Pass `fetch` explicitly on Node <18.',
+      500,
+    );
+  }
+
+  let cached: CachedToken | null = null;
+  // Single-flight: while a refresh is in progress, every concurrent caller
+  // awaits THIS promise instead of starting its own request.
+  let inflight: Promise<string> | null = null;
+
+  function isFresh(token: CachedToken): boolean {
+    return Date.now() < token.expiresAtMs - marginMs;
+  }
+
+  async function requestNewToken(): Promise<string> {
+    const controller = typeof AbortController === 'function' ? new AbortController() : undefined;
+    const timer = controller ? setTimeout(() => controller.abort(), timeoutMs) : undefined;
+    let res: Awaited<ReturnType<FetchLike>>;
+    try {
+      res = await resolvedFetch!(`${base}${TOKEN_PATH}`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          clientId: options.clientId,
+          clientSecret: options.clientSecret,
+          ...(options.scope ? { scope: options.scope } : {}),
+        }),
+        signal: controller?.signal,
+      });
+    } catch (err) {
+      throw new ServiceAuthError(
+        'TOKEN_REQUEST_FAILED',
+        `Token issuance request failed: ${(err as Error)?.message ?? 'unknown error'}`,
+        502,
+      );
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+
+    if (!res.ok) {
+      throw new ServiceAuthError(
+        'TOKEN_REQUEST_FAILED',
+        `Token issuance returned ${res.status}.`,
+        res.status === 401 || res.status === 400 ? res.status : 502,
+      );
+    }
+
+    let body: unknown;
+    try {
+      body = await res.json();
+    } catch (err) {
+      throw new ServiceAuthError(
+        'MALFORMED_RESPONSE',
+        `Token issuance returned a non-JSON body: ${(err as Error)?.message ?? 'parse error'}`,
+        502,
+      );
+    }
+
+    const payload = body as Partial<TokenIssueResponse> | null;
+    if (!payload || typeof payload.accessToken !== 'string' || !payload.accessToken) {
+      throw new ServiceAuthError(
+        'MALFORMED_RESPONSE',
+        'Token issuance response is missing a string `accessToken`.',
+        502,
+      );
+    }
+
+    const expiresIn =
+      typeof payload.expiresIn === 'number' && Number.isFinite(payload.expiresIn) && payload.expiresIn > 0
+        ? payload.expiresIn
+        : 0;
+
+    cached = {
+      accessToken: payload.accessToken,
+      expiresAtMs: Date.now() + expiresIn * 1000,
+    };
+    return cached.accessToken;
+  }
+
+  return {
+    async getToken(): Promise<string> {
+      if (cached && isFresh(cached)) return cached.accessToken;
+
+      if (!inflight) {
+        inflight = requestNewToken().finally(() => {
+          inflight = null;
+        });
+      }
+      return inflight;
+    },
+
+    invalidate(): void {
+      cached = null;
+    },
+  };
+}

--- a/packages/service-auth/src/index.ts
+++ b/packages/service-auth/src/index.ts
@@ -1,0 +1,41 @@
+/**
+ * @fuzefront/service-auth — public barrel.
+ *
+ * Runtime S2S auth for the FuzeFront family, bound to the frozen
+ * `/api/v1/security/tokens` + `/api/v1/security/tokens/introspect` contract
+ * (`@fuzefront/security-client`). Two halves:
+ *
+ *  - `createServiceAuthClient` — the CALLER: obtain + cache + auto-refresh a
+ *    machine bearer token.
+ *  - `createMachineTokenVerifier` + `requireMachineAuth` — the RESOURCE
+ *    SERVER: verify a presented machine token (fail-closed, branches on the
+ *    introspection body's `active`, never on HTTP status) and gate an
+ *    Express route with it.
+ */
+
+export {
+  SERVICE_AUTH_CONTRACT_VERSION,
+  ServiceAuthError,
+} from './types';
+export type {
+  FetchLike,
+  MachineIdentity,
+  ServiceAuthErrorCode,
+  TokenIntrospectRequest,
+  TokenIntrospection,
+  TokenIssueRequest,
+  TokenIssueResponse,
+} from './types';
+
+export { createServiceAuthClient } from './client';
+export type { ServiceAuthClient, ServiceAuthClientOptions } from './client';
+
+export { createMachineTokenVerifier } from './verifier';
+export type { MachineTokenVerifier, MachineTokenVerifierOptions } from './verifier';
+
+export { requireMachineAuth } from './middleware';
+export type {
+  MachineAuthErrorBody,
+  MachineAuthorizeHook,
+  RequireMachineAuthOptions,
+} from './middleware';

--- a/packages/service-auth/src/middleware.ts
+++ b/packages/service-auth/src/middleware.ts
@@ -1,0 +1,132 @@
+/**
+ * @fuzefront/service-auth — Express middleware.
+ *
+ * `requireMachineAuth()` gates a route to machine (client-credentials)
+ * callers only. It reads the bearer token, verifies it via a
+ * `MachineTokenVerifier` (see `verifier.ts` — fail-closed, branches on the
+ * introspection body's `active`, never on HTTP status), attaches the
+ * resulting `MachineIdentity` to `req.machineIdentity`, and never calls
+ * `next()` for a request that didn't pass.
+ *
+ * `express` is an OPTIONAL peer dependency — only importing this file pulls
+ * in Express types; `createServiceAuthClient`/`createMachineTokenVerifier`
+ * have no Express dependency at all.
+ */
+
+import type { NextFunction, Request, Response } from 'express';
+import { MachineIdentity, ServiceAuthError } from './types';
+import { MachineTokenVerifier } from './verifier';
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace Express {
+    interface Request {
+      /** Populated by `requireMachineAuth()`. Absent on requests it did not gate. */
+      machineIdentity?: MachineIdentity;
+    }
+  }
+}
+
+/** The JSON error body `requireMachineAuth` sends on rejection. */
+export interface MachineAuthErrorBody {
+  error: string;
+  code: string;
+}
+
+/**
+ * A per-caller authorization hook, run AFTER verification succeeds. This is
+ * the seam for wiring in the `/authz/*` routes once they're live — e.g.
+ * `authorize: (identity, req) => authzClient.check({ subject: identity.subject,
+ * tenant: identity.tenantId!, resource: {type: 'invoice'}, action: 'read' },
+ * bearerFromReq(req)).then(d => d.allow)`. Left unset, every verified machine
+ * identity is authorized (authentication-only gating). A thrown/rejected hook
+ * is treated as a denial — same fail-closed rule as verification itself.
+ */
+export type MachineAuthorizeHook = (
+  identity: MachineIdentity,
+  req: Request,
+) => Promise<boolean> | boolean;
+
+export interface RequireMachineAuthOptions {
+  /** The verifier used to validate tokens. Required. */
+  verifier: MachineTokenVerifier;
+  /** Header to read the token from. Default `'authorization'` with a `Bearer` scheme. */
+  header?: string;
+  /** Optional per-caller authorization check. See {@link MachineAuthorizeHook}. */
+  authorize?: MachineAuthorizeHook;
+}
+
+/** Pull the raw token out of `Authorization: Bearer <token>` (or a custom header). */
+function readBearer(req: Request, header: string): string | undefined {
+  const raw = req.headers[header.toLowerCase()];
+  const value = Array.isArray(raw) ? raw[0] : raw;
+  if (typeof value !== 'string' || !value) return undefined;
+  const [scheme, token] = value.split(' ');
+  if (scheme?.toLowerCase() !== 'bearer' || !token) return undefined;
+  return token;
+}
+
+function deny(res: Response, err: unknown): void {
+  const authErr =
+    err instanceof ServiceAuthError ? err : new ServiceAuthError('UNKNOWN', 'machine authentication failed', 401);
+  const body: MachineAuthErrorBody = { error: authErr.message, code: authErr.code };
+  res.status(authErr.status).json(body);
+}
+
+/**
+ * Express middleware factory: require a verified machine (client-credentials)
+ * identity, and optionally a passing `authorize` decision.
+ *
+ * @example
+ *   const verifier = createMachineTokenVerifier({ baseUrl: process.env.FUZEFRONT_API_URL! });
+ *   app.use('/internal', requireMachineAuth({ verifier }));
+ */
+export function requireMachineAuth(
+  options: RequireMachineAuthOptions,
+): (req: Request, res: Response, next: NextFunction) => void {
+  const { verifier, header = 'authorization', authorize } = options;
+  if (!verifier) {
+    throw new ServiceAuthError('MISCONFIGURED', 'requireMachineAuth requires a `verifier`', 500);
+  }
+
+  return function requireMachineAuthHandler(req: Request, res: Response, next: NextFunction): void {
+    const token = readBearer(req, header);
+
+    if (!token) {
+      return deny(res, new ServiceAuthError('NO_TOKEN', 'no bearer token presented', 401));
+    }
+
+    verifier
+      .verifyMachineToken(token)
+      .then(async identity => {
+        req.machineIdentity = identity;
+
+        if (!authorize) {
+          next();
+          return;
+        }
+
+        let allowed: boolean;
+        try {
+          allowed = await authorize(identity, req);
+        } catch (err) {
+          // Undecidable authz (hook threw) => deny. Never next().
+          deny(res, new ServiceAuthError('FORBIDDEN', 'authorization decision unavailable; denying', 403));
+          return;
+        }
+
+        if (!allowed) {
+          deny(res, new ServiceAuthError('FORBIDDEN', 'not permitted', 403));
+          return;
+        }
+        next();
+      })
+      .catch((err: unknown) => {
+        // Verification failure (inactive token, network error, malformed
+        // body — see verifier.ts). Always a denial; never next().
+        deny(res, err);
+      });
+  };
+}
+
+export { ServiceAuthError };

--- a/packages/service-auth/src/types.ts
+++ b/packages/service-auth/src/types.ts
@@ -1,0 +1,89 @@
+/**
+ * @fuzefront/service-auth — shared types.
+ *
+ * This package is the runtime binding for FuzeFront's S2S (machine-to-machine)
+ * identity contract, frozen in `@fuzefront/security-client`
+ * (`TokenIssueRequest`/`TokenIssueResponse`/`TokenIntrospectRequest`/
+ * `TokenIntrospection`, generated from `packages/security/openapi.yaml`).
+ *
+ * It talks to FuzeFront's OWN `/api/v1/security/tokens*` endpoints — never to
+ * the vendor identity provider behind them. That indirection is the whole
+ * point of the contract: consumers know only FuzeFront.
+ */
+
+import type { components } from '@fuzefront/security-client';
+
+/** Semantic version of this package's runtime contract. Bump on interface change. */
+export const SERVICE_AUTH_CONTRACT_VERSION = '0.1.0' as const;
+
+export type TokenIssueRequest = components['schemas']['TokenIssueRequest'];
+export type TokenIssueResponse = components['schemas']['TokenIssueResponse'];
+export type TokenIntrospectRequest = components['schemas']['TokenIntrospectRequest'];
+export type TokenIntrospection = components['schemas']['TokenIntrospection'];
+
+/** Minimal fetch shape so callers can inject an alternative implementation (tests, old Node). */
+export type FetchLike = (
+  input: string,
+  init?: {
+    method?: string;
+    headers?: Record<string, string>;
+    body?: string;
+    signal?: AbortSignal;
+  },
+) => Promise<{
+  ok: boolean;
+  status: number;
+  json: () => Promise<unknown>;
+}>;
+
+/** Stable error codes across the client, verifier, and middleware. All failures are denials. */
+export type ServiceAuthErrorCode =
+  | 'MISCONFIGURED'
+  | 'TOKEN_REQUEST_FAILED'
+  | 'MALFORMED_RESPONSE'
+  | 'NO_TOKEN'
+  | 'MALFORMED_HEADER'
+  | 'INTROSPECTION_UNAVAILABLE'
+  | 'TOKEN_INACTIVE'
+  | 'FORBIDDEN'
+  | 'UNKNOWN';
+
+/**
+ * The single error type thrown/surfaced anywhere in this package. Every
+ * ambiguity (network error, timeout, malformed body, missing `active`) becomes
+ * one of these — never a permissive fallback.
+ */
+export class ServiceAuthError extends Error {
+  readonly code: ServiceAuthErrorCode;
+  /** Suggested HTTP status for a resource server translating this to a response. */
+  readonly status: number;
+
+  constructor(code: ServiceAuthErrorCode, message: string, status = 401) {
+    super(message);
+    this.name = 'ServiceAuthError';
+    this.code = code;
+    this.status = status;
+    Object.setPrototypeOf(this, ServiceAuthError.prototype);
+  }
+}
+
+/**
+ * The normalized, typed identity a resource server gets back for a valid
+ * machine token. Deliberately narrower than the raw `TokenIntrospection` body —
+ * `scopes` is always an array (never undefined), and `raw` carries the wire
+ * shape for anything bespoke a caller still needs.
+ */
+export interface MachineIdentity {
+  /** Stable subject/client identifier for the calling service. Always present. */
+  subject: string;
+  /** Tenant scope, when the token carries one. `null` when unresolved. */
+  tenantId: string | null;
+  /** Space-delimited scope string as introspection returned it, if any. */
+  scope?: string;
+  /** `scope` split on whitespace. Always an array — empty means "no scopes". */
+  scopes: string[];
+  /** Token expiry (epoch seconds), when present. */
+  expiresAt?: number;
+  /** The raw introspection response this identity was built from. */
+  raw: TokenIntrospection;
+}

--- a/packages/service-auth/src/verifier.ts
+++ b/packages/service-auth/src/verifier.ts
@@ -1,0 +1,216 @@
+/**
+ * @fuzefront/service-auth — the RESOURCE SERVER half.
+ *
+ * `POST /api/v1/security/tokens/introspect` ALWAYS answers HTTP 200 — per
+ * `packages/security/openapi.yaml`'s `TokenIntrospection` schema, the wire
+ * contract is "fail-closed IN THE BODY": an unknown/expired/revoked token
+ * still comes back 200 with `{ active: false }`. A caller that branches on
+ * status code instead of the `active` boolean fails OPEN — every 200 would
+ * look like success. This module branches on `active`, never on status, and
+ * that is the entire reason it exists rather than "just call fetch".
+ *
+ * Every ambiguity is a denial: network error, timeout, non-200 status,
+ * unparsable body, a body missing `active`, `active` typed as anything but a
+ * boolean. None of those return a permissive identity — they throw.
+ */
+
+import { FetchLike, MachineIdentity, ServiceAuthError, TokenIntrospection } from './types';
+
+const INTROSPECT_PATH = '/api/v1/security/tokens/introspect';
+const DEFAULT_TIMEOUT_MS = 3000;
+const DEFAULT_CACHE_TTL_SECONDS = 5;
+const DEFAULT_CACHE_MAX_ENTRIES = 1000;
+
+export interface MachineTokenVerifierOptions {
+  /** FuzeFront's same-origin API base, e.g. `https://app.fuzefront.com/api`. */
+  baseUrl: string;
+  /** Inject an alternative fetch (tests, old Node). Defaults to `globalThis.fetch`. */
+  fetch?: FetchLike;
+  /** Per-request timeout. Default 3000ms. */
+  timeoutMs?: number;
+  /**
+   * How long a POSITIVE (`active: true`) result may be reused for the same
+   * token, in seconds. Default 5. Set to 0 to disable caching entirely.
+   *
+   * NEGATIVE results are NEVER cached, at any setting — an inactive/expired/
+   * revoked verdict is always re-asked next time, so a revocation is visible
+   * on the very next call rather than being masked by a stale cache entry.
+   * The cache also never outlives the token's own `exp`.
+   */
+  cacheTtlSeconds?: number;
+  /** Bound on cache size (FIFO eviction). Default 1000. */
+  cacheMaxEntries?: number;
+}
+
+export interface MachineTokenVerifier {
+  /**
+   * Introspect `token` and return its normalized identity, or throw
+   * `ServiceAuthError`. NEVER returns a value for an inactive/undecidable
+   * token — every failure mode is a throw.
+   */
+  verifyMachineToken(token: string): Promise<MachineIdentity>;
+}
+
+interface CacheEntry {
+  identity: MachineIdentity;
+  expiresAtMs: number;
+}
+
+/** Build a fail-closed verifier bound to FuzeFront's introspection endpoint. */
+export function createMachineTokenVerifier(options: MachineTokenVerifierOptions): MachineTokenVerifier {
+  if (!options?.baseUrl) {
+    throw new ServiceAuthError(
+      'MISCONFIGURED',
+      'createMachineTokenVerifier requires a baseUrl pointing at the FuzeFront Security API.',
+      500,
+    );
+  }
+
+  const base = options.baseUrl.replace(/\/+$/, '');
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const cacheTtlMs = (options.cacheTtlSeconds ?? DEFAULT_CACHE_TTL_SECONDS) * 1000;
+  const cacheMaxEntries = options.cacheMaxEntries ?? DEFAULT_CACHE_MAX_ENTRIES;
+  // Only ever holds ACTIVE identities. A cache miss means "ask introspection
+  // again", never "assume inactive" and never "assume active".
+  const cache = new Map<string, CacheEntry>();
+
+  const resolvedFetch: FetchLike | undefined =
+    options.fetch ??
+    (typeof globalThis.fetch === 'function'
+      ? (globalThis.fetch.bind(globalThis) as unknown as FetchLike)
+      : undefined);
+
+  if (!resolvedFetch) {
+    throw new ServiceAuthError(
+      'MISCONFIGURED',
+      'No fetch implementation available. Pass `fetch` explicitly on Node <18.',
+      500,
+    );
+  }
+
+  function cachedIdentity(token: string): MachineIdentity | undefined {
+    if (cacheTtlMs <= 0) return undefined;
+    const hit = cache.get(token);
+    if (!hit) return undefined;
+    if (hit.expiresAtMs <= Date.now()) {
+      cache.delete(token);
+      return undefined;
+    }
+    return hit.identity;
+  }
+
+  function remember(token: string, identity: MachineIdentity): void {
+    if (cacheTtlMs <= 0) return;
+    if (cache.size >= cacheMaxEntries) {
+      const oldest = cache.keys().next();
+      if (!oldest.done) cache.delete(oldest.value);
+    }
+    // Never cache past the token's own expiry, on top of the configured TTL.
+    let ttl = cacheTtlMs;
+    if (typeof identity.expiresAt === 'number') {
+      const tokenTtlMs = identity.expiresAt * 1000 - Date.now();
+      ttl = Math.max(0, Math.min(ttl, tokenTtlMs));
+    }
+    if (ttl <= 0) return;
+    cache.set(token, { identity, expiresAtMs: Date.now() + ttl });
+  }
+
+  async function introspect(token: string): Promise<TokenIntrospection> {
+    const controller = typeof AbortController === 'function' ? new AbortController() : undefined;
+    const timer = controller ? setTimeout(() => controller.abort(), timeoutMs) : undefined;
+    let res: Awaited<ReturnType<FetchLike>>;
+    try {
+      res = await resolvedFetch!(`${base}${INTROSPECT_PATH}`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ token }),
+        signal: controller?.signal,
+      });
+    } catch (err) {
+      // Network error, DNS failure, connection reset, timeout (abort). Every
+      // one of these is undecidable => deny, never "assume active".
+      throw new ServiceAuthError(
+        'INTROSPECTION_UNAVAILABLE',
+        `Introspection request failed: ${(err as Error)?.message ?? 'unknown error'}; denying.`,
+        401,
+      );
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+
+    if (!res.ok) {
+      // The contract says introspection always answers 200. A non-200 here
+      // means something ELSE went wrong in front of it (proxy, LB, outage) —
+      // still undecidable, still a denial. This is deliberately NOT treated
+      // the same as an in-body `active: false`.
+      throw new ServiceAuthError(
+        'INTROSPECTION_UNAVAILABLE',
+        `Introspection returned unexpected status ${res.status}; denying.`,
+        401,
+      );
+    }
+
+    let body: unknown;
+    try {
+      body = await res.json();
+    } catch (err) {
+      throw new ServiceAuthError(
+        'MALFORMED_RESPONSE',
+        `Introspection returned a non-JSON body: ${(err as Error)?.message ?? 'parse error'}; denying.`,
+        401,
+      );
+    }
+
+    const active = (body as { active?: unknown } | null)?.active;
+    if (typeof active !== 'boolean') {
+      // Missing/mistyped `active` is exactly as dangerous as a false one
+      // treated as true would be. Deny.
+      throw new ServiceAuthError(
+        'MALFORMED_RESPONSE',
+        'Introspection response is missing a boolean `active`; denying.',
+        401,
+      );
+    }
+
+    return body as TokenIntrospection;
+  }
+
+  return {
+    async verifyMachineToken(token: string): Promise<MachineIdentity> {
+      if (!token) {
+        throw new ServiceAuthError('NO_TOKEN', 'No token presented to verify.', 401);
+      }
+
+      const cached = cachedIdentity(token);
+      if (cached) return cached;
+
+      // THIS is the branch the whole package exists to get right: the HTTP
+      // call above always resolves with status 200 on success. Whether the
+      // token is usable is decided here, from the body — never from `res.ok`.
+      const introspection = await introspect(token);
+
+      if (!introspection.active) {
+        throw new ServiceAuthError('TOKEN_INACTIVE', 'Token is not active.', 401);
+      }
+      if (!introspection.subject) {
+        throw new ServiceAuthError(
+          'MALFORMED_RESPONSE',
+          'Active introspection result is missing `subject`; denying.',
+          401,
+        );
+      }
+
+      const identity: MachineIdentity = {
+        subject: introspection.subject,
+        tenantId: introspection.tenantId ?? null,
+        scope: introspection.scope,
+        scopes: introspection.scope ? introspection.scope.split(/\s+/).filter(Boolean) : [],
+        expiresAt: introspection.expiresAt,
+        raw: introspection,
+      };
+
+      remember(token, identity);
+      return identity;
+    },
+  };
+}

--- a/packages/service-auth/tests/client.test.ts
+++ b/packages/service-auth/tests/client.test.ts
@@ -1,0 +1,128 @@
+/**
+ * @fuzefront/service-auth — caller-side client tests.
+ *
+ * Covers: refresh happens BEFORE expiry (not reactively after a 401), and
+ * concurrent `getToken()` calls during a refresh share one in-flight request
+ * rather than stampeding the issuance endpoint.
+ */
+import { createServiceAuthClient } from '../src/client';
+import { ServiceAuthError } from '../src/types';
+import type { FetchLike } from '../src/types';
+
+function jsonResponse(status: number, body: unknown) {
+  return { ok: status >= 200 && status < 300, status, json: async () => body };
+}
+
+describe('createServiceAuthClient', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('throws MISCONFIGURED without baseUrl/clientId/clientSecret', () => {
+    expect(() => createServiceAuthClient({} as any)).toThrow(ServiceAuthError);
+  });
+
+  it('fetches a token and caches it for subsequent calls', async () => {
+    const fetch = jest.fn(async () => jsonResponse(200, { accessToken: 'tok-1', tokenType: 'Bearer', expiresIn: 3600 })) as unknown as FetchLike;
+    const client = createServiceAuthClient({ baseUrl: 'http://security.local/api', clientId: 'c1', clientSecret: 's1', fetch });
+
+    const t1 = await client.getToken();
+    const t2 = await client.getToken();
+    expect(t1).toBe('tok-1');
+    expect(t2).toBe('tok-1');
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('refreshes BEFORE expiry once inside the safety margin, not reactively after it', async () => {
+    jest.useFakeTimers();
+    let call = 0;
+    const fetch = jest.fn(async () => {
+      call += 1;
+      return jsonResponse(200, { accessToken: `tok-${call}`, tokenType: 'Bearer', expiresIn: 100 });
+    }) as unknown as FetchLike;
+    const client = createServiceAuthClient({
+      baseUrl: 'http://security.local/api',
+      clientId: 'c1',
+      clientSecret: 's1',
+      fetch,
+      refreshMarginSeconds: 30,
+    });
+
+    const t1 = await client.getToken();
+    expect(t1).toBe('tok-1');
+
+    // 69s elapsed of a 100s token with a 30s margin (threshold = 70s) — still fresh.
+    jest.advanceTimersByTime(69_000);
+    const t2 = await client.getToken();
+    expect(t2).toBe('tok-1');
+    expect(call).toBe(1);
+
+    // Cross the 70s threshold — next getToken() must refresh proactively,
+    // before the token has actually expired at 100s.
+    jest.advanceTimersByTime(2_000);
+    const t3 = await client.getToken();
+    expect(t3).toBe('tok-2');
+    expect(call).toBe(2);
+  });
+
+  it('single-flights concurrent getToken() calls during a refresh (no stampede)', async () => {
+    let releaseFetch: () => void = () => {};
+    const gate = new Promise<void>(resolve => {
+      releaseFetch = resolve;
+    });
+    let callCount = 0;
+    const fetch = jest.fn(async () => {
+      callCount += 1;
+      await gate;
+      return jsonResponse(200, { accessToken: 'tok-shared', tokenType: 'Bearer', expiresIn: 3600 });
+    }) as unknown as FetchLike;
+    const client = createServiceAuthClient({ baseUrl: 'http://security.local/api', clientId: 'c1', clientSecret: 's1', fetch });
+
+    const p1 = client.getToken();
+    const p2 = client.getToken();
+    const p3 = client.getToken();
+    releaseFetch();
+    const [t1, t2, t3] = await Promise.all([p1, p2, p3]);
+
+    expect(t1).toBe('tok-shared');
+    expect(t2).toBe('tok-shared');
+    expect(t3).toBe('tok-shared');
+    expect(callCount).toBe(1); // NOT 3 — the whole point of single-flight.
+  });
+
+  it('invalidate() forces the next getToken() to fetch fresh', async () => {
+    let call = 0;
+    const fetch = jest.fn(async () => {
+      call += 1;
+      return jsonResponse(200, { accessToken: `tok-${call}`, tokenType: 'Bearer', expiresIn: 3600 });
+    }) as unknown as FetchLike;
+    const client = createServiceAuthClient({ baseUrl: 'http://security.local/api', clientId: 'c1', clientSecret: 's1', fetch });
+
+    expect(await client.getToken()).toBe('tok-1');
+    client.invalidate();
+    expect(await client.getToken()).toBe('tok-2');
+  });
+
+  it('fails closed (throws) on a non-2xx issuance response', async () => {
+    const fetch = jest.fn(async () => jsonResponse(401, { error: 'invalid client credentials' })) as unknown as FetchLike;
+    const client = createServiceAuthClient({ baseUrl: 'http://security.local/api', clientId: 'bad', clientSecret: 'bad', fetch });
+
+    await expect(client.getToken()).rejects.toMatchObject({ code: 'TOKEN_REQUEST_FAILED' });
+  });
+
+  it('fails closed on a network error contacting the issuance endpoint', async () => {
+    const fetch = jest.fn(async () => {
+      throw new Error('ECONNREFUSED');
+    }) as unknown as FetchLike;
+    const client = createServiceAuthClient({ baseUrl: 'http://security.local/api', clientId: 'c1', clientSecret: 's1', fetch });
+
+    await expect(client.getToken()).rejects.toMatchObject({ code: 'TOKEN_REQUEST_FAILED' });
+  });
+
+  it('fails closed on a response missing accessToken', async () => {
+    const fetch = jest.fn(async () => jsonResponse(200, { tokenType: 'Bearer', expiresIn: 3600 })) as unknown as FetchLike;
+    const client = createServiceAuthClient({ baseUrl: 'http://security.local/api', clientId: 'c1', clientSecret: 's1', fetch });
+
+    await expect(client.getToken()).rejects.toMatchObject({ code: 'MALFORMED_RESPONSE' });
+  });
+});

--- a/packages/service-auth/tests/middleware.test.ts
+++ b/packages/service-auth/tests/middleware.test.ts
@@ -1,0 +1,150 @@
+/**
+ * @fuzefront/service-auth — Express middleware tests.
+ *
+ * Asserts the gate's contract: it never calls next() on an unauthenticated or
+ * unauthorized request, missing/garbage headers are rejected outright, and a
+ * failing/throwing `authorize` hook denies rather than passes through.
+ */
+import type { Request, Response } from 'express';
+import { requireMachineAuth } from '../src/middleware';
+import { ServiceAuthError, MachineIdentity } from '../src/types';
+import type { MachineTokenVerifier } from '../src/verifier';
+
+function mkReq(headers: Record<string, string> = {}): Request {
+  return { headers } as any;
+}
+function mkRes(): Response {
+  const res: any = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+}
+/** Run a middleware and resolve once next() or res.json() has fired. */
+function run(mw: any, req: any, res: any): Promise<{ nexted: boolean }> {
+  return new Promise(resolve => {
+    let done = false;
+    const finish = (nexted: boolean) => {
+      if (!done) {
+        done = true;
+        resolve({ nexted });
+      }
+    };
+    const originalJson = res.json;
+    res.json = jest.fn((...args: unknown[]) => {
+      finish(false);
+      return originalJson(...args);
+    });
+    mw(req, res, () => finish(true));
+  });
+}
+
+const identity: MachineIdentity = {
+  subject: 'svc-billing',
+  tenantId: 'org_1',
+  scopes: ['invoices:read'],
+  raw: { active: true },
+};
+
+function fakeVerifier(fn: (token: string) => Promise<MachineIdentity>): MachineTokenVerifier {
+  return { verifyMachineToken: jest.fn(fn) };
+}
+
+describe('requireMachineAuth', () => {
+  it('rejects a request with NO Authorization header (401 NO_TOKEN), never calls next()', async () => {
+    const verifier = fakeVerifier(async () => identity);
+    const res = mkRes();
+    const { nexted } = await run(requireMachineAuth({ verifier }), mkReq(), res);
+
+    expect(nexted).toBe(false);
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ code: 'NO_TOKEN' }));
+  });
+
+  it('rejects a garbage Authorization header (wrong scheme), never calls next()', async () => {
+    const verifier = fakeVerifier(async () => identity);
+    const res = mkRes();
+    const req = mkReq({ authorization: 'Basic garbage-not-a-bearer-token' });
+    const { nexted } = await run(requireMachineAuth({ verifier }), req, res);
+
+    expect(nexted).toBe(false);
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(verifier.verifyMachineToken).not.toHaveBeenCalled();
+  });
+
+  it('rejects "Bearer" with no token value, never calls next()', async () => {
+    const verifier = fakeVerifier(async () => identity);
+    const res = mkRes();
+    const req = mkReq({ authorization: 'Bearer ' });
+    const { nexted } = await run(requireMachineAuth({ verifier }), req, res);
+
+    expect(nexted).toBe(false);
+    expect(res.status).toHaveBeenCalledWith(401);
+  });
+
+  it('attaches the MachineIdentity and calls next() for a valid token with no authorize hook', async () => {
+    const verifier = fakeVerifier(async token => {
+      expect(token).toBe('good-token');
+      return identity;
+    });
+    const req = mkReq({ authorization: 'Bearer good-token' });
+    const res = mkRes();
+    const { nexted } = await run(requireMachineAuth({ verifier }), req, res);
+
+    expect(nexted).toBe(true);
+    expect((req as any).machineIdentity).toBe(identity);
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it('rejects when verification fails (inactive/expired/network) — never calls next()', async () => {
+    const verifier = fakeVerifier(async () => {
+      throw new ServiceAuthError('TOKEN_INACTIVE', 'inactive', 401);
+    });
+    const req = mkReq({ authorization: 'Bearer bad-token' });
+    const res = mkRes();
+    const { nexted } = await run(requireMachineAuth({ verifier }), req, res);
+
+    expect(nexted).toBe(false);
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ code: 'TOKEN_INACTIVE' }));
+  });
+
+  it('calls next() when the authorize hook allows', async () => {
+    const verifier = fakeVerifier(async () => identity);
+    const authorize = jest.fn(async () => true);
+    const req = mkReq({ authorization: 'Bearer good-token' });
+    const res = mkRes();
+    const { nexted } = await run(requireMachineAuth({ verifier, authorize }), req, res);
+
+    expect(nexted).toBe(true);
+    expect(authorize).toHaveBeenCalledWith(identity, req);
+  });
+
+  it('denies with 403 when the authorize hook returns false — never calls next()', async () => {
+    const verifier = fakeVerifier(async () => identity);
+    const authorize = jest.fn(async () => false);
+    const req = mkReq({ authorization: 'Bearer good-token' });
+    const res = mkRes();
+    const { nexted } = await run(requireMachineAuth({ verifier, authorize }), req, res);
+
+    expect(nexted).toBe(false);
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ code: 'FORBIDDEN' }));
+  });
+
+  it('fails closed (403) when the authorize hook THROWS — never calls next()', async () => {
+    const verifier = fakeVerifier(async () => identity);
+    const authorize = jest.fn(async () => {
+      throw new Error('policy engine unreachable');
+    });
+    const req = mkReq({ authorization: 'Bearer good-token' });
+    const res = mkRes();
+    const { nexted } = await run(requireMachineAuth({ verifier, authorize }), req, res);
+
+    expect(nexted).toBe(false);
+    expect(res.status).toHaveBeenCalledWith(403);
+  });
+
+  it('throws at wiring time (MISCONFIGURED) when built without a verifier', () => {
+    expect(() => requireMachineAuth({} as any)).toThrow(ServiceAuthError);
+  });
+});

--- a/packages/service-auth/tests/tsconfig.json
+++ b/packages/service-auth/tests/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "types": ["node", "jest"],
+    "noEmit": true
+  },
+  "include": ["../src/**/*.ts", "./**/*.ts"]
+}

--- a/packages/service-auth/tests/verifier.test.ts
+++ b/packages/service-auth/tests/verifier.test.ts
@@ -1,0 +1,158 @@
+/**
+ * @fuzefront/service-auth — verifier tests.
+ *
+ * The central property under test: `POST /tokens/introspect` ALWAYS answers
+ * HTTP 200, so a caller that branches on status code instead of the `active`
+ * boolean in the body fails OPEN (every 200 looks like success). The very
+ * first test below is that exact scenario. Everything else here is the same
+ * fail-closed rule applied to every other ambiguity.
+ */
+import { createMachineTokenVerifier } from '../src/verifier';
+import { ServiceAuthError } from '../src/types';
+import type { FetchLike } from '../src/types';
+
+function mockFetch(impl: (url: string, init?: any) => Promise<{ ok: boolean; status: number; json: () => Promise<unknown> }>): FetchLike {
+  return jest.fn(impl) as unknown as FetchLike;
+}
+
+function jsonResponse(status: number, body: unknown) {
+  return { ok: status >= 200 && status < 300, status, json: async () => body };
+}
+
+describe('createMachineTokenVerifier — fail-closed introspection', () => {
+  it('THE test: rejects an inactive token even though introspection answered HTTP 200', async () => {
+    const fetch = mockFetch(async () => jsonResponse(200, { active: false }));
+    const verifier = createMachineTokenVerifier({ baseUrl: 'http://security.local/api', fetch, cacheTtlSeconds: 0 });
+
+    await expect(verifier.verifyMachineToken('some-token')).rejects.toMatchObject({
+      code: 'TOKEN_INACTIVE',
+    });
+    // Prove the call really was a 200 — a status-code-only check would have
+    // treated this as success.
+    const res = await fetch('http://security.local/api/v1/security/tokens/introspect');
+    expect(res.status).toBe(200);
+  });
+
+  it('accepts an active token and returns a normalized identity', async () => {
+    const fetch = mockFetch(async () =>
+      jsonResponse(200, { active: true, subject: 'svc-billing', tenantId: 'org_1', scope: 'invoices:read invoices:write', expiresAt: 9999999999 }),
+    );
+    const verifier = createMachineTokenVerifier({ baseUrl: 'http://security.local/api', fetch, cacheTtlSeconds: 0 });
+
+    const identity = await verifier.verifyMachineToken('good-token');
+    expect(identity.subject).toBe('svc-billing');
+    expect(identity.tenantId).toBe('org_1');
+    expect(identity.scopes).toEqual(['invoices:read', 'invoices:write']);
+  });
+
+  it('fails closed on a network error (never returns a permissive identity)', async () => {
+    const fetch = mockFetch(async () => {
+      throw new Error('ECONNREFUSED');
+    });
+    const verifier = createMachineTokenVerifier({ baseUrl: 'http://security.local/api', fetch });
+
+    await expect(verifier.verifyMachineToken('t')).rejects.toMatchObject({
+      code: 'INTROSPECTION_UNAVAILABLE',
+    });
+  });
+
+  it('fails closed on a timeout', async () => {
+    jest.useFakeTimers();
+    try {
+      const fetch: FetchLike = jest.fn((_url, init) => {
+        return new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener('abort', () => reject(new Error('aborted')));
+        });
+      }) as unknown as FetchLike;
+      const verifier = createMachineTokenVerifier({ baseUrl: 'http://security.local/api', fetch, timeoutMs: 100 });
+
+      const pending = verifier.verifyMachineToken('t');
+      const assertion = expect(pending).rejects.toMatchObject({ code: 'INTROSPECTION_UNAVAILABLE' });
+      await jest.advanceTimersByTimeAsync(100);
+      await assertion;
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('fails closed on a malformed body (missing `active`)', async () => {
+    const fetch = mockFetch(async () => jsonResponse(200, { subject: 'x' }));
+    const verifier = createMachineTokenVerifier({ baseUrl: 'http://security.local/api', fetch });
+
+    await expect(verifier.verifyMachineToken('t')).rejects.toMatchObject({
+      code: 'MALFORMED_RESPONSE',
+    });
+  });
+
+  it('fails closed when `active` is not a boolean', async () => {
+    const fetch = mockFetch(async () => jsonResponse(200, { active: 'true' }));
+    const verifier = createMachineTokenVerifier({ baseUrl: 'http://security.local/api', fetch });
+
+    await expect(verifier.verifyMachineToken('t')).rejects.toMatchObject({
+      code: 'MALFORMED_RESPONSE',
+    });
+  });
+
+  it('fails closed on a non-JSON body', async () => {
+    const fetch = mockFetch(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => {
+        throw new SyntaxError('Unexpected token');
+      },
+    }));
+    const verifier = createMachineTokenVerifier({ baseUrl: 'http://security.local/api', fetch });
+
+    await expect(verifier.verifyMachineToken('t')).rejects.toMatchObject({
+      code: 'MALFORMED_RESPONSE',
+    });
+  });
+
+  it('fails closed on an active result missing `subject`', async () => {
+    const fetch = mockFetch(async () => jsonResponse(200, { active: true }));
+    const verifier = createMachineTokenVerifier({ baseUrl: 'http://security.local/api', fetch });
+
+    await expect(verifier.verifyMachineToken('t')).rejects.toMatchObject({
+      code: 'MALFORMED_RESPONSE',
+    });
+  });
+
+  it('fails closed on an unexpected non-200 status (contract says introspect always answers 200)', async () => {
+    const fetch = mockFetch(async () => jsonResponse(502, { active: true, subject: 'x' }));
+    const verifier = createMachineTokenVerifier({ baseUrl: 'http://security.local/api', fetch });
+
+    await expect(verifier.verifyMachineToken('t')).rejects.toMatchObject({
+      code: 'INTROSPECTION_UNAVAILABLE',
+    });
+  });
+
+  it('caches a POSITIVE result and does not re-introspect within the TTL', async () => {
+    const fetch = mockFetch(async () => jsonResponse(200, { active: true, subject: 'svc-a', expiresAt: Math.floor(Date.now() / 1000) + 3600 }));
+    const verifier = createMachineTokenVerifier({ baseUrl: 'http://security.local/api', fetch, cacheTtlSeconds: 60 });
+
+    await verifier.verifyMachineToken('cache-me');
+    await verifier.verifyMachineToken('cache-me');
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('NEVER caches a NEGATIVE result — a revoked token is re-checked every time', async () => {
+    const fetch = mockFetch(async () => jsonResponse(200, { active: false }));
+    const verifier = createMachineTokenVerifier({ baseUrl: 'http://security.local/api', fetch, cacheTtlSeconds: 60 });
+
+    await expect(verifier.verifyMachineToken('revoked')).rejects.toMatchObject({ code: 'TOKEN_INACTIVE' });
+    await expect(verifier.verifyMachineToken('revoked')).rejects.toMatchObject({ code: 'TOKEN_INACTIVE' });
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('throws MISCONFIGURED when constructed without a baseUrl', () => {
+    expect(() => createMachineTokenVerifier({} as any)).toThrow(ServiceAuthError);
+  });
+
+  it('rejects verifying an empty token without making a network call', async () => {
+    const fetch = mockFetch(async () => jsonResponse(200, { active: true, subject: 'x' }));
+    const verifier = createMachineTokenVerifier({ baseUrl: 'http://security.local/api', fetch });
+
+    await expect(verifier.verifyMachineToken('')).rejects.toMatchObject({ code: 'NO_TOKEN' });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});

--- a/packages/service-auth/tsconfig.json
+++ b/packages/service-auth/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "lib": ["ES2021"],
+    "types": ["node"],
+    "declaration": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "noUnusedLocals": false,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}

--- a/packages/service-auth/tsup.config.ts
+++ b/packages/service-auth/tsup.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  dts: true,
+  sourcemap: true,
+  clean: true,
+  target: 'node18',
+  // express is an optional peer — never bundle it.
+  external: ['express'],
+});


### PR DESCRIPTION
## Summary
- Adds `packages/service-auth` (`@fuzefront/service-auth`) — a real runtime TypeScript package for service-to-service auth, closing the gap left by PR #837: `@fuzefront/security-client` shipped generated TYPES ONLY for `/api/v1/security/tokens*`, so every consumer had to hand-roll its own ~15-line introspection call.
- **Caller half**: `createServiceAuthClient` obtains/caches/auto-refreshes a machine bearer token via `POST /api/v1/security/tokens`. Refreshes proactively before expiry (safety margin); concurrent `getToken()` calls during a refresh single-flight into one request.
- **Resource-server half**: `createMachineTokenVerifier` + `requireMachineAuth` Express middleware verify a presented machine token via `POST /api/v1/security/tokens/introspect`. This endpoint ALWAYS answers HTTP 200 — the verifier branches on the response body's `active` boolean, never on status code, so an inactive/revoked token is rejected even though the HTTP call "succeeded". Every ambiguity (network error, timeout, non-200, malformed/missing `active`, missing `subject`) throws rather than returning a permissive identity.
- Pluggable `authorize` hook on the middleware as the seam for the `/authz/*` routes once they're live for machine principals (a sibling PR); a throwing/failing hook denies (fail-closed), matching `@fuzefront/auth`'s `requirePermission` convention.
- Bounded introspection cache for POSITIVE results only (capped by the token's own `exp`); NEGATIVE results are never cached, at any setting, so revocation is visible on the very next call.
- Wired into the existing release pipeline the same way every other `@fuzefront/*` package is: added to the root `package.json` workspaces array; `scripts/publish-packages.mjs --dry-run` confirms it resolves and aliases correctly (`@fuzefront/service-auth -> @izzywdev/fuzefront-service-auth@0.1.0`, dep on `@fuzefront/security-client` rewritten to `@izzywdev/fuzefront-security-client`).
- README with copy-paste examples for both halves; CHANGELOG for the initial release.

## Test plan
- [x] `npm run test -w packages/service-auth` — **30/30 passing** (Jest), including the load-bearing test: an inactive token with an HTTP 200 introspection response is rejected.
- [x] `npm run type-check -w packages/service-auth` — clean, no errors.
- [x] `npm run build -w packages/service-auth` (tsup) — builds ESM+CJS+d.ts successfully.
- [x] `node scripts/publish-packages.mjs --dry-run` — package resolves/aliases correctly.
- [x] `node --test scripts/__tests__/publish-packages.test.mjs` — 8/8 passing (unaffected by this change, confirms the publish transform still works).
- CI is currently degraded fleet-wide (hosted-runner minutes throttled); not waiting on hosted checks that won't run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)