### PR TITLE
fix(service-auth): depend on security-client via ^0.8.0 range, not an exact pin

### DIFF
--- a/packages/service-auth/CHANGELOG.md
+++ b/packages/service-auth/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to this package are documented here. Versioned
 independently; bump on every interface change (SemVer — the major is the
 contract-stability guarantee consumers may assert on).
 
+## 0.1.1 — Dedupe `@fuzefront/security-client`
+
+### Changed
+
+- The dependency on `@fuzefront/security-client` is now the range `^0.8.0`
+  instead of the exact pin `0.8.0`. No runtime behaviour changes — the
+  dependency is types-only (the compiled `dist/index.js` contains no
+  `require` of it), so this is purely an install-graph fix.
+
+  Why it mattered: `security-client` is already a direct dependency of six
+  other packages in the family (`auth-ui`, `identity-ui`, `portal-admin-ui`,
+  `account-security-ui`, `packages/security`, FuzeQuality), all of which
+  declare it as `^0.8.0`. An exact pin here cannot dedupe against a caret
+  range that resolves to any other 0.8.x, so a consumer depending on BOTH
+  this package and `security-client` got two copies installed side by side —
+  two sets of types, and cross-package type errors that read as unrelated to
+  their cause. That is the same class of failure PR #841 addressed ("three
+  peer ranges excluded the security-client version we ship").
+
+  The caret form also MATCHES the family's existing convention rather than
+  introducing a new one: every other consumer already declares `^0.8.0`.
+
 ## 0.1.0 — Initial release
 
 First runtime implementation of S2S (machine-to-machine) auth for the

--- a/packages/service-auth/CHANGELOG.md
+++ b/packages/service-auth/CHANGELOG.md
@@ -8,6 +8,22 @@ contract-stability guarantee consumers may assert on).
 
 ### Changed
 
+- The optional `express` peer range is now `^4.22.2 || ^5.0.0`, was `^4.22.2`.
+
+  Express 5 consumers could not install this package AT ALL. Reproduced against
+  FuzeX's design-frames backend tier (`express@^5.2.1`):
+
+  ```
+  npm error Could not resolve dependency:
+  npm error peer express@"^4.22.2" from @izzywdev/fuzefront-service-auth@0.1.0
+  ```
+
+  `peerDependenciesMeta.express.optional: true` does not help here — optional
+  suppresses auto-INSTALL, but npm still enforces the range against an express
+  the consumer already has, so the install hard-fails. The middleware only uses
+  Express's `Request`/`Response`/`NextFunction` types and calls `next()`; nothing
+  in it is 4.x-specific.
+
 - The dependency on `@fuzefront/security-client` is now the range `^0.8.0`
   instead of the exact pin `0.8.0`. No runtime behaviour changes — the
   dependency is types-only (the compiled `dist/index.js` contains no

--- a/packages/service-auth/package.json
+++ b/packages/service-auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fuzefront/service-auth",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "engines": {
     "node": ">=24.0.0",
     "npm": ">=10.0.0"
@@ -39,7 +39,7 @@
     }
   },
   "dependencies": {
-    "@fuzefront/security-client": "0.8.0"
+    "@fuzefront/security-client": "^0.8.0"
   },
   "devDependencies": {
     "@types/express": "^4.17.25",

--- a/packages/service-auth/package.json
+++ b/packages/service-auth/package.json
@@ -31,7 +31,7 @@
     "type-check": "tsc --noEmit"
   },
   "peerDependencies": {
-    "express": "^4.22.2"
+    "express": "^4.22.2 || ^5.0.0"
   },
   "peerDependenciesMeta": {
     "express": {


### PR DESCRIPTION
## What

`packages/service-auth` declared `"@fuzefront/security-client": "0.8.0"` — an **exact pin**. Changed to `^0.8.0`, package bumped to `0.1.1`.

## Why

`@fuzefront/security-client` is already a direct dependency of six other packages in the family — `auth-ui`, `identity-ui`, `portal-admin-ui`, `account-security-ui`, `packages/security`, and FuzeQuality — **all of which declare it as `^0.8.0`**. An exact pin cannot dedupe against a caret range, so any consumer depending on BOTH `service-auth` and `security-client` gets two copies installed side by side: two sets of types, and cross-package type errors that read as unrelated to their cause. Same class of failure as #841 ("three peer ranges excluded the security-client version we ship").

Fixing it now is cheap; after N repos pin against `0.1.0` it is not.

## Risk: none at runtime

The dependency is **types-only**. Verified against the published artifact rather than assumed — `dist/index.js` contains no `require()` of `security-client` at all, and the package loads fine from a clean install in which `node_modules/@fuzefront/` does not exist:

```
$ node -e "console.log(Object.keys(require('@izzywdev/fuzefront-service-auth')))"
[ 'SERVICE_AUTH_CONTRACT_VERSION', 'ServiceAuthError',
  'createMachineTokenVerifier', 'createServiceAuthClient', 'requireMachineAuth' ]
```

So this is purely an install-graph fix.

## Why caret-in-`dependencies` rather than moving it to `peerDependencies`

The four UI packages declare `security-client` as `^0.8.0` in **peerDependencies** + `0.8.0` in devDependencies. That shape exists because those packages need a *singleton* alongside React. `service-auth` is a plain library with a types-only dep, and making it a peer would change install semantics for every consumer (npm auto-installs peers; pnpm, strictly, does not — a consumer on pnpm would get an unmet peer and a broken `.d.ts`). The caret range achieves the dedupe this PR is for without that blast radius.

Confirmed safe for the publish rename: `scripts/publish-packages.mjs` sets `DEP_FIELDS = ['dependencies', 'peerDependencies', 'optionalDependencies']`, so either field is rewritten to `@izzywdev/fuzefront-security-client` correctly.

## Publishing

Needs a `service-auth-publish.yml` run (tag `service-auth-v0.1.1`, or `workflow_dispatch`) **after merge**. Until then the published version remains `0.1.0`, and the two consumer PRs (FuzeCall#29 / FuzeX#26) pin `0.1.0` deliberately — that is the version that provably exists in the registry today.

Refs izzywdev/FuzeCall#29, izzywdev/FuzeX#26

🤖 Generated with [Claude Code](https://claude.com/claude-code)
