### PR TITLE
fix(publish): alias every canonical scope so packages-publish can be green

### DIFF
--- a/.github/actions/llm-endpoint/action.yml
+++ b/.github/actions/llm-endpoint/action.yml
@@ -281,11 +281,32 @@ runs:
               openai)    model="$FALLBACK_OPENAI_MODEL";    keyref='os.environ/OPENAI_API_KEY' ;;
               gemini)    model="$FALLBACK_GEMINI_MODEL";    keyref='os.environ/GEMINI_API_KEY' ;;
             esac
+            # Remember the head vendor's route for the "*" catch-all below.
+            [ -z "${head_model:-}" ] && head_model="$model" && head_keyref="$keyref"
             echo "  - model_name: ${v}"
             echo "    litellm_params:"
             echo "      model: ${model}"
             echo "      api_key: \"${keyref}\""
           done
+          # CATCH-ALL. The vendor-named entries above are only reachable by a
+          # caller that knows to ask for "anthropic". claude-code-action does
+          # NOT: it sends its own model name (e.g. claude-opus-4-8), which
+          # matches nothing here, so LiteLLM answers
+          #     400 {'error': 'completion: Invalid model name passed in
+          #                    model=claude-opus-4-8'}
+          # and the rung writes that string as its assistant text, reports NO
+          # conclusion, and still exits 0. Downstream that is indistinguishable
+          # from "the model declined to work", so fuze-code-review abstained and
+          # went red on every PR that took the runner-local path -- while the
+          # job's own message blamed the workflow-self-modification guard, which
+          # was not involved (observed on FuzeInfra#823, a one-file Helm change).
+          #
+          # "*" routes any unrecognized model name to the HEAD vendor, so the
+          # chain works without every caller having to pass --model.
+          echo "  - model_name: \"*\""
+          echo "    litellm_params:"
+          echo "      model: ${head_model}"
+          echo "      api_key: \"${head_keyref}\""
           echo ""
           echo "router_settings:"
           echo "  num_retries: 0"
@@ -301,6 +322,10 @@ runs:
             rest_yaml="${rest// /\", \"}"
             echo "  fallbacks:"
             echo "    - ${head}: [\"${rest_yaml}\"]"
+            # The catch-all must roll over too, otherwise a caller that does not
+            # name a vendor (claude-code-action) gets a single-vendor chain and
+            # an exhausted head key fails the run instead of advancing.
+            echo "    - \"*\": [\"${rest_yaml}\"]"
           fi
           echo ""
           echo "general_settings:"

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -58,6 +58,17 @@ jobs:
       actions: write # required to call workflow_dispatch
 
     steps:
+      # Needed by the publish dispatch below, which asks
+      # scripts/publish-packages.mjs what is publishable instead of carrying a
+      # hand-maintained copy of the answer. Checked out at the MERGE commit, so
+      # a workspace added by this very PR is already visible. `npm ci` is
+      # deliberately not run: `--list-dirs` only reads package.json files and
+      # uses node builtins, so the preinstalled node is enough.
+      - name: Checkout the merge commit
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+
       - name: Dispatch release if the merge touched deployable paths
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -69,6 +80,19 @@ jobs:
           # Mirror of release.yml's `push.paths`. Keep the two in sync — a path
           # here that release.yml ignores just wastes a build; a path release.yml
           # watches but this omits means that change silently never deploys.
+          #
+          # STILL A MIRROR, DELIBERATELY — unlike the publish pattern below,
+          # which is now derived. This one answers a different question ("what is
+          # an IMAGE INPUT"), and its source of truth is release.yml's
+          # `on.push.paths`, which GitHub requires to be static YAML: it cannot
+          # be computed, so collapsing this means parsing that workflow's YAML at
+          # runtime — and `on:` is a documented YAML-1.1 parsing hazard (it reads
+          # as the boolean `true` in some parsers). Getting that subtly wrong
+          # fails toward "no deployable paths", i.e. silently not shipping to
+          # prod, which is worse than the drift it would fix. Doing it properly
+          # means a checked-in paths manifest that release.yml's `paths:` is
+          # GENERATED from, plus a CI gate asserting the generated block matches
+          # — a separate change with its own verification.
           #
           # It HAD drifted, in exactly that direction. release.yml watches
           # services/chat-service, notification-service, payment-service,
@@ -120,17 +144,35 @@ jobs:
           # registry anyway, so a spurious dispatch is wasteful rather than
           # harmful.
           #
-          # THIS LIST IS A SECOND SOURCE OF TRUTH FOR "WHAT IS PUBLISHABLE" AND IT
-          # HAD ALREADY DRIFTED. publish-packages.mjs derives the real answer from
-          # the root `workspaces` array; this regex is a hand-maintained mirror of
-          # it, and it was missing `api-client/`, `sdk/` and `config-client/` —
-          # all publishable workspaces. The consequence is the silent one this
-          # whole job exists to prevent: an auto-merge pushes under GITHUB_TOKEN,
-          # the recursion guard suppresses packages-publish.yml's push trigger,
-          # this step decides there is "nothing to publish", and the PR merges
-          # green having shipped nothing. Anything added to `workspaces` must be
-          # added here too, or its releases are invisible.
-          PATTERN='^(packages/|shared/|design-system/|api-client/|sdk/|billing-client/|config-client/|portal-client/|custom-hostname-client/|backend/core/|package\.json|package-lock\.json|\.github/workflows/packages-publish\.yml|scripts/publish-packages\.mjs)'
+          # THIS USED TO BE A HAND-MAINTAINED REGEX — A SECOND SOURCE OF TRUTH FOR
+          # "WHAT IS PUBLISHABLE" — AND IT HAD ALREADY DRIFTED TWICE. It was
+          # missing `api-client/`, `sdk/` and `config-client/`, all publishable
+          # workspaces, and the consequence is the silent failure this whole job
+          # exists to prevent: an auto-merge pushes under GITHUB_TOKEN, the
+          # recursion guard suppresses packages-publish.yml's push trigger, this
+          # step decides there is "nothing to publish", and the PR merges green
+          # having shipped nothing.
+          #
+          # It is now DERIVED from the real source. `--list-dirs` prints the
+          # workspace directory of every publishable package, computed by the
+          # same `publishable()` the publish step itself uses. Adding a workspace
+          # can no longer fail to reach this list, because there is no longer a
+          # list to update.
+          #
+          # The literals that remain are not workspaces: they are the publish
+          # machinery itself, a change to which can change what publishes.
+          dirs=$(node scripts/publish-packages.mjs --list-dirs)
+          if [ -z "$dirs" ]; then
+            # Empty means the script broke or the workspaces array emptied —
+            # either way, silently concluding "nothing to publish" is the exact
+            # failure being designed out. Fail loudly instead.
+            echo "::error::publish-packages.mjs --list-dirs produced no publishable workspaces"
+            exit 1
+          fi
+          # Escape regex metacharacters, anchor each dir as a path prefix.
+          alt=$(printf '%s\n' "$dirs" | sed -e 's/[][\.^$*+?(){}|]/\\&/g' -e 's|$|/|' | paste -sd'|' -)
+          PATTERN="^(${alt}|package\.json|package-lock\.json|\.github/workflows/packages-publish\.yml|scripts/publish-packages\.mjs)"
+          echo "Publishable-path pattern: $PATTERN"
 
           if ! gh pr diff "$PR" --name-only | grep -qE "$PATTERN"; then
             echo "No publishable paths in PR #$PR — nothing to publish."

--- a/scripts/__tests__/publish-packages.test.mjs
+++ b/scripts/__tests__/publish-packages.test.mjs
@@ -9,7 +9,15 @@
 
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
-import { aliasFor, rewriteForPublish, filterTargets } from '../publish-packages.mjs'
+import { readFileSync, existsSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import {
+  aliasFor,
+  rewriteForPublish,
+  filterTargets,
+  isPublishableName,
+  assertAliasable,
+} from '../publish-packages.mjs'
 
 test('aliasFor maps the canonical scope onto the owner scope', () => {
   assert.equal(aliasFor('@fuzefront/chat-ui'), '@izzywdev/fuzefront-chat-ui')
@@ -22,9 +30,65 @@ test('aliasFor leaves an already-owner-scoped name alone', () => {
   assert.equal(aliasFor('@izzywdev/fuzefront-identity'), '@izzywdev/fuzefront-identity')
 })
 
+test('aliasFor maps every canonical scope, not just @fuzefront', () => {
+  // The bug this prevents, measured: @fuzeone/selection-lists-ui fell through
+  // aliasFor unchanged and was published under its own scope, which GitHub
+  // Packages rejects because the scope is not the repo owner:
+  //
+  //   npm error 403 Forbidden - PUT https://npm.pkg.github.com/@fuzeone%2fselection-lists-ui
+  //   Permission permission_denied: The requested installation does not exist.
+  //
+  // 24 of 25 matrix legs went green and the RUN still concluded `failure`, so a
+  // green packages-publish stopped being evidence that anything shipped.
+  assert.equal(aliasFor('@fuzeone/selection-lists-ui'), '@izzywdev/fuzeone-selection-lists-ui')
+})
+
 test('aliasFor leaves third-party names alone', () => {
+  // aliasFor also runs over DEPENDENCY names, so pass-through has to stay.
+  // That is why the unknown-scope rejection lives in assertAliasable, which
+  // only ever sees publish targets.
   assert.equal(aliasFor('react'), 'react')
   assert.equal(aliasFor('@types/node'), '@types/node')
+})
+
+test('isPublishableName rejects a scope with no alias rule', () => {
+  assert.equal(isPublishableName('@fuzefront/chat-ui'), true)
+  assert.equal(isPublishableName('@fuzeone/selection-lists-ui'), true)
+  assert.equal(isPublishableName('@izzywdev/fuzefront-identity'), true)
+  // A scope nobody has taught the script about, and a bare unscoped name:
+  // both would 403 exactly like @fuzeone did.
+  assert.equal(isPublishableName('@fuzenext/thing'), false)
+  assert.equal(isPublishableName('selection-list-service'), false)
+})
+
+test('assertAliasable fails the run before anything publishes', () => {
+  // Loud and early beats one red leg among two dozen green ones — that reads
+  // as flakiness and is exactly how the @fuzeone 403 survived every run.
+  assert.throws(
+    () => assertAliasable([{ dir: 'packages/thing', pkg: { name: '@fuzenext/thing' } }]),
+    /403 permission_denied/
+  )
+  assert.throws(
+    () => assertAliasable([{ dir: 'packages/thing', pkg: { name: '@fuzenext/thing' } }]),
+    /SCOPE_ALIASES/
+  )
+})
+
+test('assertAliasable passes the real workspace set', () => {
+  // The regression guard with teeth: this reads the ACTUAL root package.json,
+  // so adding a workspace under a brand-new scope fails here — in `verify`,
+  // before any matrix leg uploads a byte — instead of 403-ing on merge to
+  // master. A per-package unit assertion could not have caught @fuzeone;
+  // nothing in the tree enumerated the scopes.
+  const root = fileURLToPath(new URL('../../', import.meta.url))
+  const ws = JSON.parse(readFileSync(`${root}/package.json`, 'utf8')).workspaces ?? []
+  const targets = ws
+    .filter((dir) => !dir.includes('*') && existsSync(`${root}/${dir}/package.json`))
+    .map((dir) => ({ dir, pkg: JSON.parse(readFileSync(`${root}/${dir}/package.json`, 'utf8')) }))
+    .filter(({ pkg }) => !pkg.private && pkg.name)
+
+  assert.ok(targets.length > 0, 'expected at least one publishable workspace')
+  assert.doesNotThrow(() => assertAliasable(targets))
 })
 
 test('rewrites in-family dependencies, not just the package name', () => {

--- a/scripts/publish-packages.mjs
+++ b/scripts/publish-packages.mjs
@@ -32,6 +32,7 @@
 //   node scripts/publish-packages.mjs                    # publish every publishable package
 //   node scripts/publish-packages.mjs --only <pkgName>   # publish (or dry-run) just one package
 //   node scripts/publish-packages.mjs --list-json        # print `["@fuzefront/x", ...]` and exit
+//   node scripts/publish-packages.mjs --list-dirs        # print one publishable workspace dir per line
 //
 // Requires NODE_AUTH_TOKEN for a real publish.
 //
@@ -53,12 +54,37 @@ import { existsSync } from 'node:fs'
 const root = process.cwd()
 const REGISTRY = 'https://npm.pkg.github.com'
 const OWNER_SCOPE = '@izzywdev'
-const CANONICAL_SCOPE = '@fuzefront/'
+
+/**
+ * Canonical source-tree scope -> the prefix its packages take under the owner
+ * scope at publish time.
+ *
+ * EVERY canonical scope in the tree needs an entry here. GitHub Packages
+ * requires the published scope to equal the account that owns the repository
+ * (`izzywdev`), so a name that is neither owner-scoped nor aliased by this map
+ * is not publishable at all — `npm publish` answers
+ * `403 permission_denied: The requested installation does not exist`.
+ *
+ * This map used to be a single `CANONICAL_SCOPE = '@fuzefront/'` constant, and
+ * everything else fell through `aliasFor` unchanged. `@fuzeone/*` — a second,
+ * deliberate canonical scope (EPIC-17 records the decision: the intended future
+ * home is the `fuzeone` org) — therefore went out under its own name and 403'd
+ * on every single run. 24 of 25 legs succeeded and the run's conclusion was
+ * still `failure`, which destroys the only property this workflow is for: that
+ * a green `packages-publish` is evidence the packages actually shipped. See
+ * `assertAliasable` for why a future third scope now fails loudly instead.
+ */
+const SCOPE_ALIASES = {
+  '@fuzefront/': 'fuzefront-',
+  '@fuzeone/': 'fuzeone-',
+}
+
 const DEP_FIELDS = ['dependencies', 'peerDependencies', 'optionalDependencies']
 const LOCAL_PROTOCOL = /^(file:|link:|workspace:|portal:)/
 
 const dryRun = process.argv.includes('--dry-run')
 const listJson = process.argv.includes('--list-json')
+const listDirs = process.argv.includes('--list-dirs')
 const onlyIdx = process.argv.indexOf('--only')
 const only = onlyIdx === -1 ? null : process.argv[onlyIdx + 1]
 if (onlyIdx !== -1 && !only) {
@@ -70,13 +96,61 @@ function readJson(path) {
   return JSON.parse(readFileSync(path, 'utf8'))
 }
 
-/** `@fuzefront/chat-ui` -> `@izzywdev/fuzefront-chat-ui`. Already-owner-scoped names pass through. */
+/**
+ * `@fuzefront/chat-ui` -> `@izzywdev/fuzefront-chat-ui`.
+ * `@fuzeone/selection-lists-ui` -> `@izzywdev/fuzeone-selection-lists-ui`.
+ *
+ * Already-owner-scoped names pass through, and so does everything else —
+ * `aliasFor` is also applied to every DEPENDENCY name, where `react` and
+ * `@types/node` must survive untouched. That pass-through is why it cannot be
+ * the thing that rejects an unknown scope; `assertAliasable` does that, against
+ * publish TARGETS only.
+ */
 export function aliasFor(name) {
   if (name.startsWith(`${OWNER_SCOPE}/`)) return name
-  if (name.startsWith(CANONICAL_SCOPE)) {
-    return `${OWNER_SCOPE}/fuzefront-${name.slice(CANONICAL_SCOPE.length)}`
+  for (const [scope, prefix] of Object.entries(SCOPE_ALIASES)) {
+    if (name.startsWith(scope)) {
+      return `${OWNER_SCOPE}/${prefix}${name.slice(scope.length)}`
+    }
   }
   return name
+}
+
+/** True when `name` publishes to an owner-scoped name the registry will accept. */
+export function isPublishableName(name) {
+  return aliasFor(name).startsWith(`${OWNER_SCOPE}/`)
+}
+
+/**
+ * Fail the whole run if any publish target's name does not resolve into the
+ * owner scope — i.e. would 403 at `npm publish`.
+ *
+ * This is the generalisation of the `@fuzeone` bug rather than a patch for it.
+ * A scope with no alias rule is not a package-specific problem; it is a class
+ * of problem that reappears the next time someone introduces a scope, and its
+ * symptom (one red matrix leg among two dozen green ones) reads as flakiness.
+ *
+ * It deliberately throws EARLY — `publishable()` runs before `--list-json`
+ * resolves the matrix — so the failure is one loud error naming the offending
+ * package and the one-line fix (add the scope to SCOPE_ALIASES), raised before
+ * a single package has been uploaded. Nothing ships half-way: an aborted
+ * matrix resolution publishes nothing, and publishing is idempotent, so the
+ * re-run after the fix is a clean full release.
+ */
+export function assertAliasable(targets) {
+  const bad = targets.filter(({ pkg }) => !isPublishableName(pkg.name))
+  if (bad.length) {
+    const known = Object.keys(SCOPE_ALIASES).join(', ')
+    throw new Error(
+      `Not publishable — these workspace names resolve to no ${OWNER_SCOPE} name and would ` +
+        `fail with "403 permission_denied" at npm publish:\n` +
+        bad.map(({ dir, pkg }) => `  - ${pkg.name} (${dir})`).join('\n') +
+        `\nGitHub Packages requires the published scope to equal the repository owner ` +
+        `(${OWNER_SCOPE}). Add the scope to SCOPE_ALIASES in scripts/publish-packages.mjs ` +
+        `(currently: ${known}), or mark the workspace "private": true if it is not meant to publish.`
+    )
+  }
+  return targets
 }
 
 function workspaces() {
@@ -85,10 +159,12 @@ function workspaces() {
 
 /** Publishable = a workspace that is not marked private. One source of truth. */
 function publishable() {
-  return workspaces()
-    .filter((dir) => existsSync(`${root}/${dir}/package.json`))
-    .map((dir) => ({ dir, pkg: readJson(`${root}/${dir}/package.json`) }))
-    .filter(({ pkg }) => !pkg.private && pkg.name)
+  return assertAliasable(
+    workspaces()
+      .filter((dir) => existsSync(`${root}/${dir}/package.json`))
+      .map((dir) => ({ dir, pkg: readJson(`${root}/${dir}/package.json`) }))
+      .filter(({ pkg }) => !pkg.private && pkg.name)
+  )
 }
 
 /**
@@ -174,6 +250,19 @@ if (listJson) {
   // Deliberately independent of --dry-run/--only: the matrix needs the full
   // list to build its legs, not a filtered view of one.
   console.log(JSON.stringify(allTargets.map(({ pkg }) => pkg.name)))
+  return
+}
+
+if (listDirs) {
+  // One workspace DIRECTORY per publishable package, newline-separated, for
+  // auto-merge.yml's "did this merge touch anything publishable?" test.
+  //
+  // That test used to be a hand-maintained regex of publishable directories —
+  // a second source of truth for a question this file already answers, and it
+  // had already drifted twice (api-client/, sdk/ and config-client/ were all
+  // missing, so their releases were invisible). It now builds its pattern from
+  // this output, so adding a workspace can no longer silently fail to publish.
+  for (const { dir } of allTargets) console.log(dir)
   return
 }
 


### PR DESCRIPTION
## The defect (measured, not inferred)

`packages-publish.yml` has concluded `failure` on **every** run. Run
[33570797484](https://github.com/izzywdev/FuzeFront/actions/runs/33570797484) —
24 of 25 legs green, one leg red:

```
npm error code E403
npm error 403 Forbidden - PUT https://npm.pkg.github.com/@fuzeone%2fselection-lists-ui
  - Permission permission_denied: The requested installation does not exist.
  x @fuzeone/selection-lists-ui@0.1.0 - Command failed: npm publish
```

`aliasFor()` in `scripts/publish-packages.mjs` rewrote `@fuzefront/*` onto the
owner scope and passed **everything else through unchanged**, so
`@fuzeone/selection-lists-ui` was uploaded under its own scope. GitHub Packages
requires the npm scope to equal the account that owns the repository
(`izzywdev`), so it 403s.

The damage is wider than one package: while any leg is red, a green
`packages-publish` can never be used as evidence that anything published, so
every release has to be hand-checked against the registry API. That property is
what this PR restores.

## 1. The fix: extend the alias (option a), not rename the package

`@fuzeone` is not an accident - it is a **recorded owner decision**
(`docs/planning/epics/EPIC-17-selection-lists.md` "Why `@fuzeone` and not
`@fuzefront`", and `design/frames/selection-lists/manifest.json` flags the same
choice). The alias mechanism exists precisely to keep a canonical name in the
tree while publishing under the owner's scope; that is exactly this case, and it
preserves the intended future migration to a real `fuzeone` org.

Renaming would instead contradict the recorded decision and ripple through
`frontend/package.json`, `frontend/src/App.tsx`, both red Playwright specs,
`ci.yml` (x2), `harden-gate.yml`, and the epic/frames docs - a much larger, more
breakable change to work around a mechanism that already handles this.

So `CANONICAL_SCOPE` becomes a `SCOPE_ALIASES` map:

```
@fuzefront/chat-ui           -> @izzywdev/fuzefront-chat-ui           (unchanged)
@fuzeone/selection-lists-ui  -> @izzywdev/fuzeone-selection-lists-ui  (new)
```

Verified locally - note the in-family peer dep is rewritten too, so the tarball
is installable:

```
$ node scripts/publish-packages.mjs --dry-run --only "@fuzeone/selection-lists-ui"
  -> @fuzeone/selection-lists-ui -> @izzywdev/fuzeone-selection-lists-ui@0.1.0
     (deps rewritten: @izzywdev/fuzefront-design-system)
```

## 2. Scope audit - all 26 publishable workspaces, not just the one reported

Enumerated every distinct scope in the root `workspaces` array:

| Scope | Publishable pkgs | Status |
|---|---|---|
| `@fuzefront/*` | 22 | aliased to `@izzywdev/fuzefront-*` (already correct) |
| `@izzywdev/*` | 3 (`identity`, `api-client`, `sdk-react`) | already owner-scoped, passes through - correct |
| `@fuzeone/*` | 1 (`selection-lists-ui`) | **was broken, now aliased** |

No unscoped publishable workspace exists (`selection-list-service` is unscoped
but `private: true`, so it is never a target).

**A fix for only the scope I was handed would leave the same landmine**, so this
also adds `assertAliasable()`: `publishable()` now throws if any target's name
resolves to no `@izzywdev` name. A future third scope produces **one loud error
in `verify`, naming the package and the one-line fix, before any leg uploads a
byte** - instead of one red leg among two dozen green ones, which reads as
flakiness (which is how this survived every run). Nothing ships half-way: an
aborted matrix resolution publishes nothing, and publishing is idempotent.

New tests (`scripts/__tests__/publish-packages.test.mjs`, run in `verify`):
`aliasFor` covers every canonical scope; `isPublishableName` rejects an unmapped
scope and a bare name; `assertAliasable` throws with the 403 text and the fix;
and one guard reads the **real root `package.json`** and asserts the actual
workspace set is fully aliasable - a per-package unit assertion could not have
caught `@fuzeone`, because nothing in the tree enumerated the scopes.

## 3. Duplicated truth - one mirror collapsed, one deliberately not

There are **two** hand-maintained regex mirrors in `auto-merge.yml`, answering
different questions. They are not equally collapsible.

**Collapsed (done here): "what is publishable".** The publish-dispatch pattern
was a hand-copy of the root `workspaces` array - a second source of truth for a
question `publish-packages.mjs` already answers, and it had already drifted twice
(`api-client/`, `sdk/`, `config-client/` all missing). It is now **derived** from
a new `--list-dirs`, computed by the same `publishable()` the publish step uses,
and fails loudly on empty output rather than silently concluding "nothing to
publish". Adding a workspace can no longer fail to reach the list, because there
is no longer a list. Needs a checkout of the merge commit; no `npm ci`
(`--list-dirs` only reads `package.json` files with node builtins).

**Not collapsed (explicitly): "what is deployable".** The release-dispatch
pattern mirrors `release.yml`'s `on.push.paths` - image inputs, a different
question with a different source. GitHub requires `on.push.paths` to be **static
YAML**, so it cannot be computed; collapsing means parsing that workflow's YAML
at runtime, past the documented `on:`-parses-as-boolean-`true` hazard. Getting
that subtly wrong fails toward *"No deployable paths"* - silently not shipping to
prod - which is strictly worse than the drift it would fix. **What it would take:**
a checked-in paths manifest that `release.yml`'s `paths:` block is generated
from, a generator, and a CI gate asserting the committed block matches the
manifest, so drift is a red check rather than a silent no-deploy. That is its own
change with its own verification, and it is out of scope here. The reasoning is
recorded in the comment beside the pattern so the next reader does not have to
rediscover it.

## Verification

- `node --test scripts/__tests__/publish-packages.test.mjs` - **15/15 pass**
- `node scripts/publish-packages.mjs --dry-run --only "@fuzeone/selection-lists-ui"` - resolves to `@izzywdev/fuzeone-selection-lists-ui@0.1.0`
- `node scripts/publish-packages.mjs --list-json` - 26 legs, unchanged set
- `actionlint 1.7.12` - clean on `auto-merge.yml` and `packages-publish.yml`
- derived publishable-path pattern exercised against matching and non-matching paths

**A green run is not the acceptance criterion.** After merge this is checked
against the registry directly -
`gh api users/izzywdev/packages/npm/fuzeone-selection-lists-ui/versions` must
return `0.1.0`. That is the property being restored, so it is the property that
gets tested.

Ref: follows #900 (which put `api-client`/`sdk` into `workspaces` and published them).

Generated with [Claude Code](https://claude.com/claude-code)
