### PR TITLE
ci: render release.yml deploy triggers from a manifest + drift gate; fix two stale publishing docs

### DIFF
--- a/.fuze/installed.json
+++ b/.fuze/installed.json
@@ -552,8 +552,8 @@
       "capability": "workflows",
       "mode": "stamped",
       "sourcePath": "workflow-templates/fuze-code-review.yml",
-      "sourceSha256": "d8c46216212e373a19ace47c387cf382d57df352987ff1d85cf8b16ec4ce43da",
-      "renderedSha256": "d8c46216212e373a19ace47c387cf382d57df352987ff1d85cf8b16ec4ce43da",
+      "sourceSha256": "940d1ea7a9408a3ee766a98c1ff29ab7a073f21b6b0667eddde17273403251b6",
+      "renderedSha256": "940d1ea7a9408a3ee766a98c1ff29ab7a073f21b6b0667eddde17273403251b6",
       "renderVars": {
         "defaultBranch": "master",
         "baselineRef": "v1",

--- a/.fuze/installed.json
+++ b/.fuze/installed.json
@@ -1765,6 +1765,18 @@
       "sourcePath": "",
       "sourceSha256": "45672c1f91889a84d3a34c499bb2d75c43f3c09b3e05236d752a5c3b7b7737c4",
       "renderedSha256": "45672c1f91889a84d3a34c499bb2d75c43f3c09b3e05236d752a5c3b7b7737c4"
+    },
+    "scripts/gate_platform_auth.py": {
+      "capability": "platform-auth",
+      "mode": "managed",
+      "sourcePath": "scripts/gate_platform_auth.py",
+      "sourceSha256": "b2b643073efee75483274ad110c328960d83ecc8105ade3012d7a176500a1b63"
+    },
+    "scripts/__tests__/test_gate_platform_auth.py": {
+      "capability": "platform-auth",
+      "mode": "managed",
+      "sourcePath": "scripts/__tests__/test_gate_platform_auth.py",
+      "sourceSha256": "f2dcdf6a0ccbceb0ef8cfecf436ba2c98e6494a50c345e07fab821c3d55720fc"
     }
   },
   "workflows": {

--- a/.github/workflows/fuze-code-review.yml
+++ b/.github/workflows/fuze-code-review.yml
@@ -1,4 +1,3 @@
-# fuze:managed template=fuze-code-review.yml baseline=v1 digest=sha256:6fb89a68ff4af2ac9816339fea8d037167fe9737515370ef961f1b89a1250e41
 name: Fuze Code Review
 
 # THE CANONICAL LLM CODE REVIEW + APPROVAL GATE.
@@ -89,7 +88,7 @@ on:
     # ready_for_review is NOT optional: a bot-opened PR starts as a draft (GitHub
     # does not start workflow runs from GITHUB_TOKEN's own `opened` event), so
     # `opened` never fires for it — only `ready_for_review`, once a human or
-    # claude-auto-pr.yml marks it ready. Same reasoning as harden-gate.yml.
+    # fuze-auto-pr.yml marks it ready. Same reasoning as harden-gate.yml.
     types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:

--- a/.github/workflows/gate-deployable-paths.yml
+++ b/.github/workflows/gate-deployable-paths.yml
@@ -1,0 +1,66 @@
+name: gate-deployable-paths
+
+# release.yml's `on.push.paths` must equal what deploy/deployable-paths.json renders.
+#
+# WHAT THIS CLOSES.
+# "What is deployable/publishable" lived in three hand-maintained places that drift
+# independently:
+#   1. root package.json `workspaces` — the real source (publish-packages.mjs reads it).
+#   2. auto-merge.yml's regex mirror — COLLAPSED, it now derives from
+#      `node scripts/publish-packages.mjs --list-dirs` at runtime.
+#   3. release.yml's `on.push.paths` — this one. It CANNOT be collapsed the same way:
+#      GitHub evaluates the trigger block before any step runs, so it must be static
+#      YAML in the file. So the manifest becomes the source and the block becomes a
+#      rendered artifact — and this gate is what keeps that true. Without it, the
+#      manifest is just a FOURTH copy of the same truth.
+#
+# WHY IT HAS TO BE A GATE AND NOT A CONVENTION.
+# This mirror's failure mode is silent and inverted. A MISSING path does not produce a
+# red run — it produces NO run: the change merges green and simply never ships, and the
+# image keeps the old code. Five services (chat, notification, payment, selection-list,
+# config) each acquired a `docker/build-push-action` step whose own source dir was absent
+# from the trigger, and nothing in CI could see it. The gate also checks the other
+# direction a round-trip cannot: every Dockerfile release.yml builds must have its source
+# directory covered, which is the #432 chat-service bug exactly.
+#
+# NO `paths:` FILTER, deliberately — the same rule workspace-deps-check.yml,
+# gate-route-ownership.yml and gate-sealed-keys.yml already state. A path-filtered
+# workflow does not run at all on a PR that misses the filter, so the check run is never
+# CREATED, and a required context that is never created leaves the PR permanently at
+# "Expected — waiting for status to be reported": no red to click, nothing to re-run.
+# This gate is dependency-free (bare `node`, no `npm ci`, no js-yaml) and finishes in
+# under a second, so running it unconditionally costs nothing.
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: gate-deployable-paths-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deployable-paths:
+    name: release.yml deploy triggers match the manifest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '24.x'
+
+      # The gate's own extraction logic is the part most able to be quietly wrong: `on`
+      # is a YAML 1.1 boolean, so the classic bug is a checker that finds no `on` key,
+      # concludes "no deployable paths" and passes vacuously — failing toward exactly
+      # the silent no-ship it exists to catch. These tests assert it THROWS on every
+      # such shape, and that it fails on real injected drift. A gate never shown to fail
+      # on the bug it was written for is not evidence of anything.
+      - name: Unit-test the gate itself
+        run: npm run test:deployable-paths
+
+      - name: Check release.yml on.push.paths against deploy/deployable-paths.json
+        run: npm run check:deployable-paths

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,11 @@ on:
   push:
     branches: [master]
     paths:
+      # GENERATED BLOCK — do not hand-edit. Source of truth: deploy/deployable-paths.json.
+      # Change it there, run `npm run deployable-paths:write`, commit both.
+      # gate-deployable-paths.yml fails if these two disagree, because the failure mode of a
+      # missing path is silent: the release workflow simply does not run, so the change merges
+      # green and never ships. There is no red run to notice — there is no run.
       - 'backend/**'
       - 'shared/**'
       - 'frontend/**'

--- a/deploy/deployable-paths.json
+++ b/deploy/deployable-paths.json
@@ -1,0 +1,132 @@
+{
+  "$comment": [
+    "Deployable-paths manifest: the SOURCE OF TRUTH for release.yml's `on.push.paths`.",
+    "Rendered by scripts/gen-deployable-paths.mjs; enforced by scripts/check-deployable-paths.mjs",
+    "(gate-deployable-paths.yml). Edit THIS file, then run `npm run deployable-paths:write`.",
+    "Editing the block in .github/workflows/release.yml by hand makes the gate go red.",
+    "",
+    "WHAT BELONGS HERE.",
+    "Every path whose content is an INPUT to an image release.yml builds, plus the chart",
+    "values the tag-bump writes, plus release.yml itself. The test for an entry is:",
+    "\"if only this path changed, must an image be rebuilt and its tag bumped?\" If yes, it",
+    "belongs here. A source dir that feeds a `docker/build-push-action` step but is absent",
+    "from this list is the failure this file exists to stop.",
+    "",
+    "WHY A MANIFEST AND NOT DERIVATION.",
+    "auto-merge.yml's equivalent mirror was collapsed outright: it asks its question at",
+    "RUNTIME, so it can shell out to `node scripts/publish-packages.mjs --list-dirs`.",
+    "`on.push.paths` cannot be collapsed that way — GitHub reads the trigger block before",
+    "any step runs, so it MUST be static YAML committed in the workflow. The manifest is",
+    "therefore the source and the workflow block is a rendered artifact, kept honest by a",
+    "gate rather than by discipline.",
+    "",
+    "WHY THE GATE IS THE LOAD-BEARING PART.",
+    "This mirror's failure mode is silent and inverted: a MISSING path means the release",
+    "workflow does not trigger at all, so the change merges green and simply never ships.",
+    "There is no red run to notice — there is no run. That is how chat-service,",
+    "notification-service, payment-service, selection-list-service and config-service each",
+    "acquired a build step whose source dir could not trigger it. Without the drift gate a",
+    "manifest is just a FOURTH copy of the same truth; the gate is what makes it the only",
+    "copy that can be edited.",
+    "",
+    "FIELDS.",
+    "  path - the glob, rendered verbatim into the workflow as `- '<path>'`.",
+    "  why  - optional comment lines rendered ABOVE the entry, one `#` line each.",
+    "         Use it to record what a non-obvious entry protects; the rendered comments",
+    "         are part of the byte-for-byte comparison, so they cannot rot silently."
+  ],
+  "workflow": ".github/workflows/release.yml",
+  "header": [
+    "GENERATED BLOCK — do not hand-edit. Source of truth: deploy/deployable-paths.json.",
+    "Change it there, run `npm run deployable-paths:write`, commit both.",
+    "gate-deployable-paths.yml fails if these two disagree, because the failure mode of a",
+    "missing path is silent: the release workflow simply does not run, so the change merges",
+    "green and never ships. There is no red run to notice — there is no run."
+  ],
+  "paths": [
+    {
+      "path": "backend/**"
+    },
+    {
+      "path": "shared/**"
+    },
+    {
+      "path": "frontend/**"
+    },
+    {
+      "path": "packages/**",
+      "why": [
+        "Workspace packages are COMPILED INTO the images (the backend/applications",
+        "images build @fuzefront/feature-flags; the frontend bundles the UI",
+        "packages from source via vite aliases). Without this, a change confined",
+        "to packages/** merges green and ships nothing — the images keep the old",
+        "code, which is exactly how a \"merged\" fix can fail to reach production."
+      ]
+    },
+    {
+      "path": "api-client/**",
+      "why": [
+        "api-client/ and sdk/ became root workspaces so packages-publish.yml",
+        "could see them at all, and the four root-installing Dockerfiles now COPY",
+        "their manifests (check-dockerfile-lockfile requires the full workspace",
+        "set, or npm hoists a different tree than the lockfile). That makes them",
+        "image inputs, so a change confined to either must rebuild."
+      ]
+    },
+    {
+      "path": "sdk/**"
+    },
+    {
+      "path": "services/email-service/**"
+    },
+    {
+      "path": "services/sms-service/**"
+    },
+    {
+      "path": "services/provisioning-service/**"
+    },
+    {
+      "path": "services/billing-service/**"
+    },
+    {
+      "path": "services/chat-service/**",
+      "why": [
+        "Added in the same change that discovered the gap: #432 added the",
+        "\"Build & push chat-service\" step below, but never added chat-service's",
+        "own path here, so a change confined to services/chat-service/** (not",
+        "touching packages/**, deploy/helm/fuzefront/**, or this file) would",
+        "merge green and NEVER trigger a release — the exact same silent-ship",
+        "failure mode the packages/** comment above describes, just for a",
+        "different path. This was live for every commit between #432 and now."
+      ]
+    },
+    {
+      "path": "services/notification-service/**",
+      "why": [
+        "notification-service/** and payment-service/** were both missing here,",
+        "the same silent-ship gap the chat-service comment above describes: a",
+        "change confined to one of those service dirs would merge green and never",
+        "trigger a release, so the image would keep the old code (or, for the",
+        "never-built payment-service, stay absent entirely)."
+      ]
+    },
+    {
+      "path": "services/payment-service/**"
+    },
+    {
+      "path": "services/selection-list-service/**"
+    },
+    {
+      "path": "services/config-service/**"
+    },
+    {
+      "path": "clock-app/**"
+    },
+    {
+      "path": "deploy/helm/fuzefront/**"
+    },
+    {
+      "path": ".github/workflows/release.yml"
+    }
+  ]
+}

--- a/docs/guides/SELECTION_LIST_SERVICE.md
+++ b/docs/guides/SELECTION_LIST_SERVICE.md
@@ -85,11 +85,50 @@ rather than returning an empty string.
 
 ## Install the client
 
-The `@fuzeone` scope is not yet published to npm (tracked on FFRNT-266).
-Until the registry publish lands, install from a local build:
+### React UI package — published, install it from the registry
+
+`@fuzeone/selection-lists-ui` ships to GitHub Packages under the owner scope as
+**`@izzywdev/fuzeone-selection-lists-ui`** (`0.1.0` is live; verified against
+`GET users/izzywdev/packages/npm/fuzeone-selection-lists-ui/versions`). The
+rename is not a typo — GitHub Packages requires the npm scope to equal the
+account that owns the repository, so `publish-packages.mjs` rewrites every
+canonical scope to `@izzywdev/<scope>-*` at publish time. See
+[`shared-packages-distribution.md`](./shared-packages-distribution.md) for the
+alias mechanism.
 
 ```bash
-# In the selection-list-client workspace
+# .npmrc in the consuming repo (the scope is @izzywdev, not @fuzeone)
+@izzywdev:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}
+```
+
+```jsonc
+// package.json — alias it back to the canonical name if you prefer that import
+{
+  "dependencies": {
+    "@fuzeone/selection-lists-ui": "npm:@izzywdev/fuzeone-selection-lists-ui@^0.1.0"
+  }
+}
+```
+
+### TypeScript client — genuinely not published yet, and here is why
+
+`@fuzeone/selection-list-client` is **not** in the registry
+(`users/izzywdev/packages/npm/fuzeone-selection-list-client` → 404). The cause
+is not `publishConfig` — that is already correct in
+`selection-list-client/package.json`. It is that `selection-list-client` is
+**absent from the root `package.json` `workspaces` array**, and `workspaces` is
+the single source of truth `publish-packages.mjs` reads: a directory that is
+not a workspace produces no matrix leg, so `packages-publish` never tries to
+publish it and goes green anyway. `api-client/` and `sdk/` had exactly this
+defect until they were added as workspaces. Adding `selection-list-client` (and
+`packages/selection-list-client-py` for the Python side) to `workspaces` is the
+whole fix.
+
+Until then, install from a local build:
+
+```bash
+# In the selection-list-client directory
 cd selection-list-client
 npm install
 npm run build
@@ -100,9 +139,8 @@ npm pack
 npm install /path/to/fuzefront/selection-list-client/fuzeone-selection-list-client-1.0.0.tgz
 ```
 
-**Python client** (tracked on the same FFRNT-266 milestone) is in
-`packages/selection-list-client-py/` and follows the same pack-and-install
-pattern until PyPI publication.
+**Python client** is in `packages/selection-list-client-py/` and follows the
+same pack-and-install pattern until PyPI publication.
 
 ---
 

--- a/docs/guides/shared-packages-distribution.md
+++ b/docs/guides/shared-packages-distribution.md
@@ -1,10 +1,10 @@
-# Shared packages & middleware — publish from FuzeFront to the `fuzeone` org
+# Shared packages & middleware — publish from FuzeFront to GitHub Packages
 
-**Status:** Governance rule · **Date:** 2026-08-04
+**Status:** Governance rule · **Date:** 2026-08-04 · **Mechanism corrected:** 2026-09-02
 
 ## The rule
 
-**Any reusable middleware or library that more than one microservice needs — Express or Python — is exported as a versioned package from FuzeFront to the GitHub [`fuzeone`](https://github.com/fuzeone) org, and every microservice consumes it from there.**
+**Any reusable middleware or library that more than one microservice needs — Express or Python — is exported as a versioned, published package, and every microservice consumes it from the registry.**
 
 It is **never** left as an in-repo workspace-only package, copied between services, or re-implemented per service. If two services would share code, it becomes a published package first.
 
@@ -14,38 +14,102 @@ This is what keeps the family consistent: one implementation, one version line, 
 
 - **Express side:** cross-cutting request/DB middleware and infra utilities — e.g. the transactional-outbox `enqueueEvent` + outbox relay (`@fuzefront/core`), auth/tenant middleware, the DB bootstrap.
 - **Contract side:** event schemas, topic registry, and the typed Kafka client (`@fuzefront/shared/kafka`).
-- **Python side:** the equivalent library for Python microservices (the `fuzeone-events` package — outbox write + relay + Pydantic contract mirror).
+- **Python side:** the equivalent library for Python microservices (outbox write + relay + Pydantic contract mirror).
 
 If it's product/domain logic that only one service owns, it does **not** belong in a shared package — keep it in the service.
 
-## How packages are published (current mechanism)
+---
 
-Packages publish to **GitHub Packages** (`https://npm.pkg.github.com`) via per-package publish workflows under `.github/workflows/*-packages-publish.yml` (e.g. `packages-publish.yml`, `auth-ui-packages-publish.yml`, `security-packages-publish.yml`). A package opts in by declaring `publishConfig` in its `package.json` (see `packages/auth` and `packages/feature-flags` for the pattern) and getting an entry in a publish workflow.
+## How packages are published: the ALIAS mechanism
 
-**Target org — `fuzeone`.** GitHub Packages requires the npm scope to match the owning org, so packages published to the `fuzeone` org are scoped **`@fuzeone/*`** (e.g. `@fuzeone/express-outbox`, `@fuzeone/events`). Python ships the equivalent `fuzeone-events` distribution. Legacy `@izzywdev/fuzefront-*` packages migrate under the `fuzeone` org over time.
+> **This section previously described publishing `@fuzeone/*` to a `fuzeone` GitHub org. That is not what happens, and it is not what should happen.** There is no `fuzefront` org, and the `FuzeOne` org owns no repositories. GitHub Packages requires the npm scope to equal the account that **owns the repository**, and this repo is owned by the personal account **`izzywdev`**. A workflow gated on an org that never matched is why, for a long time, *not one package had ever been published* while every run went green.
 
-> The exact `@fuzeone/*` package names above are the working convention; confirm/adjust when wiring the publish workflow.
+Packages publish to **GitHub Packages** (`https://npm.pkg.github.com`) from one workflow, `.github/workflows/packages-publish.yml`, driven by `scripts/publish-packages.mjs`. The canonical names stay in the source tree; the script **renames at publish time**:
+
+| in the tree (canonical) | in the registry (aliased) |
+| --- | --- |
+| `@fuzefront/design-system` | `@izzywdev/fuzefront-design-system` |
+| `@fuzefront/core` | `@izzywdev/fuzefront-core` |
+| `@fuzeone/selection-lists-ui` | `@izzywdev/fuzeone-selection-lists-ui` |
+| `@izzywdev/fuzefront-sdk-react` | unchanged (already owner-scoped) |
+
+The rule is `aliasFor()` in `scripts/publish-packages.mjs`:
+
+```js
+const OWNER_SCOPE = '@izzywdev'
+const SCOPE_ALIASES = {
+  '@fuzefront/': 'fuzefront-',
+  '@fuzeone/': 'fuzeone-',
+}
+// @fuzeone/selection-lists-ui -> @izzywdev/fuzeone-selection-lists-ui
+```
+
+`@fuzeone/*` is a real, deliberate second canonical scope (EPIC-17 records the decision), not a mistake to be migrated away. It is aliased exactly like `@fuzefront/*`; both land under `@izzywdev`.
+
+**In-family dependencies are rewritten too.** A published package whose `dependencies` still named `@fuzefront/chat-client` would be uninstallable — that name resolves to nothing on any registry. `rewriteForPublish()` aliases every in-family dependency name and replaces `file:`/`workspace:` specifiers with the target's real version. This is the part the earlier one-off per-package publishers got wrong.
+
+### The guard: `assertAliasable()`
+
+A canonical scope with no entry in `SCOPE_ALIASES` is not publishable at all — `npm publish` answers `403 permission_denied`. That used to surface as one red matrix leg among two dozen green ones, which reads as flakiness: `@fuzeone/selection-lists-ui` 403'd on **every** run, so a green `packages-publish` proved nothing.
+
+`assertAliasable()` now throws in the **`verify` job**, before any package is uploaded, if any publishable workspace resolves to a name outside `@izzywdev`. The error names the offending package and the one-line fix (add the scope to `SCOPE_ALIASES`, or mark the workspace `"private": true`). Matrix resolution aborts, nothing ships half-way, and publishing is idempotent — so the re-run after the fix is a clean full release.
+
+### What makes a package publishable
+
+**The root `package.json` `workspaces` array. That is the only list.** `publishable()` = every non-`private` workspace with a `name`. There is no second register to add yourself to.
+
+This matters more than it sounds: a package with perfect `publishConfig` that is **not** a root workspace produces **no matrix leg at all**, so `packages-publish` never attempts it and goes green anyway. `api-client/` and `sdk/` sat in that state — invisible, not failing — until they were added as workspaces (`selection-list-client/` is still in it today). Absence is silent; check the registry, not the run conclusion.
+
+`auto-merge.yml` used to keep its own hand-maintained regex of publishable directories and had already drifted three packages. It now derives the list from `node scripts/publish-packages.mjs --list-dirs`, so there is one source of truth rather than a mirror.
+
+### Verifying a release
+
+**The registry read is the acceptance test, not the run conclusion.**
+
+```bash
+gh api users/izzywdev/packages/npm/fuzeone-selection-lists-ui/versions --jq '[.[].name]'
+# ["0.1.0"]
+```
 
 ## How a microservice consumes them
 
-- **Node:** map the scope to the registry in `.npmrc` (the repo already does this for `@fuzefront`):
+- **Node:** map the **`@izzywdev`** scope to the registry in `.npmrc` — this repo's own `.npmrc` does exactly this, and mapping `@fuzefront`/`@fuzeone` instead points a scope at an owner that does not exist:
+
   ```
-  @fuzeone:registry=https://npm.pkg.github.com
+  @izzywdev:registry=https://npm.pkg.github.com
   //npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}
   ```
-  then depend on the **pinned published version** (`"@fuzeone/express-outbox": "^1.2.0"`) — not a `workspace:*`/`file:` path in production consumers.
-- **Python:** install `fuzeone-events` from the org's package index and pin the version.
+
+  Then depend on the pinned published version — not a `workspace:*`/`file:` path in production consumers:
+
+  ```jsonc
+  { "dependencies": { "@izzywdev/fuzefront-core": "^1.0.0" } }
+  ```
+
+  If you want to keep the canonical import specifier in your source, use an npm alias:
+
+  ```jsonc
+  { "dependencies": { "@fuzefront/core": "npm:@izzywdev/fuzefront-core@^1.0.0" } }
+  ```
+
+  Inside **this** repo no mapping is needed: `@fuzefront/*` and `@fuzeone/*` are npm workspaces that npm links from the working tree and that never touch a registry.
+
+- **Python:** publish to PyPI via the tag-triggered `python-publish.yml` reusable workflow (e.g. `selection-list-client-py-publish.yml`, tag `selection-list-client-py/v*`), and pin the version in the consumer. PyPI trusted publishing needs a one-time human setup in the PyPI UI.
 
 ## Versioning
 
-SemVer, enforced the same way as the rest of the family (`gate-version` bump discipline). A breaking change to a shared middleware package is a major bump and a coordinated consumer update — treat it like the Module-Federation React-singleton contract: shared, therefore load-bearing for everyone.
+SemVer, enforced the same way as the rest of the family (`gate-version` bump discipline). **Versions are bumped in the PR, not by the publish job** — master enforces `required_signatures`, so an unsigned version commit pushed from Actions would be rejected after the publish had already happened. A package publishes when its version changes; if it does not change, the run skips it and says so.
+
+A breaking change to a shared middleware package is a major bump and a coordinated consumer update — treat it like the Module-Federation React-singleton contract: shared, therefore load-bearing for everyone.
 
 ## Status of the event-propagation packages
 
-| Package | Role | Published to `fuzeone`? |
-|---|---|---|
-| `@fuzefront/shared` (`/kafka`) | event contract + typed client + registry | **Not yet** on `fuzeone` — but published today as **`@izzywdev/fuzefront-shared@1.0.0`** |
-| `@fuzefront/core` (outbox + relay) | Express-side transactional-outbox middleware | **Not yet** on `fuzeone` — but published today as **`@izzywdev/fuzefront-core@1.0.0`** |
-| `fuzeone-events` (Python) | outbox + relay + Pydantic contract mirror | **Planned** (FFRNT-176) — publish from the start |
+Verified against the registry on 2026-09-02 (`gh api users/izzywdev/packages?package_type=npm`):
 
-Making these three publishable to the `fuzeone` org is the remaining step to satisfy this rule; see `docs/planning/entity-lifecycle-event-propagation.md` § Distribution & packaging.
+| Canonical name | Role | Registry name | State |
+|---|---|---|---|
+| `@fuzefront/shared` (`/kafka`) | event contract + typed client + registry | `@izzywdev/fuzefront-shared` | **Published** `1.0.0` |
+| `@fuzefront/core` (outbox + relay) | Express-side transactional-outbox middleware | `@izzywdev/fuzefront-core` | **Published** `1.0.0` |
+| Python events lib | outbox + relay + Pydantic contract mirror | PyPI | **Not published** (FFRNT-176) |
+
+The org-transfer framing of this rule is retired: the alias mechanism satisfies it today under `@izzywdev`. If a `fuzefront`/`fuzeone` org is ever created and owns these repos, the migration is two edits — `OWNER_SCOPE` in `scripts/publish-packages.mjs` and the scope line in `.npmrc` — and the canonical names in the tree never move. See `docs/planning/entity-lifecycle-event-propagation.md` § Distribution & packaging.

--- a/package.json
+++ b/package.json
@@ -53,7 +53,10 @@
     "check:dockerfile-lockfile": "node scripts/check-dockerfile-lockfile.mjs",
     "check:frames-stamped": "node scripts/stamp-frames.mjs --check",
     "stamp:frames": "node scripts/stamp-frames.mjs --write",
-    "test:frames-stamped": "node --test scripts/__tests__/stamp-frames.test.mjs"
+    "test:frames-stamped": "node --test scripts/__tests__/stamp-frames.test.mjs",
+    "check:deployable-paths": "node scripts/check-deployable-paths.mjs",
+    "deployable-paths:write": "node scripts/gen-deployable-paths.mjs --write",
+    "test:deployable-paths": "node --test scripts/__tests__/deployable-paths.test.mjs"
   },
   "devDependencies": {
     "@types/node": "^24.13.3",

--- a/scripts/__tests__/deployable-paths.test.mjs
+++ b/scripts/__tests__/deployable-paths.test.mjs
@@ -1,0 +1,204 @@
+/**
+ * Tests for the deployable-paths gate (release.yml `on.push.paths` vs
+ * deploy/deployable-paths.json).
+ *
+ * The load-bearing cases are the DRIFT ones. A gate that has only ever been seen to
+ * pass proves nothing: the whole reason this mirror rotted five times is that its
+ * failure mode is silent (a missing path means the release workflow does not run at
+ * all — no red run, no run). So this suite feeds the checker deliberately mismatched
+ * blocks and asserts it notices, including:
+ *   - a path dropped from the workflow but declared in the manifest (the real bug),
+ *   - a build step whose source dir nothing covers (the #432 chat-service bug, which a
+ *     pure round-trip comparison CANNOT see, since manifest and workflow agree),
+ *   - the vacuous-pass shapes: no `on:`, no `push:`, no `paths:`, empty `paths:`.
+ *
+ * It also pins the round-trip against the REAL repo files, so a generator bug is
+ * distinguishable from real drift.
+ *
+ * Run with:  node --test scripts/__tests__/deployable-paths.test.mjs
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+import {
+  readManifest,
+  renderPathsBlock,
+  extractPathsBlock,
+  globCovers,
+  uncoveredBuildInputs,
+  MANIFEST_PATH,
+  WORKFLOW_PATH,
+} from '../deployable-paths.mjs'
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
+const realManifest = readManifest(readFileSync(resolve(root, MANIFEST_PATH), 'utf8'))
+const realWorkflow = readFileSync(resolve(root, WORKFLOW_PATH), 'utf8')
+
+/** A minimal workflow with the same shape as release.yml. */
+const wf = (pathsBlock, extra = '') => `name: Release
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [master]
+    paths:
+${pathsBlock}
+
+jobs:
+  build-and-bump:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build & push backend
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: backend/Dockerfile
+${extra}`
+
+const BLOCK = ["      - 'backend/**'", "      # why sms", "      - 'services/sms-service/**'"].join('\n')
+
+const MANIFEST = {
+  paths: [{ path: 'backend/**' }, { path: 'services/sms-service/**', why: ['why sms'] }],
+}
+
+test('round-trips the REAL repo files (generator fidelity, not just self-consistency)', () => {
+  const rendered = renderPathsBlock(realManifest)
+  const found = extractPathsBlock(realWorkflow)
+  assert.equal(
+    rendered,
+    found.text,
+    'the committed release.yml block is not what the manifest renders — run ' +
+      '`npm run deployable-paths:write`'
+  )
+  assert.ok(found.paths.length > 0)
+})
+
+test('every Dockerfile the real release.yml builds is covered by the real manifest', () => {
+  assert.deepEqual(uncoveredBuildInputs(realWorkflow, realManifest), [])
+})
+
+test('renders comments above their entry, blank `why` lines as bare #', () => {
+  assert.equal(
+    renderPathsBlock({ paths: [{ path: 'a/**', why: ['one', '', 'two'] }] }),
+    ['      # one', '      #', '      # two', "      - 'a/**'"].join('\n')
+  )
+})
+
+test('header renders inside the compared block', () => {
+  const out = renderPathsBlock({ header: ['GENERATED'], paths: [{ path: 'a/**' }] })
+  assert.equal(out, ['      # GENERATED', "      - 'a/**'"].join('\n'))
+})
+
+test('extracts the block and its paths', () => {
+  const found = extractPathsBlock(wf(BLOCK))
+  assert.deepEqual(found.paths, ['backend/**', 'services/sms-service/**'])
+  assert.equal(found.text, BLOCK)
+})
+
+// --- DRIFT: the cases the gate exists for -----------------------------------------
+
+test('DRIFT: a path dropped from the workflow is detected and nameable', () => {
+  const drifted = extractPathsBlock(wf("      - 'backend/**'"))
+  assert.notEqual(renderPathsBlock(MANIFEST), drifted.text)
+  const missing = MANIFEST.paths.map((p) => p.path).filter((p) => !drifted.paths.includes(p))
+  assert.deepEqual(missing, ['services/sms-service/**'])
+})
+
+test('DRIFT: a path added to the workflow but not declared is detected', () => {
+  const drifted = extractPathsBlock(wf([BLOCK, "      - 'services/ghost/**'"].join('\n')))
+  const extra = drifted.paths.filter((p) => !MANIFEST.paths.some((e) => e.path === p))
+  assert.deepEqual(extra, ['services/ghost/**'])
+})
+
+test('DRIFT: same path set, changed comment text still fails the byte comparison', () => {
+  const drifted = extractPathsBlock(wf(BLOCK.replace('# why sms', '# edited by hand')))
+  assert.deepEqual(drifted.paths, MANIFEST.paths.map((p) => p.path))
+  assert.notEqual(renderPathsBlock(MANIFEST), drifted.text)
+})
+
+test('DRIFT: reordering the paths fails the byte comparison', () => {
+  const reordered = ["      - 'services/sms-service/**'", '      # why sms', "      - 'backend/**'"].join('\n')
+  assert.notEqual(renderPathsBlock(MANIFEST), extractPathsBlock(wf(reordered)).text)
+})
+
+test('DRIFT: a build step whose source dir nothing covers (#432 chat-service)', () => {
+  // Manifest and workflow AGREE here — the round-trip comparison is green. Only the
+  // build-input coverage check can see this one.
+  const source = wf(
+    BLOCK,
+    `      - name: Build & push chat-service
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: services/chat-service/Dockerfile
+`
+  )
+  assert.equal(renderPathsBlock(MANIFEST), extractPathsBlock(source).text)
+  assert.deepEqual(uncoveredBuildInputs(source, MANIFEST), [
+    { dockerfile: 'services/chat-service/Dockerfile', dir: 'services/chat-service/' },
+  ])
+})
+
+// --- VACUOUS PASSES: the shapes that must throw, not silently return nothing --------
+
+test('throws when there is no top-level `on:` (the YAML-1.1 `on`->true trap)', () => {
+  assert.throws(() => extractPathsBlock('name: Release\njobs: {}\n'), /exactly one top-level/)
+})
+
+test('throws when `on.push` is missing', () => {
+  assert.throws(
+    () => extractPathsBlock('name: R\n\non:\n  workflow_dispatch:\n\njobs: {}\n'),
+    /no `push:` trigger/
+  )
+})
+
+test('throws when `on.push.paths` is missing', () => {
+  assert.throws(
+    () => extractPathsBlock('name: R\n\non:\n  push:\n    branches: [master]\n\njobs: {}\n'),
+    /has no `paths:` key/
+  )
+})
+
+test('throws — loudly — when the paths list is EMPTY rather than passing vacuously', () => {
+  assert.throws(
+    () => extractPathsBlock('name: R\n\non:\n  push:\n    branches: [master]\n    paths:\n\njobs: {}\n'),
+    /NO deployable paths/
+  )
+})
+
+test('throws on an unrecognised line inside the block instead of skipping it', () => {
+  assert.throws(() => extractPathsBlock(wf('      - "double quoted/**"')), /unrecognised line/)
+})
+
+test('throws when the workflow builds no images (detection silently broken)', () => {
+  assert.throws(
+    () => uncoveredBuildInputs('name: R\n\non:\n  push:\n', MANIFEST),
+    /found no `file: …Dockerfile` build steps/
+  )
+})
+
+// --- manifest validation ------------------------------------------------------------
+
+test('rejects an empty manifest rather than emptying the trigger', () => {
+  assert.throws(() => readManifest('{"paths":[]}'), /declares no `paths`/)
+})
+
+test('rejects duplicate and malformed entries', () => {
+  assert.throws(() => readManifest('{"paths":[{"path":"a/**"},{"path":"a/**"}]}'), /duplicate path/)
+  assert.throws(() => readManifest('{"paths":[{}]}'), /non-empty string/)
+  assert.throws(() => readManifest('{"paths":[{"path":"a/**","why":"nope"}]}'), /array of comment lines/)
+})
+
+test('globCovers: `dir/**` covers files beneath it, exact paths match exactly', () => {
+  assert.equal(globCovers('backend/**', 'backend/Dockerfile'), true)
+  assert.equal(globCovers('backend/**', 'backend/security/Dockerfile'), true)
+  assert.equal(globCovers('services/chat-service/**', 'services/chat-ui/Dockerfile'), false)
+  assert.equal(globCovers('.github/workflows/release.yml', '.github/workflows/release.yml'), true)
+  assert.equal(globCovers('.github/workflows/release.yml', '.github/workflows/ci.yml'), false)
+})
+
+test('EOL-agnostic: a CRLF checkout is not reported as drift', () => {
+  assert.equal(extractPathsBlock(wf(BLOCK).replace(/\n/g, '\r\n')).text, BLOCK)
+})

--- a/scripts/__tests__/test_gate_platform_auth.py
+++ b/scripts/__tests__/test_gate_platform_auth.py
@@ -1,0 +1,820 @@
+"""Tests for gate-platform-auth.
+
+The governing principle, borrowed from test_gate_identifier: these assert the
+gate FAILS on a violation, not merely that it passes on a clean tree. Passing is
+not evidence. Every gate this family has shipped that only proved the happy path
+turned out to be vacuous — gate-secret-scan with zero rules loaded,
+gate-ds-conformance with no script present, gate-authz ending in `|| true`.
+
+`FuzeFinanceRegression` is the acceptance test. It reconstructs the shape of the
+code that actually shipped an unauthenticated finance service to production
+(FuzeFinance#28) and asserts this gate flags it. If that test ever passes
+without the gate reporting, the gate has stopped doing the one job it was
+written for.
+"""
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(os.path.dirname(__file__))))
+GATE = os.path.join(REPO, "scripts", "gate_platform_auth.py")
+
+
+def make_repo(files, manifest=None):
+    """A git repo on disk — the gate uses `git ls-files`, so it must be real."""
+    d = tempfile.mkdtemp()
+    for rel, body in files.items():
+        p = os.path.join(d, rel)
+        os.makedirs(os.path.dirname(p), exist_ok=True)
+        with open(p, "w", encoding="utf-8") as fh:
+            fh.write(body)
+    if manifest is not None:
+        os.makedirs(os.path.join(d, ".fuze"), exist_ok=True)
+        with open(os.path.join(d, ".fuze", "manifest.json"), "w") as fh:
+            json.dump(manifest, fh)
+    for cmd in (["git", "init", "-q", "."],
+                ["git", "config", "user.email", "t@t"],
+                ["git", "config", "user.name", "t"],
+                ["git", "add", "-A"],
+                ["git", "commit", "-qm", "x"]):
+        subprocess.run(cmd, cwd=d, check=True,
+                       stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    return d
+
+
+def run(repo, *flags):
+    r = subprocess.run([sys.executable, GATE, repo, *flags],
+                       capture_output=True, text=True)
+    return r.returncode, r.stdout + r.stderr
+
+
+CLEAN_SERVER = """
+import { createVerifier, requireAuth, createAuthzClient, requirePermission } from '@fuzefront/auth';
+import rateLimit from 'express-rate-limit';
+
+const verifier = createVerifier({
+  mode: process.env.AUTH_MODE,
+  jwksUri: process.env.JWKS_URI,
+  algorithms: ['RS256'],
+});
+const client = createAuthzClient({ baseUrl: process.env.AUTHZ_BASE_URL });
+
+app.get('/health', (req, res) => res.json({ ok: true }));
+app.use('/api', rateLimit({ windowMs: 60000, max: 100 }));
+app.use(requireAuth({ verifier }));
+app.post('/api/v1/items', requirePermission({ client, resource: 'item', action: 'create' }), h);
+"""
+
+CLEAN_PKG = json.dumps({"dependencies": {"@fuzefront/auth": "^1.0.0"}})
+
+# CLEAN_SERVER mounts `/health` ahead of the auth middleware, deliberately — the
+# canonical order puts liveness before the guard. Under the route family that is
+# an unguarded route like any other, so the clean fixture declares it. This is
+# not a workaround for the gate: it is the intended usage, and having the
+# reference "correct repo" demonstrate it is the point.
+CLEAN_PUBLIC = "GET /health  # liveness probe, mounted pre-auth by design\n"
+
+
+class CleanRepoPasses(unittest.TestCase):
+    def test_clean_repo_reports_ok(self):
+        d = make_repo({"src/server.ts": CLEAN_SERVER, "package.json": CLEAN_PKG,
+                       "governance/public-routes.txt": CLEAN_PUBLIC})
+        code, out = run(d)
+        self.assertEqual(code, 0, out)
+        self.assertIn("gate-platform-auth: OK", out)
+
+    def test_library_with_no_routes_is_out_of_scope(self):
+        """A package with no HTTP surface must not be dragged into this."""
+        d = make_repo({"src/index.ts": "export const add = (a, b) => a + b;\n",
+                       "package.json": json.dumps({"name": "lib"})})
+        code, out = run(d)
+        self.assertEqual(code, 0, out)
+        self.assertIn("OK", out)
+
+
+class FuzeFinanceRegression(unittest.TestCase):
+    """The acceptance test. This is the shape that shipped."""
+
+    SERVER = """
+let requireAuth, requireRoles;
+try {
+  const auth = require('@fuzefront/auth');
+  requireAuth = auth.requireAuth;
+  requireRoles = auth.requireRoles;
+} catch (err) {
+  console.warn("auth not resolved. Using fallbacks/mock middleware.");
+  requireAuth = () => (req, res, next) => {
+    req.identity = {
+      userId: 'user_dev_id',
+      roles: ['admin', 'finance_officer'],
+    };
+    next();
+  };
+  requireRoles = () => (req, res, next) => next();
+}
+
+app.post('/api/v1/invoices', requireAuth(), requireRoles('admin'), handler);
+"""
+    # The load-bearing detail: no @fuzefront/auth anywhere in here.
+    PKG = json.dumps({"dependencies": {"express": "^4.0.0"}})
+
+    def setUp(self):
+        self.d = make_repo({"backend/src/server.js": self.SERVER,
+                            "backend/package.json": self.PKG})
+
+    def test_gate_flags_it(self):
+        code, out = run(self.d)
+        self.assertIn("finding", out.lower(), out)
+
+    def test_f1_catches_the_permissive_fallback(self):
+        _, out = run(self.d, "--fail-open")
+        self.assertIn("F1", out)
+
+    def test_d1_catches_the_undeclared_import(self):
+        """The detail that turned a fallback into the ONLY path."""
+        _, out = run(self.d, "--declared")
+        self.assertIn("D1", out)
+
+    def test_z1_catches_the_missing_authorization(self):
+        _, out = run(self.d, "--authz")
+        self.assertIn("Z1", out)
+
+    def test_enforcing_manifest_makes_it_exit_nonzero(self):
+        d = make_repo({"backend/src/server.js": self.SERVER,
+                       "backend/package.json": self.PKG},
+                      manifest={"platformAuth": {"enforce": True}})
+        code, out = run(d)
+        self.assertEqual(code, 1, out)
+        self.assertIn("::error::", out)
+
+
+class AdoptionIsNotVacuous(unittest.TestCase):
+    """A1 — the check that fires when there is nothing else to find fault with."""
+
+    NO_AUTH = """
+app.get('/api/v1/things', (req, res) => res.json([]));
+app.post('/api/v1/things', (req, res) => res.status(201).json({}));
+"""
+
+    def test_service_with_no_auth_at_all_is_flagged(self):
+        d = make_repo({"src/server.js": self.NO_AUTH,
+                       "package.json": json.dumps({"dependencies": {}})})
+        code, out = run(d, "--adoption")
+        self.assertIn("A1", out)
+
+    def test_every_other_family_is_silent_on_it(self):
+        """The point of A1: without it this repo passes the whole gate. If this
+        ever starts failing, some other family gained coverage and A1's rationale
+        should be re-read rather than the test relaxed."""
+        d = make_repo({"src/server.js": self.NO_AUTH,
+                       "package.json": json.dumps({"dependencies": {}})})
+        for flag in ("--fail-open", "--declared", "--secrets"):
+            _, out = run(d, flag)
+            self.assertIn("OK", out, f"{flag} unexpectedly reported on a no-auth repo")
+
+
+class SecretHandling(unittest.TestCase):
+    def test_literal_secret_is_flagged(self):
+        d = make_repo({"src/a.ts": "const v = createVerifier({ secret: 'shared-dev-secret', algorithms: ['HS256'] });\n",
+                       "package.json": CLEAN_PKG})
+        _, out = run(d, "--secrets")
+        self.assertIn("S1", out)
+
+    def test_env_sourced_secret_is_not_flagged(self):
+        d = make_repo({"src/a.ts": "const v = createVerifier({ secret: process.env.JWT_SECRET, algorithms: ['HS256'] });\n",
+                       "package.json": CLEAN_PKG})
+        _, out = run(d, "--secrets")
+        self.assertNotIn("S1", out)
+
+    def test_unpinned_algorithms_are_flagged(self):
+        d = make_repo({"src/a.ts": "const v = createVerifier({ jwksUri: process.env.J });\n",
+                       "package.json": CLEAN_PKG})
+        _, out = run(d, "--secrets")
+        self.assertIn("S3", out)
+
+
+class AuthzRules(unittest.TestCase):
+    def test_direct_permit_call_is_flagged(self):
+        d = make_repo({"src/a.ts": "import { Permit } from 'permitio';\nconst ok = await permit.check(u, a, r);\n",
+                       "package.json": CLEAN_PKG})
+        _, out = run(d, "--authz")
+        self.assertIn("Z3", out)
+
+    def test_fail_open_on_decision_unavailable_is_flagged(self):
+        d = make_repo({"src/a.ts": CLEAN_SERVER + """
+if (result.reason === 'DECISION_UNAVAILABLE') {
+  return next();
+}
+""", "package.json": CLEAN_PKG})
+        _, out = run(d, "--authz")
+        self.assertIn("Z2", out)
+
+    def test_fail_closed_on_decision_unavailable_is_not_flagged(self):
+        d = make_repo({"src/a.ts": CLEAN_SERVER + """
+if (result.reason === 'DECISION_UNAVAILABLE') {
+  return res.status(403).json({ error: 'denied' });
+}
+""", "package.json": CLEAN_PKG})
+        _, out = run(d, "--authz")
+        self.assertNotIn("Z2", out)
+
+
+class RateLimiting(unittest.TestCase):
+    def test_api_without_a_limiter_is_flagged(self):
+        d = make_repo({"src/a.ts": "app.get('/api/v1/x', h);\n", "package.json": CLEAN_PKG})
+        _, out = run(d, "--rate-limit")
+        self.assertIn("R1", out)
+
+    def test_limiter_present_is_not_flagged(self):
+        d = make_repo({"src/a.ts": CLEAN_SERVER, "package.json": CLEAN_PKG})
+        _, out = run(d, "--rate-limit")
+        self.assertNotIn("R1", out)
+
+
+class InertDeclaration(unittest.TestCase):
+    def test_declared_but_never_imported_is_flagged(self):
+        """Thirteen repos declared the identity package and none imported it.
+        A dependency line is not adoption."""
+        d = make_repo({"src/a.ts": "app.get('/api/v1/x', h);\n", "package.json": CLEAN_PKG})
+        _, out = run(d, "--declared")
+        self.assertIn("D2", out)
+
+
+class RatchetDefault(unittest.TestCase):
+    """The ratchet is OPT-OUT. These pin that, and pin the cost of opting out.
+
+    The gate originally enforced only where a repo opted in, to avoid redding
+    the fleet on pre-existing violations. That is how `gate-identifier` reached
+    zero adoption across 21 repos — a check nobody enabled is indistinguishable
+    from a check that does not exist. What prevents a `|| true` is visibility,
+    not coldness, so the default inverted and the escape hatch was made legible.
+    """
+
+    FAILING = {"src/server.js": AdoptionIsNotVacuous.NO_AUTH,
+               "package.json": json.dumps({"dependencies": {}})}
+
+    def test_enforcing_by_default(self):
+        """THE test for this behaviour. No manifest at all still enforces —
+        a repo must not be able to escape by simply not declaring anything."""
+        d = make_repo(dict(self.FAILING))
+        code, out = run(d)
+        self.assertEqual(code, 1, out)
+        self.assertIn("::error::", out)
+        self.assertIn("enforcing by default", out)
+
+    def test_block_present_but_flag_absent_still_enforces(self):
+        d = make_repo(dict(self.FAILING),
+                      manifest={"platformAuth": {"mode": "federated-jwks"}})
+        code, out = run(d)
+        self.assertEqual(code, 1, out)
+
+    def test_opt_out_with_a_reason_is_report_only(self):
+        """The hatch must genuinely work — a repo mid-migration has to be able
+        to land work, or the gate gets removed instead of satisfied."""
+        d = make_repo(dict(self.FAILING),
+                      manifest={"platformAuth": {"enforce": False,
+                                                 "reason": "migrating off HS256, "
+                                                           "owner @izzywdev, tracked in #99"}})
+        code, out = run(d)
+        self.assertEqual(code, 0, out)
+        self.assertIn("report-only", out)
+        self.assertIn("::warning::", out)
+        self.assertIn("migrating off HS256", out)
+
+    def test_opt_out_without_a_reason_does_not_count(self):
+        """An undocumented opt-out is indistinguishable from an oversight, so
+        it is not honoured. This is the entire cost of the escape hatch."""
+        d = make_repo(dict(self.FAILING),
+                      manifest={"platformAuth": {"enforce": False}})
+        code, out = run(d)
+        self.assertEqual(code, 1, out)
+        self.assertIn("reason", out)
+
+    def test_blank_reason_does_not_count_either(self):
+        d = make_repo(dict(self.FAILING),
+                      manifest={"platformAuth": {"enforce": False, "reason": "   "}})
+        code, out = run(d)
+        self.assertEqual(code, 1, out)
+
+    def test_a_clean_repo_passes_while_enforcing(self):
+        """Enforcing by default must not mean failing by default."""
+        d = make_repo({"src/server.js": CLEAN_SERVER, "package.json": CLEAN_PKG,
+                       "governance/public-routes.txt": CLEAN_PUBLIC})
+        code, out = run(d)
+        self.assertEqual(code, 0, out)
+
+    def test_tests_directory_is_not_scanned(self):
+        """A test SHOULD be able to build a permissive stub. Flagging that would
+        train people to silence the gate."""
+        d = make_repo({"src/server.ts": CLEAN_SERVER,
+                       "governance/public-routes.txt": CLEAN_PUBLIC,
+                       "test/auth.test.ts": FuzeFinanceRegression.SERVER,
+                       "package.json": CLEAN_PKG})
+        code, out = run(d)
+        self.assertEqual(code, 0, out)
+        self.assertIn("OK", out)
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
+class ThePlatformIsNotAProduct(unittest.TestCase):
+    """Found only by running the gate against FuzeFront, and only once the ratchet
+    became enforce-by-default — where it produced 56 findings, 55 of them wrong.
+
+    FuzeFront publishes @fuzefront/auth AND serves /api/v1/security/authz/check. The
+    consumer rules invert there: the library that provides requirePermission is not a
+    product failing to call it, and the service that answers the authz endpoint is the
+    one place in the family that must talk to Permit. A gate that reds the reference
+    implementation for being the reference implementation teaches people the gate is
+    wrong, and it would have done so on the platform repo's every PR.
+
+    Both roles are DERIVED from the repo's own files — a published package name, a
+    served route — never from a list of exempt repositories.
+    """
+
+    IMPL_PKG = json.dumps({"name": "@fuzefront/auth", "version": "1.0.0"})
+
+    FALLBACK_IN_THE_LIBRARY = """
+import { verify } from '@fuzefront/auth';
+try {
+  mod = require('@fuzefront/auth');
+} catch (err) {
+  handler = (req, res, next) => next();
+}
+"""
+
+    def test_the_published_client_is_exempt_from_the_consumer_rules(self):
+        d = make_repo({"packages/auth/package.json": self.IMPL_PKG,
+                       "packages/auth/src/middleware.ts": self.FALLBACK_IN_THE_LIBRARY,
+                       "package.json": CLEAN_PKG})
+        _, out = run(d, "--fail-open")
+        self.assertNotIn("F1", out, out)
+
+    def test_the_same_code_outside_that_package_is_still_flagged(self):
+        """The negative control. Exempting the implementation must not exempt a
+        consumer that happens to sit in the same repo."""
+        d = make_repo({"packages/auth/package.json": self.IMPL_PKG,
+                       "backend/src/server.ts": self.FALLBACK_IN_THE_LIBRARY,
+                       "package.json": CLEAN_PKG})
+        _, out = run(d, "--fail-open")
+        self.assertIn("F1", out, out)
+
+    def test_the_authz_service_may_call_permit(self):
+        d = make_repo({"backend/security/src/routes/authz.ts":
+                       "router.post('/api/v1/security/authz/check', h);\n",
+                       "backend/security/src/config/permit.ts":
+                       "import { Permit } from 'permitio';\n",
+                       "package.json": CLEAN_PKG})
+        _, out = run(d, "--authz")
+        self.assertNotIn("Z3", out, out)
+
+    def test_a_product_that_does_not_serve_it_still_may_not(self):
+        d = make_repo({"src/permit.ts": "import { Permit } from 'permitio';\n",
+                       "package.json": CLEAN_PKG})
+        _, out = run(d, "--authz")
+        self.assertIn("Z3", out, out)
+
+    def test_an_enum_member_named_secret_is_not_a_signing_secret(self):
+        """`SECRET = "secret"` in a field-type enum. Fires in any repo with such an
+        enum, and FuzeFront ships one. A constant assigned its own lowercased name is
+        a label, not key material."""
+        d = make_repo({"src/types.py": 'class Kind(str, enum.Enum):\n'
+                                       '    URL = "url"\n'
+                                       '    SECRET = "secret"\n',
+                       "package.json": CLEAN_PKG})
+        _, out = run(d, "--secrets")
+        self.assertNotIn("S1", out, out)
+
+    def test_a_real_hardcoded_secret_is_still_flagged(self):
+        d = make_repo({"src/a.ts": 'const jwtSecret = "s3cr3t-shared-dev-value";\n',
+                       "package.json": CLEAN_PKG})
+        _, out = run(d, "--secrets")
+        self.assertIn("S1", out, out)
+
+
+class FalsePositivesFoundAgainstRealRepos(unittest.TestCase):
+    """Both of these passed the unit tests and failed against production code.
+
+    A gate that reds correct code is the most corrosive kind of wrong — people
+    learn to route around it, and then it catches nothing at all. These pin the
+    two shapes that actually broke.
+    """
+
+    def test_package_named_only_in_a_comment_is_not_an_import(self):
+        """FuzeService documents in a COMMENT that @fuzefront/auth 'is dropped in
+        behind this same interface when published'. That is an accurate note about
+        future work, not an undeclared import."""
+        d = make_repo({
+            "src/identity.ts": (
+                "/**\n"
+                " * AuthN is delegated to FuzeFront. When `@fuzefront/auth` is\n"
+                " * published its verifier drops in behind this same interface.\n"
+                " */\n"
+                "export interface TokenVerifier { verify(t: string): Promise<Claims>; }\n"
+            ),
+            "package.json": json.dumps({"dependencies": {}}),
+        })
+        _, out = run(d, "--declared")
+        self.assertNotIn("D1", out,
+                         "a package name inside a comment must not read as an import")
+
+    def test_guard_that_denies_further_down_is_not_flagged(self):
+        """FuzeHub's requireUser calls next() on success and res.status(401) on
+        failure — the 401 sits ~10 lines below the signature. An earlier windowed
+        version of F2 flagged it."""
+        d = make_repo({
+            "src/requireUser.ts": (
+                "export async function requireUser(req, res, next) {\n"
+                "  try {\n"
+                "    const session = await resolve(req);\n"
+                "    const user = await upsert(session);\n"
+                "    req.userId = user.id;\n"
+                "    req.userEmail = session.email;\n"
+                "    req.identity = session.identity;\n"
+                "    req.securityToken = session.token;\n"
+                "    next();\n"
+                "  } catch (err) {\n"
+                '    res.status(401).json({ error: "Unauthorized" });\n'
+                "  }\n"
+                "}\n"
+            ),
+            "package.json": CLEAN_PKG,
+        })
+        _, out = run(d, "--fail-open")
+        self.assertNotIn("F2", out,
+                         "a guard that denies anywhere in the file is not a stub")
+
+    def test_a_guard_that_truly_cannot_deny_is_still_flagged(self):
+        """The negative control for the fix above — F2 must not become inert."""
+        d = make_repo({
+            "src/requireUser.ts": (
+                "export function requireUser(req, res, next) {\n"
+                "  req.identity = { userId: 'dev' };\n"
+                "  next();\n"
+                "}\n"
+            ),
+            "package.json": CLEAN_PKG,
+        })
+        _, out = run(d, "--fail-open")
+        self.assertIn("F2", out, "F2 was relaxed into uselessness")
+
+
+# ===========================================================================
+# E — route-level coverage (the "a route lost its auth dependency" class)
+# ===========================================================================
+#
+# Every family above reasons about the REPO. All of them are green on a repo
+# whose auth is real but whose individual route lost its guard — the FuzeAgent
+# shape, where main.py authenticates and simple_main.py published the same
+# domain with none. These tests exist to prove the E family answers the
+# per-route question, and — the part that matters — that it FIRES when a guard
+# is REMOVED. A gate only ever exercised on clean input is the thing this whole
+# file is a reaction to.
+
+GUARDED_PY = """
+from fastapi import Depends, FastAPI
+from auth import require_auth
+
+app = FastAPI()
+
+@app.get("/items")
+async def items(_auth=Depends(require_auth)):
+    return []
+"""
+
+# Byte-for-byte GUARDED_PY with the dependency removed — nothing else differs.
+UNGUARDED_PY = GUARDED_PY.replace("(_auth=Depends(require_auth))", "()")
+
+GLOBAL_DEP_PY = """
+from fastapi import Depends, FastAPI
+from auth import get_current_user
+
+app = FastAPI(dependencies=[Depends(get_current_user)])
+
+@app.get("/items")
+async def items():
+    return []
+"""
+
+PUBLIC_DECL = "GET /items  # deliberately open, returns no tenant data\n"
+
+
+class RouteGuardRemovalIsDetected(unittest.TestCase):
+    """The mutation test. Same file, one dependency deleted."""
+
+    def test_guarded_route_produces_no_finding(self):
+        d = make_repo({"src/api.py": GUARDED_PY, "package.json": CLEAN_PKG})
+        _, out = run(d, "--routes")
+        self.assertNotIn("E1", out, "a properly guarded route was flagged")
+
+    def test_removing_the_guard_makes_the_gate_fail(self):
+        d = make_repo({"src/api.py": UNGUARDED_PY, "package.json": CLEAN_PKG})
+        code, out = run(d, "--routes")
+        self.assertEqual(code, 1, out)
+        self.assertIn("E1", out)
+        self.assertIn("GET /items", out)
+
+    def test_app_level_dependency_counts_as_a_guard(self):
+        d = make_repo({"src/api.py": GLOBAL_DEP_PY, "package.json": CLEAN_PKG})
+        _, out = run(d, "--routes")
+        self.assertNotIn("E1", out, "an app-level auth dependency was not honoured")
+
+    def test_removing_the_app_level_dependency_makes_the_gate_fail(self):
+        # The simple_main.py shape exactly: the global dependency disappears and
+        # every route on that app silently becomes public.
+        stripped = GLOBAL_DEP_PY.replace(
+            "FastAPI(dependencies=[Depends(get_current_user)])", "FastAPI()")
+        d = make_repo({"src/api.py": stripped, "package.json": CLEAN_PKG})
+        code, out = run(d, "--routes")
+        self.assertEqual(code, 1, out)
+        self.assertIn("E1", out)
+
+
+class PublicRoutesAreDeclaredNotInferred(unittest.TestCase):
+    def test_a_declared_public_route_is_accepted(self):
+        d = make_repo({"src/api.py": UNGUARDED_PY, "package.json": CLEAN_PKG,
+                       "governance/public-routes.txt": PUBLIC_DECL})
+        code, out = run(d, "--routes")
+        self.assertEqual(code, 0, out)
+
+    def test_a_declaration_without_a_reason_does_not_count(self):
+        d = make_repo({"src/api.py": UNGUARDED_PY, "package.json": CLEAN_PKG,
+                       "governance/public-routes.txt": "GET /items\n"})
+        code, out = run(d, "--routes")
+        self.assertEqual(code, 1, out)
+        self.assertIn("E4", out, "an unreasoned exemption was honoured")
+        self.assertIn("E1", out, "the route was exempted by a rejected entry")
+
+    def test_a_declaration_does_not_cover_a_different_route(self):
+        # The property that makes this a closed set rather than a denylist:
+        # exempting GET /items must not exempt POST /items.
+        body = UNGUARDED_PY.replace('@app.get("/items")', '@app.post("/items")')
+        d = make_repo({"src/api.py": body, "package.json": CLEAN_PKG,
+                       "governance/public-routes.txt": PUBLIC_DECL})
+        code, out = run(d, "--routes")
+        self.assertEqual(code, 1, out)
+        self.assertIn("POST /items", out)
+
+    def test_a_stale_exemption_is_reported(self):
+        d = make_repo({"src/api.py": GUARDED_PY, "package.json": CLEAN_PKG,
+                       "governance/public-routes.txt": PUBLIC_DECL})
+        code, out = run(d, "--routes")
+        self.assertIn("E3", out, "an exemption for a now-guarded route survived")
+
+
+class LocallyNamedGuardsAreDeclarable(unittest.TestCase):
+    LOCAL = """
+const app = express();
+app.get('/api/things', mayReadCatalog, (req, res) => res.json([]));
+"""
+
+    def test_an_unknown_guard_name_is_a_finding_by_default(self):
+        d = make_repo({"src/api.ts": self.LOCAL, "package.json": CLEAN_PKG})
+        code, out = run(d, "--routes")
+        self.assertEqual(code, 1, out)
+
+    def test_declaring_the_guard_name_resolves_it(self):
+        d = make_repo({
+            "src/api.ts": self.LOCAL, "package.json": CLEAN_PKG,
+            "governance/auth-guards.txt":
+                "mayReadCatalog  # repo-local Permit wrapper, see src/authz.ts\n"})
+        code, out = run(d, "--routes")
+        self.assertEqual(code, 0, out)
+
+    def test_guard_declaration_does_not_exempt_an_unguarded_route(self):
+        # auth-guards extends DETECTION; it must never act as an exemption.
+        body = self.LOCAL + "app.get('/api/other', (req, res) => res.json([]));\n"
+        d = make_repo({
+            "src/api.ts": body, "package.json": CLEAN_PKG,
+            "governance/auth-guards.txt": "mayReadCatalog  # wrapper\n"})
+        code, out = run(d, "--routes")
+        self.assertEqual(code, 1, out)
+        self.assertIn("/api/other", out)
+
+
+class ExpressMountOrderIsRespected(unittest.TestCase):
+    ORDERED = """
+const app = express();
+app.get('/health', (req, res) => res.json({ ok: true }));
+app.use(requireAuth({ verifier }));
+app.get('/api/items', (req, res) => res.json([]));
+"""
+
+    def test_a_route_before_the_guard_is_not_treated_as_guarded(self):
+        d = make_repo({"src/api.ts": self.ORDERED, "package.json": CLEAN_PKG})
+        code, out = run(d, "--routes")
+        self.assertEqual(code, 1, out)
+        self.assertIn("GET /health", out)
+
+    def test_a_route_after_the_guard_is_treated_as_guarded(self):
+        d = make_repo({"src/api.ts": self.ORDERED, "package.json": CLEAN_PKG})
+        _, out = run(d, "--routes")
+        self.assertNotIn("/api/items", out)
+
+
+class RouteFamilyIsNotVacuous(unittest.TestCase):
+    def test_the_census_prints_even_when_everything_passes(self):
+        # "OK" alone cannot be told apart from "examined nothing".
+        d = make_repo({"src/api.py": GUARDED_PY, "package.json": CLEAN_PKG})
+        _, out = run(d, "--routes")
+        self.assertIn("1 route(s)", out)
+        self.assertIn("1 guarded", out)
+
+    def test_route_shaped_source_the_scanner_cannot_read_is_a_finding(self):
+        # An unparsable file must never be silently skipped: unreadable is not
+        # the same as clean. This is E2, the anti-vacuity check.
+        d = make_repo({"src/api.py": "@app.get('/x')\ndef  ((( broken\n",
+                       "package.json": CLEAN_PKG})
+        code, out = run(d, "--routes")
+        self.assertIn("E2", out)
+        self.assertEqual(code, 1, out)
+
+
+class RatchetDefersBacklogButNeverANewHole(unittest.TestCase):
+    def test_changed_only_still_fails_on_a_route_the_diff_touched(self):
+        d = make_repo({"src/api.py": GUARDED_PY, "package.json": CLEAN_PKG})
+        subprocess.run(["git", "checkout", "-qb", "feat"], cwd=d, check=True)
+        with open(os.path.join(d, "src", "api.py"), "w") as fh:
+            fh.write(UNGUARDED_PY)
+        for cmd in (["git", "add", "-A"], ["git", "commit", "-qm", "drop guard"]):
+            subprocess.run(cmd, cwd=d, check=True,
+                           stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        code, out = run(d, "--routes", "--changed-only", "--base", "master")
+        self.assertEqual(code, 1, out)
+        self.assertIn("E1", out)
+
+    def test_changed_only_defers_a_route_the_diff_did_not_touch(self):
+        d = make_repo({"src/api.py": UNGUARDED_PY, "src/other.py": "x = 1\n",
+                       "package.json": CLEAN_PKG})
+        subprocess.run(["git", "checkout", "-qb", "feat"], cwd=d, check=True)
+        with open(os.path.join(d, "src", "other.py"), "w") as fh:
+            fh.write("x = 2\n")
+        for cmd in (["git", "add", "-A"], ["git", "commit", "-qm", "unrelated"]):
+            subprocess.run(cmd, cwd=d, check=True,
+                           stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        code, out = run(d, "--routes", "--changed-only", "--base", "master")
+        self.assertEqual(code, 0, out)
+        self.assertIn("deferred by the ratchet", out)
+
+    def test_an_uncomputable_diff_checks_everything_rather_than_exempting_it(self):
+        # The ratchet failing open would exempt every route in the repo and
+        # print OK — a gate passing because it looked at nothing.
+        d = make_repo({"src/api.py": UNGUARDED_PY, "package.json": CLEAN_PKG})
+        code, out = run(d, "--routes", "--changed-only", "--base", "no/such/ref")
+        self.assertEqual(code, 1, out)
+        self.assertIn("could not diff", out)
+
+
+# ---------------------------------------------------------------------------
+# Regression: the gate must never be a finding against the tooling it ships.
+#
+# `scripts/gate_platform_auth.py` is a tracked .py under `scripts/` -- a
+# directory SKIP_DIR does not cover -- so the gate SCANNED ITSELF and matched
+# its own detector strings:
+#
+#     Z3  scripts/gate_platform_auth.py:475   <- the Z3 detector regex
+#     Z2  scripts/gate_platform_auth.py:489   <- the Z2 finding message
+#     F1  scripts/gate_platform_auth.py:1055  <- its own `return True`
+#
+# Measured 2026-09-03, that produced an identical fatal set on the DEFAULT
+# BRANCH of FuzeDeploy, FuzeKeys, FuzeMarket, FuzePlan and MendysRobotics --
+# a red gate that no change to those repos could ever clear, which is how a
+# security gate gets trained into background noise.
+#
+# The skip is scoped to governance-managed files, so the paired assertion
+# below matters as much as the first: identical offending code in the repo's
+# OWN source is still reported. A skip that silenced both would be vacuous.
+# ---------------------------------------------------------------------------
+
+DIRECT_SDK = """import permitio
+from permitio import Permit
+
+permit = Permit(token="x")
+
+
+def can(user, action, resource):
+    return permit.check(user, action, resource)
+"""
+
+MANAGED_MANIFEST = json.dumps({
+    "schemaVersion": 1,
+    "files": {"scripts/gate_platform_auth.py": {"mode": "managed"}},
+})
+
+
+class GovernanceManagedFilesAreNotScanned(unittest.TestCase):
+    def test_managed_gate_script_is_not_reported(self):
+        repo = make_repo({
+            "scripts/gate_platform_auth.py": DIRECT_SDK,
+            ".fuze/installed.json": MANAGED_MANIFEST,
+        })
+        _, out = run(repo)
+        self.assertNotIn(
+            "scripts/gate_platform_auth.py", out,
+            "the governance-managed gate script must not be scanned: it is "
+            "FuzeSDLC tooling shipped into the repo, overwritten by "
+            "governance-sync, so a finding against it is never actionable")
+
+    def test_the_same_code_in_repo_source_IS_still_reported(self):
+        """The paired half. If this ever passes, the skip has gone vacuous."""
+        repo = make_repo({
+            "scripts/gate_platform_auth.py": DIRECT_SDK,
+            "src/svc.py": DIRECT_SDK,
+            ".fuze/installed.json": MANAGED_MANIFEST,
+        })
+        rc, out = run(repo)
+        self.assertIn("src/svc.py", out,
+                      "identical code in the repo's OWN source must still be "
+                      "flagged -- the skip is scoped, not a blanket silence")
+        self.assertNotEqual(rc, 0, "a real finding must still fail the gate")
+
+    def test_unmanaged_entry_is_still_scanned(self):
+        """Being listed is not enough; only mode == managed is skipped."""
+        repo = make_repo({
+            "src/svc.py": DIRECT_SDK,
+            ".fuze/installed.json": json.dumps({
+                "schemaVersion": 1,
+                "files": {"src/svc.py": {"mode": "unmanaged"}},
+            }),
+        })
+        _, out = run(repo)
+        self.assertIn("src/svc.py", out)
+
+    def test_missing_or_broken_manifest_degrades_to_scanning_everything(self):
+        """A gate that crashes on a malformed manifest is worse than a noisy
+        one, and silently skipping everything would be worse still."""
+        for manifest in (None, "{not json", '{"files": []}'):
+            files = {"src/svc.py": DIRECT_SDK}
+            if manifest is not None:
+                files[".fuze/installed.json"] = manifest
+            repo = make_repo(files)
+            rc, out = run(repo)
+            self.assertIn("src/svc.py", out,
+                          "manifest=%r must not suppress real findings" % manifest)
+
+
+# ---------------------------------------------------------------------------
+# Regression: `<anything>.get("x")` is not an HTTP route.
+#
+# JS_ROUTE's `owner` is any identifier on purpose -- real routers are named all
+# sorts of things (`r`, `v1`, `apiRouter`) -- so the first-argument check was
+# the only thing between that breadth and a reported route. It accepted any
+# string literal, so every map/cache/header/URLSearchParams read became an
+# unguarded HTTP route.
+#
+# Measured on FuzeMarket 2026-09-03: ALL EIGHT of its E1 findings were this,
+# and it had zero real detected routes. Requiring the leading "/" costs nothing
+# real -- an Express path is matched against req.path, which always starts with
+# "/", so `app.get("users")` can never match a request.
+# ---------------------------------------------------------------------------
+
+SEARCH_PARAMS = """
+export function handler(req, res) {
+  const url = new URL(req.url, 'http://x');
+  const u = url.searchParams.get("url");
+  const days = Number(url.searchParams.get("days")) || 28;
+  const ct = res.headers.get("content-type");
+  const cached = cache.get("some-key");
+  return { u, days, ct, cached };
+}
+"""
+
+REAL_ROUTE = """
+app.get('/api/v1/items', (req, res) => res.json([]));
+"""
+
+
+class NonRouteGetCallsAreNotRoutes(unittest.TestCase):
+    def test_searchparams_and_map_gets_are_not_reported_as_routes(self):
+        repo = make_repo({"src/handler.js": SEARCH_PARAMS,
+                          "package.json": CLEAN_PKG})
+        rc, out = run(repo)
+        for phantom in ("GET /url", "GET /days", "GET /content-type",
+                        "GET /some-key"):
+            self.assertNotIn(
+                phantom, out,
+                "%r came from a non-route .get() call and must not be "
+                "reported as an HTTP route" % phantom)
+
+    def test_a_real_route_is_STILL_detected(self):
+        """The paired half: narrowing must not blind the gate to real routes."""
+        repo = make_repo({"src/server.js": REAL_ROUTE,
+                          "package.json": CLEAN_PKG})
+        rc, out = run(repo)
+        self.assertIn("/api/v1/items", out,
+                      "a genuine leading-slash route must still be found")
+        self.assertNotEqual(rc, 0,
+                            "an unguarded real route must still fail the gate")
+
+    def test_mixed_file_reports_only_the_real_route(self):
+        repo = make_repo({"src/mixed.js": REAL_ROUTE + SEARCH_PARAMS,
+                          "package.json": CLEAN_PKG})
+        _, out = run(repo)
+        self.assertIn("/api/v1/items", out)
+        self.assertNotIn("GET /url", out)
+        self.assertNotIn("GET /days", out)

--- a/scripts/check-deployable-paths.mjs
+++ b/scripts/check-deployable-paths.mjs
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+// GATE: release.yml's `on.push.paths` must equal what deploy/deployable-paths.json renders,
+// and every image the workflow builds must have its source dir covered by that manifest.
+//
+// Without this check the manifest would be a FOURTH copy of "what is deployable" rather
+// than a replacement for the third. The mirror's failure mode is silent and inverted — a
+// missing path produces NO release run at all, so the change merges green and never ships.
+// There is nothing red to notice; that is why this has to be a required check and why it
+// prints the drifted paths by name instead of just exiting non-zero.
+//
+// Dependency-free: runs on a bare `node`, no `npm ci`, no js-yaml. See
+// scripts/deployable-paths.mjs for why a YAML parser is the wrong tool here (`on:` is a
+// YAML 1.1 boolean, so parsers read the key as `true` and a parser-based gate passes
+// vacuously — failing toward exactly the silent no-ship it was meant to catch).
+
+import { readFileSync } from 'node:fs'
+import {
+  MANIFEST_PATH,
+  WORKFLOW_PATH,
+  readManifest,
+  renderPathsBlock,
+  extractPathsBlock,
+  uncoveredBuildInputs,
+} from './deployable-paths.mjs'
+
+const root = process.cwd()
+const fail = (msg) => {
+  console.error(msg)
+  process.exitCode = 1
+}
+
+let manifest
+let source
+try {
+  manifest = readManifest(readFileSync(`${root}/${MANIFEST_PATH}`, 'utf8'))
+  source = readFileSync(`${root}/${WORKFLOW_PATH}`, 'utf8')
+} catch (err) {
+  console.error(`✗ deployable-paths: ${err.message}`)
+  process.exit(1)
+}
+
+let found
+try {
+  found = extractPathsBlock(source)
+} catch (err) {
+  console.error(`✗ deployable-paths: ${err.message}`)
+  process.exit(1)
+}
+
+const rendered = renderPathsBlock(manifest)
+const expected = manifest.paths.map((p) => p.path)
+const actual = found.paths
+
+if (rendered !== found.text) {
+  const missing = expected.filter((p) => !actual.includes(p))
+  const extra = actual.filter((p) => !expected.includes(p))
+
+  console.error(
+    `\n✗ deployable-paths: ${WORKFLOW_PATH} \`on.push.paths\` has DRIFTED from ${MANIFEST_PATH}.\n`
+  )
+  if (missing.length) {
+    console.error(
+      `  MISSING from the workflow (declared deployable, but a change confined to one of\n` +
+        `  these would merge green and NEVER trigger a release — no run, no red, no ship):`
+    )
+    for (const p of missing) console.error(`    - ${p}`)
+    console.error('')
+  }
+  if (extra.length) {
+    console.error(
+      `  PRESENT in the workflow but absent from the manifest (an undeclared deploy trigger —\n` +
+        `  either add it to ${MANIFEST_PATH} with a \`why\`, or drop it from the workflow):`
+    )
+    for (const p of extra) console.error(`    - ${p}`)
+    console.error('')
+  }
+  if (!missing.length && !extra.length) {
+    // Same set, different bytes: order or the explanatory comments moved.
+    const a = rendered.split('\n')
+    const b = found.text.split('\n')
+    console.error(
+      `  The path SET matches but the rendered block does not (ordering or the explanatory\n` +
+        `  comments differ). First differing lines:`
+    )
+    for (let i = 0; i < Math.max(a.length, b.length); i++) {
+      if (a[i] !== b[i]) {
+        console.error(`    line ${found.startLine + i + 1}`)
+        console.error(`      manifest renders: ${a[i] ?? '(end of block)'}`)
+        console.error(`      workflow has:     ${b[i] ?? '(end of block)'}`)
+        break
+      }
+    }
+    console.error('')
+  }
+  console.error(
+    `  FIX: edit ${MANIFEST_PATH} (the source of truth), then run\n` +
+      `       npm run deployable-paths:write\n` +
+      `  and commit the regenerated workflow. Do not hand-edit the block.\n`
+  )
+  process.exitCode = 1
+}
+
+let uncovered
+try {
+  uncovered = uncoveredBuildInputs(source, manifest)
+} catch (err) {
+  fail(`✗ deployable-paths: ${err.message}`)
+  process.exit(1)
+}
+
+if (uncovered.length) {
+  console.error(
+    `\n✗ deployable-paths: ${WORKFLOW_PATH} builds images whose SOURCE DIRECTORY no declared\n` +
+      `  path covers. A change confined to one of these dirs cannot trigger the very build\n` +
+      `  step that consumes it — the step exists, but nothing can ever run it:\n`
+  )
+  for (const { dockerfile, dir } of uncovered) {
+    console.error(`    ${dockerfile}  ->  add '${dir}**' to ${MANIFEST_PATH}`)
+  }
+  console.error(
+    `\n  This is the #432 chat-service failure exactly: a build step landed without its\n` +
+      `  trigger path, and every commit in between shipped nothing.\n`
+  )
+  process.exitCode = 1
+}
+
+if (process.exitCode) process.exit(process.exitCode)
+
+console.log(
+  `✓ deployable-paths: ${WORKFLOW_PATH} on.push.paths matches ${MANIFEST_PATH} ` +
+    `(${actual.length} path(s)), and every Dockerfile it builds is covered.`
+)

--- a/scripts/deployable-paths.mjs
+++ b/scripts/deployable-paths.mjs
@@ -1,0 +1,238 @@
+#!/usr/bin/env node
+// Library for the deployable-paths manifest -> release.yml `on.push.paths` mirror.
+//
+// THE PROBLEM THIS CLOSES.
+// "What is deployable" lived in three hand-maintained places that drift apart:
+//   1. root package.json `workspaces`  - the real source, read by publish-packages.mjs.
+//   2. auto-merge.yml's regex mirror   - COLLAPSED: it now shells out to
+//      `node scripts/publish-packages.mjs --list-dirs` at runtime.
+//   3. release.yml's `on.push.paths`   - this one. Still a mirror, because it CANNOT
+//      be collapsed the way (2) was: GitHub evaluates the trigger block before any
+//      step of the workflow runs, so it must be static YAML in the file.
+//
+// So the mirror stays, but it stops being hand-maintained: deploy/deployable-paths.json
+// is the source, this module renders the block, and check-deployable-paths.mjs fails CI
+// when the committed block and the rendered block disagree.
+//
+// WHY THE GATE IS THE POINT.
+// A missing path here does not produce a red run — it produces NO run. The change
+// merges green and never ships, and the image silently keeps the old code. Five
+// services (chat, notification, payment, selection-list, config) each shipped a
+// `docker/build-push-action` step in release.yml whose own source dir was absent from
+// the trigger. Without the gate, adding a manifest would just create a FOURTH copy of
+// the same truth.
+//
+// WHY NO YAML PARSER (deliberate, same rule as check-required-check-triggers.mjs).
+// `on` is one of YAML 1.1's boolean literals, so many parsers read the `on:` key as
+// the boolean `true` — the well-known GitHub Actions footgun. A parser-based gate that
+// hits it finds no `on` key, concludes "no deployable paths", and passes vacuously:
+// it fails toward exactly the silent no-ship this file exists to prevent. A line-based
+// indentation scan cannot make that mistake, and it also lets the block keep its
+// explanatory comments (a parser would discard them, so they could rot unnoticed).
+// Every failure mode below is an explicit throw, never a silent empty result.
+
+import { readFileSync } from 'node:fs'
+
+export const MANIFEST_PATH = 'deploy/deployable-paths.json'
+export const WORKFLOW_PATH = '.github/workflows/release.yml'
+
+/** Indentation the `paths:` list items sit at inside `on: / push: / paths:`. */
+const ITEM_INDENT = '      '
+
+export function readManifest(text) {
+  const manifest = JSON.parse(text)
+  const entries = manifest.paths
+  if (!Array.isArray(entries) || entries.length === 0) {
+    throw new Error(
+      `${MANIFEST_PATH} declares no \`paths\` — rendering it would empty release.yml's ` +
+        `trigger and silently stop every deploy. Refusing.`
+    )
+  }
+  const seen = new Set()
+  for (const entry of entries) {
+    if (!entry || typeof entry.path !== 'string' || !entry.path.trim()) {
+      throw new Error(`${MANIFEST_PATH}: every \`paths\` entry needs a non-empty string \`path\``)
+    }
+    if (entry.path.includes("'")) {
+      throw new Error(
+        `${MANIFEST_PATH}: path ${entry.path} contains a single quote; the renderer emits ` +
+          `single-quoted YAML scalars and cannot represent it`
+      )
+    }
+    if (seen.has(entry.path)) {
+      throw new Error(`${MANIFEST_PATH}: duplicate path ${entry.path}`)
+    }
+    seen.add(entry.path)
+    if (entry.why !== undefined && !Array.isArray(entry.why)) {
+      throw new Error(`${MANIFEST_PATH}: \`why\` for ${entry.path} must be an array of comment lines`)
+    }
+  }
+  return manifest
+}
+
+/**
+ * Render the manifest as the exact body of release.yml's `on.push.paths` list —
+ * comment lines and entries, at the workflow's own indentation, no trailing newline.
+ */
+export function renderPathsBlock(manifest) {
+  const out = []
+  // `header` renders as the block's first comment lines. It is INSIDE the compared
+  // region on purpose: a "do not hand-edit" notice that the gate does not enforce is a
+  // notice that can be deleted by the same edit it was meant to stop.
+  for (const line of manifest.header ?? []) {
+    out.push(line === '' ? `${ITEM_INDENT}#` : `${ITEM_INDENT}# ${line}`)
+  }
+  for (const entry of manifest.paths) {
+    for (const line of entry.why ?? []) {
+      out.push(line === '' ? `${ITEM_INDENT}#` : `${ITEM_INDENT}# ${line}`)
+    }
+    out.push(`${ITEM_INDENT}- '${entry.path}'`)
+  }
+  return out.join('\n')
+}
+
+const indentOf = (line) => line.match(/^[ \t]*/)[0].length
+
+/**
+ * Locate `on: / push: / paths:` by indentation scan and return
+ * `{ startLine, endLine, text, paths }` (line numbers 0-based, `endLine` exclusive).
+ *
+ * Throws — loudly and specifically — on every shape it does not recognise. An
+ * "I could not find it" that returned an empty result would pass the gate while the
+ * workflow was broken, which is the failure this whole mechanism is against.
+ */
+export function extractPathsBlock(source) {
+  // EOL-agnostic: git stores this file with LF (gate-line-endings.yml enforces it) but a
+  // Windows checkout with core.autocrlf materialises CRLF. Comparing raw bytes would then
+  // report drift on every path, on a working tree that is byte-identical in git.
+  const lines = source.split(/\r?\n/)
+
+  const onLines = []
+  for (let i = 0; i < lines.length; i++) {
+    if (/^on:\s*(#.*)?$/.test(lines[i])) onLines.push(i)
+  }
+  if (onLines.length !== 1) {
+    throw new Error(
+      `${WORKFLOW_PATH}: expected exactly one top-level \`on:\` line, found ${onLines.length}. ` +
+        `Cannot locate the deployable-paths block; refusing to pass.`
+    )
+  }
+
+  // Walk the `on:` mapping. It ends at the first non-blank line at indent 0.
+  const onEnd = (() => {
+    for (let i = onLines[0] + 1; i < lines.length; i++) {
+      const line = lines[i]
+      if (!line.trim()) continue
+      if (indentOf(line) === 0) return i
+    }
+    return lines.length
+  })()
+
+  const findKey = (from, to, indent, key) => {
+    const re = new RegExp(`^ {${indent}}${key}:\\s*(#.*)?$`)
+    for (let i = from; i < to; i++) {
+      if (re.test(lines[i])) return i
+    }
+    return -1
+  }
+
+  const pushLine = findKey(onLines[0] + 1, onEnd, 2, 'push')
+  if (pushLine === -1) {
+    throw new Error(
+      `${WORKFLOW_PATH}: no \`push:\` trigger under \`on:\`. Without it the release workflow ` +
+        `never runs on a merge to master and nothing ships.`
+    )
+  }
+
+  // The `push:` mapping ends at the first non-blank line indented <= 2.
+  const pushEnd = (() => {
+    for (let i = pushLine + 1; i < onEnd; i++) {
+      const line = lines[i]
+      if (!line.trim()) continue
+      if (indentOf(line) <= 2) return i
+    }
+    return onEnd
+  })()
+
+  const pathsLine = findKey(pushLine + 1, pushEnd, 4, 'paths')
+  if (pathsLine === -1) {
+    throw new Error(
+      `${WORKFLOW_PATH}: \`on.push\` has no \`paths:\` key. Either the block was deleted ` +
+        `(every push to master would now build) or it was renamed; both need a human.`
+    )
+  }
+  if (findKey(pushLine + 1, pushEnd, 4, 'paths-ignore') !== -1) {
+    throw new Error(
+      `${WORKFLOW_PATH}: \`on.push\` uses BOTH \`paths\` and \`paths-ignore\`. This gate only ` +
+        `governs \`paths\`; remove \`paths-ignore\` or teach the gate about it.`
+    )
+  }
+
+  let end = pathsLine + 1
+  while (end < pushEnd && lines[end].startsWith(ITEM_INDENT) && lines[end].trim()) end++
+
+  const body = lines.slice(pathsLine + 1, end)
+  const paths = []
+  for (const line of body) {
+    const m = /^ {6}- '(.+)'\s*$/.exec(line)
+    if (m) paths.push(m[1])
+    else if (!/^ {6}#/.test(line)) {
+      throw new Error(
+        `${WORKFLOW_PATH}: unrecognised line inside \`on.push.paths\`:\n  ${line}\n` +
+          `The gate renders entries as \`      - 'glob'\` and comments as \`      # ...\`. ` +
+          `Run \`npm run deployable-paths:write\` instead of editing this block by hand.`
+      )
+    }
+  }
+  if (paths.length === 0) {
+    throw new Error(
+      `${WORKFLOW_PATH}: \`on.push.paths\` resolved to NO deployable paths. A release ` +
+        `workflow with an empty paths list never triggers — every merge would merge green ` +
+        `and ship nothing. This is the exact silent failure the gate exists to catch.`
+    )
+  }
+
+  return { startLine: pathsLine + 1, endLine: end, text: body.join('\n'), paths }
+}
+
+/** True when the manifest glob `glob` covers the repo-relative file `file`. */
+export function globCovers(glob, file) {
+  if (glob.endsWith('/**')) return file.startsWith(glob.slice(0, -2))
+  if (glob === file) return true
+  return false
+}
+
+/**
+ * Every image release.yml actually builds must have its build context covered.
+ *
+ * This is the half a round-trip comparison cannot see. Rendering only proves the
+ * workflow matches the manifest; it does NOT notice a NEW `docker/build-push-action`
+ * step whose source dir nobody added to either. That is precisely how chat-service
+ * got a build step it could not trigger (#432), and how notification-service,
+ * payment-service, selection-list-service and config-service followed it.
+ */
+export function uncoveredBuildInputs(source, manifest) {
+  const globs = manifest.paths.map((p) => p.path)
+  const dockerfiles = [...source.matchAll(/^\s*file:\s*(\S+Dockerfile\S*)\s*$/gm)].map((m) => m[1])
+  if (dockerfiles.length === 0) {
+    throw new Error(
+      `${WORKFLOW_PATH}: found no \`file: …Dockerfile\` build steps. Either the workflow no ` +
+        `longer builds images, or this gate's step-detection broke — a gate that silently ` +
+        `checks nothing is worse than no gate.`
+    )
+  }
+  const missing = []
+  for (const df of [...new Set(dockerfiles)]) {
+    const dir = df.includes('/') ? df.slice(0, df.lastIndexOf('/') + 1) : ''
+    // A root Dockerfile has no owning dir to require; everything else must be covered.
+    if (dir === '') continue
+    if (!globs.some((g) => globCovers(g, df))) missing.push({ dockerfile: df, dir })
+  }
+  return missing
+}
+
+export function loadRepoState(root = process.cwd()) {
+  const manifest = readManifest(readFileSync(`${root}/${MANIFEST_PATH}`, 'utf8'))
+  const source = readFileSync(`${root}/${WORKFLOW_PATH}`, 'utf8')
+  return { manifest, source }
+}

--- a/scripts/gate_platform_auth.py
+++ b/scripts/gate_platform_auth.py
@@ -1,0 +1,1199 @@
+#!/usr/bin/env python3
+"""gate-platform-auth — enforce that a service's authN/authZ is real.
+
+Written after FuzeFinance shipped a production service with NO authentication
+and NO authorization, and every existing gate passed it. That is the design
+brief: each check below exists because something that should have caught this
+did not.
+
+What actually happened (FuzeFinance#28). `backend/src/server.js` wrapped its
+auth setup in try/catch. The catch arm installed a mock identity with
+`roles: ['admin','finance_officer']` and a `requireRoles` that called `next()`
+unconditionally. `@fuzefront/auth` was never declared in package.json, so the
+require ALWAYS threw and the fallback was the only path that ever ran. Every
+request was an admin. The single signal was a console.warn at boot.
+
+Why nothing caught it:
+  - gate-authz ends in `|| true`, so it cannot fail a PR.
+  - helm lint / kubeconform check shape, not behaviour.
+  - The readiness probe passed, because the service genuinely WAS healthy —
+    just unauthenticated. Health is not a security signal.
+  - Nothing asserted that an unauthenticated request gets a 401.
+
+Check families:
+
+  --fail-open   (F, default — the FuzeFinance class)
+    F1  an auth import inside try/except|catch whose fallback grants identity,
+        roles, or calls next() unconditionally. Auth that degrades to
+        permissive is worse than no auth: it looks guarded in review.
+    F2  a middleware named like an auth guard whose body only calls next()
+
+  --declared    (D, default)
+    D1  source imports @fuzefront/auth but no manifest declares the dependency.
+        This is the exact FuzeFinance defect: the import can only ever throw.
+    D2  the dependency is declared but never imported anywhere — an inert
+        declaration that satisfies a naive "is it installed" check while
+        guarding nothing
+
+  --secrets     (S, default)
+    S1  a signing secret supplied as a string literal rather than from env
+    S2  legacy-hs256 selected with no federated/JWKS path configured at all
+    S3  a verifier constructed without pinned algorithms — unpinned invites
+        `alg:none` and RS256-verified-as-HMAC confusion
+
+  --authz       (Z, default)
+    Z1  a repo with mutating routes and zero requirePermission/createAuthzClient
+        call sites. Authentication answers WHO; without this nothing answers
+        WHETHER THEY MAY.
+    Z2  a DECISION_UNAVAILABLE branch that yields anything other than a denial.
+        The client is fail-closed by contract and has no fail-open option;
+        re-introducing one locally defeats it.
+    Z3  a direct Permit SDK call from a product. Products know exactly one
+        thing: the base URL of FuzeFront's Security API.
+
+  --rate-limit  (R, default)
+    R1  a repo with an HTTP API and no rate limiter mounted anywhere
+
+  --routes      (E, default — per-route coverage, ratcheted)
+    E1  a route registered with no authentication boundary at any level and no
+        declaration that it is deliberately public. Every family below reasons
+        about the REPO; all of them are green on a repo whose auth is real but
+        whose individual route lost its guard.
+    E2  route-shaped source the scanner could not read. Unreadable is not clean.
+    E3  a public-route exemption for a route that is gone or is now guarded
+    E4  a declaration entry with no `# reason`
+    Runs as a changed-lines ratchet in CI (--changed-only): a route this diff
+    declares or edits must be classified; inherited debt is counted, not blocking.
+
+  --adoption    (A, default — the anti-vacuous check)
+    A1  a repo that serves HTTP endpoints has SOME auth boundary. Every other
+        family asks "is what is here correct"; all of them pass vacuously on a
+        service with no auth at all, which is precisely the state that shipped.
+
+The last one is the important one, and it is deliberately modelled on
+gate_identifier's --adoption: a family standard whose gate is satisfied by
+non-adoption is not a standard.
+
+RATCHET, AND WHY IT IS OPT-OUT RATHER THAN OPT-IN.
+
+This gate enforces by DEFAULT. A repo silences it by declaring
+`platformAuth.enforce: false` in .fuze/manifest.json, and that declaration
+must carry a `reason`.
+
+The first cut had it the other way round -- enforce only where a repo opted in
+-- on the reasoning that landing it hot would red most of the fleet on
+pre-existing violations, which is how gate-authz acquired its `|| true`. That
+reasoning is real but it solves the wrong half. Opt-in enforcement is exactly
+how `gate-identifier` reached ZERO adoption across 21 repos: the standard
+shipped, the gate shipped, nobody ever set the flag, and a check nobody has
+enabled is indistinguishable from a check that does not exist. The `|| true`
+and the never-set flag are the same failure wearing different clothes.
+
+The difference that matters is not hot vs. cold, it is VISIBLE vs. INVISIBLE.
+`|| true` buried in a workflow is unreadable and uncountable. An `enforce:
+false` in a manifest is one grep away, it names the repo, and with a mandatory
+`reason` it reads as debt someone wrote down rather than as a setting someone
+left alone. So the escape hatch stays -- a repo mid-migration must be able to
+land work -- but it costs a sentence, and that sentence is the artifact.
+
+Consequently an opt-out with no reason is NOT an opt-out: the gate enforces
+anyway and says why. Skipping enforcement is a decision, and an undocumented
+decision is indistinguishable from an oversight.
+
+Exit codes: 0 clean or report-only, 1 findings while enforcing, 2 bad usage.
+"""
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import os
+import re
+import subprocess
+import sys
+
+CANONICAL_AUTH_PKG = "@fuzefront/auth"
+PUBLISHED_AUTH_PKG = "@izzywdev/fuzefront-auth"
+AUTH_PKGS = (CANONICAL_AUTH_PKG, PUBLISHED_AUTH_PKG)
+
+# Source files worth reading. Deliberately excludes tests: a test SHOULD be able
+# to construct a permissive stub, and flagging that would train people to
+# silence the gate.
+SRC_EXT = (".ts", ".tsx", ".js", ".mjs", ".cjs", ".py")
+SKIP_DIR = re.compile(
+    r"(^|/)(node_modules|\.git|dist|build|coverage|vendor|__pycache__|"
+    r"\.venv|venv|test|tests|__tests__|e2e|fixtures|mocks?|examples?)(/|$)"
+)
+SKIP_FILE = re.compile(r"\.(test|spec|d)\.[tj]sx?$|^test_|_test\.py$")
+
+# A route that changes state. Used by Z1 and A1 to decide whether a repo is a
+# service at all — a library with no routes is legitimately out of scope.
+MUTATING_ROUTE = re.compile(
+    r"\b(?:app|router|api|server)\s*\.\s*(post|put|patch|delete)\s*\(", re.I)
+ANY_ROUTE = re.compile(
+    r"\b(?:app|router|api|server)\s*\.\s*(get|post|put|patch|delete)\s*\(|"
+    r"@(?:app|router|bp)\.route\(|@(?:app|router)\.(get|post|put|patch|delete)\(", re.I)
+
+PERMISSIVE = re.compile(
+    r"\broles\s*[:=]\s*\[|"          # a fabricated role list
+    r"\bnext\s*\(\s*\)|"             # unconditional pass-through
+    r"\breq\s*\.\s*identity\s*=|"    # forged identity
+    r"\breturn\s+True\b",            # python guard that always allows
+    re.I)
+
+
+class Finding:
+    def __init__(self, code, path, line, msg):
+        self.code, self.path, self.line, self.msg = code, path, line, msg
+
+    def __str__(self):
+        where = f"{self.path}:{self.line}" if self.line else self.path
+        return f"{self.code}  {where}\n      {self.msg}"
+
+
+def tracked_files(repo):
+    """git ls-files, not a depth-limited walk — nested package layouts are the
+    norm in this family and a `find -maxdepth` miscounted the fleet once already."""
+    try:
+        out = subprocess.run(["git", "ls-files"], cwd=repo, capture_output=True,
+                             text=True, check=True).stdout
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return []
+    return [p for p in out.splitlines() if p]
+
+
+def governed_files(repo):
+    """Repo-relative paths that FuzeSDLC OWNS in this repo, from
+    .fuze/installed.json's `files` map (mode == "managed").
+
+    These are governance tooling shipped INTO the repo -- the gate scripts
+    themselves included -- not the repo's product code. governance-sync
+    overwrites them from the canonical copy on every run, so they can never
+    carry repo-specific logic, and a finding against one is never actionable
+    by the repo that receives it.
+
+    Scanning them was not hypothetical. `scripts/gate_platform_auth.py` is
+    itself a tracked `.py` under `scripts/`, which SKIP_DIR does not cover, so
+    THIS GATE SCANNED ITSELF and matched on its own detector strings:
+
+        Z3  scripts/gate_platform_auth.py:475   <- the Z3 detector regex
+        Z2  scripts/gate_platform_auth.py:489   <- the Z2 finding message
+        F1  scripts/gate_platform_auth.py:1055  <- its own `return True`
+
+    Measured 2026-09-03, that produced an identical fatal triple on the
+    default branch of FuzeDeploy, FuzeKeys, FuzeMarket, FuzePlan and
+    MendysRobotics -- red gates that no change to those repos could clear,
+    which is exactly the kind of permanently-red check that teaches people to
+    ignore a security gate.
+    """
+    try:
+        with open(os.path.join(repo, ".fuze", "installed.json"),
+                  encoding="utf-8") as fh:
+            data = json.load(fh)
+    except (OSError, ValueError):
+        return frozenset()
+    files = data.get("files")
+    if not isinstance(files, dict):
+        return frozenset()
+    return frozenset(
+        rel for rel, meta in files.items()
+        if isinstance(meta, dict) and meta.get("mode") == "managed"
+    )
+
+
+def source_files(repo):
+    governed = governed_files(repo)
+    # Belt and braces for the hub, where this file is the SOURCE rather than an
+    # installed copy and so is absent from .fuze/installed.json. A gate must
+    # never be a finding against itself in any repo.
+    try:
+        own = os.path.relpath(os.path.abspath(__file__),
+                              os.path.abspath(repo)).replace(os.sep, "/")
+    except ValueError:          # different drive on Windows
+        own = None
+    for rel in tracked_files(repo):
+        if SKIP_DIR.search(rel) or SKIP_FILE.search(os.path.basename(rel)):
+            continue
+        if rel in governed or (own is not None and rel == own):
+            continue
+        if rel.endswith(SRC_EXT):
+            yield rel
+
+
+def read(repo, rel):
+    try:
+        with open(os.path.join(repo, rel), encoding="utf-8", errors="replace") as fh:
+            return fh.read()
+    except OSError:
+        return ""
+
+
+def manifests(repo):
+    """Every package.json except vendored ones."""
+    return [r for r in tracked_files(repo)
+            if os.path.basename(r) == "package.json" and not SKIP_DIR.search(r)]
+
+
+def auth_impl_dirs(repo):
+    """Directories of packages this repo PUBLISHES as the platform auth client.
+
+    Derived, never registered: any in-repo package.json whose `name` is the auth
+    package means this repo *implements* the contract rather than consuming it.
+    Its own source is therefore exempt from the consumer rules — the library that
+    provides `requirePermission` is not a product failing to call it, and the
+    module that defines a fallback path is defining the contract, not violating it.
+
+    Without this the gate flags FuzeFront, the repo that publishes the package, for
+    being the thing every other repo is told to use. A gate that reds the reference
+    implementation teaches people the gate is wrong.
+    """
+    dirs = []
+    for rel in manifests(repo):
+        try:
+            with open(os.path.join(repo, rel), encoding="utf-8") as fh:
+                name = (json.load(fh) or {}).get("name")
+        except (OSError, json.JSONDecodeError, AttributeError):
+            continue
+        if name in (CANONICAL_AUTH_PKG, PUBLISHED_AUTH_PKG):
+            dirs.append(os.path.dirname(rel))
+    return dirs
+
+
+def serves_authz_api(repo):
+    """True when this repo IS FuzeFront's Security API rather than a consumer of it.
+
+    Detected by it serving the very endpoint the rule tells products to call. The
+    service that answers /api/v1/security/authz/check is the one place in the family
+    that MUST talk to Permit directly — inverting Z3 for exactly one repo, and
+    identifying it from its own routes rather than by name.
+    """
+    for rel in source_files(repo):
+        if re.search(r"['\"`]/?(?:api/v1/)?security/authz/(?:bulk-)?check",
+                     read(repo, rel)):
+            return True
+    return False
+
+
+def _under(rel, dirs):
+    return any(rel == d or rel.startswith(d.rstrip("/") + "/") for d in dirs if d)
+
+
+def declares_auth(repo):
+    for rel in manifests(repo):
+        try:
+            data = json.loads(read(repo, rel) or "{}")
+        except json.JSONDecodeError:
+            continue
+        for field in ("dependencies", "devDependencies",
+                      "peerDependencies", "optionalDependencies"):
+            for name in (data.get(field) or {}):
+                if name in AUTH_PKGS:
+                    return rel
+                # an npm: alias — "@fuzeone/auth": "npm:@izzywdev/fuzefront-auth@^1"
+                spec = (data.get(field) or {}).get(name) or ""
+                if isinstance(spec, str) and any(p in spec for p in AUTH_PKGS):
+                    return rel
+    return None
+
+
+# A real import, not a mention. FuzeService documents in a COMMENT that
+# @fuzefront/auth "is dropped in behind this same interface when published" — an
+# accurate note about future work. Matching any occurrence of the package name
+# flagged that as an undeclared import, which is both wrong and the most
+# corrosive kind of wrong: a gate that cries wolf on correct code is one people
+# learn to route around.
+IMPORT_FORMS = tuple(
+    re.compile(pat % re.escape(pkg))
+    for pkg in AUTH_PKGS
+    for pat in (
+        r"""\bfrom\s+['"]%s['"]""",          # ES: from '@fuzefront/auth'
+        r"""\brequire\s*\(\s*['"]%s['"]""",  # CJS: require('@fuzefront/auth')
+        r"""\bimport\s*\(\s*['"]%s['"]""",   # dynamic: import('@fuzefront/auth')
+        r"""\bimport\s+['"]%s['"]""",        # side-effect: import '@fuzefront/auth'
+    )
+)
+
+
+def strip_comments(line):
+    """Good enough to keep prose out of the match. Not a parser — it only needs to
+    stop a package name inside a comment from reading as an import."""
+    return re.sub(r"^\s*(?://|#|\*|/\*).*$", "", line)
+
+
+def imports_auth(repo):
+    hits = []
+    for rel in source_files(repo):
+        body = read(repo, rel)
+        for i, line in enumerate(body.splitlines(), 1):
+            code = strip_comments(line)
+            if any(rx.search(code) for rx in IMPORT_FORMS):
+                hits.append((rel, i))
+    return hits
+
+
+# --------------------------------------------------------------------------- F
+
+def check_fail_open(repo):
+    """F1/F2 — the FuzeFinance class.
+
+    A try/catch around an auth import whose handler installs something
+    permissive. Scanned line-wise with a small window rather than parsed: this
+    must work identically on TS, JS and Python, and a real parser for three
+    languages is a much larger surface than the bug it would catch.
+
+    Skips the package this repo publishes as the auth client, if any: a module
+    that DEFINES a fallback path is writing the contract, not violating it. See
+    auth_impl_dirs().
+    """
+    out = []
+    impl = auth_impl_dirs(repo)
+    for rel in source_files(repo):
+        if _under(rel, impl):
+            continue
+        body = read(repo, rel)
+        if not any(p in body for p in AUTH_PKGS):
+            continue
+        lines = body.splitlines()
+        in_handler = False
+        handler_start = 0
+        for i, line in enumerate(lines, 1):
+            if re.search(r"^\s*\}?\s*catch\b|^\s*except\b", line):
+                in_handler, handler_start = True, i
+                continue
+            if in_handler:
+                # a handler ends at a closing brace/dedent at column 0-ish
+                if re.match(r"^\S", line) and not re.match(r"^\s*\}", line):
+                    in_handler = False
+                    continue
+                if PERMISSIVE.search(line):
+                    out.append(Finding(
+                        "F1", rel, i,
+                        "auth import is wrapped in try/catch and the handler installs a "
+                        "PERMISSIVE fallback. If the import ever fails this serves every "
+                        "request as authorized — and if the dependency is undeclared it "
+                        "fails ALWAYS, making this the only path that runs. An auth "
+                        "import must be a hard failure: refuse to start instead. "
+                        f"(handler opened at line {handler_start})"))
+                    in_handler = False
+    return out
+
+
+def check_permissive_guard(repo):
+    """F2 — a guard that cannot deny.
+
+    Deliberately conservative. The first version windowed 7 lines from the
+    function signature and flagged FuzeHub's `requireUser`, which is a perfectly
+    good guard: it calls next() on success and res.status(401) on failure, but
+    the 401 sat ~10 lines below the window. That is the worst kind of false
+    positive — a gate that reds correct code is one people learn to route around,
+    and F1 already catches the defect this family was written for.
+
+    So the bar is now: the FILE names something guard-shaped, passes the request
+    through, and contains no denial ANYWHERE in it. A real guard rejects
+    somewhere; a stub never does.
+    """
+    out = []
+    guard_def = re.compile(
+        r"\b(?:const|let|var|function|def)\s+"
+        r"(require\w*|auth\w*|ensure\w*|verify\w*|guard\w*)\b", re.I)
+    denial = re.compile(
+        r"\b(401|403|throw\b|raise\b|reject\(|abort\(|"
+        r"status\s*\(\s*4\d\d|sendStatus\s*\(\s*4\d\d)")
+    for rel in source_files(repo):
+        body = read(repo, rel)
+        if denial.search(body):
+            continue  # this file can say no somewhere — not a stub
+        lines = body.splitlines()
+        for i, line in enumerate(lines, 1):
+            m = guard_def.search(line)
+            if not m:
+                continue
+            window = "\n".join(lines[i - 1:i + 8])
+            if re.search(r"\bnext\s*\(\s*\)|\breturn\s+True\b", window):
+                out.append(Finding(
+                    "F2", rel, i,
+                    f"`{m.group(1)}` reads as an auth guard, passes the request through, "
+                    "and NOTHING in this entire file can deny — no 401, no 403, no throw, "
+                    "no rejection. A guard that cannot say no is decoration, and callers "
+                    "and reviewers will reasonably assume the routes it wraps are "
+                    "protected."))
+                break  # one finding per file is enough to make the point
+    return out
+
+
+# --------------------------------------------------------------------------- D
+
+def check_declared(repo):
+    out = []
+    declared_in = declares_auth(repo)
+    used = imports_auth(repo)
+    if used and not declared_in:
+        rel, line = used[0]
+        out.append(Finding(
+            "D1", rel, line,
+            f"imports {AUTH_PKGS[0]} but NO package.json declares it (checked "
+            "dependencies, devDependencies, peerDependencies, optionalDependencies). "
+            "The import can only ever throw at runtime. If it is wrapped in a "
+            "try/catch, the fallback is not a degraded mode — it is the only mode."))
+    if declared_in and not used:
+        out.append(Finding(
+            "D2", declared_in, None,
+            "declares the platform auth package but never imports it anywhere. An "
+            "inert dependency satisfies a naive 'is it installed' check while guarding "
+            "nothing — measured across this family, thirteen repos declared the "
+            "identity package and none imported it."))
+    return out
+
+
+# --------------------------------------------------------------------------- S
+
+def _is_real_secret_literal(line, value):
+    """Filter the enum-member shape out of S1.
+
+    `SECRET = "secret"` in a Python field-type enum is not a signing secret, and
+    FuzeFront ships exactly that. The discriminator is that a real secret does not
+    spell its own identifier: a constant assigned its own lowercased name is a
+    label, and a four-character value is not key material either.
+    """
+    ident = line.split("=")[0].split(":")[0].strip().strip("'\"")
+    if value.strip().lower() == ident.strip().lower():
+        return False
+    if len(value) < 8:
+        return False
+    return True
+
+
+def check_secrets(repo):
+    out = []
+    impl = auth_impl_dirs(repo)
+    lit_secret = re.compile(
+        r"\b(?:secret|legacySecret|jwtSecret|signingKey)\s*[:=]\s*['\"]([^'\"]{4,})['\"]", re.I)
+    saw_legacy = saw_jwks = False
+    for rel in source_files(repo):
+        if _under(rel, impl):
+            continue  # this repo publishes the client; see auth_impl_dirs()
+        body = read(repo, rel)
+        if "legacy-hs256" in body:
+            saw_legacy = True
+        if re.search(r"jwks|federated-jwks|oidc-jwks|createRemoteJWKSet", body, re.I):
+            saw_jwks = True
+        for i, line in enumerate(body.splitlines(), 1):
+            m = lit_secret.search(line)
+            if m and _is_real_secret_literal(line, m.group(1)) and not re.search(
+                    r"process\.env|os\.environ|getenv", line):
+                out.append(Finding(
+                    "S1", rel, i,
+                    "signing secret is a string literal, not read from the environment. "
+                    "Anyone with repo read access can mint a valid token for this "
+                    "service. Read it from env and fail closed when it is absent."))
+        if re.search(r"createVerifier\s*\(", body) and not re.search(
+                r"algorithms?\s*[:=]", body):
+            out.append(Finding(
+                "S3", rel, None,
+                "a verifier is constructed without pinned algorithms. Unpinned "
+                "verification accepts whatever the TOKEN claims, which is how "
+                "`alg:none` and RS256-verified-as-HMAC forgeries work. Pin the "
+                "algorithm list per mode."))
+    if saw_legacy and not saw_jwks:
+        out.append(Finding(
+            "S2", ".", None,
+            "legacy-hs256 is the only auth mode present — no JWKS/federated path "
+            "exists. A shared symmetric secret means any holder can MINT tokens, not "
+            "merely verify them, so every consumer is also an issuer."))
+    return out
+
+
+# --------------------------------------------------------------------------- Z
+
+def check_authz(repo):
+    out = []
+    impl = auth_impl_dirs(repo)
+    is_authz_service = serves_authz_api(repo)
+    mutating = [(rel, i) for rel in source_files(repo)
+                for i, l in enumerate(read(repo, rel).splitlines(), 1)
+                if MUTATING_ROUTE.search(l)]
+    has_authz = False
+    for rel in source_files(repo):
+        if _under(rel, impl):
+            continue
+        body = read(repo, rel)
+        if re.search(r"requirePermission|createAuthzClient|require_permission", body):
+            has_authz = True
+        for i, line in enumerate(body.splitlines(), 1):
+            if is_authz_service:
+                break  # this repo IS the Security API; see serves_authz_api()
+            if re.search(r"permit\.check|permitio|from\s+['\"]permitio", line, re.I):
+                out.append(Finding(
+                    "Z3", rel, i,
+                    "calls the Permit SDK directly. Products must not: they know exactly "
+                    "one thing, the base URL of FuzeFront's Security API "
+                    "(/api/v1/security/authz/check). A direct call bypasses the "
+                    "fail-closed client and couples this repo to the authz vendor."))
+        for i, line in enumerate(body.splitlines(), 1):
+            if "DECISION_UNAVAILABLE" in line:
+                window = "\n".join(body.splitlines()[i - 1:i + 5])
+                if re.search(r"\bnext\s*\(\s*\)|allow|true|200", window, re.I) and not \
+                        re.search(r"403|deny|reject|throw|raise", window, re.I):
+                    out.append(Finding(
+                        "Z2", rel, i,
+                        "DECISION_UNAVAILABLE appears to be handled by allowing the "
+                        "request. The authz client is fail-closed BY CONTRACT and offers "
+                        "no fail-open option; re-introducing one here means an authz "
+                        "outage silently becomes an authorization bypass."))
+    if mutating and not has_authz:
+        rel, line = mutating[0]
+        out.append(Finding(
+            "Z1", rel, line,
+            f"{len(mutating)} state-changing route(s) and ZERO requirePermission / "
+            "createAuthzClient call sites. Authentication answers who the caller is; "
+            "nothing here answers whether they may perform this operation on this "
+            "object (OWASP API1:2023 BOLA)."))
+    return out
+
+
+# --------------------------------------------------------------------------- R
+
+def check_rate_limit(repo):
+    limiter = re.compile(
+        r"rate[-_]?limit|rateLimit|express-rate-limit|slowDown|"
+        r"@fastify/rate-limit|flask_limiter|slowapi", re.I)
+    routed = any(ANY_ROUTE.search(read(repo, rel)) for rel in source_files(repo))
+    if not routed:
+        return []
+    if any(limiter.search(read(repo, rel)) for rel in source_files(repo)):
+        return []
+    return [Finding(
+        "R1", ".", None,
+        "serves HTTP routes with no rate limiter anywhere in the tree. Without one, "
+        "credential stuffing and enumeration against these endpoints are unbounded, "
+        "and a single client can exhaust the service for everyone.")]
+
+
+# --------------------------------------------------------------------------- A
+
+def check_adoption(repo):
+    """A1 — the check that does NOT pass vacuously.
+
+    Every other family asks "is what is here correct". All of them are silent on
+    a service with no auth at all, which is exactly the state that shipped.
+    """
+    routed = [(rel, i) for rel in source_files(repo)
+              for i, l in enumerate(read(repo, rel).splitlines(), 1)
+              if ANY_ROUTE.search(l)]
+    if not routed:
+        return []
+    if declares_auth(repo) or imports_auth(repo):
+        return []
+    rel, line = routed[0]
+    return [Finding(
+        "A1", rel, line,
+        f"serves {len(routed)} HTTP route(s) and has NO platform auth at all — the "
+        "package is neither declared nor imported. Every other check in this gate "
+        "would pass this repo, because there is nothing here to find fault with. "
+        "That is the failure mode this check exists for: a standard satisfied by "
+        "non-adoption is not a standard.")]
+
+
+# --------------------------------------------------------------------------- E
+
+# Route-level coverage. The families above all reason about the REPO: does it
+# declare the package, does it import it, does any auth boundary exist at all.
+# Every one of them is green on a repo whose auth is real but whose individual
+# route lost its guard -- which is the FuzeAgent shape: `main.py` authenticates
+# properly and `simple_main.py` published the same domain with none, so A1 saw
+# an auth boundary and stopped looking. A per-repo question cannot answer a
+# per-route one.
+#
+# CLOSED SET, NOT A DENYLIST. Every discovered route must end up in exactly one
+# of three buckets: guarded (evidence found), public (declared, with a reason),
+# or UNGUARDED (fails). There is no fourth "didn't recognise it, carry on"
+# bucket -- that bucket is how `/applications` stayed exposed behind a path
+# denylist that only knew about `/application`. A route the scanner cannot
+# classify is a finding, not a shrug.
+#
+# TWO DECLARATION FILES, AND THEY ARE NOT INTERCHANGEABLE:
+#   governance/auth-guards.txt   extends what COUNTS as a guard, for repos whose
+#                                middleware is named locally. Additive evidence.
+#   governance/public-routes.txt exempts a specific METHOD + path from needing
+#                                one. An exemption, not evidence.
+# Conflating them is how an allowlist quietly becomes the hole: "we couldn't
+# detect the guard" and "this endpoint is deliberately open" are different
+# facts and must not share a file.
+
+GUARD_FILES = ("governance/auth-guards.txt", ".fuze/auth-guards.txt")
+PUBLIC_FILES = ("governance/public-routes.txt", ".fuze/public-routes.txt")
+
+# Identifiers that constitute an authentication/authorization boundary. Seeded
+# from what the family actually runs (Express middleware, FastAPI dependencies,
+# the @fuzefront/auth surface) and extended per repo via auth-guards.txt.
+BUILTIN_GUARDS = (
+    # Express / @fuzefront/auth
+    "authenticateToken", "requireAuth", "requireUser", "requirePermission",
+    "requireRoles", "requireOrgAccess", "requireApiKey", "requireInternalToken",
+    "ensureAuthenticated", "isAuthenticated", "verifyToken", "authMiddleware",
+    "PermissionMiddleware", "tenantContext",
+    # FastAPI / Starlette
+    "require_auth", "require_user", "require_org_access", "get_current_user",
+    "authenticate_websocket", "verify_token", "current_active_user",
+)
+
+
+def _decl_file(repo, candidates):
+    for rel in candidates:
+        if os.path.exists(os.path.join(repo, rel)):
+            return rel
+    return None
+
+
+def _parse_decls(repo, candidates, kind):
+    """Read a declaration file into {value: reason} plus its findings.
+
+    A reason is MANDATORY. An entry without one is rejected rather than
+    honoured: an undocumented exemption is indistinguishable from an oversight,
+    which is the same rule `enforcing()` applies to platformAuth.enforce.
+    """
+    rel = _decl_file(repo, candidates)
+    out, findings = {}, []
+    if not rel:
+        return rel, out, findings
+    for i, raw in enumerate(read(repo, rel).splitlines(), 1):
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        value, sep, reason = line.partition("#")
+        value, reason = value.strip(), reason.strip()
+        if not value:
+            continue
+        if not sep or not reason:
+            findings.append(Finding(
+                "E4", rel, i,
+                f"{kind} entry {value!r} carries no `# reason`. Every entry here "
+                "weakens a security check, so each one states why it is correct. "
+                "An entry with no reason cannot be reviewed and does not apply."))
+            continue
+        out[value] = reason
+    return rel, out, findings
+
+
+def _norm_path(p):
+    """Compare routes by shape, not by parameter spelling: `/users/{id}` and
+    `/users/:id` are the same surface, and a rename of the parameter must not
+    silently invalidate a public-route declaration (or silently satisfy one)."""
+    p = "/" + (p or "").strip().strip("/")
+    p = re.sub(r"\{[^}]*\}", "{}", p)
+    p = re.sub(r":[A-Za-z_][A-Za-z0-9_]*", "{}", p)
+    return p.lower() or "/"
+
+
+class Route:
+    """`line` is where the route is REPORTED; `span` is what the ratchet reads.
+
+    They differ, and the difference is the whole point. A guard usually lives in
+    the handler signature or the decorator's `dependencies=[...]`, not on the
+    line naming the path — so deleting `Depends(require_auth)` from
+    `async def items(_auth=Depends(require_auth))` leaves the `@app.get("/items")`
+    line untouched. A ratchet keyed on the reported line would have called that
+    diff clean: it would miss precisely the mutation it exists to catch. The span
+    covers the decorator through the end of the handler, so any edit to the route
+    puts its auth posture back in scope.
+    """
+
+    def __init__(self, method, path, rel, line, guarded_by=None, span=None):
+        self.method = method.upper()
+        self.path = _norm_path(path)
+        self.rel, self.line = rel, line
+        self.guarded_by = guarded_by
+        self.span = set(span) if span else {line}
+
+    @property
+    def key(self):
+        return f"{self.method} {self.path}"
+
+
+PY_ROUTE_METHODS = ("get", "post", "put", "patch", "delete", "head",
+                    "options", "websocket")
+
+
+def _py_guard_names(node, guards):
+    """Guard identifiers referenced anywhere inside an AST subtree.
+
+    Deliberately name-based rather than resolving `Depends(...)`: the thing that
+    matters is whether a recognised guard is wired in, and it appears as a Name
+    either way (`Depends(require_auth)`, `Security(require_auth)`, a bare
+    annotated dependency alias). Resolving the call form and missing an alias
+    would fail open, which is the one direction this gate must never fail.
+    """
+    found = set()
+    for sub in ast.walk(node):
+        if isinstance(sub, ast.Name) and sub.id in guards:
+            found.add(sub.id)
+        elif isinstance(sub, ast.Attribute) and sub.attr in guards:
+            found.add(sub.attr)
+    return found
+
+
+def _py_routes(repo, rel, guards):
+    """FastAPI/Starlette routes via AST. Python gets a real parse because the
+    stdlib provides one; the JS/TS side below is textual and says so."""
+    try:
+        tree = ast.parse(read(repo, rel))
+    except (SyntaxError, ValueError):
+        return None  # signals "could not read this file" to the caller
+
+    # App/router objects constructed WITH a global auth dependency guard every
+    # route registered on them -- this is how simple_main.py was repaired, and
+    # how FuzeFront's security service mounts tenantContext.
+    global_guarded = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign) or not isinstance(node.value, ast.Call):
+            continue
+        fn = node.value.func
+        ctor = getattr(fn, "id", None) or getattr(fn, "attr", None)
+        if ctor not in ("FastAPI", "APIRouter"):
+            continue
+        for kw in node.value.keywords:
+            if kw.arg == "dependencies" and _py_guard_names(kw, guards):
+                for tgt in node.targets:
+                    if isinstance(tgt, ast.Name):
+                        global_guarded.add(tgt.id)
+
+    routes = []
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        for dec in node.decorator_list:
+            if not isinstance(dec, ast.Call):
+                continue
+            fn = dec.func
+            if not isinstance(fn, ast.Attribute) or fn.attr not in PY_ROUTE_METHODS:
+                continue
+            owner = getattr(fn.value, "id", None)
+            path = ""
+            if dec.args and isinstance(dec.args[0], ast.Constant) \
+                    and isinstance(dec.args[0].value, str):
+                path = dec.args[0].value
+            guard = None
+            if owner in global_guarded:
+                guard = f"app-level dependency on {owner}"
+            else:
+                # per-route: decorator `dependencies=[...]`, the handler
+                # signature, or a guard called in the body (the WebSocket shape,
+                # where app-level deps genuinely do not apply).
+                hits = (_py_guard_names(dec, guards)
+                        | _py_guard_names(node.args, guards)
+                        | {n for n in _py_guard_names(node, guards)})
+                if hits:
+                    guard = "route uses " + ", ".join(sorted(hits))
+            start = min([d.lineno for d in node.decorator_list] + [dec.lineno])
+            end = getattr(node, "end_lineno", None) or node.lineno
+            routes.append(Route(fn.attr, path, rel, dec.lineno, guard,
+                                span=range(start, end + 1)))
+    return routes
+
+
+def _balanced(text, open_idx):
+    """Text of the call whose '(' is at open_idx, brace-aware so a multi-line
+    Express registration is read whole rather than to the first newline."""
+    depth, i, n = 0, open_idx, len(text)
+    while i < n:
+        c = text[i]
+        if c in "([{":
+            depth += 1
+        elif c in ")]}":
+            depth -= 1
+            if depth == 0:
+                return text[open_idx:i + 1]
+        i += 1
+    return text[open_idx:open_idx + 2000]
+
+
+JS_ROUTE = re.compile(
+    r"\b(?P<owner>[A-Za-z_$][\w$]*)\s*\.\s*"
+    r"(?P<method>get|post|put|patch|delete|head|options|all|use)\s*\(")
+# The first argument must be a string literal that STARTS WITH "/".
+#
+# JS_ROUTE's `owner` is deliberately any identifier, because real routers are
+# named all sorts of things (`r`, `v1`, `apiRouter`). The cost of that breadth
+# is that `<anything>.get("x")` matched, and the first-argument check was the
+# only thing standing between that and a reported route -- so ANY map, cache,
+# header bag or URLSearchParams read became an unguarded HTTP route.
+#
+# Measured on FuzeMarket 2026-09-03, ALL EIGHT of its E1 findings were this,
+# and it had zero real detected routes:
+#
+#     const u = url.searchParams.get("url");          -> "GET /url"
+#     url.searchParams.get("days")                    -> "GET /days"
+#     r.headers.get("content-type")                   -> "GET /content-type"
+#
+# Requiring the leading slash is the discriminator, and it costs nothing real:
+# an Express/Fastify path is matched against req.path, which always begins with
+# "/", so `app.get("users")` can never match a request and is dead code. Routes
+# registered from a constant (`app.get(PATHS.users, h)`) were already skipped
+# here -- they are not string literals -- so this narrows nothing that worked.
+JS_PATH = re.compile(r"""^\(\s*['"`](?P<path>/[^'"`]*)['"`]""")
+
+
+def _js_routes(repo, rel, guards, mount_guarded):
+    """Express-style routes, textually.
+
+    Regex rather than a parse because there is no JS parser in the stdlib and
+    this gate is stdlib-only by house convention (same reasoning as
+    gate_manifest's optional-jsonschema fallback). The report says which engine
+    read each file so a weaker analysis is never mistaken for a stronger one.
+    """
+    body = read(repo, rel)
+    routes = []
+
+    # A bare `app.use(guard)` with no path argument guards everything mounted
+    # AFTER it in the same file — and only after it. Express middleware order is
+    # load-bearing: the canonical mount sequence puts health and openapi ahead of
+    # auth precisely so they stay reachable. Treating the guard as covering the
+    # whole file would report those pre-auth routes as protected when they are
+    # deliberately not, which is a false negative in a gate whose entire value is
+    # that it does not produce them.
+    file_guard_at = None
+    file_guarded = None
+    for m in JS_ROUTE.finditer(body):
+        if m.group("method") != "use":
+            continue
+        call = _balanced(body, m.end() - 1)
+        if JS_PATH.match(call):
+            continue  # path-scoped mount, handled by mount_guarded
+        hit = sorted(set(re.findall(r"[A-Za-z_$][\w$]*", call)) & guards)
+        if hit:
+            file_guard_at = m.start()
+            file_guarded = f"{m.group('owner')}.use({hit[0]}) earlier in this file"
+            break
+
+    for m in JS_ROUTE.finditer(body):
+        method = m.group("method")
+        if method in ("use", "all"):
+            continue
+        call = _balanced(body, m.end() - 1)
+        pm = JS_PATH.match(call)
+        if not pm:
+            continue  # not a route registration (e.g. a promise `.get`)
+        line = body.count("\n", 0, m.start()) + 1
+        idents = set(re.findall(r"[A-Za-z_$][\w$]*", call[pm.end():]))
+        hit = sorted(idents & guards)
+        guard = None
+        if hit:
+            guard = "route uses " + ", ".join(hit)
+        elif file_guarded is not None and m.start() > file_guard_at:
+            guard = file_guarded
+        elif rel in mount_guarded:
+            guard = mount_guarded[rel]
+        end_line = line + call.count("\n")
+        routes.append(Route(method, pm.group("path"), rel, line, guard,
+                            span=range(line, end_line + 1)))
+    return routes
+
+
+def _mount_guarded_files(repo, guards):
+    """Files whose router is mounted behind a guard at the mount site.
+
+    `app.use('/api', requireAuth, apiRouter)` guards every route in the file
+    `apiRouter` was imported from. Without resolving this the gate would red
+    every repo that centralises its guard at the mount point -- correct code,
+    and a gate that reds correct code is one people learn to route around.
+    """
+    out = {}
+    for rel in source_files(repo):
+        if not rel.endswith((".ts", ".tsx", ".js", ".mjs", ".cjs")):
+            continue
+        body = read(repo, rel)
+        imports = {}
+        for m in re.finditer(
+                r"""import\s+([A-Za-z_$][\w$]*)\s+from\s+['"]([^'"]+)['"]""", body):
+            imports[m.group(1)] = m.group(2)
+        for m in re.finditer(
+                r"""const\s+([A-Za-z_$][\w$]*)\s*=\s*require\(\s*['"]([^'"]+)['"]""",
+                body):
+            imports[m.group(1)] = m.group(2)
+        for m in JS_ROUTE.finditer(body):
+            if m.group("method") != "use":
+                continue
+            call = _balanced(body, m.end() - 1)
+            if not JS_PATH.match(call):
+                continue
+            idents = set(re.findall(r"[A-Za-z_$][\w$]*", call))
+            if not (idents & guards):
+                continue
+            for ident in idents & set(imports):
+                target = _resolve_import(repo, rel, imports[ident])
+                if target:
+                    out[target] = f"mounted behind a guard in {rel}"
+    return out
+
+
+def _posix(rel):
+    """A repo-relative path in POSIX form, always.
+
+    Every rel in this scanner is a GIT path: it comes from `git ls-files`, is used as a
+    dict key against those listings, and is printed in findings. `os.path.normpath` and
+    `os.path.join` emit backslashes on Windows, so a rel built that way compares unequal
+    to the identical path from git and matches nothing -- silently, because a non-match is
+    indistinguishable from "not mounted".
+    """
+    return rel.replace(os.sep, "/").replace("\\", "/")
+
+
+def _resolve_import(repo, from_rel, spec):
+    if not spec.startswith("."):
+        return None
+    base = _posix(os.path.normpath(os.path.join(os.path.dirname(from_rel), spec)))
+    for cand in (base + ".ts", base + ".tsx", base + ".js",
+                 base + "/index.ts", base + "/index.js", base):
+        if os.path.exists(os.path.join(repo, cand)):
+            return cand
+    return None
+
+
+HUNK_RE = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@")
+
+
+def changed_lines(repo, base_ref):
+    """{relpath: {added/modified line numbers}} from `git diff --unified=0 base...HEAD`.
+
+    None when the diff cannot be computed — and the caller must treat None as
+    "ratchet unavailable, check everything" rather than "nothing changed".
+    A ratchet that silently empties itself when git is unhappy is a check that
+    reports success because it looked at zero lines.
+    """
+    try:
+        res = subprocess.run(
+            ["git", "-C", repo, "diff", "--unified=0", f"{base_ref}...HEAD"],
+            capture_output=True, text=True, timeout=90)
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if res.returncode != 0:
+        return None
+    out, cur = {}, None
+    for line in res.stdout.splitlines():
+        if line.startswith("+++ "):
+            p = line[4:].strip()
+            cur = None if p == "/dev/null" else (
+                p[2:] if p.startswith(("a/", "b/")) else p)
+        elif line.startswith("@@") and cur is not None:
+            m = HUNK_RE.match(line)
+            if m:
+                start = int(m.group(1))
+                count = int(m.group(2)) if m.group(2) is not None else 1
+                out.setdefault(cur, set()).update(range(start, start + count))
+    return out
+
+
+def check_routes(repo, ratchet=None):
+    """E — every individual route is guarded, or declared public with a reason.
+
+    `ratchet` is the changed-lines map from `changed_lines()`. When present,
+    only routes DECLARED OR MODIFIED by this diff can raise E1; pre-existing
+    unguarded routes are counted and reported, never blocking.
+
+    Why a ratchet at all. Run hot on the fleet as it stands, this family
+    produces 356 findings in FuzeFront and 298 in FuzeAgent — nearly all of
+    them locally-named guards it has not been taught yet, plus health probes
+    nobody has declared public. A gate that reds every PR on pre-existing
+    debt does not get fixed, it gets `|| true`-d; that is the documented
+    history of gate-authz in this very file. The ratchet keeps the property
+    that actually matters — a route that LOSES its guard is a changed line,
+    and changed lines always fail — while the backlog burns down against a
+    visible count instead of a blocked merge queue.
+    """
+    guard_rel, extra_guards, findings = _parse_decls(
+        repo, GUARD_FILES, "auth-guards")
+    public_rel, public, pf = _parse_decls(repo, PUBLIC_FILES, "public-routes")
+    findings = list(findings) + list(pf)
+
+    guards = set(BUILTIN_GUARDS) | set(extra_guards)
+    exempt_dirs = auth_impl_dirs(repo)
+
+    py_files, js_files = [], []
+    for rel in source_files(repo):
+        if _under(rel, exempt_dirs):
+            continue
+        (py_files if rel.endswith(".py") else js_files).append(rel)
+
+    mount_guarded = _mount_guarded_files(repo, guards)
+
+    routes, unparsable = [], []
+    for rel in py_files:
+        got = _py_routes(repo, rel, guards)
+        if got is None:
+            unparsable.append(rel)
+        else:
+            routes.extend(got)
+    for rel in js_files:
+        routes.extend(_js_routes(repo, rel, guards, mount_guarded))
+
+    # E2 -- ANTI-VACUITY. The repo has route-shaped source but the scanner
+    # produced nothing. That is a broken scanner reporting a clean bill of
+    # health, which is the single failure mode this whole gate exists to stop.
+    # It must be louder than a real finding, not quieter.
+    textual = [rel for rel in py_files + js_files
+               if ANY_ROUTE.search(read(repo, rel))]
+    if textual and not routes:
+        return findings + [Finding(
+            "E2", textual[0], None,
+            f"{len(textual)} file(s) contain route registrations that the scanner "
+            "could not extract, so this family examined ZERO routes and would "
+            "otherwise have reported success. Treat this as the gate being "
+            "broken, not the repo being clean.")]
+
+    if not routes:
+        return findings  # genuinely no HTTP surface -- a library, legitimately
+
+    seen_public, unguarded, deferred = set(), 0, 0
+    for r in sorted(routes, key=lambda x: (x.rel, x.line)):
+        if r.guarded_by:
+            continue
+        if r.key in public:
+            seen_public.add(r.key)
+            continue
+        unguarded += 1
+        if ratchet is not None and not (r.span & set(ratchet.get(r.rel, ()))):
+            deferred += 1
+            continue
+        findings.append(Finding(
+            "E1", r.rel, r.line,
+            f"`{r.key}` is registered with no authentication boundary: no "
+            "app-level dependency, no router mount guard, and no recognised "
+            "guard on the route itself. If it is deliberately public, declare "
+            f"it in {public_rel or PUBLIC_FILES[0]} as `{r.key}  # why`. If it "
+            "IS guarded by a locally-named middleware, add that name to "
+            f"{guard_rel or GUARD_FILES[0]} — extending detection and exempting "
+            "a route are different claims and this gate keeps them apart."))
+
+    # The census prints unconditionally, pass or fail. A family that says only
+    # "OK" cannot be distinguished from one that examined nothing, which is the
+    # exact ambiguity this gate was written to remove.
+    print(f"gate-platform-auth routes: {len(routes)} route(s) — "
+          f"{len(routes) - unguarded - len(seen_public)} guarded, "
+          f"{len(seen_public)} declared public, {unguarded} unguarded"
+          + (f" ({deferred} pre-existing, deferred by the ratchet)"
+             if ratchet is not None and deferred else ""))
+    if ratchet is not None and deferred:
+        print(f"gate-platform-auth routes: {deferred} pre-existing unguarded "
+              "route(s) are NOT failing this PR. They are debt, not clearance — "
+              "run this gate without --changed-only to list them.")
+
+    # E3 -- a stale exemption. An allowlist that only ever grows is the hole the
+    # gate was supposed to close; an entry whose route is gone or is now guarded
+    # has to come out while someone still remembers why it went in.
+    live = {r.key for r in routes}
+    for key in sorted(set(public) - seen_public):
+        why = ("no such route exists any more" if key not in live
+               else "that route is now guarded, so the exemption is dead weight")
+        findings.append(Finding(
+            "E3", public_rel, None,
+            f"public-routes declares `{key}` but {why}. Remove the line: a "
+            "standing exemption for a route nobody can point at is how the next "
+            "unguarded route gets waved through."))
+
+    for rel in unparsable:
+        findings.append(Finding(
+            "E2", rel, None,
+            "could not be parsed, so any routes it registers were NOT checked. "
+            "Unreadable is not the same as clean."))
+    return findings
+
+
+# --------------------------------------------------------------------------- main
+
+FAMILIES = (
+    ("fail_open", "--fail-open", lambda r: check_fail_open(r) + check_permissive_guard(r)),
+    ("declared", "--declared", check_declared),
+    ("secrets", "--secrets", check_secrets),
+    ("authz", "--authz", check_authz),
+    ("rate_limit", "--rate-limit", check_rate_limit),
+    ("adoption", "--adoption", check_adoption),
+    ("routes", "--routes", check_routes),
+)
+
+
+def enforcing(repo):
+    """(hard, why) — enforce unless the repo has explicitly and legibly opted out.
+
+    Absent manifest, absent block and absent flag all enforce. Only an explicit
+    `enforce: false` carrying a non-empty `reason` downgrades to report-only.
+    """
+    path = os.path.join(repo, ".fuze", "manifest.json")
+    try:
+        with open(path, encoding="utf-8") as fh:
+            block = json.load(fh).get("platformAuth") or {}
+    except (OSError, json.JSONDecodeError):
+        return True, "no readable .fuze/manifest.json — enforcing by default"
+
+    if "enforce" not in block:
+        return True, "platformAuth.enforce not declared — enforcing by default"
+    if block.get("enforce"):
+        return True, "platformAuth.enforce: true"
+
+    reason = (block.get("reason") or "").strip()
+    if not reason:
+        return True, ("platformAuth.enforce is false with no `reason` — an "
+                      "undocumented opt-out is indistinguishable from an "
+                      "oversight, so it does not count. Add "
+                      "platformAuth.reason explaining what blocks adoption "
+                      "and who owns it.")
+    return False, f"opted out: {reason}"
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("repo", nargs="?", default=".")
+    for attr, flag, _ in FAMILIES:
+        ap.add_argument(flag, dest=attr, action="store_true")
+    ap.add_argument("--all", action="store_true", help="every family (the default)")
+    ap.add_argument("--changed-only", action="store_true",
+                    help="ratchet: only routes this diff declares or modifies can "
+                         "raise E1 (see check_routes). Pre-existing findings are "
+                         "counted and reported, never blocking.")
+    ap.add_argument("--base", default=os.environ.get("GATE_BASE_REF", "origin/master"),
+                    help="base ref for --changed-only (env GATE_BASE_REF)")
+    args = ap.parse_args(argv)
+
+    repo = os.path.abspath(args.repo)
+    selected = [fn for attr, _, fn in FAMILIES if getattr(args, attr)]
+    if not selected or args.all:
+        selected = [fn for _, _, fn in FAMILIES]
+
+    ratchet = None
+    if args.changed_only:
+        ratchet = changed_lines(repo, args.base)
+        if ratchet is None:
+            # Fail LOUD and check everything. The alternative — an empty map —
+            # would exempt every route in the repo and print OK, which is the
+            # precise shape of a gate that passes because it looked at nothing.
+            print(f"::warning::gate-platform-auth: --changed-only could not diff "
+                  f"against '{args.base}'; checking every route instead of "
+                  "silently exempting them all.")
+
+    findings = []
+    for fn in selected:
+        findings.extend(fn(repo, ratchet) if fn is check_routes else fn(repo))
+
+    hard, why = enforcing(repo)
+    mode = "enforcing" if hard else "report-only"
+    print(f"gate-platform-auth: repo={os.path.basename(repo)} mode={mode} "
+          f"families={len(selected)} ({why})")
+
+    if not findings:
+        print("gate-platform-auth: OK")
+        return 0
+
+    for f in sorted(findings, key=lambda x: (x.code, x.path, x.line or 0)):
+        print(("::error::" if hard else "::warning::") + f"gate-platform-auth {f.code}")
+        print(f)
+
+    print(f"\ngate-platform-auth: {len(findings)} finding(s)")
+    if not hard:
+        print("gate-platform-auth: report-only because this repo opted out — "
+              f"{why}. Remove platformAuth.enforce=false once these are "
+              "addressed; the opt-out is debt, not a setting.")
+        return 0
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/gen-deployable-paths.mjs
+++ b/scripts/gen-deployable-paths.mjs
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+// Render release.yml's `on.push.paths` block from deploy/deployable-paths.json.
+//
+//   node scripts/gen-deployable-paths.mjs            # print the rendered block
+//   node scripts/gen-deployable-paths.mjs --write    # rewrite the block in release.yml
+//
+// `--write` is the ONLY supported way to change that block. Hand-editing it makes
+// gate-deployable-paths.yml red. See scripts/deployable-paths.mjs for why this mirror
+// cannot be collapsed at runtime the way auto-merge.yml's was.
+
+import { readFileSync, writeFileSync } from 'node:fs'
+import {
+  MANIFEST_PATH,
+  WORKFLOW_PATH,
+  readManifest,
+  renderPathsBlock,
+  extractPathsBlock,
+} from './deployable-paths.mjs'
+
+const write = process.argv.includes('--write')
+const root = process.cwd()
+
+const manifest = readManifest(readFileSync(`${root}/${MANIFEST_PATH}`, 'utf8'))
+const rendered = renderPathsBlock(manifest)
+
+if (!write) {
+  console.log(rendered)
+  process.exit(0)
+}
+
+const source = readFileSync(`${root}/${WORKFLOW_PATH}`, 'utf8')
+const block = extractPathsBlock(source)
+
+// Preserve the file's own line ending rather than forcing LF — gate-line-endings.yml
+// governs that, and this script must not fight it or silently reformat the whole file.
+const eol = source.includes('\r\n') ? '\r\n' : '\n'
+const lines = source.split(/\r?\n/)
+const next = [
+  ...lines.slice(0, block.startLine),
+  ...rendered.split('\n'),
+  ...lines.slice(block.endLine),
+].join(eol)
+
+if (next === source) {
+  console.log(`${WORKFLOW_PATH}: already in sync with ${MANIFEST_PATH} (${block.paths.length} paths)`)
+  process.exit(0)
+}
+
+writeFileSync(`${root}/${WORKFLOW_PATH}`, next)
+console.log(
+  `${WORKFLOW_PATH}: rewrote on.push.paths from ${MANIFEST_PATH} ` +
+    `(${manifest.paths.length} path(s)). Commit the workflow with the manifest change.`
+)

--- a/selection-list-client/README.md
+++ b/selection-list-client/README.md
@@ -30,7 +30,13 @@ try {
 
 ## Install locally (pre-publish)
 
-The `@fuzeone` scope is not published yet (tracked on FFRNT-266). Until then:
+The `@fuzeone` scope IS published now — but only for packages that are root
+workspaces. `@fuzeone/selection-lists-ui` is live as
+`@izzywdev/fuzeone-selection-lists-ui@0.1.0`; **this** package is not, because
+`selection-list-client` is missing from the root `package.json` `workspaces`
+array, which is the one list `scripts/publish-packages.mjs` reads. No workspace
+entry means no matrix leg, so `packages-publish` never attempts it and stays
+green regardless. Until it is added:
 
 ```bash
 cd selection-list-client && npm install && npm run build && npm pack


### PR DESCRIPTION
## What

Closes the last hand-maintained mirror of "what is deployable/publishable", and fixes two guides the live registry contradicts.

### A. `release.yml`'s `on.push.paths` becomes a rendered artifact

"What is deployable" lived in three hand-maintained places that drift independently. Two are already closed:

1. root `package.json` `workspaces` — the real source (`publishable()` in `scripts/publish-packages.mjs` reads it).
2. `auto-merge.yml`'s regex mirror — **collapsed**, derives from `publish-packages.mjs --list-dirs` at runtime.
3. `release.yml`'s `on.push.paths` — **this PR.**

(3) cannot be collapsed the way (2) was: GitHub evaluates the trigger block before any step runs, so it must be static YAML in the file. So the block becomes a rendered artifact of a checked-in manifest, and a gate keeps the two identical.

| file | role |
| --- | --- |
| `deploy/deployable-paths.json` | the manifest — 18 paths, each carrying the existing explanatory comments (rendered, therefore compared, therefore cannot rot silently) |
| `scripts/deployable-paths.mjs` | render / extract / coverage library |
| `scripts/gen-deployable-paths.mjs` | the generator (`--write`) |
| `scripts/check-deployable-paths.mjs` | the gate — names the drifted paths |
| `.github/workflows/gate-deployable-paths.yml` | runs the gate + its unit tests |

**The gate is the load-bearing part.** Without it this is a *fourth* copy of the same truth, not a replacement for the third. This mirror's failure mode is silent and inverted: a missing path does not produce a red run, it produces **no run** — the change merges green and never ships. `chat-service` (#432), `notification-service`, `payment-service`, `selection-list-service` and `config-service` each acquired a `docker/build-push-action` step whose own source dir could not trigger it.

The gate checks two things:
- **round-trip** — the committed block must equal what the manifest renders (catches an edit to either side);
- **build-input coverage** — every `file: …Dockerfile` in `release.yml` must have its source dir covered by the manifest. This is the half a round-trip **cannot** see: when a service is missing from *both* sides they agree, and only this check notices. It is the #432 bug exactly.

**No YAML parser, deliberately.** `on` is a YAML 1.1 boolean, so parsers read the key as `true`, find no `on`, conclude "no deployable paths" and pass vacuously — failing toward exactly the silent no-ship this exists to catch. The extractor is a line-based indentation scan (same approach as `check-required-check-triggers.mjs`) and **throws** on every shape it does not recognise, including an empty `paths:` list.

`gate-deployable-paths.yml` has **no `paths:` filter**, so it can be added to the ruleset's required contexts — same rule `workspace-deps-check.yml` / `gate-route-ownership.yml` already state.

### B. Two docs the registry contradicts

- `docs/guides/SELECTION_LIST_SERVICE.md` said the `@fuzeone` scope "is not yet published to npm". It is: `@izzywdev/fuzeone-selection-lists-ui@0.1.0`. The TS **client** genuinely is not — and the real reason is now recorded: `selection-list-client` is absent from the root `workspaces` array, so it produces no matrix leg and `packages-publish` goes green without ever attempting it. (`selection-list-client/README.md` carried a third copy of the stale claim; corrected with it.)
- `docs/guides/shared-packages-distribution.md` described publishing `@fuzeone/*` to a `fuzeone` org. Rewritten around the actual mechanism: `aliasFor()` rewriting `@fuzefront/x` and `@fuzeone/x` to `@izzywdev/fuzefront-x` / `@izzywdev/fuzeone-x` (GitHub Packages requires the scope to equal the owning account), in-family dependency rewriting, and the `assertAliasable()` guard that throws in the `verify` job if a workspace resolves to no `@izzywdev` name. Also states that **the registry read is the acceptance test, not the run conclusion.**

## Verification

**Generator fidelity, proven BEFORE changing anything** — otherwise a generator bug is indistinguishable from real drift. Rendered from the manifest vs the block read straight out of the git blob at the unmodified `HEAD` (`git cat-file blob`, LF, not the autocrlf working tree):

```
BYTE-FOR-BYTE (git blob, unmodified HEAD): true
sha256 rendered  = 357707215c0464dbc2a7c60bff0dbea19a056cac9a1bcac0ad48f761178a33e0
sha256 committed = 357707215c0464dbc2a7c60bff0dbea19a056cac9a1bcac0ad48f761178a33e0
```

Consequently the entire diff to `release.yml` is **+5 lines** — the generated-block header. **Zero path changes.**

**The gate goes red on injected drift** (all four restored afterwards; the gate is green on the committed tree):

| injected | result |
| --- | --- |
| delete `- 'services/chat-service/**'` from the workflow | exit 1, `MISSING from the workflow: services/chat-service/**` |
| drop chat+config from **both** manifest and workflow (round-trip agrees) | exit 1, coverage check: `services/chat-service/Dockerfile -> add 'services/chat-service/**'`, same for config-service |
| hand-add `- 'services/ghost-service/**'` to the workflow | exit 1, `PRESENT in the workflow but absent from the manifest` |
| empty the `paths:` list entirely | exit 1, `resolved to NO deployable paths … merge green and ship nothing` |

**Other checks**

- `node --test scripts/__tests__/deployable-paths.test.mjs` — **20/20 pass**, including the four vacuous-pass shapes (no `on:`, no `push:`, no `paths:`, empty `paths:`) asserted to *throw*.
- `actionlint` (`rhysd/actionlint` container) on `gate-deployable-paths.yml` + `release.yml` — **exit 0, no findings**. Proven to be really running by feeding it a deliberately broken workflow (exit 1, `property "nope" is not defined`).
- Registry facts re-read today, not inferred: `fuzeone-selection-lists-ui` → `["0.1.0"]`; `fuzeone-selection-list-client` → **404**; `fuzefront-api-client`, `fuzefront-sdk-react`, `fuzefront-shared`, `fuzefront-core` → `1.0.0`.

**Not verified:** no real `release` run has been observed for this change — `release.yml` only fires on push to `master`, and its trigger block is unchanged in content (5 comment lines added), so the first post-merge push is the live confirmation.

## Merge note

`github-actions[bot]` pushed `chore(governance): reconcile managed files to FuzeSDLC v1` onto this branch with a skip token in its message. My commit sits on top so the head SHA gets checks — but **squash-merge concatenates every commit message**, so that token would land in the `master` commit and skip every workflow on the push, `release` included. Edit the squash message to drop it before merging.

## Follow-ups (not in this PR)

- Add `selection-list-client` (and `packages/selection-list-client-py`) to the root `workspaces` array so the client can actually publish — that is source-of-truth #1, a different slice.
- Add `release.yml deploy triggers match the manifest` to the branch ruleset's required contexts (governance owns which checks are required).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
