### PR TITLE
fix(ci): service-auth-publish install-check 401 (missing GITHUB_TOKEN)

### DIFF
--- a/.github/workflows/service-auth-publish.yml
+++ b/.github/workflows/service-auth-publish.yml
@@ -159,7 +159,14 @@ jobs:
         # `npm publish` exiting 0 is not proof anyone can install this --
         # confirm the version is resolvable from a clean `npm view` against
         # the real registry before calling the job done.
+        #
+        # BOTH names -- same 401 the Publish step's comment documents (the
+        # project-level .npmrc references ${GITHUB_TOKEN}, which outranks the
+        # NODE_AUTH_TOKEN-only .npmrc setup-node writes). Missed here once
+        # already: the publish itself succeeded but this step 401'd because
+        # only NODE_AUTH_TOKEN was set.
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           npm view "@izzywdev/fuzefront-service-auth@${{ steps.version.outputs.version }}" version --registry=https://npm.pkg.github.com


### PR DESCRIPTION
## Summary
- The first run of `service-auth-publish.yml` (triggered by tag `service-auth-v0.1.0`) succeeded through the actual `Publish` step — confirmed via `gh api users/izzywdev/packages/npm/fuzefront-service-auth/versions` showing `0.1.0` now live in the registry.
- Its final self-check step, "Verify it is actually installable", 401'd because it only set `NODE_AUTH_TOKEN`, not `GITHUB_TOKEN` — the exact failure mode the neighboring `Publish` step's own comment already documents (the project-level `.npmrc` references `${GITHUB_TOKEN}`, which outranks the `NODE_AUTH_TOKEN`-only `.npmrc` `setup-node` writes).
- Adds `GITHUB_TOKEN` alongside `NODE_AUTH_TOKEN` in that step's `env`.

## Test plan
- [x] `actionlint` clean
- [x] The package is independently confirmed published regardless of this step's outcome (registry query above)
- [ ] Re-run of `service-auth-publish.yml` (via `workflow_dispatch`, since `0.1.0` is already published and idempotent) to confirm the verify step now passes — pending merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)